### PR TITLE
Disable `choco_pack` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,7 @@ jobs:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
+    if: ${{ false }}  # temporarily disabled
     timeout-minutes: 30
     needs: [integration_tests]
     runs-on: windows-2019
@@ -265,7 +266,9 @@ jobs:
 
   gh_release:
     name: Create GH release
-    needs: [tag, choco_pack]
+    needs:
+    - tag
+    #- choco_pack
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     timeout-minutes: 30
     runs-on: ubuntu-20.04


### PR DESCRIPTION
in the `release.yml` workflow. It was causing the following error:

```
Line |
   2 |  "$LINKERD_VERSION"="$env":GITHUB_REF.Substring(17)
     |                           ~~~~~~~~~~~~~~~~~~~~~
     | Unexpected token ':GITHUB_REF.Substring' in expression or statement.
```
https://github.com/linkerd/linkerd2/runs/7910838435?check_suite_focus=true
