### PR TITLE
Reenable choco_pack job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,6 @@ jobs:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run
     name: Pack Chocolatey release
-    if: ${{ false }} # temporarily disabled
     timeout-minutes: 30
     needs: [integration_tests]
     runs-on: windows-2019
@@ -250,7 +249,7 @@ jobs:
     - name: Chocolatey - update nuspec
       if: startsWith(github.ref, 'refs/tags/stable')
       run: |
-        "$LINKERD_VERSION"="$env":GITHUB_REF.Substring(17)
+        $LINKERD_VERSION=$env:GITHUB_REF.Substring(17)
         (Get-Content bin\win\linkerd.nuspec).replace('LINKERD_VERSION', "$LINKERD_VERSION") | Set-Content bin\win\linkerd.nuspec
     - name: Chocolatey - pack
       if: startsWith(github.ref, 'refs/tags/stable')
@@ -269,7 +268,7 @@ jobs:
     needs:
     - tag
     - integration_tests
-    # - choco_pack
+    - choco_pack
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     timeout-minutes: 30
     runs-on: ubuntu-20.04
@@ -283,8 +282,7 @@ jobs:
         . bin/_release.sh
         extract_release_notes NOTES.md
     - name: Download choco package
-      # if: startsWith(github.ref, 'refs/tags/stable')
-      if: ${{ false }} # temporarily disabled
+      if: startsWith(github.ref, 'refs/tags/stable')
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
       with:
         name: choco


### PR DESCRIPTION
Closes #9362

Undo change from 58c16b6 affecting the `choco_pack` job, given that's Powershell so shellcheck has no say on it.

From my testing `actionlint` is already skipping that job so no additional annotation was necessary.

This also reenables the job, undoing 0bd3f73 and d216db3