### PR TITLE
edge-22.10.1 change notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,10 @@ by our contributors.
   @MoSattler!)
 * Added an optional PodMonitor resource to the main Helm chart (thanks
   @jaygridley!)
-* Fixed the CLI's `--api-addr` flag, that was being ignored (thanks @mikutas!)
+* Fixed the CLI ignoring the `--api-addr` flag (thanks @mikutas!)
 * Expanded the `linkerd authz` command to display AuthorizationPolicy resources
   that target namespaces (thanks @aatarasoff!)
-* Fixed the `NotIn` label selector operator in the policy resources, that was
+* Fixed the `NotIn` label selector operator in the policy resources, being
   erroneously treated as `In`.
 * Fixed warning logic around the "linkerd-viz ClusterRoles exist" and
   "linkerd-viz ClusterRoleBindings exist" checks in `linkerd viz check`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Changes
 
+## edge-22.10.1
+
+This edge release fixes some sections of the Viz dashboard that were appearing
+blank, and adds an optional PodMonitor resource to the Helm chart which allows
+having an easier integration with the Prometheus Operator. It also includes many
+fixes submitted by our contributors.
+
+* Fixed the dashboard sections Tap, Top, Routes that were appearing blank
+  (thanks @MoSattler!)
+* Added an optional PodMonitor resource to the main Helm chart (thanks
+  @jaygridley!)
+* Fixed the CLI's `--api-addr` flag (thanks @mikutas!)
+* Expanded the `linkerd authz` command to display AuthorizationPolicy resources
+  that target namespaces (thanks @aatarasoff!)
+* Fixed interpretation of the `NotIn` label selector operator in the policy
+  resources
+* Fixed warning logic around the "linkerd-viz ClusterRoles exist" and
+  "linkerd-viz ClusterRoleBindings exist" checks in `linkerd viz check`
+* Fixed proxies emitting some duplicate inbound metrics
+
 ## stable-2.12.1
 
 This release includes several control plane and proxy fixes for `stable-2.12.0`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,20 +2,20 @@
 
 ## edge-22.10.1
 
-This edge release fixes some sections of the Viz dashboard that were appearing
-blank, and adds an optional PodMonitor resource to the Helm chart which allows
-having an easier integration with the Prometheus Operator. It also includes many
-fixes submitted by our contributors.
+This edge release fixes some sections of the Viz dashboard appearing blank, and
+adds an optional PodMonitor resource to the Helm chart to enable easier
+integration with the Prometheus Operator. It also includes many fixes submitted
+by our contributors.
 
-* Fixed the dashboard sections Tap, Top, Routes that were appearing blank
-  (thanks @MoSattler!)
+* Fixed the dashboard sections Tap, Top, and Routes appearing blank (thanks
+  @MoSattler!)
 * Added an optional PodMonitor resource to the main Helm chart (thanks
   @jaygridley!)
-* Fixed the CLI's `--api-addr` flag (thanks @mikutas!)
+* Fixed the CLI's `--api-addr` flag, that was being ignored (thanks @mikutas!)
 * Expanded the `linkerd authz` command to display AuthorizationPolicy resources
   that target namespaces (thanks @aatarasoff!)
-* Fixed interpretation of the `NotIn` label selector operator in the policy
-  resources
+* Fixed the `NotIn` label selector operator in the policy resources, that was
+  erroneously treated as `In`.
 * Fixed warning logic around the "linkerd-viz ClusterRoles exist" and
   "linkerd-viz ClusterRoleBindings exist" checks in `linkerd viz check`
 * Fixed proxies emitting some duplicate inbound metrics

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.9.3
+version: 1.10.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square)
+![Version: 1.10.0-edge](https://img.shields.io/badge/Version-1.10.0--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.3.3
+version: 30.4.0-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.3.3](https://img.shields.io/badge/Version-30.3.3-informational?style=flat-square)
+![Version: 30.4.0-edge](https://img.shields.io/badge/Version-30.4.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.3
+version: 30.5.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.4.3](https://img.shields.io/badge/Version-30.4.3-informational?style=flat-square)
+![Version: 30.5.0-edge](https://img.shields.io/badge/Version-30.5.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.2.3
+version: 30.3.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.2.3](https://img.shields.io/badge/Version-30.2.3-informational?style=flat-square)
+![Version: 30.3.0-edge](https://img.shields.io/badge/Version-30.3.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.3
+version: 30.4.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.3.3](https://img.shields.io/badge/Version-30.3.3-informational?style=flat-square)
+![Version: 30.4.0-edge](https://img.shields.io/badge/Version-30.4.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release fixes some sections of the Viz dashboard appearing blank, and
adds an optional PodMonitor resource to the Helm chart to enable easier
integration with the Prometheus Operator. It also includes many fixes submitted
by our contributors.

* Fixed the dashboard sections Tap, Top, and Routes appearing blank (thanks
  @MoSattler!)
* Added an optional PodMonitor resource to the main Helm chart (thanks
  @jaygridley!)
* Fixed the CLI's `--api-addr` flag, that was being ignored (thanks @mikutas!)
* Expanded the `linkerd authz` command to display AuthorizationPolicy resources
  that target namespaces (thanks @aatarasoff!)
* Fixed the `NotIn` label selector operator in the policy resources, that was
  erroneously treated as `In`.
* Fixed warning logic around the "linkerd-viz ClusterRoles exist" and
  "linkerd-viz ClusterRoleBindings exist" checks in `linkerd viz check`
* Fixed proxies emitting some duplicate inbound metrics
