### PR TITLE
Properly inherit `linkerd.io/inject: ingress` from NS to workload

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -37,7 +37,8 @@ import (
 var (
 	rTrail = regexp.MustCompile(`\},\s*\]`)
 
-	// ProxyAnnotations is the list of possible annotations that can be applied on a pod or namespace
+	// ProxyAnnotations is the list of possible annotations that can be applied on a pod or namespace.
+	// All these annotations should be prefixed with "config.linkerd.io"
 	ProxyAnnotations = []string{
 		k8s.ProxyAdminPortAnnotation,
 		k8s.ProxyControlPortAnnotation,
@@ -202,16 +203,9 @@ func (conf *ResourceConfig) GetOwnerRef() *metav1.OwnerReference {
 // from the namespace they belong to. If the namespace has a valid config key
 // that the pod does not, then it is appended to the pod's template
 func (conf *ResourceConfig) AppendNamespaceAnnotations() {
-	for _, key := range ProxyAnnotations {
-		if _, found := conf.nsAnnotations[key]; !found {
-			continue
-		}
-		if val, ok := conf.GetConfigAnnotation(key); ok {
-			conf.AppendPodAnnotation(key, val)
-		}
-	}
+	annotations := append(ProxyAnnotations, ProxyAlphaConfigAnnotations...)
 
-	for _, key := range ProxyAlphaConfigAnnotations {
+	for _, key := range annotations {
 		if _, found := conf.nsAnnotations[key]; !found {
 			continue
 		}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -204,6 +204,7 @@ func (conf *ResourceConfig) GetOwnerRef() *metav1.OwnerReference {
 // that the pod does not, then it is appended to the pod's template
 func (conf *ResourceConfig) AppendNamespaceAnnotations() {
 	annotations := append(ProxyAnnotations, ProxyAlphaConfigAnnotations...)
+	annotations = append(annotations, k8s.ProxyInjectAnnotation)
 
 	for _, key := range annotations {
 		if _, found := conf.nsAnnotations[key]; !found {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -161,6 +161,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				k8s.ProxyOpaquePortsAnnotation:            "4320-4325,3306",
 				k8s.ProxyAwait:                            "enabled",
 				k8s.ProxyAccessLogAnnotation:              "apache",
+				k8s.ProxyInjectAnnotation:                 "ingress",
 			},
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
@@ -203,6 +204,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
 				values.Proxy.Await = true
 				values.Proxy.AccessLog = "apache"
+				values.Proxy.IsIngress = true
 				return values
 			},
 		},


### PR DESCRIPTION
Workloads were inheriting it as the default `enabled` mode.

Introduced a new entry in the inject integration test to catch this.

This fix is paired with the ingress doc clarification PR linkerd/website#1398