### PR TITLE
Remove tag signing requirement

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -260,9 +260,6 @@ After the review has passed and the branches from step 2 and 4 have been merged,
 follow the instructions below to properly create and push the release tag from
 the appropriate branch.
 
-**Note**: The release script will create a GPG-signed tag, so users must have
-GPG signing setup in their local git config.
-
 If performing an edge release then issue these commands. The appropriate tag
 will be automatically calculated:
 

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -90,7 +90,7 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 # shellcheck source=_release.sh
 tmp=$(. "$bindir"/_release.sh; extract_release_notes)
 
-# Create a signed tag with the commit message.
+# Create a tag with the commit message.
 git tag -F "$tmp" "$release_tag"
 
 # Success message

--- a/bin/create-release-tag
+++ b/bin/create-release-tag
@@ -71,7 +71,7 @@ Usage:
     current_xx=$(echo "$current_edge" | sed -n -E "s/.*$edge_tag_regex}$/\4/p")
 
     yy=$(date +"%y")
-    
+
     # Strip leading zero
     new_mm=$(date +"%-m")
 
@@ -91,10 +91,10 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 tmp=$(. "$bindir"/_release.sh; extract_release_notes)
 
 # Create a signed tag with the commit message.
-git tag -s -F "$tmp" "$release_tag"
+git tag -F "$tmp" "$release_tag"
 
 # Success message
-echo "$release_tag tag created and signed.
+echo "$release_tag tag created.
 
 tag: $release_tag
 


### PR DESCRIPTION
Containers are signed using cosign during the build jobs in CI, so we don't need
a hard requirement on signing the release tag anymore.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
