### PR TITLE
devcontainer: install Google protobuf include files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ ARG PROTOC_VERSION=v3.20.1
 RUN url="https://github.com/google/protobuf/releases/download/$PROTOC_VERSION/protoc-${PROTOC_VERSION#v}-linux-$(uname -m).zip" ; \
     cd $(mktemp -d) && \
     scurl -o protoc.zip  "$url" && \
-    unzip protoc.zip bin/protoc include/google && \
+    unzip protoc.zip bin/protoc include/** && \
     mv bin/protoc /usr/local/bin/protoc && \
     chmod +x /usr/local/bin/protoc && \
     mv include/google /usr/local/include

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -190,7 +190,6 @@ COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/
 COPY --from=yq /usr/local/bin/yq /usr/local/bin/
 ENV PROTOC_NO_VENDOR=1
 ENV PROTOC=/usr/local/bin/protoc
-ENV PROTOC_INCLUDE=/usr/local/bin/protoc/include
 ENV PROTOC_INCLUDE=/usr/local/include
 
 ##

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,14 +8,14 @@ ARG RUST_TOOLCHAIN=1.62.1
 FROM docker.io/debian:stable-slim as base
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-    curl \
-    file \
-    git \
-    jo \
-    jq \
-    time \
-    unzip \
-    xz-utils \
+        curl \
+        file \
+        git \
+        jo \
+        jq \
+        time \
+        unzip \
+        xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY bin/scurl /usr/local/bin/scurl
 
@@ -67,14 +67,14 @@ FROM docker.io/rust:${RUST_TOOLCHAIN}-slim as rust
 RUN rustup component add clippy rustfmt
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-    clang \
-    cmake \
-    curl \
-    git \
-    jo \
-    jq \
-    libssl-dev \
-    pkg-config \
+        clang \
+        cmake \
+        curl \
+        git \
+        jo \
+        jq \
+        libssl-dev \
+        pkg-config \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=cargo-action-fmt /usr/local/bin/cargo-action-fmt /usr/local/cargo/bin/
 COPY --from=cargo-deny /usr/local/bin/cargo-deny /usr/local/cargo/bin/
@@ -97,12 +97,12 @@ ENV PROTOC_INCLUDE=/usr/local/include
 FROM docker.io/golang:${GO_VERSION} as go
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-    curl \
-    file \
-    jq \
-    time \
-    unzip \
-    xz-utils \
+        curl \
+        file \
+        jq \
+        time \
+        unzip \
+        xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN for p in \
     github.com/cweill/gotests/gotests@latest \
@@ -200,19 +200,19 @@ ENV PROTOC_INCLUDE=/usr/local/include
 FROM docker.io/debian:stable as runtime
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-    clang curl \
-    cmake \
-    file \
-    jo \
-    jq \
-    libssl-dev \
-    locales \
-    lsb-release \
-    npm \
-    pkg-config \
-    sudo \
-    time \
-    unzip \
+        clang curl \
+        cmake \
+        file \
+        jo \
+        jq \
+        libssl-dev \
+        locales \
+        lsb-release \
+        npm \
+        pkg-config \
+        sudo \
+        time \
+        unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,14 +8,14 @@ ARG RUST_TOOLCHAIN=1.62.1
 FROM docker.io/debian:stable-slim as base
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-        curl \
-        file \
-        git \
-        jo \
-        jq \
-        time \
-        unzip \
-        xz-utils \
+    curl \
+    file \
+    git \
+    jo \
+    jq \
+    time \
+    unzip \
+    xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY bin/scurl /usr/local/bin/scurl
 
@@ -29,9 +29,10 @@ ARG PROTOC_VERSION=v3.20.1
 RUN url="https://github.com/google/protobuf/releases/download/$PROTOC_VERSION/protoc-${PROTOC_VERSION#v}-linux-$(uname -m).zip" ; \
     cd $(mktemp -d) && \
     scurl -o protoc.zip  "$url" && \
-    unzip protoc.zip bin/protoc && \
+    unzip protoc.zip bin/protoc include/google && \
     mv bin/protoc /usr/local/bin/protoc && \
-    chmod +x /usr/local/bin/protoc
+    chmod +x /usr/local/bin/protoc && \
+    mv include/google /usr/local/include
 
 FROM base as yq
 ARG YQ_VERSION=v4.25.1
@@ -66,14 +67,14 @@ FROM docker.io/rust:${RUST_TOOLCHAIN}-slim as rust
 RUN rustup component add clippy rustfmt
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-        clang \
-        cmake \
-        curl \
-        git \
-        jo \
-        jq \
-        libssl-dev \
-        pkg-config \
+    clang \
+    cmake \
+    curl \
+    git \
+    jo \
+    jq \
+    libssl-dev \
+    pkg-config \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=cargo-action-fmt /usr/local/bin/cargo-action-fmt /usr/local/cargo/bin/
 COPY --from=cargo-deny /usr/local/bin/cargo-deny /usr/local/cargo/bin/
@@ -81,11 +82,13 @@ COPY --from=cargo-nextest /usr/local/bin/cargo-nextest /usr/local/cargo/bin/
 COPY --from=cargo-tarpaulin /usr/local/bin/cargo-tarpaulin /usr/local/cargo/bin/
 COPY --from=just /usr/local/bin/just /usr/local/bin/
 COPY --from=protoc /usr/local/bin/protoc /usr/local/bin/
+COPY --from=protoc /usr/local/include/google /usr/local/include/
 COPY --from=yq /usr/local/bin/yq /usr/local/bin/
 COPY bin/scurl /usr/local/bin/scurl
 ENV USER=root
 ENV PROTOC_NO_VENDOR=1
 ENV PROTOC=/usr/local/bin/protoc
+ENV PROTOC_INCLUDE=/usr/local/include
 
 ##
 ## Go image
@@ -94,12 +97,12 @@ ENV PROTOC=/usr/local/bin/protoc
 FROM docker.io/golang:${GO_VERSION} as go
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-        curl \
-        file \
-        jq \
-        time \
-        unzip \
-        xz-utils \
+    curl \
+    file \
+    jq \
+    time \
+    unzip \
+    xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN for p in \
     github.com/cweill/gotests/gotests@latest \
@@ -118,9 +121,11 @@ RUN for p in \
     && rm -rf /go/pkg/* /go/src/*
 COPY bin/scurl /usr/local/bin/scurl
 COPY --from=protoc /usr/local/bin/protoc /usr/local/bin/
+COPY --from=protoc /usr/local/include/google /usr/local/include/
 COPY --from=just /usr/local/bin/just /usr/local/bin/
 ENV PROTOC_NO_VENDOR=1
 ENV PROTOC=/usr/local/bin/protoc
+ENV PROTOC_INCLUDE=/usr/local/include
 
 ##
 ## Kubernetes tools
@@ -180,10 +185,13 @@ COPY --from=k8s /usr/local/bin/helm-docs /usr/local/bin/
 COPY --from=k8s /usr/local/bin/k3d /usr/local/bin/
 COPY --from=k8s /usr/local/bin/kubectl /usr/local/bin/
 COPY --from=protoc /usr/local/bin/protoc /usr/local/bin/
+COPY --from=protoc /usr/local/include/google /usr/local/include/
 COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/
 COPY --from=yq /usr/local/bin/yq /usr/local/bin/
 ENV PROTOC_NO_VENDOR=1
 ENV PROTOC=/usr/local/bin/protoc
+ENV PROTOC_INCLUDE=/usr/local/bin/protoc/include
+ENV PROTOC_INCLUDE=/usr/local/include
 
 ##
 ## Runtime
@@ -192,19 +200,19 @@ ENV PROTOC=/usr/local/bin/protoc
 FROM docker.io/debian:stable as runtime
 RUN apt update && apt upgrade -y --autoremove \
     && apt install -y \
-        clang curl \
-        cmake \
-        file \
-        jo \
-        jq \
-        libssl-dev \
-        locales \
-        lsb-release \
-        npm \
-        pkg-config \
-        sudo \
-        time \
-        unzip \
+    clang curl \
+    cmake \
+    file \
+    jo \
+    jq \
+    libssl-dev \
+    locales \
+    lsb-release \
+    npm \
+    pkg-config \
+    sudo \
+    time \
+    unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
@@ -228,9 +236,11 @@ ENV PATH=$CARGO_HOME/bin:$PATH
 RUN rustup component add rust-analysis rust-std
 
 COPY --from=tools /usr/local/bin/* /usr/local/bin/
+COPY --from=tools /usr/local/include/google /usr/local/include/
 
 ENV PROTOC_NO_VENDOR=1
 ENV PROTOC=/usr/local/bin/protoc
+ENV PROTOC_INCLUDE=/usr/local/include
 
 ENV DOCKER_BUILDKIT=1
 RUN groupadd --gid=1000 code \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -236,7 +236,7 @@ ENV PATH=$CARGO_HOME/bin:$PATH
 RUN rustup component add rust-analysis rust-std
 
 COPY --from=tools /usr/local/bin/* /usr/local/bin/
-COPY --from=tools /usr/local/include/google /usr/local/include/
+COPY --from=protoc /usr/local/include/google /usr/local/include/
 
 ENV PROTOC_NO_VENDOR=1
 ENV PROTOC=/usr/local/bin/protoc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd2",
-    "image": "ghcr.io/linkerd/dev:v22",
+    "image": "ghcr.io/linkerd/dev:v23",
     // "dockerFile": "./Dockerfile",
     // "context": "..",
     "extensions": [

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v22-tools
+    container: ghcr.io/linkerd/dev:v23-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Run actionlint
@@ -25,7 +25,7 @@ jobs:
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v22-tools
+    container: ghcr.io/linkerd/dev:v23-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Scan workflows for other Devcontainer image versions

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
   go-lint:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v22-go
+    container: ghcr.io/linkerd/dev:v23-go
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - run: golangci-lint run --verbose --timeout=10m
@@ -24,7 +24,7 @@ jobs:
   go-format:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v22-go
+    container: ghcr.io/linkerd/dev:v23-go
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - run: bin/fmt
@@ -32,7 +32,7 @@ jobs:
   go-test:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v22-go
+    container: ghcr.io/linkerd/dev:v23-go
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - run: go mod download

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -15,7 +15,7 @@ jobs:
   helm-docs-diff:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
-    container: ghcr.io/linkerd/dev:v22-tools
+    container: ghcr.io/linkerd/dev:v23-tools
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - run: bin/helm-docs-diff

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -15,7 +15,7 @@ jobs:
   proto-diff:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v22-go
+    container: ghcr.io/linkerd/dev:v23-go
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: bin/protoc-diff

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
   fmt:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v22-rust
+    container: ghcr.io/linkerd/dev:v23-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-check-fmt
@@ -50,7 +50,7 @@ jobs:
   clippy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v22-rust
+    container: ghcr.io/linkerd/dev:v23-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch
@@ -60,7 +60,7 @@ jobs:
   check:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v22-rust
+    container: ghcr.io/linkerd/dev:v23-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch
@@ -70,7 +70,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: ghcr.io/linkerd/dev:v22-rust
+    container: ghcr.io/linkerd/dev:v23-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -15,7 +15,7 @@ jobs:
   shellcheck:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v22-tools
+    container: ghcr.io/linkerd/dev:v23-tools
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - run: bin/shellcheck-all


### PR DESCRIPTION
This commit updates the devcontainer Dockerfile to also install the
Google protobuf definitions for well-known types to
`/usr/local/include`, and set the `PROTOC_INCLUDE` environment variable
to point at these files in the devcontainer. This *should* fix [this
build failure][1] when compiling OpenCensus protobufs in the proxy repo.

I believe this will also allow us to un-vendor the Google protobuf
definitions in other places (e.g. `linkerd2-proxy-api`), as long as the
builds also happen in the devcontainer Docker image.

If this *isn't* the most correct way to resolve this, I'm happy to
consider other options (e.g., vendoring the protos in the proxy repo as
well), but it felt like the "most proper" solution.

[1]: https://github.com/linkerd/linkerd2-proxy/runs/7677474405?check_suite_focus=true