### PR TITLE
Possibility to add additional labels on all resources for linkerd-control-plane helm chart

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -165,6 +165,7 @@ Kubernetes: `>=1.21.0-0`
 | identityTrustDomain | string | clusterDomain | Trust domain used for identity |
 | imagePullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
+| labels | object | `{}` | Additional labels to add to all resources except pods |
 | linkerdVersion | string | `"linkerdVersionValue"` | control plane version. See Proxy section for proxy version |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | podAnnotations | object | `{}` | Additional annotations to add to all pods |

--- a/charts/linkerd-control-plane/templates/config.yaml
+++ b/charts/linkerd-control-plane/templates/config.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
 - apiGroups: ["apps"]
   resources: ["replicasets"]
@@ -35,6 +36,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -52,6 +54,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 {{- $host := printf "linkerd-sp-validator.%s.svc" .Release.Namespace }}
@@ -65,6 +68,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 type: kubernetes.io/tls
@@ -90,6 +94,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   namespaceSelector:
@@ -122,6 +127,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 type: kubernetes.io/tls
@@ -147,6 +153,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 webhooks:
 - name: linkerd-policy-validator.linkerd.io
   namespaceSelector:
@@ -182,6 +189,7 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
   - apiGroups:
       - ""
@@ -213,6 +221,7 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -29,6 +30,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -48,6 +50,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -67,6 +70,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -86,6 +90,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -106,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -129,6 +135,7 @@ metadata:
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: linkerd-destination
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/linkerd-control-plane/templates/heartbeat-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat-rbac.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -23,6 +24,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 roleRef:
   kind: Role
   name: linkerd-heartbeat
@@ -38,6 +40,7 @@ metadata:
   name: linkerd-heartbeat
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -52,6 +55,7 @@ metadata:
   name: linkerd-heartbeat
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 roleRef:
   kind: ClusterRole
   name: linkerd-heartbeat
@@ -69,5 +73,6 @@ metadata:
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{- end }}

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:

--- a/charts/linkerd-control-plane/templates/identity-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/identity-rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -26,6 +27,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,4 +45,5 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
@@ -29,6 +30,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
@@ -43,6 +45,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -62,6 +65,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -82,6 +86,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -105,6 +110,7 @@ metadata:
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: linkerd-identity
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
 - apiGroups: [""]
   resources: ["events"]
@@ -33,6 +34,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -51,6 +53,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 {{- $host := printf "linkerd-proxy-injector.%s.svc" .Release.Namespace }}
@@ -64,6 +67,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 type: kubernetes.io/tls
@@ -89,6 +93,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/version: {{.Values.linkerdVersion}}
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: linkerd-proxy-injector
   namespace: {{ .Release.Namespace }}
 spec:
@@ -140,6 +141,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     config.linkerd.io/opaque-ports: "443"
@@ -161,6 +163,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:

--- a/charts/linkerd-control-plane/templates/psp.yaml
+++ b/charts/linkerd-control-plane/templates/psp.yaml
@@ -9,6 +9,7 @@ metadata:
   name: linkerd-{{.Release.Namespace}}-control-plane
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:
   {{- if or .Values.proxyInit.closeWaitTimeoutSecs .Values.proxyInit.runAsRoot }}
   allowPrivilegeEscalation: true
@@ -69,6 +70,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -83,6 +85,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 roleRef:
   kind: Role
   name: linkerd-psp

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -52,6 +52,8 @@ identityTrustDomain: ""
 podAnnotations: {}
 # -- Additional labels to add to all pods
 podLabels: {}
+# -- Additional labels to add to all resources except pods
+labels: {}
 # -- Kubernetes priorityClassName for the Linkerd Pods
 priorityClassName: ""
 # -- Runtime Class Name for all the pods


### PR DESCRIPTION
```
Subject

Possibility to add additional labels on all resources for linkerd-control-plane helm chart

Problem

Currently it is not possible to add additional labels on all resources deployed by the helm chart linkerd-control-plane. 

Solution

Add a labels variable in the values.yml file that allows to add additional labels on all helm chart resources.

Validation

I passed the lint and build the helm chart to perform the deployment with the addition of a label.

Fixes #9510

```

DCO Sign off
```

Signed-off-by: BOSSER, Bastien <bastien.bosser@atos.net>

```