### PR TITLE
Set a header read timeout on HTTP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950ff2a1ad61768b9fe9b3a1eded194feba83c5b4f94252dcff9fa6dae51ce4d"
+checksum = "6b8b65e116e2617ea081f5fcbd31d508243ab0c1c6da3fa2a7177680a61af855"
 dependencies = [
  "ahash",
  "clap",

--- a/controller/webhook/server.go
+++ b/controller/webhook/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
 	pkgk8s "github.com/linkerd/linkerd2/pkg/k8s"
@@ -61,7 +62,8 @@ func NewServer(
 	}()
 
 	server := &http.Server{
-		Addr: addr,
+		Addr:              addr,
+		ReadHeaderTimeout: 10 * time.Second,
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},

--- a/controller/webhook/server_test.go
+++ b/controller/webhook/server_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 var mockHTTPServer = &http.Server{
-	Addr: ":0",
+	Addr:              ":0",
+	ReadHeaderTimeout: 10 * time.Second,
 	TLSConfig: &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	},

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -22,8 +23,9 @@ func NewServer(addr string, enablePprof bool) *http.Server {
 	}
 
 	return &http.Server{
-		Addr:    addr,
-		Handler: h,
+		Addr:              addr,
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 }
 

--- a/viz/tap/api/server.go
+++ b/viz/tap/api/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -69,7 +70,8 @@ func NewServer(
 	clientCertPool.AppendCertsFromPEM([]byte(clientCAPem))
 
 	httpServer := &http.Server{
-		Addr: addr,
+		Addr:              addr,
+		ReadHeaderTimeout: 10 * time.Second,
 		TLSConfig: &tls.Config{
 			ClientAuth: tls.VerifyClientCertIfGiven,
 			ClientCAs:  clientCertPool,

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -136,10 +136,11 @@ func NewServer(
 	}
 
 	httpServer := &http.Server{
-		Addr:         addr,
-		ReadTimeout:  timeout,
-		WriteTimeout: timeout,
-		Handler:      wrappedServer,
+		Addr:              addr,
+		ReadTimeout:       timeout,
+		ReadHeaderTimeout: timeout,
+		WriteTimeout:      timeout,
+		Handler:           wrappedServer,
 	}
 
 	// webapp routes


### PR DESCRIPTION
Newer versions of golangci-lint flag `http.Server` instances that do not
set a `ReadHeaderTimeout` as being vulnerable to "slowloris" attacks,
wherein clients initiate requests that hold connections open
indefinitely.

This change sets a `ReadHeaderTimeout` of 10s. This timeout is fairly
conservative so that clients can eagerly create connections, but is
still constrained enough that these connections won't remain open
indefinitely.

This change also updates kubert to v0.9.1, which instruments a header
read timeout on the policy admission server.
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
