### PR TITLE
policy: fix backwards `NotIn` label selector

### DIFF
--- a/policy-controller/k8s/api/src/labels.rs
+++ b/policy-controller/k8s/api/src/labels.rs
@@ -218,7 +218,27 @@ mod tests {
                 })),
                 Labels::from_iter(vec![("foo", "bar"), ("bah", "baz")]),
                 true,
-                "expression match",
+                "In expression match",
+            ),
+            (
+                Selector::from_iter(Some(Expression {
+                    key: "foo".into(),
+                    operator: Operator::NotIn,
+                    values: Some(Some("quux".to_string()).into_iter().collect()),
+                })),
+                Labels::from_iter(vec![("foo", "bar"), ("bah", "baz")]),
+                true,
+                "NotIn expression match",
+            ),
+            (
+                Selector::from_iter(Some(Expression {
+                    key: "foo".into(),
+                    operator: Operator::NotIn,
+                    values: Some(Some("bar".to_string()).into_iter().collect()),
+                })),
+                Labels::from_iter(vec![("foo", "bar"), ("bah", "baz")]),
+                false,
+                "NotIn expression non-match",
             ),
             (
                 Selector::new(

--- a/policy-controller/k8s/api/src/labels.rs
+++ b/policy-controller/k8s/api/src/labels.rs
@@ -176,7 +176,7 @@ impl Expression {
                 None => false,
             },
             (Operator::NotIn, key, Some(values)) => match labels.get(key) {
-                Some(v) => values.contains(v),
+                Some(v) => !values.contains(v),
                 None => true,
             },
             (Operator::Exists, key, None) => labels.contains_key(key),


### PR DESCRIPTION
The implementation of the `NotIn` pod selector expression in the policy controller is backwards. If a value exists for the label in the expression, and it is contained in the `NotIn` set, the expression will return `true`, and it will return `false` when the value is _not_ in the set. This is because it calls `values.contains(v)`, just like the `In` expression.

This branch fixes this.
