### PR TITLE
justfile: redirect `_k3d-dns-ready` to stderr

### DIFF
--- a/justfile
+++ b/justfile
@@ -221,7 +221,8 @@ _k3d-dns-ready:
     while [ $({{ _kubectl }} get po -n kube-system -l k8s-app=kube-dns -o json |jq '.items | length') = "0" ]; do sleep 1 ; done
     {{ _kubectl }} wait pod --for=condition=ready \
         --namespace=kube-system --selector=k8s-app=kube-dns \
-        --timeout=1m
+        --timeout=1m \
+        1>&2
 
 ##
 ## Docker images

--- a/justfile
+++ b/justfile
@@ -221,8 +221,7 @@ _k3d-dns-ready:
     while [ $({{ _kubectl }} get po -n kube-system -l k8s-app=kube-dns -o json |jq '.items | length') = "0" ]; do sleep 1 ; done
     {{ _kubectl }} wait pod --for=condition=ready \
         --namespace=kube-system --selector=k8s-app=kube-dns \
-        --timeout=1m \
-        1>&2
+        --timeout=1m
 
 ##
 ## Docker images

--- a/justfile
+++ b/justfile
@@ -258,7 +258,7 @@ proxy-image := DOCKER_REGISTRY + "/proxy"
 proxy-init-image := "ghcr.io/linkerd/proxy-init"
 policy-controller-image := DOCKER_REGISTRY + "/policy-controller"
 
-linkerd *flags: _k3d-init
+linkerd *flags:
     {{ _linkerd }} {{ flags }}
 
 # Install crds on the test cluster.


### PR DESCRIPTION
Currently, the `just linkerd` recipe cannot be used to output YAML
that's piped into another command. This is because the recipe depends on
the `_k3d-dns-ready` recipe, which runs a `kubectl wait` command to
waite for kubedns to be ready. This command outputs a line linkerd
```
pod/coredns-b96499967-p9ct5 condition met
```
to stdout.

When the `just linkerd` command is part of a pipeline, such as
```shell
:; just linkerd install | just k apply -f -
```
the line output by `kubectl wait` is prepended to the Linkerd CLI's
output. Thus, this `kubectl apply` pipeline will fail, since that line
is not valid YAML.

This PR fixes this by redirecting the `kubectl wait` output to stderr,
so that it's not preprended to the Linkerd CLI command's stdout.