### PR TITLE
dev: Add go-mod-* scripts to inspect the go module hierarchy

### DIFF
--- a/bin/go-mod-tree
+++ b/bin/go-mod-tree
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Print all (transitive) dependencies of the specified go package.
+
+set -euo pipefail
+
+if [ $# -gt 1 ]; then
+    echo "Usage: $0 [root]" >&2
+    exit 64
+fi
+declare -r MODULE="${1:-github.com/linkerd/linkerd2}"
+
+GRAPH=$(go mod graph)
+declare -r GRAPH
+
+deps_of() {
+    local pkg=$1
+    echo "$GRAPH" | awk '$1 == "'"$pkg"'" { print $2 }' | sort | uniq
+}
+
+declare -A PKGS=()
+subtree() {
+    local pkg=$1
+    local namepfx=${2:-}
+    local pfx=${3:-}
+    # If the package has already been printed, then print it with an
+    # asterisk and skip printing its dependencies
+    if (( ${PKGS[$pkg]:-0} )); then
+        echo "$namepfx$pkg (*)"
+    else
+        # Otherwise, print the package, mark it as printed, and the
+        # dependency tree for each of its depndencies
+        echo "$namepfx$pkg"
+        PKGS[$pkg]=1
+        local dep=''
+        for d in $(deps_of "$pkg") ; do
+            if [ -n "$dep" ]; then  subtree "$dep" "$pfx├── " "$pfx│   " ; fi
+            dep=$d
+        done
+        if [ -n "$dep" ]; then subtree "$dep" "$pfx└── " "$pfx    " ; fi
+    fi
+}
+
+if [[ "$MODULE" == *@* ]]; then
+    # The root specifies an exact version, so print its dependencies.
+    subtree "$MODULE"
+elif [ -n "$(echo "$GRAPH" | awk '$1 == "'"$MODULE"'" { print $0 }' | head -n 1)" ]; then
+    # The root does not specify an exact version, but that is how the
+    # package is listed in go.mod.
+    subtree "$MODULE"
+else
+    # The root does not specify an exact version, find all versions of the
+    # package and print their depdencies.
+    first=1
+    for pkg in $(echo "$GRAPH" | awk '{ print $1 }' | sort | uniq) ; do
+        if [ "${pkg%@*}" = "$MODULE" ]; then
+            if (( first )); then first=0; else echo; fi
+            subtree "$pkg"
+        fi
+    done
+fi

--- a/bin/go-mod-versions
+++ b/bin/go-mod-versions
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Print all versions of the specified go package.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <module>" >&2
+    exit 64
+fi
+declare -r MODULE="$1"
+
+if [[ "$MODULE" == *@* ]]; then
+    echo 'The dependency must not specify an exact version.' >&2
+    exit 1
+fi
+
+for pkg in $(go mod graph | awk '{ print $1; print $2 }' | sort | uniq) ; do
+    if [ "${pkg%@*}" = "$MODULE" ]; then
+        echo "$pkg"
+    fi
+done
+

--- a/bin/go-mod-why
+++ b/bin/go-mod-why
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Print all (transitive) dependenents of the specified go package.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <module>" >&2
+    exit 64
+fi
+declare -r MODULE="$1"
+
+GRAPH=$(go mod graph)
+declare -r GRAPH
+
+depends_on() {
+    local pkg=$1
+    echo "$GRAPH" | awk '$2 == "'"$pkg"'" { print $1 }' | sort | uniq
+}
+
+declare -A PKGS=()
+supertree() {
+    local pkg=$1
+    local namepfx=${2:-}
+    local pfx=${3:-}
+    if (( ${PKGS[$pkg]:-0} )); then
+        echo "$namepfx$pkg (*)"
+    else
+        PKGS[$pkg]=1
+        echo "$namepfx$pkg"
+        local parent=''
+        for p in $(depends_on "$pkg") ; do
+            if [ -n "$parent" ]; then supertree "$parent" "$pfx├── " "$pfx│   " ; fi
+            parent=$p
+        done
+        if [ -n "$parent" ]; then supertree "$parent" "$pfx└── " "$pfx    " ; fi
+    fi
+}
+
+if [[ "$MODULE" == *@* ]]; then
+    # The dependency specifies an exact version, so print the packages that
+    # depend on it.
+    supertree "$MODULE"
+else
+    # The dependency does not specify an exact version, find all versions of
+    # the package and print the packages that depend on each of them.
+    first=1
+    for pkg in $(echo "$GRAPH" | awk '{ print $1 }' | sort | uniq) ; do
+        if [ "${pkg%@*}" = "$MODULE" ]; then
+            if (( first )); then first=0; else echo; fi
+            supertree "$pkg"
+        fi
+    done
+fi


### PR DESCRIPTION
It can be difficult to understand why a given module is a part of our Go
dependencies. This change adds utility scripts--inspired by Rust's
`cargo tree`--that use `go mod graph` to inspect Go dependencies.

* `go-mod-tree` -- like `cargo tree`, prints all dependencies from an
  optional root module.
* `go-mod-versions` -- enumerates all versions of a module in the Go
  dependency graph
* `go-mod-why` -- like `cargo tree -i`, prints the tree of modules that
  depend on a given module.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
