### PR TITLE
Remove old .conf file from CNI directory when we convert .conf file to .conflist

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -147,7 +147,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - uses: tj-actions/changed-files@528984a4f814905ea80ed2a3818afc97aef8b0de
+      - uses: tj-actions/changed-files@dd7c81416dd9ddc14c594f751cd92c661e13daee
         id: changed
         with:
           files: |
@@ -286,7 +286,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - uses: tj-actions/changed-files@528984a4f814905ea80ed2a3818afc97aef8b0de
+      - uses: tj-actions/changed-files@dd7c81416dd9ddc14c594f751cd92c661e13daee
         id: changed
         with:
           files: |

--- a/cni-plugin/deployment/scripts/install-cni.sh
+++ b/cni-plugin/deployment/scripts/install-cni.sh
@@ -234,7 +234,10 @@ install_cni_conf() {
   # If the old config filename ends with .conf, rename it to .conflist, because it has changed to be a list
   filename=${cni_conf_path##*/}
   extension=${filename##*.}
+  # When this variable has a file, we must delete it later.
+  old_file_path=
   if [ "${filename}" != '01-linkerd-cni.conf' ] && [ "${extension}" = 'conf' ]; then
+   old_file_path=${cni_conf_path}
    echo "Renaming ${cni_conf_path} extension to .conflist"
    cni_conf_path="${cni_conf_path}list"
   fi
@@ -246,6 +249,7 @@ install_cni_conf() {
 
   # Move the temporary CNI config into place.
   mv "${TMP_CONF}" "${cni_conf_path}" || exit_with_error 'Failed to mv files.'
+  [ -n "$old_file_path" ] && rm -f "${old_file_path}" && echo "Removing unwanted .conf file"
 
   echo "Created CNI config ${cni_conf_path}"
 }

--- a/cni-plugin/test/install-cni_test.go
+++ b/cni-plugin/test/install-cni_test.go
@@ -112,23 +112,23 @@ func rm(dir string, t *testing.T) {
 // Checks that only a single configuration file that CNI will look for exists. CNI will look
 // for any filename ending in `.conf` or `.conflist` and pick the first in lexicographic order.
 func checkOnlyOneConfFileExists(t *testing.T, directory string) {
-       filenames := ls(directory, t)
-       possibleConfigFiles := []string{}
+	filenames := ls(directory, t)
+	possibleConfigFiles := []string{}
 
-       for _, filename := range filenames {
-               if strings.HasSuffix(filename, ".conf") || strings.HasSuffix(filename, ".conflist") {
-                       possibleConfigFiles = append(possibleConfigFiles, filename)
-               }
-       }
+	for _, filename := range filenames {
+		if strings.HasSuffix(filename, ".conf") || strings.HasSuffix(filename, ".conflist") {
+			possibleConfigFiles = append(possibleConfigFiles, filename)
+		}
+	}
 
-       if len(possibleConfigFiles) == 0 {
-	       t.Log("FAIL: no files found ending with .conf or .conflist in the CNI configuration directory")
-	       // TODO(stevej): testutil.AnnotatedFatal does not result in a Failed test
-	       t.Fail()
-       } else if len(possibleConfigFiles) > 1 {
-	       t.Logf("FAIL: CNI configuration conflict: multiple files found ending with .conf or .conflist %v", possibleConfigFiles)
-	       t.Fail()
-       }
+	if len(possibleConfigFiles) == 0 {
+		t.Log("FAIL: no files found ending with .conf or .conflist in the CNI configuration directory")
+		// TODO(stevej): testutil.AnnotatedFatal does not result in a Failed test
+		t.Fail()
+	} else if len(possibleConfigFiles) > 1 {
+		t.Logf("FAIL: CNI configuration conflict: multiple files found ending with .conf or .conflist %v", possibleConfigFiles)
+		t.Fail()
+	}
 }
 
 // populateTempDirs populates temporary test directories with golden files

--- a/cni-plugin/test/install-cni_test.go
+++ b/cni-plugin/test/install-cni_test.go
@@ -129,7 +129,6 @@ func checkOnlyOneConfFileExists(t *testing.T, directory string) {
 	       t.Logf("FAIL: CNI configuration conflict: multiple files found ending with .conf or .conflist %v", possibleConfigFiles)
 	       t.Fail()
        }
-       return
 }
 
 // populateTempDirs populates temporary test directories with golden files


### PR DESCRIPTION
Fixes #9343

* Change the integration test to check that the CNI configuration directory only has a single configuration file
* Change the install script to remove the old .conf file when it's rewritten into a .conflist

Signed-off-by: Steve Jenson <stevej@buoyant.io>
