### PR TITLE
Fix tap-injector ServiceAcc with imagePullSecrets

### DIFF
--- a/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
@@ -33,9 +33,9 @@ apiVersion: v1
 metadata:
   name: tap-injector
   {{ include "partials.namespace" . }}
-{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
   labels:
     linkerd.io/extension: viz
+{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 {{- $host := printf "tap-injector.%s.svc" .Release.Namespace }}
 {{- $ca := genSelfSignedCert $host (list) (list $host) 365 }}


### PR DESCRIPTION
### Problem
If using imagePullSecrets, the tap-injector Service Account will render into an invalid k8s manifest.

### Solution
Render the imagePullSecrets after `metadata.labels` are correctly rendered.

### Validation
Used `helm template` after the fix, and I no longer run into the error message.

Fixes #9109

Signed-off-by: Weichung Shaw <weichung.shaw@gmail.com>