### PR TITLE
Allow semver suffixes in tags

### DIFF
--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -37,7 +37,7 @@ Usage:
     stable_tag=$2
 
     # Verify the stable tag format.
-    stable_tag_regex="^([0-9]+)\.([0-9]+)\.([0-9]+)$"
+    stable_tag_regex="^([0-9]+)\.([0-9]+)\.([0-9]+(-.*)?)$"
     if [[ ! $stable_tag =~ $stable_tag_regex ]]; then
         echo 'Error: version reference incorrect
 Usage:

--- a/bin/helm-build
+++ b/bin/helm-build
@@ -54,7 +54,7 @@ if [ "$1" = package ]; then
     tag=$(named_tag)
     clean_head || { echo 'There are uncommitted changes'; exit 1; }
 
-    regex='(edge|stable)-([0-9]+\.[0-9]+\.[0-9]+)'
+    regex='(edge|stable)-([0-9]+\.[0-9]+\.[0-9]+(-.*)?)'
     if [[ ! "$tag" =~ $regex ]]; then
         echo 'Version tag is malformed'
         exit 1


### PR DESCRIPTION
Updated the regexes in `bin/create-release-tag` and `bin/helm-build` to
allow tagging releases with suffixes such as `rc2`.