### PR TITLE
Change default iptables mode to legacy

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -228,7 +228,7 @@ Kubernetes: `>=1.21.0-0`
 | proxyInit.image.name | string | `"cr.l5d.io/linkerd/proxy-init"` | Docker image for the proxy-init container |
 | proxyInit.image.pullPolicy | string | imagePullPolicy | Pull policy for the proxy-init container Docker image |
 | proxyInit.image.version | string | `"v1.6.2"` | Tag for the proxy-init container Docker image |
-| proxyInit.iptablesMode | string | `"nft"` | Variant of iptables that will be used to configure routing. Currently, proxy-init can be run either in 'nft' or in 'legacy' mode. The mode will control which utility binary will be called. The host must support whichever mode will be used |
+| proxyInit.iptablesMode | string | `"legacy"` | Variant of iptables that will be used to configure routing. Currently, proxy-init can be run either in 'nft' or in 'legacy' mode. The mode will control which utility binary will be called. The host must support whichever mode will be used |
 | proxyInit.logFormat | string | plain | Log format (`plain` or `json`) for the proxy-init |
 | proxyInit.logLevel | string | info | Log level for the proxy-init |
 | proxyInit.resources.cpu.limit | string | `"100m"` | Maximum amount of CPU units that the proxy-init container can use |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -179,7 +179,7 @@ proxyInit:
   # proxy-init can be run either in 'nft' or in 'legacy' mode. The mode will
   # control which utility binary will be called. The host must support
   # whichever mode will be used
-  iptablesMode: "nft"
+  iptablesMode: "legacy"
   # -- Default set of inbound ports to skip via iptables
   # - Galera (4567,4568)
   ignoreInboundPorts: "4567,4568"

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -1,6 +1,6 @@
 {{- define "partials.proxy-init" -}}
 args:
