### PR TITLE
Add changes for edge-22.11.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes
 
+## edge-22.11.2
+
+This edge release introduces the use of the Kubernetes metadata API in the
+proxy-injector and tap-injector components. This can reduce the IO and memory
+footprint for those components as they now only need to track the metadata for
+certain resources, rather than the entire resource itself. Similar changes will
+be made for the destination component in an upcoming release.
+
+* Bumped HTTP dependencies to fix a potential deadlock in HTTP/2 clients
+* Changed the proxy-injector and tap-injector components to use the metadata API
+  which should result in less memory consumption
+
 ## edge-22.11.1
 
 This edge releases ships a few fixes in Linkerd's dashboard, and the

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.10.3-edge
+version: 1.10.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.10.3-edge](https://img.shields.io/badge/Version-1.10.3--edge-informational?style=flat-square)
+![Version: 1.10.4-edge](https://img.shields.io/badge/Version-1.10.4--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.4.3-edge
+version: 30.4.4-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.4.3-edge](https://img.shields.io/badge/Version-30.4.3--edge-informational?style=flat-square)
+![Version: 30.4.4-edge](https://img.shields.io/badge/Version-30.4.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.5.3-edge
+version: 30.5.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.5.3-edge](https://img.shields.io/badge/Version-30.5.3--edge-informational?style=flat-square)
+![Version: 30.5.4-edge](https://img.shields.io/badge/Version-30.5.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.3-edge
+version: 30.3.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.3.3-edge](https://img.shields.io/badge/Version-30.3.3--edge-informational?style=flat-square)
+![Version: 30.3.4-edge](https://img.shields.io/badge/Version-30.3.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.3-edge
+version: 30.4.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.4.3-edge](https://img.shields.io/badge/Version-30.4.3--edge-informational?style=flat-square)
+![Version: 30.4.4-edge](https://img.shields.io/badge/Version-30.4.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-22.11.2

This edge release introduces the use of the Kubernetes metadata API in the
proxy-injector and tap-injector components. This can reduce the IO and memory
footprint for those components as they now only need to track the metadata for
certain resources, rather than the entire resource itself. Similar changes will
be made for the destination component in an upcoming release.

* Bumped HTTP dependencies to fix a potential deadlock in HTTP/2 clients
* Changed the proxy-injector and tap-injector components to use the metadata API
  which should result in less memory consumption

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
