### PR TITLE
Pass TAG into arm64 integration tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,16 +206,19 @@ jobs:
     - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
       with:
         go-version: '1.17'
-    - name: Install linkerd CLI
+    - name: Set environment variables from scripts
       run: |
         TAG='${{ needs.tag.outputs.tag }}'
         CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-amd64"
+        echo "CMD=$CMD" >> "$GITHUB_ENV"
+        echo "TAG=$TAG" >> "$GITHUB_ENV"
+    - name: Install linkerd CLI
+      run: |
         bin/docker-pull-binaries "$TAG"
         "$CMD" version --client
         # validate CLI version matches the repo
         [[ "$TAG" == "$($CMD version --short --client)" ]]
         echo "Installed Linkerd CLI version: $TAG"
-        echo "CMD=$CMD" >> "$GITHUB_ENV"
     - name: Set KUBECONFIG environment variables
       run: |
         mkdir -p "$HOME"/.kube


### PR DESCRIPTION
The arm64 integration tests require that the TAG env variable is set properly so that they can invoke the correct tag of the cni-plugin image.  However, this env variable is not being set for the integration tests, resulting in the wrong tag being used.

e.g. see https://github.com/linkerd/linkerd2/runs/7810461484?check_suite_focus=true

We set the TAG variable into the GITHUB_ENV so that it is available to the integration test.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
