### PR TITLE
cli: Display `AuthorizationPolicy` resources that target namespaces

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -41,6 +41,9 @@ const (
 	LinkAPIGroupVersion = "multicluster.linkerd.io/v1alpha1"
 	LinkKind            = "Link"
 
+	K8sCoreAPIGroup = "core"
+
+	NamespaceKind = "Namespace"
 	ServerKind    = "Server"
 	HTTPRouteKind = "HTTPRoute"
 


### PR DESCRIPTION
The `authz` command does not show `AuthorizationPolicy`s that applied to a `Server` **if they refer to a namespace**