-{{- if (.Values.proxyInit.iptablesMode | default "nft" | eq "nft") }}
+{{- if (.Values.proxyInit.iptablesMode | default "legacy" | eq "nft") }}
 - --firewall-bin-path
 - "iptables-nft"
 - --firewall-save-bin-path

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -102,7 +102,7 @@ func TestRender(t *testing.T) {
 			Await:       true,
 		},
 		ProxyInit: &charts.ProxyInit{
-			IptablesMode: "nft",
+			IptablesMode: "legacy",
 			Image: &charts.Image{
 				Name:       "ProxyInitImageName",
 				PullPolicy: "ImagePullPolicy",

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -149,10 +149,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -149,10 +149,6 @@ spec:
           name: server
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -351,10 +347,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -149,10 +149,6 @@ spec:
           name: server
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -189,10 +189,6 @@ spec:
         - mountPath: /config
           name: contour-config
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -160,10 +160,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -373,10 +369,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -586,10 +578,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -799,10 +787,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -160,10 +160,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -163,10 +163,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -152,10 +152,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -173,10 +173,6 @@ spec:
           runAsUser: 33
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -177,10 +177,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -160,10 +160,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -373,10 +369,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -165,10 +165,6 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -160,10 +160,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -161,10 +161,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -161,10 +161,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -161,10 +161,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -162,10 +162,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -162,10 +162,6 @@ spec:
           protocol: UDP
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -162,10 +162,6 @@ items:
             name: http
         initContainers:
         - args:
-          - --firewall-bin-path
-          - iptables-nft
-          - --firewall-save-bin-path
-          - iptables-nft-save
           - --incoming-proxy-port
           - "4143"
           - --outgoing-proxy-port
@@ -369,10 +365,6 @@ items:
             protocol: TCP
         initContainers:
         - args:
-          - --firewall-bin-path
-          - iptables-nft
-          - --firewall-save-bin-path
-          - iptables-nft-save
           - --incoming-proxy-port
           - "4143"
           - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -162,10 +162,6 @@ items:
             name: http
         initContainers:
         - args:
-          - --firewall-bin-path
-          - iptables-nft
-          - --firewall-save-bin-path
-          - iptables-nft-save
           - --incoming-proxy-port
           - "4143"
           - --outgoing-proxy-port
@@ -369,10 +365,6 @@ items:
             protocol: TCP
         initContainers:
         - args:
-          - --firewall-bin-path
-          - iptables-nft
-          - --firewall-save-bin-path
-          - iptables-nft-save
           - --incoming-proxy-port
           - "4143"
           - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -144,10 +144,6 @@ spec:
     name: vote-bot
   initContainers:
   - args:
-    - --firewall-bin-path
-    - iptables-nft
-    - --firewall-save-bin-path
-    - iptables-nft-save
     - --incoming-proxy-port
     - "4143"
     - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -147,10 +147,6 @@ spec:
     name: vote-bot
   initContainers:
   - args:
-    - --firewall-bin-path
-    - iptables-nft
-    - --firewall-save-bin-path
-    - iptables-nft-save
     - --incoming-proxy-port
     - "4143"
     - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -146,10 +146,6 @@ spec:
     name: vote-bot
   initContainers:
   - args:
-    - --firewall-bin-path
-    - iptables-nft
-    - --firewall-save-bin-path
-    - iptables-nft-save
     - --incoming-proxy-port
     - "4143"
     - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -155,10 +155,6 @@ spec:
     name: vote-bot
   initContainers:
   - args:
-    - --firewall-bin-path
-    - iptables-nft
-    - --firewall-save-bin-path
-    - iptables-nft-save
     - --incoming-proxy-port
     - "4143"
     - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -161,10 +161,6 @@ spec:
           name: http
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -162,10 +162,6 @@ spec:
         - containerPort: 9090
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -377,10 +373,6 @@ spec:
         - containerPort: 9090
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -214,10 +214,6 @@ spec:
       dnsPolicy: ClusterFirst
       initContainers:
       - args:
-        - --firewall-bin-path
-        - iptables-nft
-        - --firewall-save-bin-path
-        - iptables-nft-save
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -882,10 +882,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1301,10 +1297,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1606,10 +1598,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -881,10 +881,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1299,10 +1295,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1604,10 +1596,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -564,7 +564,7 @@ data:
         name: my.custom.registry/linkerd-io/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -881,10 +881,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1299,10 +1295,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1604,10 +1596,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -881,10 +881,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1299,10 +1295,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1604,10 +1596,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -881,10 +881,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1299,10 +1295,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1604,10 +1596,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -879,10 +879,6 @@ spec:
           name: linkerd-identity-end-entity
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1288,10 +1284,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1584,10 +1576,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -591,7 +591,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -963,10 +963,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1427,10 +1423,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1768,10 +1760,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -591,7 +591,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -963,10 +963,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1427,10 +1423,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1768,10 +1760,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -495,7 +495,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -812,10 +812,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1230,10 +1226,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1485,10 +1477,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -540,7 +540,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: test-proxy-init-version
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -851,10 +851,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1272,10 +1268,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1582,10 +1574,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -567,7 +567,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: test-proxy-init-version
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -933,10 +933,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1400,10 +1396,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1746,10 +1738,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -571,7 +571,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: test-proxy-init-version
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -941,10 +941,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1412,10 +1408,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1766,10 +1758,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -562,7 +562,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: test-proxy-init-version
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -923,10 +923,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1390,10 +1386,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1736,10 +1728,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -557,7 +557,7 @@ data:
         name: ProxyInitImageName
         pullPolicy: ImagePullPolicy
         version: ProxyInitVersion
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -872,10 +872,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1295,10 +1291,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1600,10 +1592,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -881,10 +881,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1299,10 +1295,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1604,10 +1596,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -564,7 +564,7 @@ data:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
         version: v1.6.2
-      iptablesMode: nft
+      iptablesMode: legacy
       logFormat: ""
       logLevel: ""
       resources:
@@ -881,10 +881,6 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1299,10 +1295,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port
@@ -1604,10 +1596,6 @@ spec:
           readOnly: true
       initContainers:
       - args:
-        - --firewall-bin-path
-        - "iptables-nft"
-        - --firewall-save-bin-path
-        - "iptables-nft-save"
         - --incoming-proxy-port
         - "4143"
         - --outgoing-proxy-port

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -42,10 +42,6 @@
     "path": "/spec/initContainers/-",
     "value": {
       "args": [
-        "--firewall-bin-path",
-        "iptables-nft",
-        "--firewall-save-bin-path",
-        "iptables-nft-save",
         "--incoming-proxy-port",
         "4143",
         "--outgoing-proxy-port",

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -52,10 +52,6 @@
     "path": "/spec/initContainers/-",
     "value": {
       "args": [
-        "--firewall-bin-path",
-        "iptables-nft",
-        "--firewall-save-bin-path",
-        "iptables-nft-save",
         "--incoming-proxy-port",
         "4143",
         "--outgoing-proxy-port",

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -42,10 +42,6 @@
     "path": "/spec/initContainers/-",
     "value": {
       "args": [
-        "--firewall-bin-path",
-        "iptables-nft",
-        "--firewall-save-bin-path",
-        "iptables-nft-save",
         "--incoming-proxy-port",
         "4143",
         "--outgoing-proxy-port",

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -116,7 +116,7 @@ func TestNewValues(t *testing.T) {
 			Await:                  true,
 		},
 		ProxyInit: &ProxyInit{
-			IptablesMode:        "nft",
+			IptablesMode:        "legacy",
 			IgnoreInboundPorts:  "4567,4568",
 			IgnoreOutboundPorts: "4567,4568",
 			LogLevel:            "",


### PR DESCRIPTION
Some hosts may not have 'nft' modules available. Currently, proxy-init
defaults to using 'iptables-nft'; if the host does not have support for
nft modules, the init container will crash, blocking all injected
workloads from starting up.

This change defaults the 'iptablesMode' value to 'legacy'.

* Update linkerd-control-plane/values file default
* Update proxy-init partial to default to 'legacy' when no mode is
  specified
* Change expected values in 'pkg/charts/linkerd2/values_test.go' and in
  'cli/cmd/install_test'
* Update golden files

Fixes #9053

Signed-off-by: Matei David <matei@buoyant.io>


<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
