### PR TITLE
Require all gateway clients to be authenticated

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -32,6 +32,7 @@ spec:
         linkerd.io/inject: enabled
         config.linkerd.io/proxy-require-identity-inbound-ports: "{{.Values.gateway.port}}"
         config.linkerd.io/enable-gateway: "true"
+        config.linkerd.io/default-inbound-policy: all-authenticated
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: {{.Values.gateway.name}}

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -31,6 +31,7 @@ spec:
         linkerd.io/inject: enabled
         config.linkerd.io/proxy-require-identity-inbound-ports: "4143"
         config.linkerd.io/enable-gateway: "true"
+        config.linkerd.io/default-inbound-policy: all-authenticated
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: linkerd-gateway

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -34,6 +34,7 @@ spec:
         linkerd.io/inject: enabled
         config.linkerd.io/proxy-require-identity-inbound-ports: "4143"
         config.linkerd.io/enable-gateway: "true"
+        config.linkerd.io/default-inbound-policy: all-authenticated
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: linkerd-gateway

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -31,6 +31,7 @@ spec:
         linkerd.io/inject: enabled
         config.linkerd.io/proxy-require-identity-inbound-ports: "4143"
         config.linkerd.io/enable-gateway: "true"
+        config.linkerd.io/default-inbound-policy: all-authenticated
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: linkerd-gateway


### PR DESCRIPTION
Closes #9145

This adds the `config.linkerd.io/default-inbound-policy: all-authenticated` annotation to linkerd-multicluster’s Gateway deployment so that all clients are required to be authenticated. This ensures that clients — including those for the `/metrics` and `/env.json` routes — are authenticated.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
