### PR TITLE
justfile: allow passing additional args to `linkerd install`

### DIFF
--- a/justfile
+++ b/justfile
@@ -287,7 +287,7 @@ linkerd-crds-install: _k3d-init
         --timeout=1m
 
 # Install linkerd on the test cluster using test images.
-linkerd-install: linkerd-load linkerd-crds-install && _linkerd-ready
+linkerd-install *args='': linkerd-load linkerd-crds-install && _linkerd-ready
     {{ _linkerd }} install \
             --set='imagePullPolicy=Never' \
             --set='controllerImage={{ controller-image }}' \
@@ -299,6 +299,7 @@ linkerd-install: linkerd-load linkerd-crds-install && _linkerd-ready
             --set='proxy.image.version={{ linkerd-tag }}' \
             --set='proxyInit.image.name={{ proxy-init-image }}' \
             --set="proxyInit.image.version=$(yq .proxyInit.image.version charts/linkerd-control-plane/values.yaml)" \
+            {{ args }} \
         | {{ _kubectl }} apply -f -
 
 # Wait for all test namespaces to be removed before uninstalling linkerd from the cluster.


### PR DESCRIPTION
The justfile has a `linkerd-install` recipe that installs Linkerd in the
test k3d cluster, with the appropriate flags to use locally built Docker
image versions. This is useful when testing changes to Linkerd manually,
as well as when running automated tests. In some cases, though, testing
a change may require passing arguments to the `linkerd install` command,
such as a default inbound policy, but this recipe doesn't currently
provide a way to do this.

This branch updates the Justfile so that the `linkerd-install` recipe
can be provided with an optional set of additional arguments, which are
passed to `linkerd install`.