### PR TITLE
policy-test: Clean up logging

### DIFF
--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -238,7 +238,7 @@ impl Running {
         };
         let code = get_exit_code(&pod).expect("curl pod must have an exit code");
         tracing::debug!(pod = %self.name, %code, "Curl exited");
-        for c in pod.spec.unwrap().containers.iter() {
+        for c in pod.spec.unwrap().containers {
             super::logs(&self.client, &self.namespace, &self.name, &c.name).await;
         }
 

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -228,15 +228,19 @@ impl Running {
             &self.name,
             |obj: Option<&k8s::Pod>| -> bool { obj.and_then(get_exit_code).is_some() },
         );
-        let code = match time::timeout(time::Duration::from_secs(30), finished).await {
-            Ok(Ok(Some(pod))) => get_exit_code(&pod).expect("curl pod must have an exit code"),
+        let pod = match time::timeout(time::Duration::from_secs(30), finished).await {
+            Ok(Ok(Some(pod))) => pod,
             Ok(Ok(None)) => unreachable!("Condition must wait for pod"),
             Ok(Err(error)) => panic!("Failed to wait for exit code: {}: {}", self.name, error),
             Err(_timeout) => {
                 panic!("Timeout waiting for exit code: {}", self.name);
             }
         };
+        let code = get_exit_code(&pod).expect("curl pod must have an exit code");
         tracing::debug!(pod = %self.name, %code, "Curl exited");
+        for c in pod.spec.unwrap().containers.iter() {
+            super::logs(&self.client, &self.namespace, &self.name, &c.name).await;
+        }
 
         if let Err(error) = api
             .delete(&self.name, &kube::api::DeleteParams::foreground())

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -71,13 +71,27 @@ pub async fn create_ready_pod(client: &kube::Client, pod: k8s::Pod) -> k8s::Pod 
     };
 
     let pod = create(client, pod).await;
-    await_condition(
+    let pod = await_condition(
         client,
         &pod.namespace().unwrap(),
         &pod.name_unchecked(),
         pod_ready,
     )
-    .await;
+    .await
+    .unwrap();
+
+    tracing::trace!(
+        pod = %pod.name_any(),
+        ip = %pod
+            .status.as_ref().expect("pod must have a status")
+            .pod_ips.as_ref().unwrap()[0]
+            .ip.as_deref().expect("pod ip must be set"),
+        containers = ?pod
+            .spec.as_ref().expect("pod must have a spec")
+            .containers.iter().map(|c| &*c.name).collect::<Vec<_>>(),
+        "Ready",
+    );
+
     pod
 }
 
@@ -98,6 +112,21 @@ pub async fn await_pod_ip(client: &kube::Client, ns: &str, name: &str) -> std::n
         .expect("pod must have an IP")
         .parse()
         .expect("pod IP must be valid")
+}
+
+#[tracing::instrument(skip_all, fields(%pod, %container))]
+pub async fn logs(client: &kube::Client, ns: &str, pod: &str, container: &str) {
+    let params = kube::api::LogParams {
+        container: Some(container.to_string()),
+        ..kube::api::LogParams::default()
+    };
+    let log = kube::Api::<k8s::Pod>::namespaced(client.clone(), ns)
+        .logs(pod, &params)
+        .await
+        .expect("must fetch logs");
+    for msg in log.lines() {
+        tracing::trace!(%msg);
+    }
 }
 
 /// Runs a test with a random namespace that is deleted on test completion
@@ -227,6 +256,8 @@ fn init_tracing() -> tracing::subscriber::DefaultGuard {
     tracing::subscriber::set_default(
         tracing_subscriber::fmt()
             .with_test_writer()
+            .with_thread_names(true)
+            .without_time()
             .with_env_filter(
                 tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                     "trace,tower=info,hyper=info,kube=info,h2=info"

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -124,8 +124,8 @@ pub async fn logs(client: &kube::Client, ns: &str, pod: &str, container: &str) {
         .logs(pod, &params)
         .await
         .expect("must fetch logs");
-    for msg in log.lines() {
-        tracing::trace!(%msg);
+    for message in log.lines() {
+        tracing::trace!(%message);
     }
 }
 

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -19,7 +19,6 @@ async fn server_with_server_authorization() {
         // Create a pod that does nothing. It's injected with a proxy, so we can
         // attach policies to its admin server.
         let pod = create_ready_pod(&client, mk_pause(&ns, "pause")).await;
-        tracing::trace!(?pod);
 
         let mut rx = retry_watch_server(&client, &ns, &pod.name_unchecked()).await;
         let config = rx
@@ -156,7 +155,6 @@ async fn server_with_authorization_policy() {
         // Create a pod that does nothing. It's injected with a proxy, so we can
         // attach policies to its admin server.
         let pod = create_ready_pod(&client, mk_pause(&ns, "pause")).await;
-        tracing::trace!(?pod);
 
         let mut rx = retry_watch_server(&client, &ns, &pod.name_unchecked()).await;
         let config = rx
@@ -292,7 +290,6 @@ async fn server_with_http_route() {
         // Create a pod that does nothing. It's injected with a proxy, so we can
         // attach policies to its admin server.
         let pod = create_ready_pod(&client, mk_pause(&ns, "pause")).await;
-        tracing::trace!(?pod);
 
         let mut rx = retry_watch_server(&client, &ns, &pod.name_unchecked()).await;
         let config = rx


### PR DESCRIPTION
* Include the test (thread) name in log lines
* Emit ready pod container names & ip instead of logging the whole pod
  manifest (with proxy configuration).
* Add a utility to emit container logs at TRACE. Use it when waiting for
  pod exits.
* Omit timestamps in log output for space

For example:

```
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=*   Trying 10.43.12.44:80...
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=* Connected to web (10.43.12.44) port 80 (#0)
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=> GET / HTTP/1.1
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=> Host: web
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=> User-Agent: curl/7.84.0-DEV
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=> Accept: */*
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=>
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=* Mark bundle as not supporting multiuse
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=< HTTP/1.1 204 No Content
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=< server: hokay/0.2.2
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=< date: Fri, 22 Jul 2022 06:33:33 GMT
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=<
TRACE either test{ns=linkerd-policy-test-ds6qn0}:logs{pod=curl-cursed-injected container=curl}: linkerd_policy_test: msg=* Connection #0 to host web left intact
```

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
