### PR TITLE
Mark linkerd2 chart as deprecated

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -54,11 +54,11 @@ jobs:
         - viz
         - default-policy-deny
         - external
-        - helm-upgrade
+        #- helm-upgrade
         - multicluster
         - uninstall
         - upgrade-edge
-        - upgrade-stable
+        #- upgrade-stable
         - cni-calico-deep
         - default-policy-deny
     needs: [docker_build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,10 +133,10 @@ jobs:
         - viz
         - default-policy-deny
         - external
-        - helm-upgrade
+        #- helm-upgrade
         - uninstall
         - upgrade-edge
-        - upgrade-stable
+        #- upgrade-stable
     needs: [docker_build, policy_controller_manifest]
     name: Integration tests (${{ matrix.integration_test }})
     timeout-minutes: 60

--- a/charts/linkerd2/Chart.yaml
+++ b/charts/linkerd2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: "v1"
 # this version will be updated by the CI before publishing the Helm tarball
 appVersion: edge-XX.X.X
 deprecated: true
-description: "DEPRECATED: Use linkerd-crds and linkerd-control-plane instead - Linkerd gives you observability, reliability, and security for your microservices — with no code change required."
+description: "DEPRECATED: Use linkerd-crds and linkerd-control-plane for Linkerd 2.12.0 and later (see https://linkerd.io/2.12/tasks/upgrade/#upgrading-to-2-12-0-using-helm) - Linkerd gives you observability, reliability, and security for your microservices — with no code change required."
 home: https://linkerd.io
 keywords:
 - service-mesh

--- a/charts/linkerd2/Chart.yaml
+++ b/charts/linkerd2/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: "v1"
 # this version will be updated by the CI before publishing the Helm tarball
 appVersion: edge-XX.X.X
-description: |
-  Linkerd gives you observability, reliability, and security
-  for your microservices — with no code change required.
+deprecated: true
+description: "DEPRECATED: Use linkerd-crds and linkerd-control-plane instead - Linkerd gives you observability, reliability, and security for your microservices — with no code change required."
 home: https://linkerd.io
 keywords:
 - service-mesh

--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -1,6 +1,6 @@
 # linkerd2
 
-DEPRECATED: Use linkerd-crds and linkerd-control-plane instead - Linkerd gives you observability, reliability, and security for your microservices — with no code change required.
+DEPRECATED: Use linkerd-crds and linkerd-control-plane for Linkerd 2.12.0 and later (see https://linkerd.io/2.12/tasks/upgrade/#upgrading-to-2-12-0-using-helm) - Linkerd gives you observability, reliability, and security for your microservices — with no code change required.
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
 

--- a/charts/linkerd2/README.md
+++ b/charts/linkerd2/README.md
@@ -1,7 +1,6 @@
 # linkerd2
 
-Linkerd gives you observability, reliability, and security
-for your microservices — with no code change required.
+DEPRECATED: Use linkerd-crds and linkerd-control-plane instead - Linkerd gives you observability, reliability, and security for your microservices — with no code change required.
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
 


### PR DESCRIPTION
Also added a note in the chart's description. I had to inline that description because the `DEPRECATED:` part confuses the yaml parser, from what I can remember when I deprecated the old linkerd2-multicluster chart.