### PR TITLE
Add `--destination-pod flag` to `linkerd diagnostics endpoints` subcommand

### DIFF
--- a/cli/cmd/endpoints.go
+++ b/cli/cmd/endpoints.go
@@ -25,7 +25,8 @@ import (
 )
 
 type endpointsOptions struct {
-	outputFormat string
+	outputFormat   string
+	destinationPod string
 }
 
 type (
@@ -95,7 +96,7 @@ destination.`,
 				return err
 			}
 
-			client, conn, err := destination.NewExternalClient(cmd.Context(), controlPlaneNamespace, k8sAPI)
+			client, conn, err := destination.NewExternalClient(cmd.Context(), controlPlaneNamespace, k8sAPI, options.destinationPod)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating destination client: %s\n", err)
 				os.Exit(1)
@@ -116,6 +117,7 @@ destination.`,
 	}
 
 	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, fmt.Sprintf("Output format; one of: \"%s\" or \"%s\"", tableOutput, jsonOutput))
+	cmd.PersistentFlags().StringVar(&options.destinationPod, "destination-pod", "", "Target a specific destination Pod when there are multiple running")
 
 	pkgcmd.ConfigureOutputFlagCompletion(cmd)
 

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -119,8 +119,7 @@ func getDeploymentForPod(ctx context.Context, k8sAPI *KubernetesAPI, pod corev1.
 }
 
 // NewPodPortForward returns an instance of the PortForward struct that can be
-// used to establish a port-forward connection to a specific Pod in a
-// Deployment.
+// used to establish a port-forward connection to a specific Pod.
 func NewPodPortForward(
 	k8sAPI *KubernetesAPI,
 	namespace, podName string,

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -57,7 +57,7 @@ func NewContainerMetricsForward(
 		return nil, fmt.Errorf("no %s port found for container %s/%s", portName, pod.GetName(), container.Name)
 	}
 
-	return newPortForward(k8sAPI, pod.GetNamespace(), pod.GetName(), "localhost", 0, int(port.ContainerPort), emitLogs)
+	return NewPodPortForward(k8sAPI, pod.GetNamespace(), pod.GetName(), "localhost", 0, int(port.ContainerPort), emitLogs)
 }
 
 // NewPortForward returns an instance of the PortForward struct that can be used
@@ -99,7 +99,7 @@ func NewPortForward(
 		return nil, fmt.Errorf("no running pods found for %s", deployName)
 	}
 
-	return newPortForward(k8sAPI, namespace, podName, host, localPort, remotePort, emitLogs)
+	return NewPodPortForward(k8sAPI, namespace, podName, host, localPort, remotePort, emitLogs)
 }
 
 func getDeploymentForPod(ctx context.Context, k8sAPI *KubernetesAPI, pod corev1.Pod) (string, error) {
@@ -118,7 +118,10 @@ func getDeploymentForPod(ctx context.Context, k8sAPI *KubernetesAPI, pod corev1.
 	return grandparents[0].Name, nil
 }
 
-func newPortForward(
+// NewPodPortForward returns an instance of the PortForward struct that can be
+// used to establish a port-forward connection to a specific Pod in a
+// Deployment.
+func NewPodPortForward(
 	k8sAPI *KubernetesAPI,
 	namespace, podName string,
 	host string, localPort, remotePort int,


### PR DESCRIPTION
Closes #9141

This introduces the `--destination-pod` flag to the `linkerd diagnostics endpoints` command which allows users to target a specific destination Pod when there are multiple running in a cluster.

This can be useful for issues like #8956, where Linkerd HA is installed and there seem to be stale endpoints in the destination service. Being able to run this command and identity which destination Pod (if not all) have an incorrect view of the cluster.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
