### PR TITLE
Resuscitate `helm-upgrade` integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -252,8 +252,7 @@ jobs:
           - default-policy-deny
           - external
           - rsa-ca
-          # Skipping Helm upgrade test given chart in 2.11 is backwards-incompatible
-          #- helm-upgrade
+          - helm-upgrade
           - uninstall
           - upgrade-edge
           - upgrade-stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,8 +168,7 @@ jobs:
         - default-policy-deny
         - external
         - rsa-ca
-        # Skipping Helm upgrade test given chart in 2.11 is backwards-incompatible
-        #- helm-upgrade
+        - helm-upgrade
         - uninstall
         - upgrade-edge
         - upgrade-stable

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -404,6 +404,7 @@ setup_helm() {
   helm_charts="$( cd "$bindir"/.. && pwd )"/charts
   export helm_charts
   export helm_release_name='helm-test'
+  export helm_viz_release_name='l5d-viz'
   export helm_multicluster_release_name='multicluster-test'
   "$bindir"/helm-build
   "$helm_path" --kube-context="$context" repo add linkerd https://helm.linkerd.io/stable
@@ -413,16 +414,13 @@ setup_helm() {
 helm_cleanup() {
   (
     set -e
-    "$helm_path" --kube-context="$context" --namespace linkerd delete "$helm_release_name-crds" || true
-    "$helm_path" --kube-context="$context" --namespace linkerd delete "$helm_release_name-control-plane" || true
-    kubectl delete ns/linkerd
     "$helm_path" --kube-context="$context" --namespace linkerd-multicluster delete "$helm_multicluster_release_name" || true
-    kubectl delete ns/linkerd-multicluster
-    # We wait for the namespace to be gone so the following call to `cleanup` doesn't fail when it attempts to delete
-    # the same namespace that is already being deleted here (error thrown by the NamespaceLifecycle controller).
-    # We don't have that problem with global resources, so no need to wait for them to be gone.
-    kubectl wait --for=delete ns/linkerd --timeout=120s || true
-    kubectl wait --for=delete ns/linkerd-multicluster --timeout=120s || true
+    kubectl delete ns/linkerd-multicluster || true
+    "$helm_path" --kube-context="$context" --namespace linkerd-viz delete "$helm_viz_release_name" || true
+    kubectl delete ns/linkerd-viz || true
+    "$helm_path" --kube-context="$context" --namespace linkerd delete "$helm_release_name-control-plane" || true
+    "$helm_path" --kube-context="$context" --namespace linkerd delete "$helm_release_name-crds" || true
+    kubectl delete ns/linkerd
   )
   exit_on_err 'error cleaning up Helm'
 }
@@ -439,7 +437,7 @@ run_helm-upgrade_test() {
   setup_helm
   helm_viz_chart="$( cd "$bindir"/.. && pwd )"/viz/charts/linkerd-viz
   run_test "$test_directory/install/install_test.go" --helm-path="$helm_path" --helm-charts="$helm_charts" \
-  --viz-helm-chart="$helm_viz_chart" --helm-stable-chart='linkerd/linkerd2' --viz-helm-stable-chart="linkerd/linkerd-viz" --helm-release="$helm_release_name" --upgrade-helm-from-version="$stable_version"
+  --viz-helm-chart="$helm_viz_chart" --viz-helm-stable-chart="linkerd/linkerd-viz" --helm-release="$helm_release_name" --upgrade-helm-from-version="$stable_version"
   helm_cleanup
 }
 

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -243,7 +243,8 @@ func runExtensionChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, opts
 		nsLabels[i] = ns.Labels[k8s.LinkerdExtensionLabel]
 	}
 
-	extensionSuccess, extensionWarning := healthcheck.RunExtensionsChecks(wout, werr, nsLabels, getExtensionCheckFlags(cmd.Flags()), opts.output)
+	flags := getExtensionCheckFlags(cmd.Flags())
+	extensionSuccess, extensionWarning := healthcheck.RunExtensionsChecks(wout, werr, nsLabels, flags, opts.output, opts.cliVersionOverride)
 	return extensionSuccess, extensionWarning, nil
 }
 

