### PR TITLE
ci: Cancel stale workflows for each PR

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,6 +10,14 @@ env:
   DOCKER_REGISTRY: ghcr.io/linkerd
 
 jobs:
+  cleanup-stale:
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7
+        with:
+          access_token: ${{ github.token }}
 
   docker_build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/policy_controller.yml
+++ b/.github/workflows/policy_controller.yml
@@ -28,8 +28,16 @@ env:
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
 
-
 jobs:
+  cleanup-stale:
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: write
+    steps:
+      - uses: styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7
+        with:
+          access_token: ${{ github.token }}
+
   docker-build:
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
When pushing to a branch multiple times, we can end up with a backlog of
integration tests chewing up CI resources. This change updates the
integration test workflows to cancel prior instances of integration test
workflows (for the same branch).

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
