### PR TITLE
helm: Do not encode `runAsUser: 0` when `runAsNonRoot` is set

### DIFF
--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -69,7 +69,7 @@ securityContext:
   {{- else }}
   privileged: false
   runAsNonRoot: true
-  runAsUser: {{.Values.proxyInit.runAsUser}}
+  runAsUser: {{ .Values.proxyInit.runAsUser | int | eq 0 | ternary 65534 .Values.proxyInit.runAsUser }}
   {{- end }}
   readOnlyRootFilesystem: true
 terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
If a values.yaml is missing the `proxyInit.runAsUser` field, it can default to 0 even though this configuration is incoherent.

This change adds helm templating to use the default value (65534) when the value is unset.
