### PR TITLE
stable-2.12.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,16 @@
 
 ## stable-2.12.1
 
-This release blah blah blah
+This release includes several control plane and proxy fixes for `stable-2.12.0`.
+In particular, it fixes issues related to control plane HTTP servers' header
+read timeouts resulting in decreased controller success rates, lowers the
+inbound connection pool idle timeout in the proxy, and fixes an issue where the
+jaeger injector would put pods into an error state when upgrading from
+stable-2.11.x.
+
+Additionally, this release adds the `linkerd.io/trust-root-sha256` annotation to
+all injected workloads allowing predictable comparison of all workloads' trust
+anchors via the Kubernetes API.
 
 * Proxy
   * Lowered inbound connection pool idle timeout to 3s
@@ -22,8 +31,7 @@ This release blah blah blah
   * Restored `namespace` field in Linkerd helm charts
 
 * Extensions
-
-* Fixed jaeger injector interfering with upgrades to 2.12.x
+  * Fixed jaeger injector interfering with upgrades to 2.12.x
 
 ## edge-22.9.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,30 @@
 # Changes
 
+## stable-2.12.1
+
+This release blah blah blah
+
+* Proxy
+  * Lowered inbound connection pool idle timeout to 3s
+
+* Control Plane
+  * Updated AdmissionRegistration API version usage to v1
+  * Added `linkerd.io/trust-root-sha256` annotation on all injected workloads
+    to indicate certifcate bundle
+  * Updated fields in `AuthorizationPolicy` and `MeshTLSAuthentication` to
+    conform to specification (thanks @aatarasoff!)
+  * Updated the identity controller to not require a `ClusterRoleBinding`
+    to read all deployment resources.
+  * Increase servers' header read timeouts so they no longer match default probe
+    and Prometheus scrape intervals
+
+* Helm
+  * Restored `namespace` field in Linkerd helm charts
+
+* Extensions
+
+* Fixed jaeger injector interfering with upgrades to 2.12.x
+
 ## edge-22.9.2
 
 This release fixes an issue where the jaeger injector would put pods into an

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,9 +23,9 @@ anchors via the Kubernetes API.
   * Updated fields in `AuthorizationPolicy` and `MeshTLSAuthentication` to
     conform to specification (thanks @aatarasoff!)
   * Updated the identity controller to not require a `ClusterRoleBinding`
-    to read all deployment resources.
-  * Increase servers' header read timeouts so they no longer match default probe
-    and Prometheus scrape intervals
+    to read all deployment resources
+  * Increased servers' header read timeouts so they no longer match default
+    probe and Prometheus scrape intervals
 
 * Helm
   * Restored `namespace` field in Linkerd helm charts

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@ Additionally, this release adds the `linkerd.io/trust-root-sha256` annotation to
 all injected workloads allowing predictable comparison of all workloads' trust
 anchors via the Kubernetes API.
 
+For Windows users, note that the Linkerd CLI's `nupkg` file for Chocolatey is
+once again included in the release assets (it was previously removed in
+stable-2.10.0).
+
 * Proxy
   * Lowered inbound connection pool idle timeout to 3s
 
@@ -29,6 +33,8 @@ anchors via the Kubernetes API.
 
 * Helm
   * Restored `namespace` field in Linkerd helm charts
+  * Updated `PodDisruptionBudget` `apiVersion` from `policy/v1beta1` to
+    `policy/v1` (thanks @Vrx555!)
 
 * Extensions
   * Fixed jaeger injector interfering with upgrades to 2.12.x

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.9.3-edge
+version: 1.9.3
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.9.3-edge](https://img.shields.io/badge/Version-1.9.3--edge-informational?style=flat-square)
+![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.3.3-edge
+version: 30.3.3

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.3.3-edge](https://img.shields.io/badge/Version-30.3.3--edge-informational?style=flat-square)
+![Version: 30.3.3](https://img.shields.io/badge/Version-30.3.3-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.3-edge
+version: 30.4.3
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.4.3-edge](https://img.shields.io/badge/Version-30.4.3--edge-informational?style=flat-square)
+![Version: 30.4.3](https://img.shields.io/badge/Version-30.4.3-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.3-edge
+version: 30.2.3
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.2.3-edge](https://img.shields.io/badge/Version-30.2.3--edge-informational?style=flat-square)
+![Version: 30.2.3](https://img.shields.io/badge/Version-30.2.3-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.3-edge
+version: 30.3.3
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.3.3-edge](https://img.shields.io/badge/Version-30.3.3--edge-informational?style=flat-square)
+![Version: 30.3.3](https://img.shields.io/badge/Version-30.3.3-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This release includes several control plane and proxy fixes for `stable-2.12.0`. In particular, it fixes issues related to control plane HTTP servers' header read timeouts resulting in decreased controller success rates, lowers the inbound connection pool idle timeout in the proxy, and fixes an issue where the jaeger injector would put pods into an error state when upgrading from stable-2.11.x.

Additionally, this release adds the `linkerd.io/trust-root-sha256` annotation to all injected workloads allowing predictable comparison of all workloads' trust anchors via the Kubernetes API.

* Proxy
  * Lowered inbound connection pool idle timeout to 3s

* Control Plane
  * Updated AdmissionRegistration API version usage to v1
  * Added `linkerd.io/trust-root-sha256` annotation on all injected workloads to indicate certifcate bundle
  * Updated fields in `AuthorizationPolicy` and `MeshTLSAuthentication` to conform to specification (thanks @aatarasoff!)
  * Updated the identity controller to not require a `ClusterRoleBinding` to read all deployment resources.
  * Increase servers' header read timeouts so they no longer match default probe and Prometheus scrape intervals

* Helm
  * Restored `namespace` field in Linkerd helm charts

* Extensions
  * Fixed jaeger injector interfering with upgrades to 2.12.x