### PR TITLE
Add web dashboard Ingress to the viz Helm chart

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -78,6 +78,12 @@ Kubernetes: `>=1.21.0-0`
 | dashboard.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the  web component |
 | dashboard.image.registry | string | defaultRegistry | Docker registry for the web instance |
 | dashboard.image.tag | string | linkerdVersion | Docker image tag for the web instance |
+| dashboard.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/configuration-snippet":"proxy_set_header Origin \"\";\nproxy_hide_header l5d-remote-ip;\nproxy_hide_header l5d-server-id;\n","nginx.ingress.kubernetes.io/service-upstream":"true","nginx.ingress.kubernetes.io/upstream-vhost":"$service_name.$namespace.svc.cluster.local:8084"}` | Ingress annotations, defaults are based on nginx controller |
+| dashboard.ingress.className | string | `""` | For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName See <https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress> |
+| dashboard.ingress.enabled | bool | `false` | Toggle field to enable or disable ingress for the web dashboard |
+| dashboard.ingress.extraAnnotations | object | `{}` | Ingress additional annotations |
+| dashboard.ingress.hosts | list | `[]` | Ingress hosts Must be provided when ingress is enabled |
+| dashboard.ingress.tls | list | `[]` | Ingress TLS configuration |
 | dashboard.logFormat | string | defaultLogFormat | log format of the dashboard component |
 | dashboard.logLevel | string | defaultLogLevel | log level of the dashboard component |
 | dashboard.proxy | string | `nil` |  |

--- a/viz/charts/linkerd-viz/templates/web-ingress.yaml
+++ b/viz/charts/linkerd-viz/templates/web-ingress.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.dashboard.ingress.enabled -}}
+---
+###
+### Web Ingress
+###
+{{- if and .Values.dashboard.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.dashboard.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.dashboard.ingress.annotations "kubernetes.io/ingress.class" .Values.dashboard.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: web
+  {{ include "partials.namespace" . }}
+  labels:
+    linkerd.io/extension: viz
+    component: web
+    namespace: {{ .Release.Namespace }}
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+    {{- if .Values.dashboard.ingress.annotations }}
+    {{ toYaml .Values.dashboard.ingress.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.dashboard.ingress.extraAnnotations }}
+    {{ toYaml .Values.dashboard.ingress.extraAnnotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if and .Values.dashboard.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.dashboard.ingress.className }}
+  {{- end }}
+  {{- if .Values.dashboard.ingress.tls }}
+  tls:
+    {{- range .Values.dashboard.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.dashboard.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: web
+                port:
+                  number: 8084
+              {{- else }}
+              serviceName: web
+              servicePort: 8084
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -348,6 +348,36 @@ dashboard:
     # into the dashboard component
     # resources:
 
+  # Ingress configuration, See <https://linkerd.io/2.11/tasks/exposing-dashboard>
+  ingress:
+    # -- Toggle field to enable or disable ingress for the web dashboard
+    enabled: false
+    # -- For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See <https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress>
+    className: ""
+    # -- Ingress annotations, defaults are based on nginx controller
+    annotations:
+      nginx.ingress.kubernetes.io/service-upstream: "true"
+      nginx.ingress.kubernetes.io/upstream-vhost: "$service_name.$namespace.svc.cluster.local:8084"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_set_header Origin "";
+        proxy_hide_header l5d-remote-ip;
+        proxy_hide_header l5d-server-id;
+    # -- Ingress additional annotations
+    extraAnnotations: {}
+    # -- Ingress hosts
+    # Must be provided when ingress is enabled
+    hosts: []
+    #  - host: chart-example.local
+    #    paths:
+    #      - path: /
+    #        pathType: Prefix
+    # -- Ingress TLS configuration
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 grafana:
   # -- url of an in-cluster Grafana instance with reverse proxy configured, used by the
   # Linkerd viz web dashboard to provide direct links to specific Grafana


### PR DESCRIPTION
When installing linkerd-viz extension we are missing possibility to expose web dashboard via ingress (nginx-controller).

Added generic Ingress resource (disabled by default) to the viz Helm chart with sensible defaults for nginx controller based on the [docs recommendations](https://linkerd.io/2.11/tasks/exposing-dashboard/).

Once merged, it will be possible to expose web dashboard via bundled Ingress resource.

Signed-off-by: Martin Odstrcilik <martin.odstrcilik@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
