### PR TITLE
policy: validate that `HTTPRoute` paths are absolute 

### DIFF
--- a/policy-controller/k8s/api/src/policy.rs
+++ b/policy-controller/k8s/api/src/policy.rs
@@ -17,3 +17,19 @@ pub use self::{
     server_authorization::{ServerAuthorization, ServerAuthorizationSpec},
     target_ref::{ClusterTargetRef, LocalTargetRef, NamespacedTargetRef},
 };
+
+fn targets_kind<T>(group: Option<&str>, kind: &str) -> bool
+where
+    T: kube::Resource,
+    T::DynamicType: Default,
+{
+    let dt = Default::default();
+
+    let mut t_group = &*T::group(&dt);
+    if t_group.is_empty() {
+        t_group = "core";
+    }
+
+    group.unwrap_or("core").eq_ignore_ascii_case(t_group)
+        && kind.eq_ignore_ascii_case(&*T::kind(&dt))
+}

--- a/policy-controller/k8s/api/src/policy/httproute.rs
+++ b/policy-controller/k8s/api/src/policy/httproute.rs
@@ -184,14 +184,19 @@ impl HttpRouteFilter {
     }
 }
 
-pub fn parent_ref_targets_server(p: &ParentReference) -> bool {
-    match (p.group.as_deref(), p.kind.as_deref()) {
-        (Some(group), Some(kind)) => {
-            group.eq_ignore_ascii_case("policy.linkerd.io") && kind.eq_ignore_ascii_case("server")
-        }
-        _ => false,
-    }
+pub fn parent_ref_targets_kind<T>(parent_ref: &ParentReference) -> bool
+where
+    T: kube::Resource,
+    T::DynamicType: Default,
+{
+    let kind = match parent_ref.kind {
+        Some(ref kind) => kind,
+        None => return false,
+    };
+
+    super::targets_kind::<T>(parent_ref.group.as_deref(), kind)
 }
+
 pub fn matches_have_relative_paths(matches: &Option<Vec<HttpRouteMatch>>) -> bool {
     matches.iter().flatten().any(|m| {
         m.path

--- a/policy-controller/k8s/api/src/policy/target_ref.rs
+++ b/policy-controller/k8s/api/src/policy/target_ref.rs
@@ -1,3 +1,5 @@
+use super::targets_kind;
+
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct ClusterTargetRef {
     pub group: Option<String>,
@@ -187,22 +189,6 @@ fn canonical_kind(group: Option<&str>, kind: &str) -> String {
     } else {
         kind.to_string()
     }
-}
-
-fn targets_kind<T>(group: Option<&str>, kind: &str) -> bool
-where
-    T: kube::Resource,
-    T::DynamicType: Default,
-{
-    let dt = Default::default();
-
-    let mut t_group = &*T::group(&dt);
-    if t_group.is_empty() {
-        t_group = "core";
-    }
-
-    group.unwrap_or("core").eq_ignore_ascii_case(t_group)
-        && kind.eq_ignore_ascii_case(&*T::kind(&dt))
 }
 
 fn group_kind_name<T>(resource: &T) -> (Option<String>, String, String)

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -2,7 +2,7 @@ use ahash::AHashMap as HashMap;
 use anyhow::{bail, ensure, Error, Result};
 use k8s_gateway_api as api;
 use linkerd_policy_controller_core::http_route;
-use linkerd_policy_controller_k8s_api::policy::httproute as policy;
+use linkerd_policy_controller_k8s_api::policy::{httproute as policy, Server};
 use std::num::NonZeroU16;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -269,7 +269,7 @@ impl InboundParentRef {
         parent_ref: api::ParentReference,
     ) -> Option<Result<Self, InvalidParentRef>> {
         // Skip parent refs that don't target a `Server` resource.
-        if !policy::parent_ref_targets_server(&parent_ref) || parent_ref.name.is_empty() {
+        if !policy::parent_ref_targets_kind::<Server>(&parent_ref) || parent_ref.name.is_empty() {
             return None;
         }
 

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -1,5 +1,5 @@
 use ahash::AHashMap as HashMap;
-use anyhow::{bail, Error, Result};
+use anyhow::{bail, ensure, Error, Result};
 use k8s_gateway_api as api;
 use linkerd_policy_controller_core::http_route;
 use linkerd_policy_controller_k8s_api::policy::httproute as policy;
@@ -122,13 +122,20 @@ impl InboundRouteBinding {
         }: api::HttpRouteMatch,
     ) -> Result<http_route::HttpRouteMatch> {
         let path = path
-            .map(|pm| match pm {
-                api::HttpPathMatch::Exact { value } => Ok(http_route::PathMatch::Exact(value)),
-                api::HttpPathMatch::PathPrefix { value } => {
-                    Ok(http_route::PathMatch::Prefix(value))
-                }
-                api::HttpPathMatch::RegularExpression { value } => {
-                    value.parse().map(http_route::PathMatch::Regex)
+            .map(|pm| {
+                ensure!(
+                    !policy::path_match_has_relative_paths(&pm),
+                    "HttpPathMatch paths must be absolute (begin with `/`)"
+                );
+                match pm {
+                    api::HttpPathMatch::Exact { value } => Ok(http_route::PathMatch::Exact(value)),
+                    api::HttpPathMatch::PathPrefix { value } => {
+                        Ok(http_route::PathMatch::Prefix(value))
+                    }
+                    api::HttpPathMatch::RegularExpression { value } => value
+                        .parse()
+                        .map(http_route::PathMatch::Regex)
+                        .map_err(Into::into),
                 }
             })
             .transpose()?;
@@ -259,26 +266,21 @@ impl InboundParentRef {
 
     fn from_parent_ref(
         route_ns: Option<&str>,
-        api::ParentReference {
-            group,
-            kind,
+        parent_ref: api::ParentReference,
+    ) -> Option<Result<Self, InvalidParentRef>> {
+        // Skip parent refs that don't target a `Server` resource.
+        if !policy::parent_ref_targets_server(&parent_ref) || parent_ref.name.is_empty() {
+            return None;
+        }
+
+        let api::ParentReference {
+            group: _,
+            kind: _,
             namespace,
             name,
             section_name,
             port,
-        }: api::ParentReference,
-    ) -> Option<Result<Self, InvalidParentRef>> {
-        // Ignore parents that are not a Server.
-        if let Some(g) = group {
-            if let Some(k) = kind {
-                if !g.eq_ignore_ascii_case("policy.linkerd.io")
-                    || !k.eq_ignore_ascii_case("server")
-                    || name.is_empty()
-                {
-                    return None;
-                }
-            }
-        }
+        } = parent_ref;
 
         if namespace.is_some() && namespace.as_deref() != route_ns {
             return Some(Err(InvalidParentRef::ServerInAnotherNamespace));
@@ -295,6 +297,8 @@ impl InboundParentRef {
 }
 
 mod convert {
+    use api::HttpRequestRedirectFilter;
+
     use super::*;
     pub(super) fn http_match(hostname: api::Hostname) -> http_route::HostMatch {
         if hostname.starts_with("*.") {
@@ -332,14 +336,19 @@ mod convert {
     }
 
     pub(super) fn req_redirect(
-        api::HttpRequestRedirectFilter {
+        filter: HttpRequestRedirectFilter,
+    ) -> Result<http_route::RequestRedirectFilter> {
+        ensure!(
+            !policy::request_redirect_has_relative_paths(&filter),
+            "RequestRedirect filters may only contain absolute paths (starting with '/')"
+        );
+        let api::HttpRequestRedirectFilter {
             scheme,
             hostname,
             path,
             port,
             status_code,
-        }: api::HttpRequestRedirectFilter,
-    ) -> Result<http_route::RequestRedirectFilter> {
+        } = filter;
         Ok(http_route::RequestRedirectFilter {
             scheme: scheme.as_deref().map(TryInto::try_into).transpose()?,
             host: hostname,

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -7,7 +7,7 @@ use crate::k8s::{
         ServerAuthorizationSpec, ServerSpec,
     },
 };
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, ensure, Result};
 use futures::future;
 use hyper::{body::Buf, http, Body, Request, Response};
 use k8s_openapi::api::core::v1::{Namespace, ServiceAccount};
@@ -417,13 +417,71 @@ impl Validate<ServerAuthorizationSpec> for Admission {
 #[async_trait::async_trait]
 impl Validate<HttpRouteSpec> for Admission {
     async fn validate(self, _ns: &str, _name: &str, spec: HttpRouteSpec) -> Result<()> {
-        // The validation for the policy.linkerd.io HTTPRoute type is much
-        // simpler than for the Gateway API version: the route must only target
-        // `Server` resources.
-        //
-        // We don't have to do any validation that unsupported filters aren't
-        // present, because Linkerd's HTTPRoute CRD doesn't include those
-        // filters at all.
+        use httproute::{HttpRouteFilter, HttpRouteMatch, HttpRouteRule};
+
+        fn parent_ref_targets_server(p: &httproute::ParentReference) -> bool {
+            match (p.group.as_deref(), p.kind.as_deref()) {
+                (Some(group), Some(kind)) => {
+                    group.eq_ignore_ascii_case("policy.linkerd.io")
+                        && kind.eq_ignore_ascii_case("server")
+                }
+                _ => false,
+            }
+        }
+
+        fn validate_matches<'matches>(
+            matches: impl IntoIterator<Item = &'matches HttpRouteMatch>,
+        ) -> Result<()> {
+            use httproute::HttpPathMatch;
+
+            for m in matches {
+                match m.path {
+                    Some(HttpPathMatch::Exact { ref value }) => ensure!(
+                        value.starts_with('/'),
+                        "invalid Exact path match {value:?}: path matches must begin with '/'"
+                    ),
+                    Some(HttpPathMatch::PathPrefix { ref value }) => ensure!(
+                        value.starts_with('/'),
+                        "invalid PathPrefix path match {value:?}: path matches must begin with '/'"
+                    ),
+                    _ => {}
+                }
+            }
+
+            Ok(())
+        }
+
+        fn validate_filters<'filters>(
+            filters: impl IntoIterator<Item = &'filters HttpRouteFilter>,
+        ) -> Result<()> {
+            use httproute::{HttpPathModifier, HttpRequestRedirectFilter};
+
+            for f in filters {
+                if let HttpRouteFilter::RequestRedirect {
+                    request_redirect:
+                        HttpRequestRedirectFilter {
+                            path: Some(ref path),
+                            ..
+                        },
+                } = f
+                {
+                    match path {
+                        HttpPathModifier::ReplaceFullPath(ref path) => ensure!(
+                            path.starts_with('/'),
+                            "invalid ReplaceFullPath path {path:?}: paths must be absolute (begin with '/')"
+                        ),
+                        HttpPathModifier::ReplacePrefixMatch(ref path) => ensure!(
+                            path.starts_with('/'),
+                            "invalid ReplacePrefixMatch path prefix {path:?}: path prefixes must be absolute (begin with '/')"
+                        ),
+                    }
+                }
+            }
+
+            Ok(())
+        }
+
+        // Ensure that the `HTTPRoute` targets a `Server` as its parent ref
         let all_target_servers = spec
             .inner
             .parent_refs
@@ -434,15 +492,13 @@ impl Validate<HttpRouteSpec> for Admission {
             all_target_servers,
             "policy.linkerd.io HTTPRoutes must target only Server resources"
         );
-        Ok(())
-    }
-}
 
-fn parent_ref_targets_server(p: &httproute::ParentReference) -> bool {
-    match (p.group.as_deref(), p.kind.as_deref()) {
-        (Some(group), Some(kind)) => {
-            group.eq_ignore_ascii_case("policy.linkerd.io") && kind.eq_ignore_ascii_case("server")
+        // Validate the rules in this spec.
+        for HttpRouteRule { matches, filters } in spec.rules.iter().flatten() {
+            validate_matches(matches.iter().flatten())?;
+            validate_filters(filters.iter().flatten())?
         }
-        _ => false,
+
+        Ok(())
     }
 }

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -423,7 +423,7 @@ impl Validate<HttpRouteSpec> for Admission {
             .parent_refs
             .iter()
             .flatten()
-            .all(httproute::parent_ref_targets_server);
+            .all(httproute::parent_ref_targets_kind::<Server>);
         ensure!(
             all_target_servers,
             "policy.linkerd.io HTTPRoutes must target only Server resources"

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -12,7 +12,9 @@ pub use linkerd_policy_controller_core::{
 };
 pub use linkerd_policy_controller_grpc as grpc;
 pub use linkerd_policy_controller_k8s_api as k8s;
-pub use linkerd_policy_controller_k8s_index::{ClusterInfo, DefaultPolicy, Index, SharedIndex};
+pub use linkerd_policy_controller_k8s_index::{
+    self as index, ClusterInfo, DefaultPolicy, Index, SharedIndex,
+};
 
 #[derive(Clone, Debug)]
 pub struct IndexDiscover(SharedIndex);

--- a/policy-test/tests/admit_http_route.rs
+++ b/policy-test/tests/admit_http_route.rs
@@ -24,11 +24,7 @@ async fn accepts_valid() {
 #[tokio::test(flavor = "current_thread")]
 async fn rejects_non_server_parent_ref() {
     admission::rejects(|ns| HttpRoute {
-        metadata: api::ObjectMeta {
-            namespace: Some(ns.clone()),
-            name: Some("test".to_string()),
-            ..Default::default()
-        },
+        metadata: meta(&ns),
         spec: HttpRouteSpec {
             inner: CommonRouteSpec {
                 parent_refs: Some(vec![non_server_parent_ref(ns)]),
@@ -46,17 +42,10 @@ async fn rejects_non_server_parent_ref() {
 #[tokio::test(flavor = "current_thread")]
 async fn rejects_mixed_parent_ref() {
     admission::rejects(|ns| HttpRoute {
-        metadata: api::ObjectMeta {
-            namespace: Some(ns.clone()),
-            name: Some("test".to_string()),
-            ..Default::default()
-        },
+        metadata: meta(&ns),
         spec: HttpRouteSpec {
             inner: CommonRouteSpec {
-                parent_refs: Some(vec![
-                    server_parent_ref(ns.clone()),
-                    non_server_parent_ref(ns),
-                ]),
+                parent_refs: Some(vec![server_parent_ref(&ns), non_server_parent_ref(ns)]),
             },
             hostnames: None,
             rules: Some(rules()),
@@ -66,25 +55,89 @@ async fn rejects_mixed_parent_ref() {
     .await;
 }
 
-fn server_parent_ref(ns: String) -> ParentReference {
+#[tokio::test(flavor = "current_thread")]
+async fn rejects_relative_path_match() {
+    admission::rejects(|ns| HttpRoute {
+        metadata: meta(&ns),
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![server_parent_ref(ns)]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::Exact {
+                        value: "foo/bar".to_string(),
+                    }),
+                    ..HttpRouteMatch::default()
+                }]),
+                filters: None,
+            }]),
+        },
+        status: None,
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejects_relative_redirect_path() {
+    admission::rejects(|ns| HttpRoute {
+        metadata: meta(&ns),
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![server_parent_ref(ns)]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::Exact {
+                        value: "/foo".to_string(),
+                    }),
+                    ..HttpRouteMatch::default()
+                }]),
+                filters: Some(vec![HttpRouteFilter::RequestRedirect {
+                    request_redirect: HttpRequestRedirectFilter {
+                        scheme: None,
+                        hostname: None,
+                        path: Some(HttpPathModifier::ReplaceFullPath("foo/bar".to_string())),
+                        port: None,
+                        status_code: None,
+                    },
+                }]),
+            }]),
+        },
+        status: None,
+    })
+    .await;
+}
+
+fn server_parent_ref(ns: impl ToString) -> ParentReference {
     ParentReference {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("Server".to_string()),
-        namespace: Some(ns),
+        namespace: Some(ns.to_string()),
         name: "my-server".to_string(),
         section_name: None,
         port: None,
     }
 }
 
-fn non_server_parent_ref(ns: String) -> ParentReference {
+fn non_server_parent_ref(ns: impl ToString) -> ParentReference {
     ParentReference {
         group: Some("foo.bar.bas".to_string()),
         kind: Some("Gateway".to_string()),
-        namespace: Some(ns),
+        namespace: Some(ns.to_string()),
         name: "my-gateway".to_string(),
         section_name: None,
         port: None,
+    }
+}
+
+fn meta(ns: impl ToString) -> api::ObjectMeta {
+    api::ObjectMeta {
+        namespace: Some(ns.to_string()),
+        name: Some("test".to_string()),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
The proxy won't handle `httproute` paths (in URI rewrites or matches)
when paths are relative. The policy admission controller and indexer
should catch this case and fail to handle routes that deal in paths that
do not start in `/`.

This branch adds validation to the policy controller's validating
admission controller and indexer to ensure that all paths in an
`httproute` rule are absolute.

This was implemented by adding some methods in the `api` crate for
testing whether various types in the `httproute` CRD contain relative
paths. These methods are called by both the admission controller and the
indexer.

Depends on #8959
Closes #8948