### PR TITLE
Maps a port to the container's port if the request comes in from the …

### DIFF
--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -23,6 +23,7 @@ const clusterIP = "172.17.12.0"
 const clusterIPOpaque = "172.17.12.1"
 const podIP1 = "172.17.0.12"
 const podIP2 = "172.17.0.13"
+const podIP3 = "172.17.0.17"
 const podIPOpaque = "172.17.0.14"
 const podIPSkipped = "172.17.0.15"
 const podIPPolicy = "172.17.0.16"
@@ -796,6 +797,45 @@ func toAddress(path string, port uint32) (*net.TcpAddress, error) {
 	}, nil
 }
 
+func TestHostPortMapping(t *testing.T) {
+	hostPort := uint32(7777)
+	containerPort := uint32(80)
+	server := makeServer(t)
+	stream := &bufferingGetProfileStream{
+		updates:          []*pb.DestinationProfile{},
+		MockServerStream: util.NewMockServerStream(),
+	}
+	stream.Cancel()
+
+	dest := &pb.GetDestination{
+		ContextToken: "name:hostport-mapping",
+		Path:         fmt.Sprintf("%s:%d", externalIP, hostPort),
+	}
+
+	err := server.GetProfile(dest, stream)
+	if err != nil {
+		t.Fatalf("Got error from GetProfile: %s", err)
+	}
+
+	pod, err := getPodByIP(server.k8sAPI, externalIP, hostPort, server.log)
+	if err != nil {
+		t.Fatalf("error retrieving pod by external IP %s", err)
+	}
+
+	address, err := server.createAddress(pod, externalIP, hostPort)
+	if err != nil {
+		t.Fatalf("error calling createAddress() %s", err)
+	}
+
+	if address.IP != podIP3 {
+		t.Fatalf("expected podIP (%s), received other IP (%s)", podIP3, address.IP)
+	}
+
+	if address.Port != containerPort {
+		t.Fatalf("expected containerPort (%d) but received port (%d) instead", containerPort, address.Port)
+	}
+}
+
 func TestIpWatcherGetSvcID(t *testing.T) {
 	name := "service"
 	namespace := "test"
@@ -854,8 +894,8 @@ spec:
 func TestIpWatcherGetPod(t *testing.T) {
 	podIP := "10.255.0.1"
 	hostIP := "172.0.0.1"
-	var hostPort1 uint32 = 12345
-	var hostPort2 uint32 = 12346
+	var hostPort1 uint32 = 22345
+	var hostPort2 uint32 = 22346
 	expectedPodName := "hostPortPod1"
 	k8sConfigs := []string{`
 apiVersion: v1
@@ -870,13 +910,13 @@ spec:
     ports:
     - containerPort: 12345
       hostIP: 172.0.0.1
-      hostPort: 12345
+      hostPort: 22345
   - image: test
     name: hostPortContainer2
     ports:
     - containerPort: 12346
       hostIP: 172.0.0.1
-      hostPort: 12346
+      hostPort: 22346
 status:
   phase: Running
   podIP: 10.255.0.1

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -314,6 +314,26 @@ spec:
   proxyProtocol: opaque`,
 	}
 
+	hostPortMapping := []string{
+		`
+kind: Pod
+apiVersion: v1
+metadata:
+  name: hostport-mapping
+status:
+  phase: Running
+  hostIP: 192.168.1.20
+  podIP: 172.17.0.17
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+      hostPort: 7777
+      name: nginx-7777`,
+	}
+
 	res := append(meshedPodResources, clientSP...)
 	res = append(res, unmeshedPod)
 	res = append(res, meshedOpaquePodResources...)
@@ -321,6 +341,7 @@ spec:
 	res = append(res, meshedSkippedPodResource...)
 	res = append(res, meshedStatefulSetPodResource...)
 	res = append(res, policyResources...)
+	res = append(res, hostPortMapping...)
 	k8sAPI, err := k8s.NewFakeAPI(res...)
 	if err != nil {
 		t.Fatalf("NewFakeAPI returned an error: %s", err)


### PR DESCRIPTION
Maps the request port to the container's port if the request comes in from the node network and has a hostPort mapping.

Problem:

When a request for a container comes in from the node network, the node port is used ignoring the hostPort mapping.

Solution:

When a request is seen coming from the node network, get the container Port from the Spec.

Validation:

Fixed an existing unit test and wrote a new one driving GetProfile specifically.

Fixes #9677 

Signed-off-by: Steve Jenson <stevej@buoyant.io>
