### PR TITLE
Update authz help text to indicate that it shows all authorizations

### DIFF
--- a/cli/cmd/authz.go
+++ b/cli/cmd/authz.go
@@ -16,8 +16,8 @@ func newCmdAuthz() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "authz [flags] resource",
-		Short: "List server authorizations for a resource",
-		Long:  "List server authorizations for a resource.",
+		Short: "List authorizations for a resource",
+		Long:  "List authorizations for a resource.",
 		Args:  cobra.RangeArgs(1, 2),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 

--- a/viz/cmd/authz.go
+++ b/viz/cmd/authz.go
@@ -26,8 +26,8 @@ func NewCmdAuthz() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "authz [flags] resource",
-		Short: "Display stats for server authorizations for a resource",
-		Long:  "Display stats for server authorizations for a resource.",
+		Short: "Display stats for authorizations for a resource",
+		Long:  "Display stats for authorizations for a resource.",
 		Args:  cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 


### PR DESCRIPTION
The `linkerd authz` command help indicates that it shows server authorizations, but it shows authorization policies too.  

We update the help text to indicate that all authorizations are shown.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
