### PR TITLE
dev: Pre-load hokay images instead of nginx

### DIFF
--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -141,19 +141,19 @@ jobs:
         run: |
           docker pull -q docker.io/bitnami/kubectl:latest &
           docker pull -q docker.io/curlimages/curl:latest &
-          docker pull -q docker.io/library/nginx:latest &
+          docker pull -q ghcr.io/olix0r/hokay:latest &
           docker pull -q "ghcr.io/linkerd/proxy-init:$PROXY_INIT_VERSION" &
           wait # Wait for pulls to complete
           docker load <image-archives/controller.tar
           docker load <image-archives/policy-controller.tar
           docker load <image-archives/proxy.tar
-          docker image ls | grep -F -e bitnami/kubectl -e curlimages/curl -e nginx -e ghcr.io/linkerd
+          docker image ls | grep -F -e bitnami/kubectl -e curlimages/curl -e hokay -e ghcr.io/linkerd
           tag="$(CI_FORCE_CLEAN=1 bin/root-tag)"
           # Image loading is flakey in CI, so retry!
           until k3d image import \
                   bitnami/kubectl:latest \
                   curlimages/curl:latest \
-                  nginx:latest \
+                  ghcr.io/olix0r/hokay:latest \
                   "ghcr.io/linkerd/controller:$tag" \
                   "ghcr.io/linkerd/policy-controller:$tag" \
                   "ghcr.io/linkerd/proxy:$tag" \


### PR DESCRIPTION
Our dev & CI test helpers preload containers onto clusters so the images
need not be pulled at runtime (which, anecdotally, is much slower). When
we changed the policy tests to use hokay instead of nginx, the helpers
were not updated to preload the correct image.

This change also updates the `justfile` to make it easier to build test
clusters with additional configurations.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
