### PR TITLE
Fix upgrade stable test

### DIFF
--- a/test/integration/upgrade-stable/upgrade_stable_test.go
+++ b/test/integration/upgrade-stable/upgrade_stable_test.go
@@ -73,14 +73,33 @@ func TestInstallResourcesPreUpgrade(t *testing.T) {
 	// Nest all pre-upgrade tests here so they can install and check resources
 	// using the latest stable CLI
 	t.Run(fmt.Sprintf("installing Linkerd %s control plane", linkerdBaseStableVersion), func(t *testing.T) {
+		// Install CRDS
 		args := []string{
+			"install",
+			"--crds",
+		}
+
+		// Pipe cmd & args to `linkerd`
+		out, err := TestHelper.CmdRun(cliPath, args...)
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "'linkerd install --crds' command failed", "'linkerd install --crds' command failed:\n%v", err)
+		}
+
+		out, err = TestHelper.KubectlApply(out, "")
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
+				"'kubectl apply' command failed\n%s", out)
+		}
+
+		// Install control plane
+		args = []string{
 			"install",
 			"--controller-log-level", "debug",
 			"--set", "proxyInit.ignoreInboundPorts=1234\\,5678",
 		}
 
 		// Pipe cmd & args to `linkerd`
-		out, err := TestHelper.CmdRun(cliPath, args...)
+		out, err = TestHelper.CmdRun(cliPath, args...)
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "'linkerd install' command failed", "'linkerd install' command failed:\n%v", err)
 		}


### PR DESCRIPTION
The upgrade stable test starts by installing the latest stable release of Linkerd.  Previously, that was stable-2.11.4 which did not require installing the CRDs as a separate step.  Now the latest is stable-2.12.0 which does require installing the CRDs first.  This was causing the install step to fail in this test.

We update the test to first install the CRDs.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
