### PR TITLE
Add `trust-root-sha256` annotation to injected workloads

### DIFF
--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -11,6 +11,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: nginx
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -11,6 +11,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: redis
         linkerd.io/control-plane-ns: linkerd
@@ -210,6 +211,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: nginx
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -11,6 +11,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: redis
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -15,6 +15,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
         prometheus.io/format: prometheus
         prometheus.io/path: /stats
         prometheus.io/port: "9001"

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd
@@ -223,6 +224,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd
@@ -433,6 +435,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd
@@ -643,6 +646,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -14,6 +14,7 @@ spec:
         config.linkerd.io/access-log: apache
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: nginx
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -21,6 +21,7 @@ spec:
         config.linkerd.io/skip-outbound-ports: "9999"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: override
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd
@@ -223,6 +224,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -14,6 +14,7 @@ spec:
         config.linkerd.io/enable-debug-sidecar: "true"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -14,6 +14,7 @@ spec:
         config.linkerd.io/opaque-ports: 3000,5000-6000,mysql
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -14,6 +14,7 @@ spec:
         config.linkerd.io/admin-port: "1234"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -15,6 +15,7 @@ spec:
         config.linkerd.io/skip-outbound-ports: "5432"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -13,6 +13,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -15,6 +15,7 @@ items:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
           linkerd.io/proxy-version: test-inject-proxy-version
+          linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
         labels:
           app: web-svc
           linkerd.io/control-plane-ns: linkerd
@@ -224,6 +225,7 @@ items:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
           linkerd.io/proxy-version: test-inject-proxy-version
+          linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
         labels:
           app: emoji-svc
           linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -15,6 +15,7 @@ items:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
           linkerd.io/proxy-version: test-inject-proxy-version
+          linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
         labels:
           app: web-svc
           linkerd.io/control-plane-ns: linkerd
@@ -224,6 +225,7 @@ items:
         annotations:
           linkerd.io/created-by: linkerd/cli dev-undefined
           linkerd.io/proxy-version: test-inject-proxy-version
+          linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
         labels:
           app: emoji-svc
           linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/proxy-version: test-inject-proxy-version
+    linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
   labels:
     app: vote-bot
     linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -5,6 +5,7 @@ metadata:
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/inject: ingress
     linkerd.io/proxy-version: test-inject-proxy-version
+    linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
   labels:
     app: vote-bot
     linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -6,6 +6,7 @@ metadata:
     config.linkerd.io/skip-outbound-ports: "5432"
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/proxy-version: test-inject-proxy-version
+    linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
   labels:
     app: vote-bot
     linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -8,6 +8,7 @@ metadata:
     config.linkerd.io/proxy-memory-request: 100Mi
     linkerd.io/created-by: linkerd/cli dev-undefined
     linkerd.io/proxy-version: test-inject-proxy-version
+    linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
   labels:
     app: vote-bot
     linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -14,6 +14,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: web-svc
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -9,6 +9,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: get-test
         linkerd.io/control-plane-ns: linkerd
@@ -221,6 +222,7 @@ spec:
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: testinjectversion
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         app: get-test
         linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -30,6 +30,7 @@ spec:
         config.linkerd.io/enable-debug-sidecar: "true"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
+        linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
       labels:
         linkerd.io/control-plane-component: tap
         linkerd.io/control-plane-ns: linkerd

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -6,6 +6,11 @@
   },
   {
     "op": "add",
+    "path": "/metadata/annotations/linkerd.io~1trust-root-sha256",
+    "value": "5090806bcf2daff5d54739ba02a8e7b919f7e62b2a46757e11089c916ec97fc2"
+  },
+  {
+    "op": "add",
     "path": "/metadata/labels/linkerd.io~1control-plane-ns",
     "value": "linkerd"
   },

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -16,6 +16,11 @@
   },
   {
     "op": "add",
+    "path": "/metadata/annotations/linkerd.io~1trust-root-sha256",
+    "value": "5090806bcf2daff5d54739ba02a8e7b919f7e62b2a46757e11089c916ec97fc2"
+  },
+  {
+    "op": "add",
     "path": "/metadata/labels/linkerd.io~1control-plane-ns",
     "value": "linkerd"
   },

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -6,6 +6,11 @@
   },
   {
     "op": "add",
+    "path": "/metadata/annotations/linkerd.io~1trust-root-sha256",
+    "value": "5090806bcf2daff5d54739ba02a8e7b919f7e62b2a46757e11089c916ec97fc2"
+  },
+  {
+    "op": "add",
     "path": "/metadata/labels/linkerd.io~1control-plane-ns",
     "value": "linkerd"
   },

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -2,6 +2,8 @@ package inject
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -794,6 +796,11 @@ func (conf *ResourceConfig) serviceAccountVolumeMount() *corev1.VolumeMount {
 func (conf *ResourceConfig) injectObjectMeta(values *podPatch) {
 
 	values.Annotations[k8s.ProxyVersionAnnotation] = values.Proxy.Image.Version
+
+	// Add the cert bundle's checksum to the workload's annotations.
+	checksumBytes := sha256.Sum256([]byte(values.IdentityTrustAnchorsPEM))
+	checksum := hex.EncodeToString(checksumBytes[:])
+	values.Annotations[k8s.ProxyTrustRootSHA] = checksum
 
 	if len(conf.pod.labels) > 0 {
 		values.AddRootLabels = len(conf.pod.meta.Labels) == 0

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -112,6 +112,10 @@ const (
 	// disable injection for a pod or namespace.
 	ProxyInjectDisabled = Disabled
 
+	// ProxyTrustRootSHA indicates the cert bundle configured on the injected
+	// workload.
+	ProxyTrustRootSHA = Prefix + "/trust-root-sha256"
+
 	/*
 	 * Proxy config annotations
 	 */


### PR DESCRIPTION
Closes #9312

#9118 introduced the `linkerd.io/trust-root-sha256` annotation which is automatically added to control plane components.

This change ensures that all injected workloads also receive this annotation.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
