### PR TITLE
fix: Add gateway pauseImage to CLI values struct

### DIFF
--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -47,6 +47,7 @@ type Gateway struct {
 	Probe              *Probe            `json:"probe"`
 	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
 	LoadBalancerIP     string            `json:"loadBalancerIP"`
+	PauseImage         string            `json:"pauseImage"`
 }
 
 // Probe contains all options for the Probe Service


### PR DESCRIPTION
PR https://github.com/linkerd/linkerd2/pull/9566 forgot to update the chart values struct used by the CLI to render the manifests. As a result, `linkerd multicluster install` would fail because the pause container image would be missing:

```
:; bin/linkerd mc install | rg 'pause' -A 1
        - name: pause
          image:
```

After the fix

```
:; bin/linkerd mc install | rg 'pause' -A 1
        - name: pause
          image: gcr.io/google_containers/pause:3.2
```

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
