### PR TITLE
helm: Use a default value for `iptablesMode`

### DIFF
--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -1,6 +1,6 @@
 {{- define "partials.proxy-init" -}}
 args:
-{{- if (eq .Values.proxyInit.iptablesMode "nft") }}
+{{- if (.Values.proxyInit.iptablesMode | default "nft" | eq "nft") }}
 - --firewall-bin-path
 - "iptables-nft"
 - --firewall-save-bin-path


### PR DESCRIPTION
Running the policy tests, we hit an issue where the proxy injector seems
to reject resources when `iptablesMode` is unset:

```
admission webhook \"linkerd-proxy-injector.linkerd.io\" denied the request: execution error at (patch/templates/patch.json:67:10):
Unsupported value \"\" for proxyInit.iptablesMode\nValid values: [\"nft\", \"legacy\"]
```

This change updates the Helm chart to use a default to avoid hitting
this error when the value is unset.

It's unclear why this is only being hit in the policy tests--these tests
don't do anything special--but this fix seems like a generally good
change.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
