### PR TITLE
helm: use `proxyInit`'s user for the `noop` init container

### DIFF
--- a/charts/partials/templates/_noop.tpl
+++ b/charts/partials/templates/_noop.tpl
@@ -3,4 +3,6 @@ args:
 - -v
 image: gcr.io/google_containers/pause:3.2
 name: noop
+securityContext:
+  runAsUser: {{ .Values.proxyInit.runAsUser | int | eq 0 | ternary 65534 .Values.proxyInit.runAsUser }}
 {{- end -}}

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -168,6 +168,8 @@ spec:
         - -v
         image: gcr.io/google_containers/pause:3.2
         name: noop
+        securityContext:
+          runAsUser: 65534
       volumes:
       - emptyDir:
           medium: Memory

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -293,6 +293,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: linkerd
+
 ---
 ###
 ### Proxy Injector RBAC
@@ -902,9 +903,11 @@ spec:
           name: linkerd-identity-token
       initContainers:
       - args:
-          - -v
+        - -v
         image: gcr.io/google_containers/pause:3.2
         name: noop
+        securityContext:
+          runAsUser: 65534
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1290,9 +1293,11 @@ spec:
           readOnly: true
       initContainers:
       - args:
-          - -v
+        - -v
         image: gcr.io/google_containers/pause:3.2
         name: noop
+        securityContext:
+          runAsUser: 65534
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1564,9 +1569,11 @@ spec:
           readOnly: true
       initContainers:
       - args:
-          - -v
+        - -v
         image: gcr.io/google_containers/pause:3.2
         name: noop
+        securityContext:
+          runAsUser: 65534
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:


### PR DESCRIPTION
Currently, the `noop` init container created by the Linkerd CNI plugin causes issues when a workload with
```yaml
securityContext:
  runAsNonRoot: true
```
is injected, since it will add a container that runs as root to that workload.

This branch resolves this issue by changing the Helm template for the noop init container to use the same user as the `proxyInit` init container. I've tested this by injecting a deployment with the above `securityContext` configuration and verifying that the `noop` init container is now allowed to run.

This PR is against the `release/stable-2.12` branch, as the `noop` init container has been removed on the edge branch (as it was replaced with the CNI validator init container).

Fixes #9671