### PR TITLE
Remove _pause-image variable from justfile

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -291,6 +291,7 @@ jobs:
           files: |
             .github/workflows/integration.yml
             .proxy-version
+            justfile
             viz/**
             test/integration/viz/**
     outputs:
@@ -334,6 +335,7 @@ jobs:
           files: |
             .github/workflows/integration.yml
             .proxy-version
+            justfile
             multicluster/**
             test/integration/multicluster/**
     outputs:

--- a/justfile
+++ b/justfile
@@ -264,11 +264,12 @@ linkerd-tag := `bin/root-tag`
 
 docker-arch := ''
 
-_pause-image := `yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml`
-
 _pause-load: _k3d-init
-    if [ -z "$(docker image ls -q '{{ _pause-image }}')" ]; then docker pull -q '{{ _pause-image }}'; fi
-    k3d image import --mode=direct --cluster='{{ k3d-name }}' {{ _pause-image }}
+    if [ -z "$(docker image ls -q $(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml))" ]; then \
+       docker pull -q "$(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml)"; \
+    fi
+    k3d image import --mode=direct --cluster='{{ k3d-name }}' \
+        "$(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml)"
 
 ##
 ## Linkerd CLI

--- a/justfile
+++ b/justfile
@@ -267,11 +267,11 @@ docker-arch := ''
 _pause-load: _k3d-init
     #!/usr/bin/env bash
     set -euo pipefail
-    pauseImage="$(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml)"
-    if [ -z "$(docker image ls -q $pauseImage)" ]; then
-       docker pull -q "$pauseImage"
+    img="$(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml)"
+    if [ -z "$(docker image ls -q "$img")" ]; then
+       docker pull -q "$img"
     fi
-    k3d image import --mode=direct --cluster='{{ k3d-name }}' "$pauseImage"
+    k3d image import --mode=direct --cluster='{{ k3d-name }}' "$img"
 
 ##
 ## Linkerd CLI

--- a/justfile
+++ b/justfile
@@ -265,11 +265,13 @@ linkerd-tag := `bin/root-tag`
 docker-arch := ''
 
 _pause-load: _k3d-init
-    if [ -z "$(docker image ls -q $(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml))" ]; then \
-       docker pull -q "$(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml)"; \
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pauseImage="$(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml)"
+    if [ -z "$(docker image ls -q $pauseImage)" ]; then
+       docker pull -q "$pauseImage"
     fi
-    k3d image import --mode=direct --cluster='{{ k3d-name }}' \
-        "$(yq .gateway.pauseImage multicluster/charts/linkerd-multicluster/values.yaml)"
+    k3d image import --mode=direct --cluster='{{ k3d-name }}' "$pauseImage"
 
 ##
 ## Linkerd CLI


### PR DESCRIPTION
Just does not support lazy evaluation of commands when their output is stored in a variable. `_pause-load` was used to store the output of a `yq` command that would fetch the pause image used in the gateway template for multicluster.

When running workloads in CI that do not run in the devcontainer, yq is missing as a dependency. Since the command is eagerly evaluated, we get an error (even when the recipe that makes use of the variable is not invoked). This change removes the variable and hardcodes the command in the recipe itself.

To work around parsing issues for multi-line constructs, we also escape newlines with slashes ('\').

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
