### PR TITLE
Add support for `--cli-version-override` in `linkerd viz check`

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -243,7 +243,8 @@ func runExtensionChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, opts
 		nsLabels[i] = ns.Labels[k8s.LinkerdExtensionLabel]
 	}
 
-	extensionSuccess, extensionWarning := healthcheck.RunExtensionsChecks(wout, werr, nsLabels, getExtensionCheckFlags(cmd.Flags()), opts.output)
+	flags := getExtensionCheckFlags(cmd.Flags())
+	extensionSuccess, extensionWarning := healthcheck.RunExtensionsChecks(wout, werr, nsLabels, flags, opts.output, opts.cliVersionOverride)
 	return extensionSuccess, extensionWarning, nil
 }
 

--- a/pkg/healthcheck/healthcheck_output.go
+++ b/pkg/healthcheck/healthcheck_output.go
@@ -96,7 +96,7 @@ func PrintChecksResult(wout io.Writer, output string, success bool, warning bool
 // RunExtensionsChecks runs checks for each extension name passed into the `extensions` parameter
 // and handles formatting the output for each extension's check. This function also handles
 // finding the extension in the user's path and runs it.
-func RunExtensionsChecks(wout io.Writer, werr io.Writer, extensions []string, flags []string, output string) (bool, bool) {
+func RunExtensionsChecks(wout io.Writer, werr io.Writer, extensions []string, flags []string, output, cliVersionOverride string) (bool, bool) {
 	if output == TableOutput {
 		PrintChecksHeader(wout, extensionsHeader)
 	}
@@ -122,6 +122,9 @@ func RunExtensionsChecks(wout io.Writer, werr io.Writer, extensions []string, fl
 		case "viz":
 			path = os.Args[0]
 			args = append([]string{"viz"}, args...)
+			if cliVersionOverride != "" {
+				args = append(args, "--cli-version-override", cliVersionOverride)
+			}
 		case "multicluster":
 			path = os.Args[0]
 			args = append([]string{"multicluster"}, args...)


### PR DESCRIPTION
This also forwards the `--cli-version-override` flag from the main `linkerd check` call to the child `linkerd viz check` call. This is required for resurrecting the `helm-upgrade` integration test (#9856)