### PR TITLE
dev: Add a reusable action-dev-check script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -193,6 +193,7 @@ COPY --from=protoc /usr/local/bin/protoc /usr/local/bin/
 COPY --from=protoc /usr/local/include/google /usr/local/include/google
 COPY --from=shellcheck /usr/local/bin/shellcheck /usr/local/bin/
 COPY --from=yq /usr/local/bin/yq /usr/local/bin/
+COPY bin/action-dev-check /usr/local/bin/
 ENV PROTOC_NO_VENDOR=1
 ENV PROTOC=/usr/local/bin/protoc
 ENV PROTOC_INCLUDE=/usr/local/include

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd2",
-    "image": "ghcr.io/linkerd/dev:v27",
+    "image": "ghcr.io/linkerd/dev:v28",
     // "dockerFile": "./Dockerfile",
     // "context": "..",
     "extensions": [

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 *.iml
 **/node_modules
 bin
+!bin/action-dev-check
 !bin/fetch-proxy
 !bin/install-deps
 !bin/scurl

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,32 +13,15 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v27-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Run actionlint
-        run: |
-          # shellcheck disable=SC2016
-          actionlint \
-            -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' \
-            .github/workflows/*
+        run: just action-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v27-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - name: Scan workflows for other Devcontainer image versions
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Strip jsonc comments because `jq` doesn't support them.
-          image=$(json5-to-json <.devcontainer/devcontainer.json |jq -r '.image')
-          for f in .github/workflows/* ; do
-            for i in $(yq '.jobs.* | .container.image // .container // "" | match("ghcr.io/linkerd/dev:v[0-9]+").string' < "$f") ; do
-              if [ "$i" != "$image" ]; then
-                echo "::error file=$f::Workflow '$f' uses incorrect Devcontainer image '$i'"
-                exit 1
-              fi
-            done
-          done
+      - run: just action-dev-check

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
   go-lint:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v27-go
+    container: ghcr.io/linkerd/dev:v28-go
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just go-lint --verbose
@@ -24,7 +24,7 @@ jobs:
   go-format:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v27-go
+    container: ghcr.io/linkerd/dev:v28-go
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just go-fmt
@@ -32,7 +32,7 @@ jobs:
   go-test:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v27-go
+    container: ghcr.io/linkerd/dev:v28-go
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just go-fetch

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -15,7 +15,7 @@ jobs:
   helm-docs-diff:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
-    container: ghcr.io/linkerd/dev:v27-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - run: bin/helm-docs-diff

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -15,7 +15,7 @@ jobs:
   proto-diff:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v27-go
+    container: ghcr.io/linkerd/dev:v28-go
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: bin/protoc-diff

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
   fmt:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v27-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-check-fmt
@@ -50,7 +50,7 @@ jobs:
   clippy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v27-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch
@@ -60,7 +60,7 @@ jobs:
   check:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v27-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch
@@ -70,7 +70,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: ghcr.io/linkerd/dev:v27-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just rs-fetch

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -15,7 +15,7 @@ jobs:
   shellcheck:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v27-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just sh-lint

--- a/bin/action-dev-check
+++ b/bin/action-dev-check
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Ensure the all github workflows and actions reference the same devcontainer
+# version as that in .devcontainer.json.
+
+set -euo pipefail
+
+IMAGE=$(json5-to-json <.devcontainer/devcontainer.json |jq -r '.image')
+
+check_image() {
+    if [ "$1" != "$IMAGE" ]; then
+        # Report all line numbers with the unexpected image.
+        for n in $(grep -nF "$1" "$2" | cut -d: -f1) ; do
+            if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+                echo "::error file=${2},line=${n}::Expected image '${IMAGE}'; found '${1}'">&2
+            else
+                echo "${2}:${n}: Expected image '${IMAGE}'; found '${1}'" >&2
+            fi
+        done
+        return 1
+    fi
+}
+
+EX=0
+
+# Check workflows for devcontainer images
+for f in .github/workflows/* ; do
+    # Find all container images that look like our dev image, dropping the
+    # `-suffix` from the tag.
+    for i in $(yq '.jobs.* |  (.container | select(.) | (.image // .)) | match("ghcr.io/linkerd/dev:v[0-9]+").string' < "$f") ; do
+        if ! check_image "$i" "$f" ; then
+            EX=$((EX+1))
+            break
+        fi
+    done
+done
+
+# Check actions for devcontainer images
+while IFS= read -r f ; do
+    for i in $(awk 'toupper($1) ~ "FROM" { print $2 }' "$f" \
+                | sed -Ene 's,(ghcr\.io/linkerd/dev:v[0-9]+).*,\1,p')
+    do
+        if ! check_image "$i" "$f" ; then
+            EX=$((EX+1))
+            break
+        fi
+    done
+done < <(find .github/actions -name Dockerfile\*)
+
+exit $EX

--- a/justfile
+++ b/justfile
@@ -465,11 +465,26 @@ _devcontainer-build tag target='':
         --{{ if devcontainer-build-mode == "push" { "push" } else { "load" } }}
 
 ##
-## Other tools...
+## GitHub Actions
 ##
 
+
+# Format actionlint output for Github Actions if running in CI.
+_actionlint-fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {
+  '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}'
+}
+
+# Lints all GitHub Actions workflows
 action-lint:
-    actionlint .github/workflows/*.yml
+    actionlint {{ if _actionlint-fmt != '' { "-format '" + _actionlint-fmt + "'" } else { "" } }} .github/workflows/*
+
+# Ensure all devcontainer versions are in sync
+action-dev-check:
+    bin/action-dev-check
+
+##
+## Other tools...
+##
 
 md-lint:
     markdownlint-cli2 '**/*.md' '!**/node_modules' '!target'


### PR DESCRIPTION
Each of our repos now has variations of a script to check that all
github workflows/actions use the same version of the devcontainer as
that specified in devcontainer.json. Some versions of this have had
small problems (mostly with regard to `yq` syntax).

This change extracts a reusable script, `bin/action-dev-check`, that is
now bundled in v28 of the devcontainer. This will enable other
repositories to use the same validation logic.

```
:; just action-dev-check
bin/action-dev-check
.github/workflows/actions.yml:16: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/actions.yml:24: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/go.yml:19: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/go.yml:27: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/go.yml:35: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/helm.yml:18: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/proto.yml:18: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/rust.yml:45: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/rust.yml:53: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/rust.yml:63: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/rust.yml:73: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
.github/workflows/shell.yml:18: Expected image 'ghcr.io/linkerd/dev:v28'; found 'ghcr.io/linkerd/dev:v27'
```

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
