### PR TITLE
Update destination.yaml PodDisruptionBudget api 'policy/v1beta1' to 'policy/v1'

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -99,7 +99,7 @@ spec:
 {{- if .Values.enablePodDisruptionBudget }}
 ---
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 metadata:
   name: linkerd-dst
   {{ include "partials.namespace" . }}


### PR DESCRIPTION
Change PodDisruptionBudget api 'policy/v1beta1' to 'policy/v1'

policy/v1beta1 PodDisruptionBudget is deprecated in K8s v1.21+ and unavailable in v1.25+; use policy/v1 PodDisruptionBudget. Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/

By changing PodDisruptionBudget api 'policy/v1beta1' to 'policy/v1' warning messages are omitted in K8s v1.21-24 and 
feature keeps working with latest v1.25+ releases Ref: https://kubernetes.io/releases/

Signed-off-by: Virko Püss virko@markit.eu
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
