### PR TITLE
Adds a default Exists toleration to linkerd-cni

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -41,7 +41,7 @@ about testing from source can be found in the [TEST.md](TEST.md) guide.
   - [Making changes to the chart templates](#making-changes-to-the-chart-templates)
   - [Generating Helm charts docs](#generating-helm-charts-docs)
   - [Using helm-docs](#using-helm-docs)
-  - [Annotating values.yml](#annotating-valuesyml)
+  - [Annotating values.yaml](#annotating-valuesyaml)
   - [Markdown templates](#markdown-templates)
 
 ## Repo layout
@@ -510,8 +510,8 @@ the templates.
 
 ### Generating Helm charts docs
 
-Whenever a new chart is created, or updated a README should be generated from
-the chart's values.yml. This can be done by utilizing the bundled
+Whenever a new chart is created or updated a README should be generated from
+the chart's `values.yaml`. This can be done by utilizing the bundled
 [helm-docs](https://github.com/norwoodj/helm-docs) binary. For adding additional
 information, such as specific installation instructions a README template is
 required to be created. Check existing charts for examples.
@@ -531,9 +531,9 @@ Note:
 The tool searches through the current directory and sub-directories by default.
 For additional information checkout their repo above.
 
-#### Annotating values.yml
+#### Annotating values.yaml
 
-To allow helm-docs to properly document the values in values.yml a descriptive
+To allow helm-docs to properly document the values in `values.yaml` a descriptive
 comment is required. This can be done in two ways.
 Either comment the value directly above with
 `# -- This is a really nice value` where the double dashes automatically

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -42,7 +42,7 @@ Kubernetes: `>=1.21.0-0`
 | proxyAdminPort | int | `4191` | Admin port for the proxy container |
 | proxyControlPort | int | `4190` | Control port for the proxy container |
 | proxyUID | int | `2102` | User id under which the proxy shall be ran |
-| tolerations[0].operator | object | `{"operator": "Exists"}` |  |
+| tolerations[0] | object | `{"operator":"Exists"}` | tolerations properties |
 | useWaitFlag | bool | `false` | Configures the CNI plugin to use the -w flag for the iptables command |
 
 ----------------------------------------------

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -42,7 +42,6 @@ Kubernetes: `>=1.21.0-0`
 | proxyAdminPort | int | `4191` | Admin port for the proxy container |
 | proxyControlPort | int | `4190` | Control port for the proxy container |
 | proxyUID | int | `2102` | User id under which the proxy shall be ran |
-| tolerations[0].effect | string | `"NoSchedule"` |  |
 | tolerations[0].operator | string | `"Exists"` |  |
 | useWaitFlag | bool | `false` | Configures the CNI plugin to use the -w flag for the iptables command |
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -42,7 +42,7 @@ Kubernetes: `>=1.21.0-0`
 | proxyAdminPort | int | `4191` | Admin port for the proxy container |
 | proxyControlPort | int | `4190` | Control port for the proxy container |
 | proxyUID | int | `2102` | User id under which the proxy shall be ran |
-| tolerations[0] | object | `{"operator":"Exists"}` | tolerations properties |
+| tolerations[0] | object | `{"operator":"Exists"}` | toleration properties |
 | useWaitFlag | bool | `false` | Configures the CNI plugin to use the -w flag for the iptables command |
 
 ----------------------------------------------

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -42,7 +42,7 @@ Kubernetes: `>=1.21.0-0`
 | proxyAdminPort | int | `4191` | Admin port for the proxy container |
 | proxyControlPort | int | `4190` | Control port for the proxy container |
 | proxyUID | int | `2102` | User id under which the proxy shall be ran |
-| tolerations[0].operator | string | `"Exists"` |  |
+| tolerations[0].operator | object | `{"operator": "Exists"}` |  |
 | useWaitFlag | bool | `false` | Configures the CNI plugin to use the -w flag for the iptables command |
 
 ----------------------------------------------

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -42,6 +42,8 @@ Kubernetes: `>=1.21.0-0`
 | proxyAdminPort | int | `4191` | Admin port for the proxy container |
 | proxyControlPort | int | `4190` | Control port for the proxy container |
 | proxyUID | int | `2102` | User id under which the proxy shall be ran |
+| tolerations[0].effect | string | `"NoSchedule"` |  |
+| tolerations[0].operator | string | `"Exists"` |  |
 | useWaitFlag | bool | `false` | Configures the CNI plugin to use the -w flag for the iptables command |
 
 ----------------------------------------------

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -45,7 +45,6 @@ privileged: false
 # for more information
 tolerations:
 - operator: Exists
-  effect: NoSchedule
 
 # -|- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -44,7 +44,7 @@ privileged: false
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 # for more information
 tolerations:
-  # -- tolerations properties
+  # -- toleration properties
   - operator: Exists
 
 # -|- NodeAffinity section, See the

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -43,7 +43,9 @@ privileged: false
 # -|- Tolerations section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 # for more information
-#tolerations:
+tolerations:
+- operator: Exists
+  effect: NoSchedule
 
 # -|- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -44,7 +44,8 @@ privileged: false
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 # for more information
 tolerations:
-- operator: Exists
+  # -- tolerations properties
+  - operator: Exists
 
 # -|- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)

--- a/cli/cmd/install_cni_helm_test.go
+++ b/cli/cmd/install_cni_helm_test.go
@@ -122,9 +122,9 @@ func chartCniPlugin(t *testing.T) *chart.Chart {
 
 	cniChart.AddDependency(chartPartials)
 
-	cniChart.Templates = append(cniChart.Templates,
-		&chart.File{Name: "templates/cni-plugin.yaml"},
-	)
+	cniChart.Templates = append(cniChart.Templates, &chart.File{
+		Name: "templates/cni-plugin.yaml",
+	})
 
 	for _, template := range cniChart.Templates {
 		filepath := filepath.Join(cniChart.Metadata.Sources[0], template.Name)

--- a/cli/cmd/install_cni_helm_test.go
+++ b/cli/cmd/install_cni_helm_test.go
@@ -107,6 +107,7 @@ func chartCniPlugin(t *testing.T) *chart.Chart {
 	chartPartials := chartPartials([]string{
 		"templates/_helpers.tpl",
 		"templates/_metadata.tpl",
+		"templates/_tolerations.tpl",
 	})
 
 	cniChart := &chart.Chart{
@@ -121,9 +122,9 @@ func chartCniPlugin(t *testing.T) *chart.Chart {
 
 	cniChart.AddDependency(chartPartials)
 
-	cniChart.Templates = append(cniChart.Templates, &chart.File{
-		Name: "templates/cni-plugin.yaml",
-	})
+	cniChart.Templates = append(cniChart.Templates,
+		&chart.File{Name: "templates/cni-plugin.yaml"},
+	)
 
 	for _, template := range cniChart.Templates {
 		filepath := filepath.Join(cniChart.Metadata.Sources[0], template.Name)

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -103,6 +103,9 @@ spec:
         linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -104,8 +104,7 @@ spec:
         linkerd.io/inject: disabled
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -103,6 +103,9 @@ spec:
         linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -104,8 +104,7 @@ spec:
         linkerd.io/inject: disabled
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -103,6 +103,9 @@ spec:
         linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -104,8 +104,7 @@ spec:
         linkerd.io/inject: disabled
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -103,6 +103,9 @@ spec:
         linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -104,8 +104,7 @@ spec:
         linkerd.io/inject: disabled
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -105,8 +105,7 @@ spec:
         linkerd.io/inject: disabled
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -104,6 +104,9 @@ spec:
         linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -97,6 +97,9 @@ spec:
         linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -98,8 +98,7 @@ spec:
         linkerd.io/inject: disabled
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -97,6 +97,9 @@ spec:
         linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -98,8 +98,7 @@ spec:
         linkerd.io/inject: disabled
     spec:
       tolerations:
-        - effect: NoSchedule
-          operator: Exists
+        - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true

--- a/pkg/charts/charts.go
+++ b/pkg/charts/charts.go
@@ -123,6 +123,7 @@ func (c *Chart) RenderCNI() (bytes.Buffer, error) {
 		{Name: "charts/partials/templates/_helpers.tpl"},
 		{Name: "charts/partials/templates/_metadata.tpl"},
 		{Name: "charts/partials/templates/_pull-secrets.tpl"},
+		{Name: "charts/partials/templates/_tolerations.tpl"},
 	}
 	return c.render(cniPartials)
 }

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -17,28 +17,27 @@ const (
 
 // Values contains the top-level elements in the cni Helm chart
 type Values struct {
-	InboundProxyPort    uint          `json:"inboundProxyPort"`
-	OutboundProxyPort   uint          `json:"outboundProxyPort"`
-	IgnoreInboundPorts  string        `json:"ignoreInboundPorts"`
-	IgnoreOutboundPorts string        `json:"ignoreOutboundPorts"`
-	CliVersion          string        `json:"cliVersion"`
-	CNIPluginImage      string        `json:"cniPluginImage"`
-	CNIPluginVersion    string        `json:"cniPluginVersion"`
-	LogLevel            string        `json:"logLevel"`
-	PortsToRedirect     string        `json:"portsToRedirect"`
-	ProxyUID            int64         `json:"proxyUID"`
-	DestCNINetDir       string        `json:"destCNINetDir"`
-	DestCNIBinDir       string        `json:"destCNIBinDir"`
-	UseWaitFlag         bool          `json:"useWaitFlag"`
-	PriorityClassName   string        `json:"priorityClassName"`
-	ProxyAdminPort      string        `json:"proxyAdminPort"`
-	ProxyControlPort    string        `json:"proxyControlPort"`
-	Tolerations         []Tolerations `json:"tolerations"`
+	InboundProxyPort    uint         `json:"inboundProxyPort"`
+	OutboundProxyPort   uint         `json:"outboundProxyPort"`
+	IgnoreInboundPorts  string       `json:"ignoreInboundPorts"`
+	IgnoreOutboundPorts string       `json:"ignoreOutboundPorts"`
+	CliVersion          string       `json:"cliVersion"`
+	CNIPluginImage      string       `json:"cniPluginImage"`
+	CNIPluginVersion    string       `json:"cniPluginVersion"`
+	LogLevel            string       `json:"logLevel"`
+	PortsToRedirect     string       `json:"portsToRedirect"`
+	ProxyUID            int64        `json:"proxyUID"`
+	DestCNINetDir       string       `json:"destCNINetDir"`
+	DestCNIBinDir       string       `json:"destCNIBinDir"`
+	UseWaitFlag         bool         `json:"useWaitFlag"`
+	PriorityClassName   string       `json:"priorityClassName"`
+	ProxyAdminPort      string       `json:"proxyAdminPort"`
+	ProxyControlPort    string       `json:"proxyControlPort"`
+	Tolerations         []Toleration `json:"tolerations"`
 }
 
 type Toleration struct {
 	Operator string `json:"operator"`
-	Effect   string `json:"effect"`
 }
 
 // NewValues returns a new instance of the Values type.

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -36,7 +36,7 @@ type Values struct {
 	Tolerations         []Tolerations `json:"tolerations"`
 }
 
-type Tolerations struct {
+type Toleration struct {
 	Operator string `json:"operator"`
 	Effect   string `json:"effect"`
 }

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -17,23 +17,23 @@ const (
 
 // Values contains the top-level elements in the cni Helm chart
 type Values struct {
-	InboundProxyPort    uint         `json:"inboundProxyPort"`
-	OutboundProxyPort   uint         `json:"outboundProxyPort"`
-	IgnoreInboundPorts  string       `json:"ignoreInboundPorts"`
-	IgnoreOutboundPorts string       `json:"ignoreOutboundPorts"`
-	CliVersion          string       `json:"cliVersion"`
-	CNIPluginImage      string       `json:"cniPluginImage"`
-	CNIPluginVersion    string       `json:"cniPluginVersion"`
-	LogLevel            string       `json:"logLevel"`
-	PortsToRedirect     string       `json:"portsToRedirect"`
-	ProxyUID            int64        `json:"proxyUID"`
-	DestCNINetDir       string       `json:"destCNINetDir"`
-	DestCNIBinDir       string       `json:"destCNIBinDir"`
-	UseWaitFlag         bool         `json:"useWaitFlag"`
-	PriorityClassName   string       `json:"priorityClassName"`
-	ProxyAdminPort      string       `json:"proxyAdminPort"`
-	ProxyControlPort    string       `json:"proxyControlPort"`
-	Tolerations         []Toleration `json:"tolerations"`
+	InboundProxyPort    uint          `json:"inboundProxyPort"`
+	OutboundProxyPort   uint          `json:"outboundProxyPort"`
+	IgnoreInboundPorts  string        `json:"ignoreInboundPorts"`
+	IgnoreOutboundPorts string        `json:"ignoreOutboundPorts"`
+	CliVersion          string        `json:"cliVersion"`
+	CNIPluginImage      string        `json:"cniPluginImage"`
+	CNIPluginVersion    string        `json:"cniPluginVersion"`
+	LogLevel            string        `json:"logLevel"`
+	PortsToRedirect     string        `json:"portsToRedirect"`
+	ProxyUID            int64         `json:"proxyUID"`
+	DestCNINetDir       string        `json:"destCNINetDir"`
+	DestCNIBinDir       string        `json:"destCNIBinDir"`
+	UseWaitFlag         bool          `json:"useWaitFlag"`
+	PriorityClassName   string        `json:"priorityClassName"`
+	ProxyAdminPort      string        `json:"proxyAdminPort"`
+	ProxyControlPort    string        `json:"proxyControlPort"`
+	Tolerations         []interface{} `json:"tolerations"`
 }
 
 type Toleration struct {

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -17,23 +17,23 @@ const (
 
 // Values contains the top-level elements in the cni Helm chart
 type Values struct {
-	InboundProxyPort    uint   `json:"inboundProxyPort"`
-	OutboundProxyPort   uint   `json:"outboundProxyPort"`
-	IgnoreInboundPorts  string `json:"ignoreInboundPorts"`
-	IgnoreOutboundPorts string `json:"ignoreOutboundPorts"`
-	CliVersion          string `json:"cliVersion"`
-	CNIPluginImage      string `json:"cniPluginImage"`
-	CNIPluginVersion    string `json:"cniPluginVersion"`
-	LogLevel            string `json:"logLevel"`
-	PortsToRedirect     string `json:"portsToRedirect"`
-	ProxyUID            int64  `json:"proxyUID"`
-	DestCNINetDir       string `json:"destCNINetDir"`
-	DestCNIBinDir       string `json:"destCNIBinDir"`
-	UseWaitFlag         bool   `json:"useWaitFlag"`
-	PriorityClassName   string `json:"priorityClassName"`
-	ProxyAdminPort      string `json:"proxyAdminPort"`
-	ProxyControlPort    string `json:"proxyControlPort"`
-	Tolerations         string `json:"tolerations"`
+	InboundProxyPort    uint          `json:"inboundProxyPort"`
+	OutboundProxyPort   uint          `json:"outboundProxyPort"`
+	IgnoreInboundPorts  string        `json:"ignoreInboundPorts"`
+	IgnoreOutboundPorts string        `json:"ignoreOutboundPorts"`
+	CliVersion          string        `json:"cliVersion"`
+	CNIPluginImage      string        `json:"cniPluginImage"`
+	CNIPluginVersion    string        `json:"cniPluginVersion"`
+	LogLevel            string        `json:"logLevel"`
+	PortsToRedirect     string        `json:"portsToRedirect"`
+	ProxyUID            int64         `json:"proxyUID"`
+	DestCNINetDir       string        `json:"destCNINetDir"`
+	DestCNIBinDir       string        `json:"destCNIBinDir"`
+	UseWaitFlag         bool          `json:"useWaitFlag"`
+	PriorityClassName   string        `json:"priorityClassName"`
+	ProxyAdminPort      string        `json:"proxyAdminPort"`
+	ProxyControlPort    string        `json:"proxyControlPort"`
+	Tolerations         []Tolerations `json:"tolerations"`
 }
 
 type Tolerations struct {

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -33,6 +33,12 @@ type Values struct {
 	PriorityClassName   string `json:"priorityClassName"`
 	ProxyAdminPort      string `json:"proxyAdminPort"`
 	ProxyControlPort    string `json:"proxyControlPort"`
+	Tolerations         string `json:"tolerations"`
+}
+
+type Tolerations struct {
+	Operator string `json:"operator"`
+	Effect   string `json:"effect"`
 }
 
 // NewValues returns a new instance of the Values type.

--- a/pkg/charts/cni/values.go
+++ b/pkg/charts/cni/values.go
@@ -36,10 +36,6 @@ type Values struct {
 	Tolerations         []interface{} `json:"tolerations"`
 }
 
-type Toleration struct {
-	Operator string `json:"operator"`
-}
-
 // NewValues returns a new instance of the Values type.
 func NewValues() (*Values, error) {
 	chartDir := fmt.Sprintf("%s/", helmDefaultCNIChartDir)


### PR DESCRIPTION
Subject:
Adds a default toleration to linkerd-cni as a convenience for users. `Exists` with an empty `key` matches all tolerations.

Problem:
A user issue arose where they were tediously required to add a toleration when deploying to tainted nodes.

Solution:
Instead of requiring users to manually add `tolerations[0].operator = Exists`, we now make that the default for linkerd-cni.

Validation:
I tested this by tainting a node in k3d and deploying linkerd-cni. before this change, linkerd-cni would not deploy.

Fixes #9699 

I also fixed a small `BUILD.md` misspelling.

Signed-off-by: Steve Jenson <stevej@buoyant.io>
