### PR TITLE
Fix MC gateway UID when installing through CLI

### DIFF
--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -48,6 +48,7 @@ type Gateway struct {
 	ServiceAnnotations map[string]string `json:"serviceAnnotations"`
 	LoadBalancerIP     string            `json:"loadBalancerIP"`
 	PauseImage         string            `json:"pauseImage"`
+	UID                int64             `json:"UID"`
 }
 
 // Probe contains all options for the Probe Service


### PR DESCRIPTION
When installing the multicluster extension through the CLI, the gateway's `pause` container `runAsUser` field is empty. K8s then uses the UID defined in the `pause` image, which is [65535](https://github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile#L19).

The source of the problem is that the `gateway.UID` values.yaml entry isn't backed by an entry in the multicluster `values.go`'s `Gateway` struct.

How to repro:

```bash
# before the fix
$ linkerd mc install --ignore-cluster | grep runAsUser
            runAsUser:

# after the fix
$ linkerd mc install --ignore-cluster | grep runAsUser
            runAsUser: 2103
```