### PR TITLE
Revert stable release CI changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,6 @@ jobs:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
-    if: ${{ false }}  # temporarily disabled
     timeout-minutes: 30
     needs: [integration_tests]
     runs-on: windows-2019
@@ -269,7 +268,7 @@ jobs:
     needs:
     - tag
     - integration_tests
-    #- choco_pack
+    - choco_pack
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     timeout-minutes: 30
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,8 +312,7 @@ jobs:
   website_publish:
     name: Linkerd website publish
     needs: [gh_release]
-    #if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
-    if: ${{ false }}  # temporarily disabled
+    if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     permissions:
@@ -330,8 +329,7 @@ jobs:
     name: Linkerd website publish check
     needs: [tag, website_publish]
     timeout-minutes: 30
-    #if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
-    if: ${{ false }}  # temporarily disabled
+    if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,8 +282,7 @@ jobs:
         . bin/_release.sh
         extract_release_notes NOTES.md
     - name: Download choco package
-      #if: startsWith(github.ref, 'refs/tags/stable')
-      if: ${{ false }}  # temporarily disabled
+      if: startsWith(github.ref, 'refs/tags/stable')
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
       with:
         name: choco


### PR DESCRIPTION
Several changes were made to CI during the release of `stable-2.12.0-rc2` so that it was not published on the website.

This reverts
- Parts of #9202 which disabled website publish and website check
- #9205 
- #9215

This is purposely not reverting
- #9204 which allows sever suffixes in tags (but does not require it)
- #9217 which fixed an existing dependency graph issue

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
