### PR TITLE
policy: update `tonic` to 0.8 and `proxy-api` to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af1b0893c92d50e1af9a9342df7bd1ba73b9ef2abce700e170f2b2d4c84ac72"
+checksum = "9461e1bf61263ffa493117f2177c15a470b4b66f6b58c74e548401293f9ea639"
 dependencies = [
  "http",
  "ipnet",
@@ -1372,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1382,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df35198f0777b75e9ff669737c6da5136b59dba33cf5a010a6d1cc4d56defc6f"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
  "bytes",
  "prost",
@@ -1983,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+checksum = "498f271adc46acce75d66f639e4d35b31b2394c295c82496727dafa16d465dd2"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -11,9 +11,9 @@ async-trait = "0.1"
 drain = "0.1"
 hyper = { version = "0.14", features = ["http2", "server", "tcp"] }
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.6", features = ["inbound"] }
+linkerd2-proxy-api = { version = "0.7", features = ["inbound"] }
 linkerd-policy-controller-core = { path = "../core" }
 maplit = "1"
 tokio = { version = "1", features = ["macros"] }
-tonic = { version = "0.7", default-features = false }
+tonic = { version = "0.8", default-features = false }
 tracing = "0.1"

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -173,7 +173,7 @@ fn to_server(srv: &InboundServer, cluster_networks: &[IpNet]) -> proto::Server {
         kind: match srv.protocol {
             ProxyProtocol::Detect { timeout } => Some(proto::proxy_protocol::Kind::Detect(
                 proto::proxy_protocol::Detect {
-                    timeout: Some(timeout.into()),
+                    timeout: timeout.try_into().map_err(|error| tracing::warn!(%error, "failed to convert protocol detect timeout to protobuf")).ok(),
                     http_routes: to_http_route_list(&srv.http_routes, cluster_networks),
                 },
             )),

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -14,13 +14,13 @@ k8s-gateway-api = "0.6"
 k8s-openapi = { version = "0.15", features = ["v1_20"] }
 linkerd-policy-controller-core = { path = "../policy-controller/core" }
 linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
-linkerd2-proxy-api = { version = "0.6", features = ["inbound"] }
+linkerd2-proxy-api = { version = "0.7", features = ["inbound"] }
 maplit = "1"
 rand = "0.8"
 serde = "1"
 serde_json = "1"
 schemars = "0.8"
-tonic = { version = "0.7", default-features = false }
+tonic = { version = "0.8", default-features = false }
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/policy-test/src/grpc.rs
+++ b/policy-test/src/grpc.rs
@@ -43,7 +43,7 @@ macro_rules! assert_protocol_detect {
             Some(inbound::ProxyProtocol {
                 kind: Some(inbound::proxy_protocol::Kind::Detect(
                     inbound::proxy_protocol::Detect {
-                        timeout: Some(time::Duration::from_secs(10).into()),
+                        timeout: Some(time::Duration::from_secs(10).try_into().unwrap()),
                         http_routes: vec![$crate::grpc::defaults::http_route()],
                     }
                 )),


### PR DESCRIPTION
This branch updates the policy controller's dependency on `tonic` to
v0.8, and `linkerd2-proxy-api` to 0.7. `tonic` 0.8 is a breaking API
change, and `tonic` and `linkerd2-proxy-api` must be updated together,
rather than separately, so this cannot be done by Dependabot.

Closes #9078