### PR TITLE
ci: Only run `viz` test suite when viz code changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -208,14 +208,10 @@ jobs:
       - run: just policy-test-run --jobs=1
 
   ##
-  ## Viz: Run tests that require viz tests separately
-  ##
-  ## TODO(ver) we should only run viz tests when the viz extension
-  ## or proxy changes, but to do this # we really need extract viz
-  ## from tests that exercise core functionality.
+  ## Ext: Run tests that require non-core components.
   ##
 
-  build-viz:
+  build-ext:
     needs: [tag]
     runs-on: ubuntu-20.04
     strategy:
@@ -244,13 +240,13 @@ jobs:
           name: image-archives
           path: /home/runner/archives
 
-  test-viz:
-    needs: [tag, build-cli, build-core, build-viz]
+  # These tests exercise core functionality, but need the viz extension.
+  test-ext:
+    needs: [tag, build-cli, build-core, build-ext]
     strategy:
       matrix:
         integration_test:
           - cluster-domain
-          - viz
           - default-policy-deny
           - external
           # Skipping Helm upgrade test given chart in 2.11 is backwards-incompatible
@@ -274,6 +270,47 @@ jobs:
       - run: cp image-archives/linkerd "$HOME" && chmod 755 "$HOME/linkerd"
       - run: ls -l image-archives/linkerd
       - run: bin/tests --images archive --cleanup-docker --name '${{ matrix.integration_test }}' "$HOME/linkerd"
+        env:
+          LINKERD_DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
+
+  ##
+  ## Viz: Run the (flakey) `viz` suite only when the `viz` extension is updated.
+  ##
+
+  changed-viz:
+    needs: [cleanup]
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: tj-actions/changed-files@6c44eb8294bb9c93d6118427f4ff8404b695e1d7
+        id: changed
+        with:
+          files: |
+            .github/workflows/integration.yml
+            .proxy-version
+            viz/**
+    outputs:
+      modified: ${{ steps.changed.outputs.any_modified }}
+
+  test-viz:
+    needs: [tag, changed-viz, build-cli, build-core, build-ext]
+    if: needs.changed-viz.outputs.modified == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
+        with:
+          go-version: '1.17'
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: image-archives
+          path: image-archives
+      - run: cp image-archives/linkerd "$HOME" && chmod 755 "$HOME/linkerd"
+      - run: ls -l image-archives/linkerd
+      - run: bin/tests --images archive --cleanup-docker --name viz "$HOME/linkerd"
         env:
           LINKERD_DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
 


### PR DESCRIPTION
The `viz` test suite is particularly unreliable. A high percentage of
test runs need to be retried due to spurious failures.

Until we can make these tests more robust, this change isolates the
`viz` test suite to only run when the `viz` directory changes or when
the proxy version is updated.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
