### PR TITLE
policy: Deterministically order probe paths

### DIFF
--- a/policy-controller/k8s/index/src/index.rs
+++ b/policy-controller/k8s/index/src/index.rs
@@ -23,7 +23,11 @@ use linkerd_policy_controller_core::{
 };
 use linkerd_policy_controller_k8s_api::{self as k8s, policy::server::Port, ResourceExt};
 use parking_lot::RwLock;
-use std::{collections::hash_map::Entry, num::NonZeroU16, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, BTreeSet},
+    num::NonZeroU16,
+    sync::Arc,
+};
 use tokio::sync::watch;
 use tracing::info_span;
 
@@ -94,7 +98,7 @@ struct Pod {
     /// In order for the policy controller to authorize probes, it must be
     /// aware of the probe ports and the expected paths on which probes are
     /// expected.
-    probes: pod::PortMap<HashSet<String>>,
+    probes: pod::PortMap<BTreeSet<String>>,
 }
 
 /// Holds the state of a single port on a pod.
@@ -827,7 +831,7 @@ impl PodIndex {
         name: String,
         meta: pod::Meta,
         port_names: HashMap<String, pod::PortSet>,
-        probes: PortMap<HashSet<String>>,
+        probes: PortMap<BTreeSet<String>>,
     ) -> Result<Option<&mut Pod>> {
         let pod = match self.by_name.entry(name.clone()) {
             Entry::Vacant(entry) => entry.insert(Pod {


### PR DESCRIPTION
Using a `HashSet` to store probe paths means that the paths are not
ordered deterministically in API responses. This change replaces the
`HashSet` with a `BTreeSet` so that probe paths are always sorted
lexically.

Fixes tests in https://github.com/linkerd/linkerd2/pull/9091

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
