### PR TITLE
viz: check for default-deny in `linkerd viz check --proxy`

### DIFF
--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -140,7 +140,7 @@ func (kubeAPI *KubernetesAPI) CheckVersion(versionInfo *version.Info) error {
 
 // NamespaceExists validates whether a given namespace exists.
 func (kubeAPI *KubernetesAPI) NamespaceExists(ctx context.Context, namespace string) (bool, error) {
-	ns, err := kubeAPI.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	ns, err := kubeAPI.GetNamespace(ctx, namespace)
 	if kerrors.IsNotFound(err) {
 		return false, nil
 	}
@@ -149,6 +149,11 @@ func (kubeAPI *KubernetesAPI) NamespaceExists(ctx context.Context, namespace str
 	}
 
 	return ns != nil, nil
+}
+
+// GetNamespace returns the namespace with a given name, if one exists.
+func (kubeAPI *KubernetesAPI) GetNamespace(ctx context.Context, namespace string) (*corev1.Namespace, error) {
+	return kubeAPI.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 }
 
 // GetNodes returs all the nodes in a cluster.

--- a/test/integration/upgrade-edge/testdata/check.upgrade.golden
+++ b/test/integration/upgrade-edge/testdata/check.upgrade.golden
@@ -103,6 +103,7 @@ linkerd-viz
 linkerd-viz-data-plane
 ----------------------
 √ data plane namespace exists
+√ prometheus is authorized to scrape data plane pods
 √ data plane proxy metrics are present in Prometheus
 
 Status check results are √

--- a/test/integration/upgrade-stable/testdata/check.upgrade.golden
+++ b/test/integration/upgrade-stable/testdata/check.upgrade.golden
@@ -103,6 +103,7 @@ linkerd-viz
 linkerd-viz-data-plane
 ----------------------
 √ data plane namespace exists
+√ prometheus is authorized to scrape data plane pods
 √ data plane proxy metrics are present in Prometheus
 
 Status check results are √

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -432,8 +432,12 @@ func (hc *HealthChecker) checkPromAuthorizedPods(pods []struct {
 		if defaultPolicy == k8s.Deny {
 			var ns string
 			if pod.string == hc.DataPlaneNamespace {
+				// if we're only checking one namespace, don't bother appending the
+				// namespace name to the pod's name in the error output
 				ns = ""
 			} else {
+				// otherwise, include the namespace name as well as the pod's
+				// name, since we are checking all namespaces.
 				ns = pod.string + "/"
 			}
 			unauthorizedPods = append(unauthorizedPods, fmt.Sprintf("\t* %s%s", ns, pod.Name))

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -304,7 +304,7 @@ func (hc *HealthChecker) VizDataPlaneCategory() *healthcheck.Category {
 			}),
 		*healthcheck.NewChecker("prometheus is authorized to scrape data plane pods").
 			WithHintAnchor("l5d-viz-data-plane-prom-authz").
-			Fatal().
+			Warning().
 			WithCheck(func(ctx context.Context) error {
 				return hc.checkPromAuthorized(ctx)
 			}),
@@ -409,7 +409,7 @@ func (hc *HealthChecker) checkPromAuthorized(ctx context.Context) error {
 	}
 
 	if len(notAuthorizedNses) > 0 {
-		return fmt.Errorf("Prometheus is not authorized to scrape data plane pods in the following namespaces: %s", strings.Join(notAuthorizedNses, ", "))
+		return fmt.Errorf("Prometheus may not be authorized to scrape data plane pods in the following namespaces: %s", strings.Join(notAuthorizedNses, ", "))
 	}
 
 	return nil


### PR DESCRIPTION
This branch adds a check to `linkerd viz check --proxy` that checks if
the data plane namespace (or any namespace, if the check is run without
a namespace) has the `config.linkerd.io/default-inbound-policy: deny`
annotation, indicating that the `linkerd-viz` Prometheus instance may
not be authorized to scrape proxies in that namespace.

For example, after installing emojivoto with the default-deny
annotation:

```
linkerd-viz-data-plane
----------------------
√ data plane namespace exists
‼ prometheus is authorized to scrape data plane pods
    prometheus may not be authorized to scrape the following pods:
	* emojivoto/emoji-699d77c79-77w7f
	* emojivoto/voting-55d76f4bcb-6lsml
	* emojivoto/web-6c54d9554d-md2sd
	* emojivoto/vote-bot-b57689ffb-fq8t5
    see https://linkerd.io/2/checks/#l5d-viz-data-plane-prom-authz for hints
```

This check is a warning rather than fatal, because it's possible that
user-created policies may exist that authorize scrapes, which the check
is not currently aware of. We could, potentially, do more exhaustive
checking for whether _any_ policy would authorize scrapes, but that
would require reimplementing a bunch of policy logic inside the `viz`
extension CLI. For now, I settled on making the check a warning, and
having the error message say "prometheus _may_ not be authorized...".
The subsequent check that data plane metrics exist will fail if
Prometheus actually can't scrape anything.

In a subsequent branch, I'll add a `linkerd viz` subcommand for
generating policy resources to allow Prometheus to scrape the proxies in
a namespace; once this is implemented, the check will also check for the
existance of such a policy in that namespace. If the policy does not
exist, the check output will suggest using that command to generate a
policy to allow scrapes.

See #9150