### PR TITLE
Add changes for `edge-22.8.1`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@
 This releases introduces default probe authorization. This means that on
 clusters that use a default `deny` policy, probes do not have to be explicitly
 authorized using policy resources. Additionally, the
-`policyController.probeNetworks` value has been added which allows users to
-configure the networks that probes are expected to be performed from.
+`policyController.probeNetworks` Helm value has been added, which allows users
+to configure the networks that probes are expected to be performed from.
 
 Additionally, the `linkerd authz` command has been updated to support the policy
 resources AuthorizationPolicy and HttpRoute.
@@ -18,14 +18,14 @@ environments by default.
 
 * Updated the `linkerd authz` command to support AuthorizationPolicy and
   HttpRoute resources
-* Changed the `proxy.await` configuration value to allow disabling
+* Changed the `proxy.await` Helm value so that users can now disable
   `linkerd-await` on control plane components
 * Added probe authorization by default allowing clusters that use a default
   `deny` policy to not explicitly need to authorize probes
 * Added ability to run the Linkerd CNI plugin in non-chained (stand-alone) mode
-* Added the `policyController.probeNetworks` value for configuring the networks
-  that probes are expected to be performed from
-* Changed the default value of iptables mode to `legacy`
+* Added the `policyController.probeNetworks` Helm value for configuring the
+  networks that probes are expected to be performed from
+* Changed the default iptables mode to `legacy`
 
 ## edge-22.7.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,32 @@
 # Changes
 
+## edge-22.8.1
+
+This releases introduces default probe authorization. This means that on
+clusters that use a default `deny` policy, probes do not have to be explicitly
+authorized using policy resources. Additionally, the
+`policyController.probeNetworks` value has been added which allows users to
+configure the networks that probes are expected to be performed from.
+
+Additionally, the `linkerd authz` command has been updated to support the policy
+resources AuthorizationPolicy and HttpRoute.
+
+Finally, some smaller changes include allowing to disable `linkerd-await` on
+control plane components (using the existing `proxy.await` configuration) and
+changing the default iptables mode back to `legacy` to support more cluster
+environments by default.
+
+* Updated the `linkerd authz` command to support AuthorizationPolicy and
+  HttpRoute resources
+* Changed the `proxy.await` configuration value to allow disabling
+  `linkerd-await` on control plane components
+* Added probe authorization by default allowing clusters that use a default
+  `deny` policy to not explicitly need to authorize probes
+* Added ability to run the Linkerd CNI plugin in non-chained (stand-alone) mode
+* Added the `policyController.probeNetworks` value for configuring the networks
+  that probes are expected to be performed from
+* Changed the default value of iptables mode to `legacy`
+
 ## edge-22.7.3
 
 This release adds a new `nft` iptables mode, used by default in proxy-init.

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.7.0-edge
+version: 1.7.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.7.1-edge
+version: 1.8.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.7.1-edge](https://img.shields.io/badge/Version-1.7.1--edge-informational?style=flat-square)
+![Version: 1.8.0-edge](https://img.shields.io/badge/Version-1.8.0--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.7.0-edge](https://img.shields.io/badge/Version-1.7.0--edge-informational?style=flat-square)
+![Version: 1.7.1-edge](https://img.shields.io/badge/Version-1.7.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.1.7-edge
+version: 30.2.0-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.1.7-edge](https://img.shields.io/badge/Version-30.1.7--edge-informational?style=flat-square)
+![Version: 30.2.0-edge](https://img.shields.io/badge/Version-30.2.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.8-edge
+version: 30.3.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.3.8-edge](https://img.shields.io/badge/Version-30.3.8--edge-informational?style=flat-square)
+![Version: 30.3.9-edge](https://img.shields.io/badge/Version-30.3.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.1.8-edge
+version: 30.1.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.1.8-edge](https://img.shields.io/badge/Version-30.1.8--edge-informational?style=flat-square)
+![Version: 30.1.9-edge](https://img.shields.io/badge/Version-30.1.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.8-edge
+version: 30.2.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.2.8-edge](https://img.shields.io/badge/Version-30.2.8--edge-informational?style=flat-square)
+![Version: 30.2.9-edge](https://img.shields.io/badge/Version-30.2.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-22.8.1

This releases introduces default probe authorization. This means that on
clusters that use a default `deny` policy, probes do not have to be explicitly
authorized using policy resources. Additionally, the
`policyController.probeNetworks` value has been added which allows users to
configure the networks that probes are expected to be performed from.

Additionally, the `linkerd authz` command has been updated to support the policy
resources AuthorizationPolicy and HttpRoute.

Finally, some smaller changes include allowing to disable `linkerd-await` on
control plane components (using the existing `proxy.await` configuration) and
changing the default iptables mode back to `legacy` to support more cluster
environments by default.

* Updated the `linkerd authz` command to support AuthorizationPolicy and
  HttpRoute resources
* Changed the `proxy.await` configuration value to allow disabling
  `linkerd-await` on control plane components
* Added probe authorization by default allowing clusters that use a default
  `deny` policy to not explicitly need to authorize probes
* Added ability to run the Linkerd CNI plugin in non-chained (stand-alone) mode
* Added the `policyController.probeNetworks` value for configuring the networks
  that probes are expected to be performed from
* Changed the default value of iptables mode to `legacy`
