### PR TITLE
Change the default proxyProtocol for multicluster. Fixes #9574

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/gateway-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway-policy.yaml
@@ -15,7 +15,7 @@ spec:
     matchLabels:
       app: {{.Values.gateway.name}}
   port: linkerd-proxy
-  proxyProtocol: HTTP/1
+  proxyProtocol: unknown 
 ---
 apiVersion: policy.linkerd.io/v1beta1
 kind: ServerAuthorization


### PR DESCRIPTION
The default Server resource for the multicluster gateway is limiting traffic to HTTP. This is unexpected once you try to use different protocols (such as TLS traffic) across clusters. 

Changing the default to unknown fits with the "default-allow" policy that linkerd has when installing, and when people only want to use the mesh functionality.

Fixes #9574

Signed-off-by: Peter Smit <peter.smit@inscripta.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
