### PR TITLE
Add HTTPRoute to known types to facilitate serialization

### DIFF
--- a/controller/gen/apis/policy/v1alpha1/register.go
+++ b/controller/gen/apis/policy/v1alpha1/register.go
@@ -42,12 +42,12 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AuthorizationPolicy{},
 		&AuthorizationPolicyList{},
+		&HTTPRoute{},
+		&HTTPRouteList{},
 		&MeshTLSAuthentication{},
 		&MeshTLSAuthenticationList{},
 		&NetworkAuthentication{},
 		&NetworkAuthenticationList{},
-		&HTTPRoute{},
-		&HTTPRouteList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/controller/gen/apis/policy/v1alpha1/register.go
+++ b/controller/gen/apis/policy/v1alpha1/register.go
@@ -46,6 +46,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&MeshTLSAuthenticationList{},
 		&NetworkAuthentication{},
 		&NetworkAuthenticationList{},
+		&HTTPRoute{},
+		&HTTPRouteList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
Add HTTPRoute to known types

# Problem

In our policy apis, we add various policy types to the scheme. We define our own version of HTTPRoutes, but we did not add this to the scheme. Thus, when using `"github.com/linkerd/linkerd2/controller/gen/apis/policy"` for serialization of http routes, we get a `no kind is registered for the type v1alpha1.HTTPRoute in scheme "pkg/runtime/scheme.go:100` error.

# Solution

Add `HTTPRoute{}` and `HTTPRouteList{}` to the known types added in `scheme.AddKnownTypes`

# Validation

Use the following to test the changes.

```go
package main

import (
	"fmt"

	policy "github.com/linkerd/linkerd2/controller/gen/apis/policy/v1alpha1"
	l5dscheme "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/scheme"
	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
	"k8s.io/apimachinery/pkg/runtime"
	"k8s.io/kubectl/pkg/scheme"
	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
)

func main() {
	obj := &policy.HTTPRoute{
		TypeMeta: metav1.TypeMeta{
			APIVersion: policy.SchemeGroupVersion.Identifier(),
			Kind:       "HTTPRoute",
		},
		ObjectMeta: metav1.ObjectMeta{
			Name:      "http-route-1",
			Namespace: "route-ns",
		},
		Spec: policy.HTTPRouteSpec{
			Hostnames: []gatewayapiv1alpha2.Hostname{},
			Rules:     []policy.HTTPRouteRule{},
		},
	}

	l5dscheme.AddToScheme(scheme.Scheme)
	jsonSerializer := scheme.DefaultJSONEncoder()
	encoder := scheme.Codecs.EncoderForVersion(jsonSerializer, policy.SchemeGroupVersion)

	buf, err := runtime.Encode(encoder, obj.DeepCopyObject())
	if err != nil {
		fmt.Printf("Encode failed: %s", err)
		return
	}
	fmt.Println(buf)
}
```

* Run it in main, you should see the encode fail with `Encode failed: no kind is registered for the type v1alpha1.HTTPRoute in scheme "pkg/runtime/scheme.go:100`

* Run it on this branch; you should see the encoded bytes.