### PR TITLE
Updates release.yaml to use Go 1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - name: Download image archives
       uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
       with:
@@ -179,7 +179,7 @@ jobs:
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - name: Set environment variables from scripts
       run: |
         TAG='${{ needs.tag.outputs.tag }}'
@@ -205,7 +205,7 @@ jobs:
       uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
       with:
-        go-version: '1.17'
+        go-version: '1.18'
     - name: Set environment variables from scripts
       run: |
         TAG='${{ needs.tag.outputs.tag }}'


### PR DESCRIPTION
This change matches the `go-version` in `release.yaml` to be the same as `integration.yaml`

Several build errors occurred during the release of `edge-22.10.3`: https://github.com/linkerd/linkerd2/actions/runs/3340932323/jobs/5531813673#step:5:230

`Error: ../../../go/pkg/mod/k8s.io/apimachinery@v0.25.3/third_party/forked/golang/reflect/deep_equal.go:376:7: undefined: reflect.Pointer`

`reflect.Ptr` was renamed to `reflect.Pointer` in Go 1.18.

Signed-off-by: Steve Jenson <stevej@buoyant.io>

