### PR TITLE
Fix "cluster networks contains all services" check fails with services with no ClusterIP

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1939,7 +1939,8 @@ func (hc *HealthChecker) checkClusterNetworksContainAllServices(ctx context.Cont
 		return err
 	}
 	for _, svc := range svcs.Items {
-		if svc.Spec.ClusterIP != "None" && !clusterNetworksContainIP(clusterIPNets, svc.Spec.ClusterIP) {
+		clusterIP := svc.Spec.ClusterIP
+		if clusterIP != "" && clusterIP != "None" && !clusterNetworksContainIP(clusterIPNets, svc.Spec.ClusterIP) {
 			return fmt.Errorf("the Linkerd clusterNetworks [%q] do not include svc %s/%s (%s)", hc.linkerdConfig.ClusterNetworks, svc.Namespace, svc.Name, svc.Spec.ClusterIP)
 		}
 	}


### PR DESCRIPTION
Fixes #9661

This excludes any service with no ClusterIP from this check, which includes the services of type ExternalName.