### PR TITLE
policy: Ensure routes have a deterministic order 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,6 +981,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "async-trait",
+ "chrono",
  "futures",
  "http",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
 name = "linkerd-policy-controller-grpc"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "async-stream",
  "async-trait",
  "drain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,8 +1029,10 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "chrono",
  "futures",
  "k8s-gateway-api",
+ "k8s-openapi",
  "kubert",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,6 @@ dependencies = [
 name = "linkerd-policy-controller-grpc"
 version = "0.1.0"
 dependencies = [
- "ahash",
  "async-stream",
  "async-trait",
  "drain",
@@ -1032,7 +1031,6 @@ dependencies = [
  "chrono",
  "futures",
  "k8s-gateway-api",
- "k8s-openapi",
  "kubert",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",

--- a/policy-controller/core/Cargo.toml
+++ b/policy-controller/core/Cargo.toml
@@ -13,3 +13,4 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 http = "0.2"
 ipnet = "2"
 regex = "1"
+chrono = { version = "0.4.19", default_features = false }

--- a/policy-controller/core/Cargo.toml
+++ b/policy-controller/core/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 ahash = "0.7"
 anyhow = "1"
 async-trait = "0.1"
+chrono = { version = "0.4.19", default_features = false }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 http = "0.2"
 ipnet = "2"
 regex = "1"
-chrono = { version = "0.4.19", default_features = false }

--- a/policy-controller/core/src/http_route.rs
+++ b/policy-controller/core/src/http_route.rs
@@ -1,6 +1,7 @@
 use crate::{AuthorizationRef, ClientAuthorization};
 use ahash::AHashMap as HashMap;
 use anyhow::Result;
+use chrono::{offset::Utc, DateTime};
 pub use http::{
     header::{HeaderName, HeaderValue},
     uri::Scheme,
@@ -14,6 +15,9 @@ pub struct InboundHttpRoute {
     pub hostnames: Vec<HostMatch>,
     pub rules: Vec<InboundHttpRouteRule>,
     pub authorizations: HashMap<AuthorizationRef, ClientAuthorization>,
+    /// This is required for ordering returned `HttpRoute`s by their creation
+    /// timestamp.
+    pub creation_timestamp: DateTime<Utc>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/policy-controller/core/src/http_route.rs
+++ b/policy-controller/core/src/http_route.rs
@@ -15,6 +15,7 @@ pub struct InboundHttpRoute {
     pub hostnames: Vec<HostMatch>,
     pub rules: Vec<InboundHttpRouteRule>,
     pub authorizations: HashMap<AuthorizationRef, ClientAuthorization>,
+
     /// This is required for ordering returned `HttpRoute`s by their creation
     /// timestamp.
     pub creation_timestamp: DateTime<Utc>,

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+ahash = "0.7"
 async-stream = "0.3"
 async-trait = "0.1"
 drain = "0.1"

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -6,7 +6,6 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-ahash = "0.7"
 async-stream = "0.3"
 async-trait = "0.1"
 drain = "0.1"

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod http_route;
 
+use ahash::AHashMap as HashMap;
 use futures::prelude::*;
 use linkerd2_proxy_api::{
     self as api,
@@ -174,29 +175,17 @@ fn to_server(srv: &InboundServer, cluster_networks: &[IpNet]) -> proto::Server {
             ProxyProtocol::Detect { timeout } => Some(proto::proxy_protocol::Kind::Detect(
                 proto::proxy_protocol::Detect {
                     timeout: Some(timeout.into()),
-                    http_routes: srv
-                        .http_routes
-                        .iter()
-                        .map(|(name, route)| to_http_route(name, route.clone(), cluster_networks))
-                        .collect(),
+                    http_routes: to_http_route_list(&srv.http_routes, cluster_networks),
                 },
             )),
             ProxyProtocol::Http1 => Some(proto::proxy_protocol::Kind::Http1(
                 proto::proxy_protocol::Http1 {
-                    routes: srv
-                        .http_routes
-                        .iter()
-                        .map(|(name, route)| to_http_route(name, route.clone(), cluster_networks))
-                        .collect(),
+                    routes: to_http_route_list(&srv.http_routes, cluster_networks),
                 },
             )),
             ProxyProtocol::Http2 => Some(proto::proxy_protocol::Kind::Http2(
                 proto::proxy_protocol::Http2 {
-                    routes: srv
-                        .http_routes
-                        .iter()
-                        .map(|(name, route)| to_http_route(name, route.clone(), cluster_networks))
-                        .collect(),
+                    routes: to_http_route_list(&srv.http_routes, cluster_networks),
                 },
             )),
             ProxyProtocol::Grpc => Some(proto::proxy_protocol::Kind::Grpc(
@@ -364,12 +353,63 @@ fn to_authz(
     }
 }
 
+fn to_http_route_list(
+    routes: &HashMap<String, InboundHttpRoute>,
+    cluster_networks: &[IpNet],
+) -> Vec<proto::HttpRoute> {
+    let mut route_list = routes
+        .iter()
+        .map(|(name, route)| to_http_route(name, route.clone(), cluster_networks))
+        .collect::<Vec<_>>();
+
+    fn name(route: &proto::HttpRoute) -> &str {
+        let meta = route
+            .metadata
+            .as_ref()
+            .expect("routes converted to protobuf by `to_http_route` will always have metadata");
+        match meta.kind {
+            Some(metadata::Kind::Resource (api::meta::Resource { ref name, .. })) => name,
+            _ => unreachable!("routes converted to protobuf by `to_http_route` will always have the Resource metadata kind"),
+        }
+    }
+    let creation_timestamp = |route: &str| {
+        routes
+            .get(route)
+            .expect("route should exist in the map, since we got it by iterating over the map")
+            .creation_timestamp
+    };
+    (&mut route_list[..]).sort_by(|a, b| {
+        let a_name = name(a);
+        let b_name = name(b);
+        // Per the Gateway API spec:
+        //
+        // > If ties still exist across multiple Routes, matching precedence MUST be
+        // > determined in order of the following criteria, continuing on ties:
+        // >
+        // >    The oldest Route based on creation timestamp.
+        // >    The Route appearing first in alphabetical order by
+        // >   "{namespace}/{name}".
+        //
+        // Note that we don't need to include the route's namespace in this
+        // comparison, because all these routes will exist in the same
+        // namespace.
+        creation_timestamp(a_name)
+            .cmp(&creation_timestamp(b_name))
+            // Oldest first!
+            .reverse()
+            .then_with(|| a_name.cmp(b_name))
+    });
+
+    route_list
+}
+
 fn to_http_route(
     name: impl ToString,
     InboundHttpRoute {
         hostnames,
         rules,
         authorizations,
+        creation_timestamp: _,
     }: InboundHttpRoute,
     cluster_networks: &[IpNet],
 ) -> proto::HttpRoute {

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -395,8 +395,6 @@ fn to_http_route_list(
         // namespace.
         creation_timestamp(a_name)
             .cmp(&creation_timestamp(b_name))
-            // Oldest first!
-            .reverse()
             .then_with(|| a_name.cmp(b_name))
     });
 

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -3,7 +3,6 @@
 
 mod http_route;
 
-use ahash::AHashMap as HashMap;
 use futures::prelude::*;
 use linkerd2_proxy_api::{
     self as api,
@@ -353,52 +352,33 @@ fn to_authz(
     }
 }
 
-fn to_http_route_list(
-    routes: &HashMap<String, InboundHttpRoute>,
+fn to_http_route_list<'r>(
+    routes: impl IntoIterator<Item = (&'r String, &'r InboundHttpRoute)>,
     cluster_networks: &[IpNet],
 ) -> Vec<proto::HttpRoute> {
-    let mut route_list = routes
-        .iter()
-        .map(|(name, route)| to_http_route(name, route.clone(), cluster_networks))
-        .collect::<Vec<_>>();
-
-    fn name(route: &proto::HttpRoute) -> &str {
-        let meta = route
-            .metadata
-            .as_ref()
-            .expect("routes converted to protobuf by `to_http_route` will always have metadata");
-        match meta.kind {
-            Some(metadata::Kind::Resource (api::meta::Resource { ref name, .. })) => name,
-            _ => unreachable!("routes converted to protobuf by `to_http_route` will always have the Resource metadata kind"),
-        }
-    }
-    let creation_timestamp = |route: &str| {
-        routes
-            .get(route)
-            .expect("route should exist in the map, since we got it by iterating over the map")
-            .creation_timestamp
-    };
-    (&mut route_list[..]).sort_by(|a, b| {
-        let a_name = name(a);
-        let b_name = name(b);
-        // Per the Gateway API spec:
-        //
-        // > If ties still exist across multiple Routes, matching precedence MUST be
-        // > determined in order of the following criteria, continuing on ties:
-        // >
-        // >    The oldest Route based on creation timestamp.
-        // >    The Route appearing first in alphabetical order by
-        // >   "{namespace}/{name}".
-        //
-        // Note that we don't need to include the route's namespace in this
-        // comparison, because all these routes will exist in the same
-        // namespace.
-        creation_timestamp(a_name)
-            .cmp(&creation_timestamp(b_name))
+    // Per the Gateway API spec:
+    //
+    // > If ties still exist across multiple Routes, matching precedence MUST be
+    // > determined in order of the following criteria, continuing on ties:
+    // >
+    // >    The oldest Route based on creation timestamp.
+    // >    The Route appearing first in alphabetical order by
+    // >   "{namespace}/{name}".
+    //
+    // Note that we don't need to include the route's namespace in this
+    // comparison, because all these routes will exist in the same
+    // namespace.
+    let mut route_list = routes.into_iter().collect::<Vec<_>>();
+    route_list.sort_by(|(a_name, a), (b_name, b)| {
+        a.creation_timestamp
+            .cmp(&b.creation_timestamp)
             .then_with(|| a_name.cmp(b_name))
     });
 
     route_list
+        .into_iter()
+        .map(|(name, route)| to_http_route(name, route.clone(), cluster_networks))
+        .collect()
 }
 
 fn to_http_route(

--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -13,7 +13,10 @@ pub use k8s_openapi::{
             PodStatus, Probe, ServiceAccount,
         },
     },
-    apimachinery::pkg::util::intstr::IntOrString,
+    apimachinery::{
+        self,
+        pkg::{apis::meta::v1::Time, util::intstr::IntOrString},
+    },
 };
 pub use kube::{
     api::{ObjectMeta, Resource, ResourceExt},

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -19,6 +19,8 @@ tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
+chrono = { version = "0.4", default-features = false }
+k8s-openapi = { version = "0.15", default-features = false, features = ["v1_20"] }
 maplit = "1"
 tokio-stream = "0.1"
 tokio-test = "0.4"

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -20,7 +20,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false }
-k8s-openapi = { version = "0.15", default-features = false, features = ["v1_20"] }
 maplit = "1"
 tokio-stream = "0.1"
 tokio-test = "0.4"

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -36,7 +36,7 @@ impl TryFrom<api::HttpRoute> for InboundRouteBinding {
 
     fn try_from(route: api::HttpRoute) -> Result<Self, Self::Error> {
         let route_ns = route.metadata.namespace.as_deref();
-       let creation_timestamp = route
+        let creation_timestamp = route
             .metadata
             .creation_timestamp
             .map(|k8s::Time(t)| t)
@@ -86,7 +86,7 @@ impl TryFrom<policy::HttpRoute> for InboundRouteBinding {
 
     fn try_from(route: policy::HttpRoute) -> Result<Self, Self::Error> {
         let route_ns = route.metadata.namespace.as_deref();
-       let creation_timestamp = route
+        let creation_timestamp = route
             .metadata
             .creation_timestamp
             .map(|k8s::Time(t)| t)

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -36,11 +36,16 @@ impl TryFrom<api::HttpRoute> for InboundRouteBinding {
 
     fn try_from(route: api::HttpRoute) -> Result<Self, Self::Error> {
         let route_ns = route.metadata.namespace.as_deref();
-        let creation_timestamp = route
+       let creation_timestamp = route
             .metadata
             .creation_timestamp
-            .ok_or_else(|| anyhow!("HTTPRoute resource did not have a creation timestamp!"))?
-            .0;
+            .map(|k8s::Time(t)| t)
+            .unwrap_or_else(|| {
+                tracing::warn!("HTTPRoute resource did not have a creation timestamp!");
+                // If the resource is missing a creation timestamp, we'll use the current time so
+                // that existing resources have precedence over newly added ones.
+                std::time::SystemTime::now().into()
+            });
         let parents = InboundParentRef::collect_from(route_ns, route.spec.inner.parent_refs)?;
         let hostnames = route
             .spec

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -1,8 +1,11 @@
 use ahash::AHashMap as HashMap;
-use anyhow::{anyhow, bail, ensure, Error, Result};
+use anyhow::{bail, ensure, Error, Result};
 use k8s_gateway_api as api;
 use linkerd_policy_controller_core::http_route;
-use linkerd_policy_controller_k8s_api::policy::{httproute as policy, Server};
+use linkerd_policy_controller_k8s_api::{
+    self as k8s,
+    policy::{httproute as policy, Server},
+};
 use std::num::NonZeroU16;
 
 #[derive(Clone, Debug, PartialEq)]

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -86,11 +86,16 @@ impl TryFrom<policy::HttpRoute> for InboundRouteBinding {
 
     fn try_from(route: policy::HttpRoute) -> Result<Self, Self::Error> {
         let route_ns = route.metadata.namespace.as_deref();
-        let creation_timestamp = route
+       let creation_timestamp = route
             .metadata
             .creation_timestamp
-            .ok_or_else(|| anyhow!("HTTPRoute resource did not have a creation timestamp!"))?
-            .0;
+            .map(|k8s::Time(t)| t)
+            .unwrap_or_else(|| {
+                tracing::warn!("HTTPRoute resource did not have a creation timestamp!");
+                // If the resource is missing a creation timestamp, we'll use the current time so
+                // that existing resources have precedence over newly added ones.
+                std::time::SystemTime::now().into()
+            });
         let parents = InboundParentRef::collect_from(route_ns, route.spec.inner.parent_refs)?;
         let hostnames = route
             .spec

--- a/policy-controller/k8s/index/src/tests/http_routes.rs
+++ b/policy-controller/k8s/index/src/tests/http_routes.rs
@@ -75,12 +75,15 @@ fn mk_route(
     name: impl ToString,
     server: impl ToString,
 ) -> k8s::policy::HttpRoute {
+    use chrono::Utc;
     use k8s::policy::httproute::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
 
     HttpRoute {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
+            creation_timestamp: Some(Time(Utc::now())),
             ..Default::default()
         },
         spec: HttpRouteSpec {

--- a/policy-controller/k8s/index/src/tests/http_routes.rs
+++ b/policy-controller/k8s/index/src/tests/http_routes.rs
@@ -76,8 +76,7 @@ fn mk_route(
     server: impl ToString,
 ) -> k8s::policy::HttpRoute {
     use chrono::Utc;
-    use k8s::policy::httproute::*;
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+    use k8s::{policy::httproute::*, Time};
 
     HttpRoute {
         metadata: k8s::ObjectMeta {

--- a/policy-test/tests/api.rs
+++ b/policy-test/tests/api.rs
@@ -543,7 +543,7 @@ async fn http_routes_ordered_by_creation() {
         assert_eq!(route_path(0), Some("/metrics"));
         assert_eq!(route_path(1), Some("/ready"));
         assert_eq!(route_path(2), Some("/shutdown"));
-        assert_eq!(route_path(4), Some("/proxy-log-level"));
+        assert_eq!(route_path(3), Some("/proxy-log-level"));
     })
     .await
 }


### PR DESCRIPTION
When there are multiple equivalent routes (e.g., two routes with the
same match), the proxy will use the first route in the returned list. We
need to ensure that the policy controller returns routes in a
deterministic order--and the Gateway API defines such an order:

> If ties still exist across multiple Routes, matching precedence MUST
> be determined in order of the following criteria, continuing on ties:
>
> * The oldest Route based on creation timestamp.
> * The Route appearing first in alphabetical order by
>   "{namespace}/{name}".

This branch updates the policy controller to return the list of
`HttpRoute`s for an inbound server with a deterministic ordering based
on these rules. This is done by tracking the creation timestamp for
indexed `HTTPRoute` resources, and sorting the list of protobuf
`HttpRoute`s when the API server constructs an `InboundServer` response.

The implementation is *somewhat* hairy, because we can't just define a
custom `Ord` implementation for the protobuf `HttpRoute` type that
includes the timestamp --- doing so would require actually storing the
creation timestamp in the protobuf type, which would be a change in
`linkerd2-proxy-api` (and would result in serializing additional
information that the proxy itself doesn't actually care about). Instead,
we use `slice::sort_by` with a closure that looks up routes by name in
the hash map stored by the indexer in order to determine their
timestamps, and implements a custom ordering that first compares the
timestamp, and falls back to comparing the route's name if the
timestamps are equal. Note that we don't include the namespace in that
comparison, because all the routes for a given `InboundServer` are
already known to be in the same namespace.

I've also added an end-to-end test that the API returns the route list
in the correct order. Unfortunately, this test has 4 seconds of `sleep`s
in it, because the minimum resolution of Kubernetes creation timestamps
is 1 second. I figured a test that takes five or six seconds to run was
probably not a huge deal in the end to end tests --- some of the policy
tests take as long as a minute to run, at least on my machine.

Closes #8946