### PR TITLE
heartbeat: Include the CPU architecture in reports

### DIFF
--- a/controller/cmd/heartbeat/main.go
+++ b/controller/cmd/heartbeat/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"net/url"
+	"runtime"
 
 	"github.com/linkerd/linkerd2/controller/heartbeat"
 	"github.com/linkerd/linkerd2/pkg/flags"
@@ -36,6 +37,7 @@ func Main(args []string) {
 	// TODO:
 	// - k8s-env
 	v := url.Values{}
+	v.Set("arch", runtime.GOARCH)
 	v.Set("version", version.Version)
 	v.Set("source", "heartbeat")
 

--- a/controller/heartbeat/heartbeat.go
+++ b/controller/heartbeat/heartbeat.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -28,6 +29,7 @@ type containerMeta struct {
 // K8sValues gathers relevant heartbeat information from Kubernetes
 func K8sValues(ctx context.Context, kubeAPI *k8s.KubernetesAPI, controlPlaneNamespace string) url.Values {
 	v := url.Values{}
+	v.Set("arch", runtime.GOARCH)
 
 	cm, err := config.FetchLinkerdConfigMap(ctx, kubeAPI, controlPlaneNamespace)
 	if err != nil {

--- a/controller/heartbeat/heartbeat.go
+++ b/controller/heartbeat/heartbeat.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strconv"
 	"time"
 
@@ -29,7 +28,6 @@ type containerMeta struct {
 // K8sValues gathers relevant heartbeat information from Kubernetes
 func K8sValues(ctx context.Context, kubeAPI *k8s.KubernetesAPI, controlPlaneNamespace string) url.Values {
 	v := url.Values{}
-	v.Set("arch", runtime.GOARCH)
 
 	cm, err := config.FetchLinkerdConfigMap(ctx, kubeAPI, controlPlaneNamespace)
 	if err != nil {


### PR DESCRIPTION
It would be useful to know how prevalent 32-bit ARM deployments are so that we can determine whether it makes sense to continue supporting this platform. This change adds an `arch` field to heartbeats indicating the CPU architecture of the heartbeat container.

Signed-off-by: Oliver Gould <ver@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
