### PR TITLE
inject: add `config.linkerd.io/shutdown-grace-period` annotation

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -219,6 +219,7 @@ Kubernetes: `>=1.21.0-0`
 | proxy.resources.ephemeral-storage.request | string | `""` | Amount of ephemeral storage that the proxy requests |
 | proxy.resources.memory.limit | string | `""` | Maximum amount of memory that the proxy can use |
 | proxy.resources.memory.request | string | `""` | Maximum amount of memory that the proxy requests |
+| proxy.shutdownGracePeriod | string | `""` | Grace period for graceful proxy shutdowns. If this timeout elapses before all open connections have completed, the proxy will terminate forcefully, closing any remaining connections. |
 | proxy.uid | int | `2102` | User id under which the proxy runs |
 | proxy.waitBeforeExitSeconds | int | `0` | If set the proxy sidecar will stay alive for at least the given period before receiving SIGTERM signal from Kubernetes but no longer than pod's `terminationGracePeriodSeconds`. See [Lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) for more info on container lifecycle hooks. |
 | proxyInit.closeWaitTimeoutSecs | int | `0` |  |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -170,6 +170,8 @@ proxy:
   # - ElasticSearch (9300) server-first
   # - Memcached (11211) clients do not issue any preamble, which breaks detection
   opaquePorts: "25,587,3306,4444,5432,6379,9300,11211"
+  # -- Grace period for graceful proxy shutdowns. If this timeout elapses before all open connections have completed, the proxy will terminate forcefully, closing any remaining connections.
+  shutdownGracePeriod: ""
 
 # proxy-init configuration
 proxyInit:

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -126,6 +126,10 @@ be used in other contexts.
 - name: LINKERD2_PROXY_ACCESS_LOG
   value: {{.Values.proxy.accessLog | quote}}
 {{ end -}}
+{{ if .Values.proxy.shutdownGracePeriod -}}
+- name: LINKERD2_PROXY_SHUTDOWN_GRACE_PERIOD
+  value: {{.Values.proxy.shutdownGracePeriod | quote}}
+{{ end -}}
 image: {{.Values.proxy.image.name}}:{{.Values.proxy.image.version | default .Values.linkerdVersion}}
 imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPolicy}}
 livenessProbe:

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -236,5 +236,9 @@ func generateAnnotationsDocs() []annotationDoc {
 			Name:        k8s.ProxySkipSubnetsAnnotation,
 			Description: "Comma-separated list of subnets in valid CIDR format that should be skipped by the proxy",
 		},
+		{
+			Name:        k8s.ProxyShutdownGracePeriodAnnotation,
+			Description: "Grace period for graceful proxy shutdowns. If this timeout elapses before all open connections have completed, the proxy will terminate forcefully, closing any remaining connections.",
+		},
 	}
 }

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -490,6 +490,10 @@ func getOverrideAnnotations(values *charts.Values, base *charts.Values) map[stri
 		overrideAnnotations[k8s.ProxyAccessLogAnnotation] = proxy.AccessLog
 	}
 
