### PR TITLE
Modify k8s client to use admissionregistration/v1

### DIFF
--- a/bin/install-deps
+++ b/bin/install-deps
@@ -29,7 +29,7 @@ CGO_ENABLED=0 GOOS=linux GOARCH=$arch go install -mod=readonly \
     k8s.io/client-go/discovery \
     k8s.io/client-go/kubernetes \
     k8s.io/client-go/kubernetes/scheme \
-    k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1 \
+    k8s.io/client-go/kubernetes/typed/admissionregistration/v1 \
     k8s.io/client-go/kubernetes/typed/apps/v1 \
     k8s.io/client-go/kubernetes/typed/apps/v1beta1 \
     k8s.io/client-go/kubernetes/typed/apps/v1beta2 \

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
-	arinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
+	arinformers "k8s.io/client-go/informers/admissionregistration/v1"
 	appv1informers "k8s.io/client-go/informers/apps/v1"
 	batchv1informers "k8s.io/client-go/informers/batch/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -244,7 +244,7 @@ func newAPI(
 			api.syncChecks = append(api.syncChecks, api.job.Informer().HasSynced)
 			api.addInformerSizeGauge("job", api.job.Informer())
 		case MWC:
-			api.mwc = sharedInformers.Admissionregistration().V1beta1().MutatingWebhookConfigurations()
+			api.mwc = sharedInformers.Admissionregistration().V1().MutatingWebhookConfigurations()
 			api.syncChecks = append(api.syncChecks, api.mwc.Informer().HasSynced)
 			api.addInformerSizeGauge("mutating_webhook_configuration", api.mwc.Informer())
 		case NS:


### PR DESCRIPTION
The controller's k8s client was using `admissionregistration/v1beta1`
for its MWC shared informer. `v1beta1` was removed in k8s 1.22, and `v1`
was introduced in k8s 1.16:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22

Modify the controller's k8s client to use `admissionregistration/v1` for
its MWC shared informer.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>