### PR TITLE
Validate `--default-inbound-policy` values

### DIFF
--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -583,7 +583,7 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
 		values.PolicyController.DefaultAllowPolicy = "everybody"
-		expected := "--default-inbound-policy must be one of: all-authenticated, all-unauthenticated, cluster-authenticated, cluster-unauthenticated, deny"
+		expected := "--default-inbound-policy must be one of: all-authenticated, all-unauthenticated, cluster-authenticated, cluster-unauthenticated, deny (got everybody)"
 
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -583,7 +583,7 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
 		values.PolicyController.DefaultAllowPolicy = "everybody"
-		expected := "--default-inbound-policy must be one of: all-authenticated,all-unauthenticated,cluster-authenticated,cluster-unauthenticated,deny"
+		expected := "--default-inbound-policy must be one of: all-authenticated, all-unauthenticated, cluster-authenticated, cluster-unauthenticated, deny"
 
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -576,6 +576,23 @@ func TestValidate(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Rejects invalid default-inbound-policy", func(t *testing.T) {
+		values, err := testInstallOptions()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v\n", err)
+		}
+		values.PolicyController.DefaultAllowPolicy = "everybody"
+		expected := "--default-inbound-policy must be one of: all-authenticated,all-unauthenticated,cluster-authenticated,cluster-unauthenticated,deny"
+
+		err = validateValues(context.Background(), nil, values)
+		if err == nil {
+			t.Fatal("Expected error, got nothing")
+		}
+		if err.Error() != expected {
+			t.Fatalf("Expected error string \"%s\", got \"%s\"", expected, err)
+		}
+	})
 }
 
 func fakeHeartbeatSchedule() string {

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -545,16 +545,9 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 		}
 	}
 
-	validPolicies := []string{"all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny"}
-	validPolicy := false
-	for _, policy := range validPolicies {
-		if policy == values.PolicyController.DefaultAllowPolicy {
-			validPolicy = true
-			break
-		}
-	}
-	if !validPolicy {
-		return fmt.Errorf("--default-inbound-policy must be one of: %s", strings.Join(validPolicies, ","))
+	err = validatePolicy(values.PolicyController.DefaultAllowPolicy)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -632,6 +625,16 @@ func validateProxyValues(values *l5dcharts.Values) error {
 	}
 
 	return nil
+}
+
+func validatePolicy(policy string) error {
+	validPolicies := []string{"all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny"}
+	for _, p := range validPolicies {
+		if p == policy {
+			return nil
+		}
+	}
+	return fmt.Errorf("--default-inbound-policy must be one of: %s", strings.Join(validPolicies, ", "))
 }
 
 // initializeIssuerCredentials populates the identity issuer TLS credentials.

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -545,6 +545,18 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 		}
 	}
 
+	validPolicies := []string{"all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny"}
+	validPolicy := false
+	for _, policy := range validPolicies {
+		if policy == values.PolicyController.DefaultAllowPolicy {
+			validPolicy = true
+			break
+		}
+	}
+	if !validPolicy {
+		return fmt.Errorf("--default-inbound-policy must be one of: %s", strings.Join(validPolicies, ","))
+	}
+
 	return nil
 }
 

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -634,7 +634,7 @@ func validatePolicy(policy string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("--default-inbound-policy must be one of: %s", strings.Join(validPolicies, ", "))
+	return fmt.Errorf("--default-inbound-policy must be one of: %s (got %s)", strings.Join(validPolicies, ", "), policy)
 }
 
 // initializeIssuerCredentials populates the identity issuer TLS credentials.


### PR DESCRIPTION
Closes #9148

With this change, the value of `—default-inbound-policy` is verified to be one of the accepted values. 

When the value is not an accepted value we now error

```shell
$ linkerd install --default-inbound-policy=everybody
Error: --default-inbound-policy must be one of: all-authenticated, all-unauthenticated, cluster-authenticated, cluster-unauthenticated, deny
Usage:
  linkerd install [flags]
...
```

A unit test has also been added.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
