### PR TITLE
Temporary fix for go lint breakage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,14 @@ issues:
     - gosec
     text: "G101: Potential hardcoded credentials"
 
+  # Temporarily disable this check until the next golang-ci upgrade (greater
+  # than v1.50.1) which upgrades gosec from v2.13.1 to v2.14.0. The fix is in
+  # this commit, that refers to G404 but it seems it also affects G402:
+  # https://github.com/securego/gosec/commit/dfde579243e1bfe0856ddafc5fc6aebb29c0edf6
+  - linters:
+    - gosec
+    text: "G402: TLS MinVersion too low"
+
   # Flag operations are fallible if the flag does not exist. We assume these
   # exist as they are generally flags we are deprecating or use only for
   # development.


### PR DESCRIPTION
Temporarily disable the G402 check until the next golang-ci upgrade (greater than v1.50.1) which upgrades gosec from v2.13.1 to v2.14.0. The fix is in this commit, that refers to G404 but it seems it also affects G402: https://github.com/securego/gosec/commit/dfde579243e1bfe0856ddafc5fc6aebb29c0edf6

This unblocks #9678 and #9692