### PR TITLE
cli: Fix upgrade when using --from-manifests

### DIFF
--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -101,11 +101,12 @@ A full list of configurable values can be found at https://www.github.com/linker
 				return nil
 			}
 
-			k, err := k8sClient(manifests)
+			k, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create a kubernetes client: %w", err)
 			}
-			if err = upgradeControlPlaneRunE(cmd.Context(), k, flags, options); err != nil {
+
+			if err = upgradeControlPlaneRunE(cmd.Context(), k, flags, options, manifests); err != nil {
 				fmt.Fprintln(os.Stderr, err.Error())
 				os.Exit(1)
 			}
@@ -122,25 +123,26 @@ A full list of configurable values can be found at https://www.github.com/linker
 	return cmd
 }
 
-func k8sClient(manifestsFile string) (*k8s.KubernetesAPI, error) {
-	// We need a Kubernetes client to fetch configs and issuer secrets.
-	var k *k8s.KubernetesAPI
-	var err error
-	if manifestsFile != "" {
-		readers, err := read(manifestsFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse manifests from %s: %w", manifestsFile, err)
-		}
+// makeConfigClient is used to re-initialize the Kubernetes client in order
+// to fetch existing configuration. It accepts two arguments: a Kubernetes
+// client, and a path to a manifest file. If the manifest path is empty, the
+// client will not be re-initialized. When non-empty, the client will be
+// replaced by a fake Kubernetes client that will hold the values parsed from
+// the manifest.
+func makeConfigClient(k *k8s.KubernetesAPI, localManifestPath string) (*k8s.KubernetesAPI, error) {
+	if localManifestPath == "" {
+		return k, nil
+	}
 
-		k, err = k8s.NewFakeAPIFromManifests(readers)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse Kubernetes objects from manifest %s: %w", manifestsFile, err)
-		}
-	} else {
-		k, err = k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create a kubernetes client: %w", err)
-		}
+	// We need a Kubernetes client to fetch configs and issuer secrets.
+	readers, err := read(localManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse manifests from %s: %w", localManifestPath, err)
+	}
+
+	k, err = k8s.NewFakeAPIFromManifests(readers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Kubernetes objects from manifest %s: %w", localManifestPath, err)
 	}
 	return k, nil
 }
@@ -163,7 +165,7 @@ func makeUpgradeFlags() *pflag.FlagSet {
 	return upgradeFlags
 }
 
-func upgradeControlPlaneRunE(ctx context.Context, k *k8s.KubernetesAPI, flags []flag.Flag, options valuespkg.Options) error {
+func upgradeControlPlaneRunE(ctx context.Context, k *k8s.KubernetesAPI, flags []flag.Flag, options valuespkg.Options, localManifestPath string) error {
 
 	crds := bytes.Buffer{}
 	err := renderCRDs(&crds, options)
@@ -174,6 +176,12 @@ func upgradeControlPlaneRunE(ctx context.Context, k *k8s.KubernetesAPI, flags []
 	err = healthcheck.CheckCustomResourceDefinitions(ctx, k, crds.String())
 	if err != nil {
 		return fmt.Errorf("Linkerd CRDs must be installed first. Run linkerd upgrade with the --crds flag:\n%w", err)
+	}
+
+	// Re-initialize client if a local manifest path is used
+	k, err = makeConfigClient(k, localManifestPath)
+	if err != nil {
+		return err
 	}
 
 	buf, err := upgradeControlPlane(ctx, k, flags, options)


### PR DESCRIPTION
When the `--from-manifests` flag is used to upgrade through the CLI, the kube client used to fetch existing configuration (from the ConfigMap) is a "fake" client. The fake client returns values from a local source. The two clients are used interchangeably to perform the upgrade; which one is initialized depends on whether a value has been passed to `--from-manifests`.

Unfortunately, this breaks CLI upgrades to any stable-2.12.x version when the flag is used. Since a fake client is used, the upgrade will fail when checking for the existence of CRDs, even if the CRDs have been previously installed in the cluster.

This change fixes the issue by first initializing an actual Kubernetes client (that will be used to check for CRDs). If the values should be read from a local source, the client is replaced with a fake one. Since this takes place after the CRD check, the upgrade will not fail on the CRD precondition.

Fixes #9788

Signed-off-by: Matei David <matei@buoyant.io>

---

Unfortunately, I haven't found a better way to do this. The easiest (and most readable) change to me seemed to be to just wire up the manifest path as a parameter in the upgrade function. Based on wether this is an empty string or an actual path, we re-initialize the client before loading the values. Open to suggestions on how to simplify, if we can :)

### Steps to test manually

1. Create a Kubernetes cluster and install `stable-2.11.4`
2. Get the values from the configmaps and issuer secret, as described in the issue: `kubectl -n linkerd get secret/linkerd-identity-issuer configmap/linkerd-config secret/linkerd-config-overrides -o yaml > linkerd-manifests.yaml`
3. Build branch CLI & images, load images into k3d.
4. Upgrade CRDs: `bin/linkerd upgrade --crds | kubectl apply -f -`
5. Upgrade linkerdL `bin/linkerd upgrade --from-manifests linkerd-manifests.yaml | kubectl apply -f -`

e.g

```
:; bin/linkerd version
Client version: dev-04d45a88-matei
Server version: stable-2.11.4

:; kgp -n linkerd
NAME                                     READY   STATUS    RESTARTS   AGE
linkerd-identity-5f4dbf785d-dr759        2/2     Running   0          65m
linkerd-destination-7d5fdfc968-xwvks     4/4     Running   0          65m
linkerd-proxy-injector-5564ffb87-xkzs7   2/2     Running   0          65m

:; linkerd upgrade --crds | kubectl apply -f -

:; bin/linkerd upgrade --from-manifests linkerd-manifests.yaml | kubectl apply --prune -l linkerd.io/control-plane-ns=linkerd -f -
namespace/linkerd unchanged
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-identity configured
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-identity unchanged
serviceaccount/linkerd-identity unchanged
clusterrole.rbac.authorization.k8s.io/linkerd-linkerd-destination configured
clusterrolebinding.rbac.authorization.k8s.io/linkerd-linkerd-destination unchanged
serviceaccount/linkerd-destination unchanged
secret/linkerd-sp-validator-k8s-tls configured
validatingwebhookconfiguration.admissionregistration.k8s.io/linkerd-sp-validator-webhook-config configured
secret/linkerd-policy-validator-k8s-tls configured

:; kgp -n linkerd
NAME                                     READY   STATUS    RESTARTS   AGE
linkerd-identity-fd58d9f4d-dppjw         2/2     Running   0          14m
linkerd-proxy-injector-9bd47b564-48hwh   2/2     Running   0          14m
linkerd-destination-7fdbbbd864-qd7lw     4/4     Running   0          14m
```
