### PR TITLE
Move pause container declaration to values

### DIFF
--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -76,6 +76,7 @@ Kubernetes: `>=1.21.0-0`
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |
+| gateway.pauseImage | string | `"gcr.io/google_containers/pause:3.2"` | The pause container to use |
 | gateway.port | int | `4143` | The port on which all the gateway will accept incoming traffic |
 | gateway.probe.path | string | `"/ready"` | The path that will be used by remote clusters for determining whether the gateway is alive |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -42,7 +42,7 @@ spec:
       {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
         - name: pause
-          image: gcr.io/google_containers/pause:3.2
+          image: {{ .Values.gateway.pauseImage }}
           securityContext:
             runAsUser: {{.Values.gateway.UID}}
       serviceAccountName: {{.Values.gateway.name}}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -26,6 +26,9 @@ gateway:
   # -- Set loadBalancerIP on gateway service
   loadBalancerIP: ""
 
+  # -- The pause container to use
+  pauseImage: "gcr.io/google_containers/pause:3.2"
+
   # -- User id under which the gateway shall be ran
   UID: 2103
 


### PR DESCRIPTION
For our multicluster gateway we use a pause container as the "main" container in the pod. Currently, the image version and registry are both hardcoded into the template itself. This makes a bit difficult to write CI logic and just recipes.

To keep everything simpler (and neater) to use, this change decouples the registry and image of the pause container from the template, by having a unified declaration in the multicluster values file.

This should unblock and help with PR#9135 (run mc tests on min and max k8s versions)

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
