### PR TITLE
Change notes for stable-2.12.0-rc2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,7 +307,8 @@ jobs:
   website_publish:
     name: Linkerd website publish
     needs: [gh_release]
-    if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
+    #if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
+    if: ${{ false }}  # temporarily disabled
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     permissions:
@@ -324,7 +325,8 @@ jobs:
     name: Linkerd website publish check
     needs: [tag, website_publish]
     timeout-minutes: 30
-    if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
+    #if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
+    if: ${{ false }}  # temporarily disabled
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,42 @@
 # Changes
 
+## stable-2.12.0-rc2
+
+This release is the second release candidate for stable-2.12.0.
+
+At this point the Helm charts can be retrieved from the stable repo:
+
+```sh
+helm repo add linkerd https://helm.linkerd.io/stable
+helm repo up
+helm install linkerd-crds -n linkerd --create-namespace linkerd/linkerd-crds
+helm install linkerd-control-plane \
+  -n linkerd \
+  --set-file identityTrustAnchorsPEM=ca.crt \
+  --set-file identity.issuer.tls.crtPEM=issuer.crt \
+  --set-file identity.issuer.tls.keyPEM=issuer.key \
+  linkerd/linkerd-control-plane
+```
+
+The following lists all the changes since edge-22.8.2:
+
+* Fixed inheritance of the `linkerd.io/inject` annotation from Namespace to
+  Workloads when its value is `ingress`
+* Added the `config.linkerd.io/default-inbound-policy: all-authenticated`
+  annotation to linkerd-multicluster’s Gateway deployment so that all clients
+  are required to be authenticated
+* Added a `ReadHeaderTimeout` of 10s to all the go `http.Server` instances, to
+  avoid being vulnerable to "slowrolis" attacks
+* Added check in `linkerd viz check --proxy` to warn in case namespace have the
+  `config.linkerd.io/default-inbound-policy: deny` annotation, which would not
+  authorize scrapes coming from the linkerd-viz Prometheus instance
+* Added validation for accepted values for the `--default-inbound-policy` flag
+* Fixed invalid URL in the `linkerd install --help` output
+* Added `--destination-pod` flag to `linkerd diagnostics endpoints` subcommand
+* Added `proxyInit.runAsUser` in `values.yaml` defaulting to non-zero, to
+  complement the new default `proxyInit.runAsRoot: false` that was rencently
+  changed
+
 ## edge-22.8.2
 
 This release is considered a release candidate for stable-2.12.0 and we

--- a/charts/artifacthub-repo-stable.yml
+++ b/charts/artifacthub-repo-stable.yml
@@ -1,4 +1,4 @@
-#repositoryID: To be determined after the stable repo gets claimed
+repositoryID: d6ca06cd-6db1-4931-bdc6-c1d5d5d52624
 owners:
   - name: olix0r
     email: ver@buoyant.io

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.8.1-edge
+version: 1.9.0-rc2
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.8.1-edge](https://img.shields.io/badge/Version-1.8.1--edge-informational?style=flat-square)
+![Version: 1.9.0-rc2](https://img.shields.io/badge/Version-1.9.0--rc2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.3.0-edge
+version: 1.4.0-rc2
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.3.0-edge](https://img.shields.io/badge/Version-1.3.0--edge-informational?style=flat-square)
+![Version: 1.4.0-rc2](https://img.shields.io/badge/Version-1.4.0--rc2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.2.1-edge
+version: 30.3.0-rc2
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.2.1-edge](https://img.shields.io/badge/Version-30.2.1--edge-informational?style=flat-square)
+![Version: 30.3.0-rc2](https://img.shields.io/badge/Version-30.3.0--rc2-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.3.0-edge
+    helm.sh/chart: linkerd-crds-1.4.0-rc2
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -104,7 +104,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.3.0-edge
+    helm.sh/chart: linkerd-crds-1.4.0-rc2
     linkerd.io/control-plane-ns: linkerd
   creationTimestamp: null
   name: httproutes.policy.linkerd.io
@@ -1640,7 +1640,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.3.0-edge
+    helm.sh/chart: linkerd-crds-1.4.0-rc2
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -1726,7 +1726,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.3.0-edge
+    helm.sh/chart: linkerd-crds-1.4.0-rc2
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -1779,7 +1779,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.3.0-edge
+    helm.sh/chart: linkerd-crds-1.4.0-rc2
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -2045,7 +2045,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.3.0-edge
+    helm.sh/chart: linkerd-crds-1.4.0-rc2
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -2180,7 +2180,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.3.0-edge
+    helm.sh/chart: linkerd-crds-1.4.0-rc2
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.10-edge
+version: 30.4.0-rc2
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.3.10-edge](https://img.shields.io/badge/Version-30.3.10--edge-informational?style=flat-square)
+![Version: 30.4.0-rc2](https://img.shields.io/badge/Version-30.4.0--rc2-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.0-edge
+version: 30.2.0-rc2
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.2.0-edge](https://img.shields.io/badge/Version-30.2.0--edge-informational?style=flat-square)
+![Version: 30.2.0-rc2](https://img.shields.io/badge/Version-30.2.0--rc2-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.10-edge
+version: 30.3.0-rc2
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.2.10-edge](https://img.shields.io/badge/Version-30.2.10--edge-informational?style=flat-square)
+![Version: 30.3.0-rc2](https://img.shields.io/badge/Version-30.3.0--rc2-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This release is the second release candidate for stable-2.12.0.

At this point the Helm charts can be retrieved from the stable repo:

helm repo add linkerd https://helm.linkerd.io/stable
helm repo up
helm install linkerd-crds -n linkerd --create-namespace linkerd/linkerd-crds
helm install linkerd-control-plane \
  -n linkerd \
  --set-file identityTrustAnchorsPEM=ca.crt \
  --set-file identity.issuer.tls.crtPEM=issuer.crt \
  --set-file identity.issuer.tls.keyPEM=issuer.key \
  linkerd/linkerd-control-plane

The following lists all the changes since edge-22.8.2:

* Fixed inheritance of the `linkerd.io/inject` annotation from Namespace to
  Workloads when its value is `ingress`
* Added the `config.linkerd.io/default-inbound-policy: all-authenticated`
  annotation to linkerd-multicluster’s Gateway deployment so that all clients
  are required to be authenticated
* Added a `ReadHeaderTimeout` of 10s to all the go `http.Server` instances, to
  avoid being vulnerable to "slowrolis" attacks
* Added check in `linkerd viz check --proxy` to warn in case namespace have the
  `config.linkerd.io/default-inbound-policy: deny` annotation, which would not
  authorize scrapes coming from the linkerd-viz Prometheus instance
* Added validation for accepted values for the `--default-inbound-policy` flag
* Fixed invalid URL in the `linkerd install --help` output
* Added `--destination-pod` flag to `linkerd diagnostics endpoints` subcommand
* Added `proxyInit.runAsUser` in `values.yaml` defaulting to non-zero, to
  complement the new default `proxyInit.runAsRoot: false` that was rencently
  changed
