### PR TITLE
Change notes for stable-2.12.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,11 +12,11 @@ Prometheus Operator. Several other fixes are included.
   * Fixed proxies emitting some duplicate inbound metrics
 
 * Control Plane
-  * Fixed handling of .conf files in the CNI plugin so that the Linkerd CNI
+  * Fixed handling of `.conf` files in the CNI plugin so that the Linkerd CNI
     plugin can be used alongside other CNI plugins such as Cilium
   * Added a noop init container to injected pods when the CNI plugin is enabled
     to prevent certain scenarios where a pod can get stuck without an IP address
-  * Fixed the `NotIn` label selector operator in the policy resources, being
+  * Fixed the `NotIn` label selector operator in the policy resources being
     erroneously treated as `In`.
   * Fixed a bug where the`config.linkerd.io/proxy-version` annotation could be
     empty
@@ -26,8 +26,8 @@ Prometheus Operator. Several other fixes are included.
   * Added a check that ClusterIP services are in the cluster networks
   * Expanded the `linkerd authz` command to display AuthorizationPolicy
     resources that target namespaces (thanks @aatarasoff!)
-  * Fixed warning logic around the "linkerd-viz ClusterRoles exist" and
-    "linkerd-viz ClusterRoleBindings exist" checks in `linkerd viz check`
+  * Fixed warning logic in the "linkerd-viz ClusterRoles exist" and "linkerd-viz
+    ClusterRoleBindings exist" checks in `linkerd viz check`
   * Fixed the CLI ignoring the `--api-addr` flag (thanks @mikutas!)
 
 * Helm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,45 @@
 # Changes
 
+## stable-2.12.2
+
+This stable release fixes an issue with CNI chaining that was preventing the
+Linkerd CNI plugin from working with other CNI plugins such as Cilium. It also
+fixes some sections of the Viz dashboard appearing blank, and adds an optional
+PodMonitor resource to the Helm chart to enable easier integration with the
+Prometheus Operator. Several other fixes are included.
+
+* Proxy
+  * Fixed proxies emitting some duplicate inbound metrics
+
+* Control Plane
+  * Fixed handling of .conf files in the CNI plugin so that the Linkerd CNI
+    plugin can be used alongside other CNI plugins such as Cilium
+  * Added a noop init container to injected pods when the CNI plugin is enabled
+    to prevent certain scenarios where a pod can get stuck without an IP address
+  * Fixed the `NotIn` label selector operator in the policy resources, being
+    erroneously treated as `In`.
+  * Fixed a bug where the`config.linkerd.io/proxy-version` annotation could be
+    empty
+
+* CLI
+  * Added a `linkerd diagnostics policy` command to inspect Linkerd policy state
+  * Added a check that ClusterIP services are in the cluster networks
+  * Expanded the `linkerd authz` command to display AuthorizationPolicy
+    resources that target namespaces (thanks @aatarasoff!)
+  * Fixed warning logic around the "linkerd-viz ClusterRoles exist" and
+    "linkerd-viz ClusterRoleBindings exist" checks in `linkerd viz check`
+  * Fixed the CLI ignoring the `--api-addr` flag (thanks @mikutas!)
+
+* Helm
+  * Added an optional PodMonitor resource to the main Helm chart (thanks
+    @jaygridley!)
+
+* Dashboard
+  * Fixed the dashboard sections Tap, Top, and Routes appearing blank (thanks
+    @MoSattler!)
+  * Updated Grafana dashboards to use variable duration parameter so that they
+    can be used when Prometheus has a longer scrape interval (thanks @TarekAS)
+
 ## edge-22.10.2
 
 This edge release fixes an issue with CNI chaining that was preventing the

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.10.1-edge
+version: 1.9.4
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.10.1-edge](https://img.shields.io/badge/Version-1.10.1--edge-informational?style=flat-square)
+![Version: 1.9.4](https://img.shields.io/badge/Version-1.9.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.4.1-edge
+version: 30.3.4

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.4.1-edge](https://img.shields.io/badge/Version-30.4.1--edge-informational?style=flat-square)
+![Version: 30.3.4](https://img.shields.io/badge/Version-30.3.4-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.5.1-edge
+version: 30.4.4
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.5.1-edge](https://img.shields.io/badge/Version-30.5.1--edge-informational?style=flat-square)
+![Version: 30.4.4](https://img.shields.io/badge/Version-30.4.4-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.1-edge
+version: 30.2.4
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.3.1-edge](https://img.shields.io/badge/Version-30.3.1--edge-informational?style=flat-square)
+![Version: 30.2.4](https://img.shields.io/badge/Version-30.2.4-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.1-edge
+version: 30.3.4
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.4.1-edge](https://img.shields.io/badge/Version-30.4.1--edge-informational?style=flat-square)
+![Version: 30.3.4](https://img.shields.io/badge/Version-30.3.4-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
* Note that this release is based off of edge-22.10.2 *

## stable-2.12.2

This stable release fixes an issue with CNI chaining that was preventing the Linkerd CNI plugin from working with other CNI plugins such as Cilium. It also fixes some sections of the Viz dashboard appearing blank, and adds an optional PodMonitor resource to the Helm chart to enable easier integration with the Prometheus Operator. Several other fixes are included.

* Proxy
  * Fixed proxies emitting some duplicate inbound metrics

* Control Plane
  * Fixed handling of .conf files in the CNI plugin so that the Linkerd CNI plugin can be used alongside other CNI plugins such as Cilium
  * Added a noop init container to injected pods when the CNI plugin is enabled to prevent certain scenarios where a pod can get stuck without an IP address
  * Fixed the `NotIn` label selector operator in the policy resources, being erroneously treated as `In`.
  * Fixed a bug where the`config.linkerd.io/proxy-version` annotation could be empty

* CLI
  * Added a `linkerd diagnostics policy` command to inspect Linkerd policy state
  * Added a check that ClusterIP services are in the cluster networks
  * Expanded the `linkerd authz` command to display AuthorizationPolicy resources that target namespaces (thanks @aatarasoff!)
  * Fixed warning logic around the "linkerd-viz ClusterRoles exist" and "linkerd-viz ClusterRoleBindings exist" checks in `linkerd viz check`
  * Fixed the CLI ignoring the `--api-addr` flag (thanks @mikutas!)

* Helm
  * Added an optional PodMonitor resource to the main Helm chart (thanks @jaygridley!)

* Dashboard
  * Fixed the dashboard sections Tap, Top, and Routes appearing blank (thanks @MoSattler!)
  * Updated Grafana dashboards to use variable duration parameter so that they can be used when Prometheus has a longer scrape interval (thanks @TarekAS)