### PR TITLE
go: Copy port range utilities from the proxy-init repo

### DIFF
--- a/controller/api/destination/watcher/opaque_ports_watcher.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/linkerd/linkerd2-proxy-init/ports"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	labels "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/util"
@@ -202,7 +201,7 @@ func parseServiceOpaquePorts(annotation string, sps []corev1.ServicePort) []stri
 		if named {
 			values = append(values, strconv.Itoa(int(port)))
 		} else {
-			pr, err := ports.ParsePortRange(pr)
+			pr, err := util.ParsePortRange(pr)
 			if err != nil {
 				logging.Warnf("Invalid port range [%v]: %s", pr, err)
 				continue

--- a/pkg/util/parsing.go
+++ b/pkg/util/parsing.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/linkerd/linkerd2-proxy-init/ports"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -16,7 +15,7 @@ func ParsePorts(portsString string) (map[uint32]struct{}, error) {
 	if portsString != "" {
 		portRanges := GetPortRanges(portsString)
 		for _, pr := range portRanges {
-			portsRange, err := ports.ParsePortRange(pr)
+			portsRange, err := ParsePortRange(pr)
 			if err != nil {
 				log.Warnf("Invalid port range [%v]: %s", pr, err)
 				continue
@@ -41,7 +40,7 @@ func ParseContainerOpaquePorts(override string, containers []corev1.Container) [
 		if named {
 			values = append(values, strconv.Itoa(int(port)))
 		} else {
-			pr, err := ports.ParsePortRange(pr)
+			pr, err := ParsePortRange(pr)
 			if err != nil {
 				log.Warnf("Invalid port range [%v]: %s", pr, err)
 				continue

--- a/pkg/util/portrange.go
+++ b/pkg/util/portrange.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PortRange defines the upper- and lower-bounds for a range of ports.
+type PortRange struct {
+	LowerBound int
+	UpperBound int
+}
+
+// ParsePort parses and verifies the validity of the port candidate.
+func ParsePort(port string) (int, error) {
+	i, err := strconv.Atoi(port)
+	if err != nil || !isPort(i) {
+		return -1, fmt.Errorf("\"%s\" is not a valid TCP port", port)
+	}
+	return i, nil
+}
+
+// ParsePortRange parses and checks the provided range candidate to ensure it is
+// a valid TCP port range.
+func ParsePortRange(portRange string) (PortRange, error) {
+	bounds := strings.Split(portRange, "-")
+	if len(bounds) > 2 {
+		return PortRange{}, fmt.Errorf("ranges expected as <lower>-<upper>")
+	}
+	if len(bounds) == 1 {
+		// If only provided a single value, treat as both lower- and upper-bounds
+		bounds = append(bounds, bounds[0])
+	}
+	lower, err := strconv.Atoi(bounds[0])
+	if err != nil || !isPort(lower) {
+		return PortRange{}, fmt.Errorf("\"%s\" is not a valid lower-bound", bounds[0])
+	}
+	upper, err := strconv.Atoi(bounds[1])
+	if err != nil || !isPort(upper) {
+		return PortRange{}, fmt.Errorf("\"%s\" is not a valid upper-bound", bounds[1])
+	}
+	if upper < lower {
+		return PortRange{}, fmt.Errorf("\"%s\": upper-bound must be greater than or equal to lower-bound", portRange)
+	}
+	return PortRange{LowerBound: lower, UpperBound: upper}, nil
+}
+
+// isPort checks the provided to determine whether or not the port
+// candidate is a valid TCP port number. Valid TCP ports range from 0 to 65535.
+func isPort(port int) bool {
+	return 0 <= port && port <= 65535
+}

--- a/pkg/util/portrange_test.go
+++ b/pkg/util/portrange_test.go
@@ -1,0 +1,86 @@
+package util
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParsePort(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect int
+	}{
+		{"0", 0},
+		{"8080", 8080},
+		{"65535", 65535},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if check, _ := ParsePort(tt.input); check != tt.expect {
+				t.Fatalf("expected %d but received %d", tt.expect, check)
+			}
+		})
+	}
+}
+
+func TestParsePort_Errors(t *testing.T) {
+	tests := []string{"-1", "65536"}
+	for _, tt := range tests {
+		t.Run(tt, func(t *testing.T) {
+			if r, err := ParsePort(tt); err == nil {
+				t.Fatalf("expected error but received %d", r)
+			}
+		})
+	}
+}
+
+func TestParsePortRange(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected PortRange
+	}{
+		{"23-23", PortRange{LowerBound: 23, UpperBound: 23}},
+		{"25-27", PortRange{LowerBound: 25, UpperBound: 27}},
+		{"0-65535", PortRange{LowerBound: 0, UpperBound: 65535}},
+		{"33", PortRange{LowerBound: 33, UpperBound: 33}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			check, _ := ParsePortRange(tt.input)
+			reflect.DeepEqual(tt.expected, check)
+		})
+	}
+}
+
+func TestParsePortRange_Errors(t *testing.T) {
+	tests := []struct {
+		input string
+		check string
+	}{
+		{"", "not a valid lower-bound"},
+		{"notanumber", "not a valid lower-bound"},
+		{"not-number", "not a valid lower-bound"},
+		{"-23-25", "ranges expected as"},
+		{"-23", "not a valid lower-bound"},
+		{"25-23", "upper-bound must be greater than or equal to"},
+		{"65536-65539", "not a valid lower-bound"},
+		{"23-notanumber", "not a valid upper-bound"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, err := ParsePortRange(tt.input)
+			assertError(t, err, tt.check)
+		})
+	}
+}
+
+// assertError confirms that the provided is an error having the provided message.
+func assertError(t *testing.T, err error, containing string) {
+	if err == nil {
+		t.Fatal("expected error; got nothing")
+	}
+	if !strings.Contains(err.Error(), containing) {
+		t.Fatalf("expected error to contain '%s' but received '%s'", containing, err.Error())
+	}
+}


### PR DESCRIPTION
The proxy-init repo is changing its structure and, as such, we want to
minimize cross-repo dependencies from linkerd2 to linkerd2-proxy-init.
(We expect the cni-plugin code to move in a followup change).

This change duplicates the port range parsing utility (about 50 lines,
plus tests). This avoids stray dependencies on linkerd2-proxy-init.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