+	if proxy.ShutdownGracePeriod != baseProxy.ShutdownGracePeriod {
+		overrideAnnotations[k8s.ProxyShutdownGracePeriodAnnotation] = proxy.ShutdownGracePeriod
+	}
+
 	return overrideAnnotations
 }
 

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -678,6 +678,7 @@ func TestProxyConfigurationAnnotations(t *testing.T) {
 	values.Proxy.WaitBeforeExitSeconds = 10
 	values.Proxy.Await = false
 	values.Proxy.AccessLog = "apache"
+	values.Proxy.ShutdownGracePeriod = "60s"
 
 	expectedOverrides := map[string]string{
 		k8s.ProxyIgnoreInboundPortsAnnotation:  "8500-8505",
@@ -698,6 +699,7 @@ func TestProxyConfigurationAnnotations(t *testing.T) {
 		k8s.ProxyWaitBeforeExitSecondsAnnotation:  "10",
 		k8s.ProxyAwait:                            "disabled",
 		k8s.ProxyAccessLogAnnotation:              "apache",
+		k8s.ProxyShutdownGracePeriodAnnotation:    "60s",
 	}
 
 	overrides := getOverrideAnnotations(values, baseValues)

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1083,7 +1083,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1453,7 +1453,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1082,7 +1083,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1452,7 +1453,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1081,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1450,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1082,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1451,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1081,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1450,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1082,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1451,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1081,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1450,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1082,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1451,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1081,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1450,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1082,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1451,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1073,7 +1073,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1433,7 +1433,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1072,7 +1073,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1432,7 +1433,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -589,6 +589,7 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -589,6 +589,7 @@ data:
           limit: 250Mi
           request: 300Mi
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -667,7 +667,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1013,7 +1013,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1332,7 +1332,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -493,6 +493,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -666,7 +667,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1012,7 +1013,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1331,7 +1332,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -400,7 +400,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-  
+
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -538,6 +538,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -604,7 +605,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -618,7 +619,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -632,7 +633,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -651,7 +652,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -678,7 +679,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-  
+
 spec:
   replicas: 1
   selector:
@@ -705,7 +706,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -923,7 +924,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -942,7 +943,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -961,7 +962,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -980,7 +981,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -999,7 +1000,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1026,7 +1027,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-  
+
 spec:
   replicas: 1
   selector:
@@ -1054,7 +1055,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1340,7 +1341,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1401,7 +1402,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-  
+
 spec:
   replicas: 1
   selector:
@@ -1428,7 +1429,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1644,7 +1645,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -400,7 +400,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-
+  
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -605,7 +605,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -619,7 +619,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -633,7 +633,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -652,7 +652,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -679,7 +679,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-
+  
 spec:
   replicas: 1
   selector:
@@ -706,7 +706,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -924,7 +924,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -943,7 +943,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -962,7 +962,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -981,7 +981,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1000,7 +1000,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1027,7 +1027,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-
+  
 spec:
   replicas: 1
   selector:
@@ -1055,7 +1055,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1341,7 +1341,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1402,7 +1402,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-
+  
 spec:
   replicas: 1
   selector:
@@ -1429,7 +1429,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1645,7 +1645,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -400,7 +400,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-
+  
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -641,7 +641,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -655,7 +655,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -669,7 +669,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -688,7 +688,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -707,7 +707,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -731,7 +731,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-
+  
 spec:
   replicas: 3
   selector:
@@ -1006,7 +1006,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1025,7 +1025,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1044,7 +1044,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1063,7 +1063,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1082,7 +1082,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1101,7 +1101,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-dst
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1125,7 +1125,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-
+  
 spec:
   replicas: 3
   selector:
@@ -1469,7 +1469,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1536,7 +1536,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-
+  
 spec:
   replicas: 3
   selector:
@@ -1809,7 +1809,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1829,7 +1829,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -400,7 +400,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-  
+
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -565,6 +565,7 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -640,7 +641,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -654,7 +655,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -668,7 +669,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -687,7 +688,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -706,7 +707,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -730,7 +731,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-  
+
 spec:
   replicas: 3
   selector:
@@ -1005,7 +1006,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1024,7 +1025,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1043,7 +1044,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1062,7 +1063,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1081,7 +1082,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1100,7 +1101,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-dst
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1124,7 +1125,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-  
+
 spec:
   replicas: 3
   selector:
@@ -1468,7 +1469,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1535,7 +1536,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-  
+
 spec:
   replicas: 3
   selector:
@@ -1808,7 +1809,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1828,7 +1829,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -400,7 +400,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-
+  
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -645,7 +645,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -659,7 +659,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -673,7 +673,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -692,7 +692,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -711,7 +711,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -735,7 +735,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-
+  
 spec:
   replicas: 3
   selector:
@@ -1014,7 +1014,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1033,7 +1033,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1052,7 +1052,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1071,7 +1071,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1090,7 +1090,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1109,7 +1109,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-dst
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1133,7 +1133,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-
+  
 spec:
   replicas: 3
   selector:
@@ -1481,7 +1481,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1552,7 +1552,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-
+  
 spec:
   replicas: 3
   selector:
@@ -1829,7 +1829,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1849,7 +1849,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -400,7 +400,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-  
+
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -569,6 +569,7 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -644,7 +645,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -658,7 +659,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -672,7 +673,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -691,7 +692,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -710,7 +711,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -734,7 +735,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-  
+
 spec:
   replicas: 3
   selector:
@@ -1013,7 +1014,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1032,7 +1033,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1051,7 +1052,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1070,7 +1071,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1089,7 +1090,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1108,7 +1109,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-dst
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1132,7 +1133,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-  
+
 spec:
   replicas: 3
   selector:
@@ -1480,7 +1481,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1551,7 +1552,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-  
+
 spec:
   replicas: 3
   selector:
@@ -1828,7 +1829,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1848,7 +1849,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -395,7 +395,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-  
+
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -560,6 +560,7 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -630,7 +631,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -644,7 +645,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -658,7 +659,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -677,7 +678,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -696,7 +697,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-identity
-  
+
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -720,7 +721,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-  
+
 spec:
   replicas: 3
   selector:
@@ -995,7 +996,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1014,7 +1015,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1033,7 +1034,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1052,7 +1053,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1071,7 +1072,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1090,7 +1091,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-dst
-  
+
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1114,7 +1115,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-  
+
 spec:
   replicas: 3
   selector:
@@ -1458,7 +1459,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-  
+
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1525,7 +1526,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-  
+
 spec:
   replicas: 3
   selector:
@@ -1798,7 +1799,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1818,7 +1819,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-proxy-injector
-  
+
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -44,7 +44,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -98,7 +98,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -237,7 +237,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 rules:
@@ -250,7 +250,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-ns: linkerd-dev
 roleRef:
@@ -295,7 +295,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd-dev
@@ -350,7 +350,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -395,7 +395,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-
+  
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: linkerd-dev
@@ -631,7 +631,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -645,7 +645,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -659,7 +659,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -678,7 +678,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -697,7 +697,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-identity
-
+  
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
@@ -721,7 +721,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-identity
-
+  
 spec:
   replicas: 3
   selector:
@@ -996,7 +996,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1015,7 +1015,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1034,7 +1034,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1053,7 +1053,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1072,7 +1072,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1091,7 +1091,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-dst
-
+  
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1115,7 +1115,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-destination
-
+  
 spec:
   replicas: 3
   selector:
@@ -1459,7 +1459,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-
+  
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd
@@ -1526,7 +1526,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
   name: linkerd-proxy-injector
-
+  
 spec:
   replicas: 3
   selector:
@@ -1799,7 +1799,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev
@@ -1819,7 +1819,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
   name: linkerd-proxy-injector
-
+  
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1045,7 +1045,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1377,7 +1377,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1044,7 +1045,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1376,7 +1377,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -725,7 +725,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1070,7 +1070,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1445,7 +1445,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -555,6 +555,7 @@ data:
           limit: memory-limit
           request: memory-request
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: ProxyContainerName
@@ -724,7 +725,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1069,7 +1070,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1444,7 +1445,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1081,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1450,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1082,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1451,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -562,6 +562,7 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0
     proxyContainerName: linkerd-proxy
@@ -735,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1081,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1450,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -736,7 +736,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1082,7 +1082,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1451,7 +1451,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -112,6 +112,7 @@ type (
 		Await                         bool             `json:"await"`
 		DefaultInboundPolicy          string           `json:"defaultInboundPolicy"`
 		AccessLog                     string           `json:"accessLog"`
+		ShutdownGracePeriod           string           `json:"shutdownGracePeriod"`
 	}
 
 	// ProxyInit contains the fields to set the proxy-init container

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -70,6 +70,7 @@ var (
 		k8s.ProxyDefaultInboundPolicyAnnotation,
 		k8s.ProxySkipSubnetsAnnotation,
 		k8s.ProxyAccessLogAnnotation,
+		k8s.ProxyShutdownGracePeriodAnnotation,
 	}
 	// ProxyAlphaConfigAnnotations is the list of all alpha configuration
 	// (config.alpha prefix) that can be applied to a pod or namespace.
@@ -922,6 +923,15 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 			log.Warnf("unrecognized proxy-inbound-connect-timeout duration value found on pod annotation: %s", err.Error())
 		} else {
 			values.Proxy.InboundConnectTimeout = fmt.Sprintf("%dms", int(duration.Seconds()*1000))
+		}
+	}
+
+	if override, ok := annotations[k8s.ProxyShutdownGracePeriodAnnotation]; ok {
+		duration, err := time.ParseDuration(override)
+		if err != nil {
+			log.Warnf("unrecognized proxy-shutdown-grace-period duration value found on pod annotation: %s", err.Error())
+		} else {
+			values.Proxy.ShutdownGracePeriod = fmt.Sprintf("%dms", int(duration.Seconds()*1000))
 		}
 	}
 

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -69,6 +69,7 @@ func TestGetOverriddenValues(t *testing.T) {
 							k8s.ProxyAwait:                                   "enabled",
 							k8s.ProxySkipSubnetsAnnotation:                   "172.17.0.0/16",
 							k8s.ProxyAccessLogAnnotation:                     "apache",
+							k8s.ProxyShutdownGracePeriodAnnotation:           "30s",
 						},
 					},
 					Spec: corev1.PodSpec{},
@@ -116,6 +117,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
 				values.Proxy.Await = true
 				values.Proxy.AccessLog = "apache"
+				values.Proxy.ShutdownGracePeriod = "30000ms"
 				return values
 			},
 		},

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -271,6 +271,10 @@ const (
 	// Deny denies all connections.
 	Deny = "deny"
 
+	// ProxyShutdownGracePeriodAnnotation configures the grace period for
+	// graceful shutdowns in the proxy.
+	ProxyShutdownGracePeriodAnnotation = ProxyConfigAnnotationsPrefix + "/shutdown-grace-period"
+
 	/*
 	 * Component Names
 	 */


### PR DESCRIPTION
PR linkerd/linkerd2-proxy#1815 added support for a
`LINKERD2_PROXY_SHUTDOWN_GRACE_PERIOD` environment variable that
configures the proxy's maximum grace period for graceful shutdown. This
is intended to ensure that if a proxy is shut down, it will eventually
terminate in a relatively timely manner, even if some stubborn
connections don't close gracefully.

This branch adds support for a `config.linkerd.io/shutdown-grace-period`
annotation that can be used to override the default grace period
duration.

Hopefully I've added this everywhere it needs to be added --- please let
me know if I've missed anything!
