### PR TITLE
policy-test: Replace nginx with hokay

### DIFF
--- a/justfile
+++ b/justfile
@@ -124,8 +124,8 @@ _proxy-init-image := "ghcr.io/linkerd/proxy-init"
 _policy-controller-image := DOCKER_REGISTRY + "/policy-controller"
 
 # Run the policy controller integration tests in a k3d cluster
-policy-test: test-cluster-install-linkerd && _policy-test-uninstall
-    cd policy-test && {{ _cargo }} {{ _cargo-test }}
+policy-test *flags: test-cluster-install-linkerd && _policy-test-uninstall
+    cd policy-test && {{ _cargo }} {{ _cargo-test }} {{ flags }}
 
 # Delete all test namespaces and remove Linkerd from the cluster.
 policy-test-cleanup: && _policy-test-uninstall
@@ -199,7 +199,7 @@ _policy-test-uninstall:
 # Creates a k3d cluster that can be used for testing.
 test-cluster-create: && _test-cluster-api-ready _test-cluster-dns-ready
     k3d cluster create {{ test-cluster-name }} \
-        --kubeconfig-merge-default \
+        --kubeconfig-update-default \
         --kubeconfig-switch-context=false \
         --image=+{{ test-cluster-k8s }} \
         --no-lb --k3s-arg "--no-deploy=local-storage,traefik,servicelb,metrics-server@server:*"

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -157,7 +157,7 @@ impl Runner {
             spec: Some(k8s::PodSpec {
                 service_account: Some("curl".to_string()),
                 init_containers: Some(vec![k8s::api::core::v1::Container {
-                    name: "wait-for-nginx".to_string(),
+                    name: "wait-for-web".to_string(),
                     image: Some("docker.io/bitnami/kubectl:latest".to_string()),
                     // In CI, we can hit failures where the watch isn't updated
                     // after the configmap is deleted, even with a long timeout.

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -4,7 +4,7 @@
 pub mod admission;
 pub mod curl;
 pub mod grpc;
-pub mod nginx;
+pub mod web;
 
 use linkerd_policy_controller_k8s_api::{self as k8s, ResourceExt};
 use maplit::{btreemap, convert_args};

--- a/policy-test/src/web.rs
+++ b/policy-test/src/web.rs
@@ -1,3 +1,4 @@
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use linkerd_policy_controller_k8s_api::{self as k8s};
 use maplit::{btreemap, convert_args};
 
@@ -5,22 +6,23 @@ pub fn pod(ns: &str) -> k8s::Pod {
     k8s::Pod {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
-            name: Some("nginx".to_string()),
+            name: Some("web".to_string()),
             annotations: Some(convert_args!(btreemap!(
                 "linkerd.io/inject" => "enabled",
                 "config.linkerd.io/proxy-log-level" => "linkerd=trace,info",
             ))),
             labels: Some(convert_args!(btreemap!(
-                "app" => "nginx",
+                "app" => "web",
             ))),
             ..Default::default()
         },
         spec: Some(k8s::PodSpec {
             containers: vec![k8s::api::core::v1::Container {
-                name: "nginx".to_string(),
-                image: Some("docker.io/library/nginx:latest".to_string()),
+                name: "web".to_string(),
+                image: Some("ghcr.io/olix0r/hokay:latest".to_string()),
                 ports: Some(vec![k8s::api::core::v1::ContainerPort {
-                    container_port: 80,
+                    name: Some("http".to_string()),
+                    container_port: 8080,
                     ..Default::default()
                 }]),
                 ..Default::default()
@@ -35,12 +37,12 @@ pub fn server(ns: &str) -> k8s::policy::Server {
     k8s::policy::Server {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
-            name: Some("nginx".to_string()),
+            name: Some("web".to_string()),
             ..Default::default()
         },
         spec: k8s::policy::ServerSpec {
-            pod_selector: k8s::labels::Selector::from_iter(Some(("app", "nginx"))),
-            port: k8s::policy::server::Port::Number(80.try_into().unwrap()),
+            pod_selector: k8s::labels::Selector::from_iter(Some(("app", "web"))),
+            port: k8s::policy::server::Port::Name("http".to_string()),
             proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
         },
     }
@@ -50,16 +52,17 @@ pub fn service(ns: &str) -> k8s::api::core::v1::Service {
     k8s::api::core::v1::Service {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
-            name: Some("nginx".to_string()),
+            name: Some("web".to_string()),
             ..Default::default()
         },
         spec: Some(k8s::api::core::v1::ServiceSpec {
             type_: Some("ClusterIP".to_string()),
             selector: Some(convert_args!(btreemap!(
-                "app" => "nginx"
+                "app" => "web"
             ))),
             ports: Some(vec![k8s::api::core::v1::ServicePort {
                 port: 80,
+                target_port: Some(IntOrString::String("http".to_string())),
                 ..Default::default()
             }]),
             ..Default::default()

--- a/policy-test/tests/e2e_authorization_policy.rs
+++ b/policy-test/tests/e2e_authorization_policy.rs
@@ -2,48 +2,48 @@ use linkerd_policy_controller_k8s_api::{
     self as k8s,
     policy::{LocalTargetRef, NamespacedTargetRef},
 };
-use linkerd_policy_test::{create, create_ready_pod, curl, nginx, with_temp_ns, LinkerdInject};
+use linkerd_policy_test::{create, create_ready_pod, curl, web, with_temp_ns, LinkerdInject};
 
 #[tokio::test(flavor = "current_thread")]
 async fn meshtls() {
     with_temp_ns(|client, ns| async move {
-        // First create all of the policies we'll need so that the nginx pod
+        // First create all of the policies we'll need so that the web pod
         // starts up with the correct policy (to prevent races).
         //
         // The policy requires that all connections are authenticated with MeshTLS.
         let (srv, all_mtls) = tokio::join!(
-            create(&client, nginx::server(&ns)),
+            create(&client, web::server(&ns)),
             create(&client, all_authenticated(&ns))
         );
         create(
             &client,
             authz_policy(
                 &ns,
-                "nginx",
+                "web",
                 LocalTargetRef::from_resource(&srv),
                 Some(NamespacedTargetRef::from_resource(&all_mtls)),
             ),
         )
         .await;
 
-        // Create the nginx pod and wait for it to be ready.
+        // Create the web pod and wait for it to be ready.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
-            curl.run("curl-injected", "http://nginx", LinkerdInject::Enabled),
-            curl.run("curl-uninjected", "http://nginx", LinkerdInject::Disabled),
+            curl.run("curl-injected", "http://web", LinkerdInject::Enabled),
+            curl.run("curl-uninjected", "http://web", LinkerdInject::Disabled),
         );
         let (injected_status, uninjected_status) =
             tokio::join!(injected.exit_code(), uninjected.exit_code());
         assert_eq!(
             injected_status, 0,
-            "uninjected curl must fail to contact nginx"
+            "uninjected curl must fail to contact web"
         );
-        assert_ne!(uninjected_status, 0, "injected curl must contact nginx");
+        assert_ne!(uninjected_status, 0, "injected curl must contact web");
     })
     .await;
 }
@@ -51,19 +51,19 @@ async fn meshtls() {
 #[tokio::test(flavor = "current_thread")]
 async fn targets_namespace() {
     with_temp_ns(|client, ns| async move {
-        // First create all of the policies we'll need so that the nginx pod
+        // First create all of the policies we'll need so that the web pod
         // starts up with the correct policy (to prevent races).
         //
         // The policy requires that all connections are authenticated with MeshTLS.
         let (_srv, all_mtls) = tokio::join!(
-            create(&client, nginx::server(&ns)),
+            create(&client, web::server(&ns)),
             create(&client, all_authenticated(&ns))
         );
         create(
             &client,
             authz_policy(
                 &ns,
-                "nginx",
+                "web",
                 LocalTargetRef {
                     group: None,
                     kind: "Namespace".to_string(),
@@ -74,23 +74,23 @@ async fn targets_namespace() {
         )
         .await;
 
-        // Create the nginx pod and wait for it to be ready.
+        // Create the web pod and wait for it to be ready.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
-            curl.run("curl-injected", "http://nginx", LinkerdInject::Enabled),
-            curl.run("curl-uninjected", "http://nginx", LinkerdInject::Disabled),
+            curl.run("curl-injected", "http://web", LinkerdInject::Enabled),
+            curl.run("curl-uninjected", "http://web", LinkerdInject::Disabled),
         );
         let (injected_status, uninjected_status) =
             tokio::join!(injected.exit_code(), uninjected.exit_code());
-        assert_eq!(injected_status, 0, "injected curl must contact nginx");
+        assert_eq!(injected_status, 0, "injected curl must contact web");
         assert_ne!(
             uninjected_status, 0,
-            "uninjected curl must fail to contact nginx"
+            "uninjected curl must fail to contact web"
         );
     })
     .await;
@@ -99,43 +99,43 @@ async fn targets_namespace() {
 #[tokio::test(flavor = "current_thread")]
 async fn meshtls_namespace() {
     with_temp_ns(|client, ns| async move {
-        // First create all of the policies we'll need so that the nginx pod
+        // First create all of the policies we'll need so that the web pod
         // starts up with the correct policy (to prevent races).
         //
         // The policy requires that all connections are authenticated with MeshTLS
         // and come from service accounts in the given namespace.
         let (srv, mtls_ns) = tokio::join!(
-            create(&client, nginx::server(&ns)),
+            create(&client, web::server(&ns)),
             create(&client, ns_authenticated(&ns))
         );
         create(
             &client,
             authz_policy(
                 &ns,
-                "nginx",
+                "web",
                 LocalTargetRef::from_resource(&srv),
                 Some(NamespacedTargetRef::from_resource(&mtls_ns)),
             ),
         )
         .await;
 
-        // Create the nginx pod and wait for it to be ready.
+        // Create the web pod and wait for it to be ready.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
-            curl.run("curl-injected", "http://nginx", LinkerdInject::Enabled),
-            curl.run("curl-uninjected", "http://nginx", LinkerdInject::Disabled),
+            curl.run("curl-injected", "http://web", LinkerdInject::Enabled),
+            curl.run("curl-uninjected", "http://web", LinkerdInject::Disabled),
         );
         let (injected_status, uninjected_status) =
             tokio::join!(injected.exit_code(), uninjected.exit_code());
-        assert_eq!(injected_status, 0, "injected curl must contact nginx");
+        assert_eq!(injected_status, 0, "injected curl must contact web");
         assert_ne!(
             uninjected_status, 0,
-            "uninjected curl must fail to contact nginx"
+            "uninjected curl must fail to contact web"
         );
     })
     .await;
@@ -146,7 +146,7 @@ async fn network() {
     // In order to test the network policy, we need to create the client pod
     // before creating the authorization policy. To avoid races, we do this by
     // creating a `curl-lock` configmap that prevents curl from actually being
-    // executed. Once nginx is running with the correct policy, the configmap is
+    // executed. Once web is running with the correct policy, the configmap is
     // deleted to unblock the curl pods.
     with_temp_ns(|client, ns| async move {
         let curl = curl::Runner::init(&client, &ns).await;
@@ -154,46 +154,46 @@ async fn network() {
 
         // Create a curl pod and wait for it to get an IP.
         let blessed = curl
-            .run("curl-blessed", "http://nginx", LinkerdInject::Disabled)
+            .run("curl-blessed", "http://web", LinkerdInject::Disabled)
             .await;
         let blessed_ip = blessed.ip().await;
         tracing::debug!(curl.blessed.ip = %blessed_ip);
 
-        // Once we know the IP of the (blocked) pod, create an nginx
+        // Once we know the IP of the (blocked) pod, create an web
         // authorization policy that permits connections from this pod.
         let (srv, allow_ips) = tokio::join!(
-            create(&client, nginx::server(&ns)),
+            create(&client, web::server(&ns)),
             create(&client, allow_ips(&ns, Some(blessed_ip)))
         );
         create(
             &client,
             authz_policy(
                 &ns,
-                "nginx",
+                "web",
                 LocalTargetRef::from_resource(&srv),
                 Some(NamespacedTargetRef::from_resource(&allow_ips)),
             ),
         )
         .await;
 
-        // Start nginx with the policy.
+        // Start web with the policy.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
-        // Once the nginx pod is ready, delete the `curl-lock` configmap to
+        // Once the web pod is ready, delete the `curl-lock` configmap to
         // unblock curl from running.
         curl.delete_lock().await;
 
-        // The blessed pod should be able to connect to the nginx pod.
+        // The blessed pod should be able to connect to the web pod.
         let status = blessed.exit_code().await;
         assert_eq!(status, 0, "blessed curl pod must succeed");
 
         // Create another curl pod that is not included in the authorization. It
-        // should fail to connect to the nginx pod.
+        // should fail to connect to the web pod.
         let status = curl
-            .run("curl-cursed", "http://nginx", LinkerdInject::Disabled)
+            .run("curl-cursed", "http://web", LinkerdInject::Disabled)
             .await
             .exit_code()
             .await;
@@ -207,7 +207,7 @@ async fn both() {
     // In order to test the network policy, we need to create the client pod
     // before creating the authorization policy. To avoid races, we do this by
     // creating a `curl-lock` configmap that prevents curl from actually being
-    // executed. Once nginx is running with the correct policy, the configmap is
+    // executed. Once web is running with the correct policy, the configmap is
     // deleted to unblock the curl pods.
     with_temp_ns(|client, ns| async move {
         let curl = curl::Runner::init(&client, &ns).await;
@@ -216,12 +216,12 @@ async fn both() {
         let (blessed_injected, blessed_uninjected) = tokio::join!(
             curl.run(
                 "curl-blessed-injected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Enabled,
             ),
             curl.run(
                 "curl-blessed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             )
         );
@@ -230,10 +230,10 @@ async fn both() {
         tracing::debug!(curl.blessed.injected.ip = ?blessed_injected_ip);
         tracing::debug!(curl.blessed.uninjected.ip = ?blessed_uninjected_ip);
 
-        // Once we know the IP of the (blocked) pod, create an nginx
+        // Once we know the IP of the (blocked) pod, create an web
         // authorization policy that permits connections from this pod.
         let (srv, allow_ips, all_mtls) = tokio::join!(
-            create(&client, nginx::server(&ns)),
+            create(&client, web::server(&ns)),
             create(
                 &client,
                 allow_ips(&ns, vec![blessed_injected_ip, blessed_uninjected_ip]),
@@ -244,7 +244,7 @@ async fn both() {
             &client,
             authz_policy(
                 &ns,
-                "nginx",
+                "web",
                 LocalTargetRef::from_resource(&srv),
                 vec![
                     NamespacedTargetRef::from_resource(&allow_ips),
@@ -254,39 +254,35 @@ async fn both() {
         )
         .await;
 
-        // Start nginx with the policy.
+        // Start web with the policy.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
-        // Once the nginx pod is ready, delete the `curl-lock` configmap to
+        // Once the web pod is ready, delete the `curl-lock` configmap to
         // unblock curl from running.
         curl.delete_lock().await;
         tracing::info!("unblocked curl");
 
         let (blessed_injected_status, blessed_uninjected_status) =
             tokio::join!(blessed_injected.exit_code(), blessed_uninjected.exit_code());
-        // The blessed and injected pod should be able to connect to the nginx pod.
+        // The blessed and injected pod should be able to connect to the web pod.
         assert_eq!(
             blessed_injected_status, 0,
             "blessed injected curl pod must succeed"
         );
-        // The blessed and uninjected pod should NOT be able to connect to the nginx pod.
+        // The blessed and uninjected pod should NOT be able to connect to the web pod.
         assert_ne!(
             blessed_uninjected_status, 0,
             "blessed uninjected curl pod must NOT succeed"
         );
 
         let (cursed_injected, cursed_uninjected) = tokio::join!(
-            curl.run(
-                "curl-cursed-injected",
-                "http://nginx",
-                LinkerdInject::Enabled,
-            ),
+            curl.run("curl-cursed-injected", "http://web", LinkerdInject::Enabled,),
             curl.run(
                 "curl-cursed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             )
         );
@@ -309,7 +305,7 @@ async fn either() {
     // In order to test the network policy, we need to create the client pod
     // before creating the authorization policy. To avoid races, we do this by
     // creating a `curl-lock` configmap that prevents curl from actually being
-    // executed. Once nginx is running with the correct policy, the configmap is
+    // executed. Once web is running with the correct policy, the configmap is
     // deleted to unblock the curl pods.
     with_temp_ns(|client, ns| async move {
         let curl = curl::Runner::init(&client, &ns).await;
@@ -318,12 +314,12 @@ async fn either() {
         let (blessed_injected, blessed_uninjected) = tokio::join!(
             curl.run(
                 "curl-blessed-injected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Enabled,
             ),
             curl.run(
                 "curl-blessed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             )
         );
@@ -332,10 +328,10 @@ async fn either() {
         tracing::debug!(curl.blessed.injected.ip = ?blessed_injected_ip);
         tracing::debug!(curl.blessed.uninjected.ip = ?blessed_uninjected_ip);
 
-        // Once we know the IP of the (blocked) pod, create an nginx
+        // Once we know the IP of the (blocked) pod, create an web
         // authorization policy that permits connections from this pod.
         let (srv, allow_ips, all_mtls) = tokio::join!(
-            create(&client, nginx::server(&ns)),
+            create(&client, web::server(&ns)),
             create(&client, allow_ips(&ns, vec![blessed_uninjected_ip])),
             create(&client, all_authenticated(&ns))
         );
@@ -344,7 +340,7 @@ async fn either() {
                 &client,
                 authz_policy(
                     &ns,
-                    "nginx-from-ip",
+                    "web-from-ip",
                     LocalTargetRef::from_resource(&srv),
                     vec![NamespacedTargetRef::from_resource(&allow_ips)],
                 ),
@@ -353,46 +349,42 @@ async fn either() {
                 &client,
                 authz_policy(
                     &ns,
-                    "nginx-from-id",
+                    "web-from-id",
                     LocalTargetRef::from_resource(&srv),
                     vec![NamespacedTargetRef::from_resource(&all_mtls)],
                 ),
             )
         );
 
-        // Start nginx with the policy.
+        // Start web with the policy.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns)),
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns)),
         );
 
-        // Once the nginx pod is ready, delete the `curl-lock` configmap to
+        // Once the web pod is ready, delete the `curl-lock` configmap to
         // unblock curl from running.
         curl.delete_lock().await;
         tracing::info!("unblocking curl");
 
         let (blessed_injected_status, blessed_uninjected_status) =
             tokio::join!(blessed_injected.exit_code(), blessed_uninjected.exit_code());
-        // The blessed and injected pod should be able to connect to the nginx pod.
+        // The blessed and injected pod should be able to connect to the web pod.
         assert_eq!(
             blessed_injected_status, 0,
             "blessed injected curl pod must succeed"
         );
-        // The blessed and uninjected pod should NOT be able to connect to the nginx pod.
+        // The blessed and uninjected pod should NOT be able to connect to the web pod.
         assert_eq!(
             blessed_uninjected_status, 0,
             "blessed uninjected curl pod must succeed"
         );
 
         let (cursed_injected, cursed_uninjected) = tokio::join!(
-            curl.run(
-                "curl-cursed-injected",
-                "http://nginx",
-                LinkerdInject::Enabled,
-            ),
+            curl.run("curl-cursed-injected", "http://web", LinkerdInject::Enabled,),
             curl.run(
                 "curl-cursed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             ),
         );
@@ -414,29 +406,29 @@ async fn either() {
 async fn empty_authentications() {
     with_temp_ns(|client, ns| async move {
         // Create a policy that does not require any authentications.
-        let srv = create(&client, nginx::server(&ns)).await;
+        let srv = create(&client, web::server(&ns)).await;
         create(
             &client,
-            authz_policy(&ns, "nginx", LocalTargetRef::from_resource(&srv), None),
+            authz_policy(&ns, "web", LocalTargetRef::from_resource(&srv), None),
         )
         .await;
 
-        // Create the nginx pod and wait for it to be ready.
+        // Create the web pod and wait for it to be ready.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
         // All requests should work.
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
-            curl.run("curl-injected", "http://nginx", LinkerdInject::Enabled),
-            curl.run("curl-uninjected", "http://nginx", LinkerdInject::Disabled),
+            curl.run("curl-injected", "http://web", LinkerdInject::Enabled),
+            curl.run("curl-uninjected", "http://web", LinkerdInject::Disabled),
         );
         let (injected_status, uninjected_status) =
             tokio::join!(injected.exit_code(), uninjected.exit_code());
-        assert_eq!(injected_status, 0, "injected curl must contact nginx");
-        assert_eq!(uninjected_status, 0, "uninjected curl must contact nginx");
+        assert_eq!(injected_status, 0, "injected curl must contact web");
+        assert_eq!(uninjected_status, 0, "uninjected curl must contact web");
     })
     .await;
 }

--- a/policy-test/tests/e2e_server_authorization.rs
+++ b/policy-test/tests/e2e_server_authorization.rs
@@ -1,18 +1,18 @@
 use linkerd_policy_controller_k8s_api::{
     self as k8s, policy::server_authorization::Client as ClientAuthz, ResourceExt,
 };
-use linkerd_policy_test::{create, create_ready_pod, curl, nginx, with_temp_ns, LinkerdInject};
+use linkerd_policy_test::{create, create_ready_pod, curl, web, with_temp_ns, LinkerdInject};
 
 #[tokio::test(flavor = "current_thread")]
 async fn meshtls() {
     with_temp_ns(|client, ns| async move {
-        let srv = create(&client, nginx::server(&ns)).await;
+        let srv = create(&client, web::server(&ns)).await;
 
         create(
             &client,
             server_authz(
                 &ns,
-                "nginx",
+                "web",
                 &srv,
                 ClientAuthz {
                     mesh_tls: Some(k8s::policy::server_authorization::MeshTls {
@@ -25,16 +25,16 @@ async fn meshtls() {
         )
         .await;
 
-        // Create the nginx pod and wait for it to be ready.
+        // Create the web pod and wait for it to be ready.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
-            curl.run("curl-injected", "http://nginx", LinkerdInject::Enabled),
-            curl.run("curl-uninjected", "http://nginx", LinkerdInject::Disabled),
+            curl.run("curl-injected", "http://web", LinkerdInject::Enabled),
+            curl.run("curl-uninjected", "http://web", LinkerdInject::Disabled),
         );
         let (injected_status, uninjected_status) =
             tokio::join!(injected.exit_code(), uninjected.exit_code());
@@ -56,19 +56,19 @@ async fn network() {
 
         // Create a curl pod and wait for it to get an IP.
         let blessed = curl
-            .run("curl-blessed", "http://nginx", LinkerdInject::Disabled)
+            .run("curl-blessed", "http://web", LinkerdInject::Disabled)
             .await;
         let blessed_ip = blessed.ip().await;
         tracing::debug!(curl.blessed.ip = %blessed_ip);
 
-        // Once we know the IP of the (blocked) pod, create an nginx
+        // Once we know the IP of the (blocked) pod, create an web
         // authorization policy that permits connections from this pod.
-        let srv = create(&client, nginx::server(&ns)).await;
+        let srv = create(&client, web::server(&ns)).await;
         create(
             &client,
             server_authz(
                 &ns,
-                "nginx",
+                "web",
                 &srv,
                 ClientAuthz {
                     networks: Some(vec![k8s::policy::Network {
@@ -82,23 +82,23 @@ async fn network() {
         )
         .await;
 
-        // Start nginx with the policy.
+        // Start web with the policy.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
         tracing::info!("Unblocking curl");
         curl.delete_lock().await;
 
-        // The blessed pod should be able to connect to the nginx pod.
+        // The blessed pod should be able to connect to the web pod.
         let status = blessed.exit_code().await;
         assert_eq!(status, 0, "blessed curl must succeed");
 
         // Create another curl pod that is not included in the authorization. It
-        // should fail to connect to the nginx pod.
+        // should fail to connect to the web pod.
         let status = curl
-            .run("curl-cursed", "http://nginx", LinkerdInject::Disabled)
+            .run("curl-cursed", "http://web", LinkerdInject::Disabled)
             .await
             .exit_code()
             .await;
@@ -120,12 +120,12 @@ async fn both() {
         let (blessed_injected, blessed_uninjected) = tokio::join!(
             curl.run(
                 "curl-blessed-injected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Enabled,
             ),
             curl.run(
                 "curl-blessed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             )
         );
@@ -134,14 +134,14 @@ async fn both() {
         tracing::debug!(curl.blessed.injected.ip = ?blessed_injected_ip);
         tracing::debug!(curl.blessed.uninjected.ip = ?blessed_uninjected_ip);
 
-        // Once we know the IP of the (blocked) pod, create an nginx
+        // Once we know the IP of the (blocked) pod, create an web
         // authorization policy that permits connections from this pod.
-        let srv = create(&client, nginx::server(&ns)).await;
+        let srv = create(&client, web::server(&ns)).await;
         create(
             &client,
             server_authz(
                 &ns,
-                "nginx",
+                "web",
                 &srv,
                 ClientAuthz {
                     networks: Some(vec![
@@ -164,39 +164,35 @@ async fn both() {
         )
         .await;
 
-        // Start nginx with the policy.
+        // Start web with the policy.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns))
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns))
         );
 
-        // Once the nginx pod is ready, delete the `curl-lock` configmap to
+        // Once the web pod is ready, delete the `curl-lock` configmap to
         // unblock curl from running.
         tracing::info!("Unblocking curl");
         curl.delete_lock().await;
 
         let (blessed_injected_status, blessed_uninjected_status) =
             tokio::join!(blessed_injected.exit_code(), blessed_uninjected.exit_code());
-        // The blessed and injected pod should be able to connect to the nginx pod.
+        // The blessed and injected pod should be able to connect to the web pod.
         assert_eq!(
             blessed_injected_status, 0,
             "blessed injected curl must succeed"
         );
-        // The blessed and uninjected pod should NOT be able to connect to the nginx pod.
+        // The blessed and uninjected pod should NOT be able to connect to the web pod.
         assert_eq!(
             blessed_uninjected_status, 22,
             "blessed uninjected curl must fail"
         );
 
         let (cursed_injected, cursed_uninjected) = tokio::join!(
-            curl.run(
-                "curl-cursed-injected",
-                "http://nginx",
-                LinkerdInject::Enabled,
-            ),
+            curl.run("curl-cursed-injected", "http://web", LinkerdInject::Enabled,),
             curl.run(
                 "curl-cursed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             )
         );
@@ -222,12 +218,12 @@ async fn either() {
         let (blessed_injected, blessed_uninjected) = tokio::join!(
             curl.run(
                 "curl-blessed-injected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Enabled,
             ),
             curl.run(
                 "curl-blessed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             )
         );
@@ -236,15 +232,15 @@ async fn either() {
         tracing::debug!(curl.blessed.injected.ip = ?blessed_injected_ip);
         tracing::debug!(curl.blessed.uninjected.ip = ?blessed_uninjected_ip);
 
-        // Once we know the IP of the (blocked) pod, create an nginx
+        // Once we know the IP of the (blocked) pod, create an web
         // authorization policy that permits connections from this pod.
-        let srv = create(&client, nginx::server(&ns)).await;
+        let srv = create(&client, web::server(&ns)).await;
         tokio::join!(
             create(
                 &client,
                 server_authz(
                     &ns,
-                    "nginx-from-ip",
+                    "web-from-ip",
                     &srv,
                     ClientAuthz {
                         unauthenticated: true,
@@ -266,7 +262,7 @@ async fn either() {
                 &client,
                 server_authz(
                     &ns,
-                    "nginx-from-id",
+                    "web-from-id",
                     &srv,
                     ClientAuthz {
                         mesh_tls: Some(k8s::policy::server_authorization::MeshTls {
@@ -279,10 +275,10 @@ async fn either() {
             ),
         );
 
-        // Start nginx with the policy.
+        // Start web with the policy.
         tokio::join!(
-            create(&client, nginx::service(&ns)),
-            create_ready_pod(&client, nginx::pod(&ns)),
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, web::pod(&ns)),
         );
 
         tracing::info!("Unblocking curl");
@@ -300,14 +296,10 @@ async fn either() {
         );
 
         let (cursed_injected, cursed_uninjected) = tokio::join!(
-            curl.run(
-                "curl-cursed-injected",
-                "http://nginx",
-                LinkerdInject::Enabled,
-            ),
+            curl.run("curl-cursed-injected", "http://web", LinkerdInject::Enabled,),
             curl.run(
                 "curl-cursed-uninjected",
-                "http://nginx",
+                "http://web",
                 LinkerdInject::Disabled,
             ),
         );


### PR DESCRIPTION
`policy-test` uses `nginx` as a test web server. `nginx` returns a 404
on all endpoints that are not `/` and is >100x the size of `hokay`
(142MB vs 1.2MB).

`hokay` (https://github.com/olix0r/hokay) is a minimal HTTP server that
always returns a `204 No Content` response.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
