### PR TITLE
Fix CI dependency graph

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,7 @@ jobs:
     name: Create GH release
     needs:
     - tag
+    - integration_tests
     #- choco_pack
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     timeout-minutes: 30


### PR DESCRIPTION
#9205 removed the dependency of `gh_release` to `choco_pack`, the latter
being the only job waiting on `integration_tests`, which messed up the
dependencies, having `gh_release` run without waiting for the docker
builds nor the integration tests to finish.

This fixes this by adding `integration_tests` as a dependency to
`gh_release`.