--- a/jaeger/cmd/check.go
+++ b/jaeger/cmd/check.go
@@ -33,10 +33,11 @@ var (
 )
 
 type checkOptions struct {
-	wait      time.Duration
-	output    string
-	proxy     bool
-	namespace string
+	wait               time.Duration
+	output             string
+	proxy              bool
+	namespace          string
+	cliVersionOverride string
 }
 
 func jaegerCategory(hc *healthcheck.HealthChecker) *healthcheck.Category {
@@ -184,6 +185,9 @@ code.`,
 	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.Flags().BoolVar(&options.proxy, "proxy", options.proxy, "Also run data-plane checks, to determine if the data plane is healthy")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")
+	cmd.Flags().StringVar(&options.cliVersionOverride, "cli-version-override", "", "Used to override the version of the cli (mostly for testing)")
+
+	cmd.Flags().MarkHidden("cli-version-override")
 
 	pkgcmd.ConfigureNamespaceFlagCompletion(
 		cmd, []string{"namespace"},
@@ -197,6 +201,10 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, options *checkOptions
 	err := options.validate()
 	if err != nil {
 		return fmt.Errorf("Validation error when executing check command: %w", err)
+	}
+
+	if options.cliVersionOverride != "" {
+		version.Version = options.cliVersionOverride
 	}
 
 	hc := healthcheck.NewHealthChecker([]healthcheck.CategoryID{}, &healthcheck.Options{

--- a/pkg/healthcheck/healthcheck_output.go
+++ b/pkg/healthcheck/healthcheck_output.go
@@ -96,7 +96,7 @@ func PrintChecksResult(wout io.Writer, output string, success bool, warning bool
 // RunExtensionsChecks runs checks for each extension name passed into the `extensions` parameter
 // and handles formatting the output for each extension's check. This function also handles
 // finding the extension in the user's path and runs it.
-func RunExtensionsChecks(wout io.Writer, werr io.Writer, extensions []string, flags []string, output string) (bool, bool) {
+func RunExtensionsChecks(wout io.Writer, werr io.Writer, extensions []string, flags []string, output, cliVersionOverride string) (bool, bool) {
 	if output == TableOutput {
 		PrintChecksHeader(wout, extensionsHeader)
 	}
@@ -119,9 +119,15 @@ func RunExtensionsChecks(wout io.Writer, werr io.Writer, extensions []string, fl
 		case "jaeger":
 			path = os.Args[0]
 			args = append([]string{"jaeger"}, args...)
+			if cliVersionOverride != "" {
+				args = append(args, "--cli-version-override", cliVersionOverride)
+			}
 		case "viz":
 			path = os.Args[0]
 			args = append([]string{"viz"}, args...)
+			if cliVersionOverride != "" {
+				args = append(args, "--cli-version-override", cliVersionOverride)
+			}
 		case "multicluster":
 			path = os.Args[0]
 			args = append([]string{"multicluster"}, args...)

--- a/test/cli/cli_install_static_test.go
+++ b/test/cli/cli_install_static_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 		exit(1, "-linkerd flag is required")
 	}
 
-	TestHelper = testutil.NewGenericTestHelper(*linkerd, "", "l5d", "linkerd-viz", "", "", "", "", "", "", "", "", false, false, false, false, false, false, *http.DefaultClient, testutil.KubernetesHelper{})
+	TestHelper = testutil.NewGenericTestHelper(*linkerd, "", "l5d", "linkerd-viz", "", "", "", "", "", "", "", false, false, false, false, false, false, *http.DefaultClient, testutil.KubernetesHelper{})
 	os.Exit(m.Run())
 }
 

--- a/test/integration/install/testdata/check.golden
+++ b/test/integration/install/testdata/check.golden
@@ -1,0 +1,92 @@
+Linkerd core checks
+===================
+
+kubernetes-api
+--------------
+√ can initialize the client
+√ can query the Kubernetes API
+
+kubernetes-version
+------------------
+√ is running the minimum Kubernetes API version
+
+linkerd-existence
+-----------------
+√ 'linkerd-config' config map exists
+√ heartbeat ServiceAccount exist
+√ control plane replica sets are ready
+√ no unschedulable pods
+√ control plane pods are ready
+√ cluster networks contains all node podCIDRs
+√ cluster networks contains all pods
+√ cluster networks contains all services
+
+linkerd-config
+--------------
+√ control plane Namespace exists
+√ control plane ClusterRoles exist
+√ control plane ClusterRoleBindings exist
+√ control plane ServiceAccounts exist
+√ control plane CustomResourceDefinitions exist
+√ control plane MutatingWebhookConfigurations exist
+√ control plane ValidatingWebhookConfigurations exist
+√ proxy-init container runs as root user if docker container runtime is used
+
+linkerd-identity
+----------------
+√ certificate config is valid
+√ trust anchors are using supported crypto algorithm
+√ trust anchors are within their validity period
+√ trust anchors are valid for at least 60 days
+√ issuer cert is using supported crypto algorithm
+√ issuer cert is within its validity period
+√ issuer cert is valid for at least 60 days
+√ issuer cert is issued by the trust anchor
+
+linkerd-webhooks-and-apisvc-tls
+-------------------------------
+√ proxy-injector webhook has valid cert
+√ proxy-injector cert is valid for at least 60 days
+√ sp-validator webhook has valid cert
+√ sp-validator cert is valid for at least 60 days
+√ policy-validator webhook has valid cert
+√ policy-validator cert is valid for at least 60 days
+
+linkerd-version
+---------------
+√ can determine the latest version
+√ cli is up-to-date
+
+control-plane-version
+---------------------
+√ can retrieve the control plane version
+√ control plane is up-to-date
+√ control plane and cli versions match
+
+linkerd-control-plane-proxy
+---------------------------
+√ control plane proxies are healthy
+√ control plane proxies are up-to-date
+√ control plane proxies and cli versions match
+
+Linkerd extensions checks
+=========================
+
+linkerd-viz
+-----------
+√ linkerd-viz Namespace exists
+√ linkerd-viz ClusterRoles exist
+√ linkerd-viz ClusterRoleBindings exist
+√ tap API server has valid cert
+√ tap API server cert is valid for at least 60 days
+√ tap API service is running
+√ linkerd-viz pods are injected
+√ viz extension pods are running
+√ viz extension proxies are healthy
+√ viz extension proxies are up-to-date
+√ viz extension proxies and cli versions match
+√ prometheus is installed and configured correctly
+√ can initialize the client
+√ viz extension self-check
+
+Status check results are √

--- a/test/integration/install/testdata/check.viz.proxy.golden
+++ b/test/integration/install/testdata/check.viz.proxy.golden
@@ -20,6 +20,7 @@ linkerd-viz
 linkerd-viz-data-plane
 ----------------------
 √ data plane namespace exists
+√ prometheus is authorized to scrape data plane pods
 √ data plane proxy metrics are present in Prometheus
 
 Status check results are √

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -51,7 +51,6 @@ type helm struct {
 	multiclusterChart       string
 	vizChart                string
 	vizStableChart          string
-	stableChart             string
 	releaseName             string
 	multiclusterReleaseName string
 	upgradeFromVersion      string
@@ -130,7 +129,6 @@ func NewGenericTestHelper(
 	clusterDomain,
 	helmPath,
 	helmCharts,
-	helmStableChart,
 	helmReleaseName,
 	helmMulticlusterReleaseName,
 	helmMulticlusterChart string,
@@ -154,7 +152,6 @@ func NewGenericTestHelper(
 			charts:                  helmCharts,
 			multiclusterChart:       helmMulticlusterChart,
 			multiclusterReleaseName: helmMulticlusterReleaseName,
-			stableChart:             helmStableChart,
 			releaseName:             helmReleaseName,
 			upgradeFromVersion:      upgradeFromVersion,
 		},
@@ -191,7 +188,6 @@ func NewTestHelper() *TestHelper {
 	multiclusterHelmChart := flag.String("multicluster-helm-chart", "charts/linkerd-multicluster", "path to linkerd2's multicluster Helm chart")
 	vizHelmChart := flag.String("viz-helm-chart", "charts/linkerd-viz", "path to linkerd2's viz extension Helm chart")
 	vizHelmStableChart := flag.String("viz-helm-stable-chart", "charts/linkerd-viz", "path to linkerd2's viz extension stable Helm chart")
-	helmStableChart := flag.String("helm-stable-chart", "linkerd/linkerd2", "path to linkerd2's stable Helm chart")
 	helmReleaseName := flag.String("helm-release", "", "install linkerd via Helm using this release name")
 	multiclusterHelmReleaseName := flag.String("multicluster-helm-release", "", "install linkerd multicluster via Helm using this release name")
 	upgradeFromVersion := flag.String("upgrade-from-version", "", "when specified, the upgrade test uses it as the base version of the upgrade")
@@ -240,7 +236,6 @@ func NewTestHelper() *TestHelper {
 			multiclusterChart:       *multiclusterHelmChart,
 			vizChart:                *vizHelmChart,
 			vizStableChart:          *vizHelmStableChart,
-			stableChart:             *helmStableChart,
 			releaseName:             *helmReleaseName,
 			multiclusterReleaseName: *multiclusterHelmReleaseName,
 			upgradeFromVersion:      *upgradeHelmFromVersion,
@@ -342,11 +337,6 @@ func (h *TestHelper) GetLinkerdVizHelmChart() string {
 // stable chart
 func (h *TestHelper) GetLinkerdVizHelmStableChart() string {
 	return h.helm.vizStableChart
-}
-
-// GetHelmStableChart returns the path to the Linkerd Helm stable chart
-func (h *TestHelper) GetHelmStableChart() string {
-	return h.helm.stableChart
 }
 
 // UpgradeHelmFromVersion returns the version from which Linkerd should be upgraded with Helm
@@ -520,10 +510,10 @@ func (h *TestHelper) KubectlStream(arg ...string) (*Stream, error) {
 }
 
 // HelmUpgrade runs the helm upgrade subcommand, with the provided arguments
-func (h *TestHelper) HelmUpgrade(chart string, arg ...string) (string, string, error) {
+func (h *TestHelper) HelmUpgrade(chart, releaseName string, arg ...string) (string, string, error) {
 	withParams := append([]string{
 		"upgrade",
-		h.helm.releaseName,
+		releaseName,
 		"--kube-context", h.k8sContext,
 		"--namespace", h.namespace,
 		"--timeout", "60m",


### PR DESCRIPTION
Based off of the `alpeb/ext-cli-version-override` branch (depends on #9855).

This had been commented-out when we jumped to the new 2.12 helm charts. It can be used again to test upgrades from 2.12.x.

- Some of the logic in `test/integration/install/install_test.go` still hadn't considered the need to upgrade both the `linkerd-crds` and `linkerd-control-plane` charts, so that got fixed.
- Removed references to the now-deprecated `linkerd2` chart.
- Improved the `helm_cleanup()` function by uninstalling the charts in reverse order (extensions first, core last). We delete the namespaces afterwards because helm sometimes doesn't remove them, and so we shouldn't fail if we attempt to delete one that is already gone. Also removed unneeded `kubectl wait`s because `kubect delete ns` should be blocking.

Disclaimer: This is still not an ideal test setup, but it was a minor effort getting the existing code fixed before migrating to an approach less dependent on bash.