### PR TITLE
Disable choco_pack job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,7 @@ jobs:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
+    if: ${{ false }} # temporarily disabled
     timeout-minutes: 30
     needs: [integration_tests]
     runs-on: windows-2019
@@ -268,7 +269,7 @@ jobs:
     needs:
     - tag
     - integration_tests
-    - choco_pack
+    # - choco_pack
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     timeout-minutes: 30
     runs-on: ubuntu-20.04


### PR DESCRIPTION
CI is [failing](https://github.com/linkerd/linkerd2/runs/7982322612?check_suite_focus=true). This is possible related to a linting change made in #8737 — or at least the last time we changed that line.

```shell
   2 |  "$LINKERD_VERSION"="$env":GITHUB_REF.Substring(17)
     |                           ~~~~~~~~~~~~~~~~~~~~~
     | Unexpected token ':GITHUB_REF.Substring' in expression or statement.
Error: Process completed with exit code 1.
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
