### PR TITLE
Add changes for edge-22.9.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,15 @@
 ## edge-22.9.1
 
 This release adds the `linkerd.io/trust-root-sha256` annotation to all injected
-workloads; allowing predictable comparison of all workloads' trust anchors via
+workloads allowing predictable comparison of all workloads' trust anchors via
 the Kubernetes API.
+
+Additionally, this release lowers the inbound connection pool idle timeout to
+3s. This should help avoid socket errors, especially for Kubernetes probes.
 
 * Added `linkerd.io/trust-root-sha256` annotation on all injected workloads
   to indicate certifcate bundle
+* Lowered inbound connection pool idle timeout to 3s
 * Restored `namespace` field in Linkerd helm charts
 * Updated fields in `AuthorizationPolicy` and `MeshTLSAuthentication` to
   conform to specification (thanks @aatarasoff!)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Additionally, this release lowers the inbound connection pool idle timeout to
 * Restored `namespace` field in Linkerd helm charts
 * Updated fields in `AuthorizationPolicy` and `MeshTLSAuthentication` to
   conform to specification (thanks @aatarasoff!)
+* Updated the identity controller to not require a `ClusterRoleBinding`
+  to read all deployment resources.
 
 ## edge-22.8.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes
 
+## edge-22.9.1
+
+This release adds the `linkerd.io/trust-root-sha256` annotation to all injected
+workloads; allowing predictable comparison of all workloads' trust anchors via
+the Kubernetes API.
+
+* Added `linkerd.io/trust-root-sha256` annotation on all injected workloads
+  to indicate certifcate bundle
+* Restored `namespace` field in Linkerd helm charts
+* Updated fields in `AuthorizationPolicy` and `MeshTLSAuthentication` to
+  conform to specification (thanks @aatarasoff!)
+
 ## edge-22.8.3
 
 Increased control plane HTTP servers' read timeouts so that they no longer

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.9.1-edge
+version: 1.9.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.9.1-edge](https://img.shields.io/badge/Version-1.9.1--edge-informational?style=flat-square)
+![Version: 1.9.2-edge](https://img.shields.io/badge/Version-1.9.2--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,5 +9,5 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.3.1-edge
+version: 30.3.2-edge
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.3.1-edge](https://img.shields.io/badge/Version-30.3.1--edge-informational?style=flat-square)
+![Version: 30.3.2-edge](https://img.shields.io/badge/Version-30.3.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.1-edge
+version: 30.4.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.4.1-edge](https://img.shields.io/badge/Version-30.4.1--edge-informational?style=flat-square)
+![Version: 30.4.2-edge](https://img.shields.io/badge/Version-30.4.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.1-edge
+version: 30.2.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.2.1-edge](https://img.shields.io/badge/Version-30.2.1--edge-informational?style=flat-square)
+![Version: 30.2.2-edge](https://img.shields.io/badge/Version-30.2.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.1-edge
+version: 30.3.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.3.1-edge](https://img.shields.io/badge/Version-30.3.1--edge-informational?style=flat-square)
+![Version: 30.3.2-edge](https://img.shields.io/badge/Version-30.3.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-22.9.1

This release adds the `linkerd.io/trust-root-sha256` annotation to all injected
workloads allowing predictable comparison of all workloads' trust anchors via
the Kubernetes API.

Additionally, this release lowers the inbound connection pool idle timeout to
3s. This should help avoid socket errors, especially for Kubernetes probes.

* Added `linkerd.io/trust-root-sha256` annotation on all injected workloads
  to indicate certifcate bundle
* Lowered inbound connection pool idle timeout to 3s
* Restored `namespace` field in Linkerd helm charts
* Updated fields in `AuthorizationPolicy` and `MeshTLSAuthentication` to
  conform to specification (thanks @aatarasoff!)
* Updated the identity controller to not require a `ClusterRoleBinding`
  to read all deployment resources.
