### PR TITLE
Remove extra whitespace in helm templates

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -317,7 +317,7 @@ spec:
         The destination controller needs to connect to the Kubernetes API before the proxy is able
         to proxy requests, so we always skip these connections.
       */}}
-      {{- $_ := set $tree.Values.proxyInit "ignoreOutboundPorts" "443" }}
+      {{- $_ := set $tree.Values.proxyInit "ignoreOutboundPorts" "443" -}}
       - {{- include "partials.proxy-init" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       {{- if .Values.priorityClassName -}}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -214,7 +214,7 @@ spec:
         proxy requests, so we always skip these connections. The identity controller makes no other
         outbound connections (so it's not important to persist any other skip ports here)
       */}}
-      {{- $_ := set $tree.Values.proxyInit "ignoreOutboundPorts" "443" }}
+      {{- $_ := set $tree.Values.proxyInit "ignoreOutboundPorts" "443" -}}
       - {{- include "partials.proxy-init" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       {{- if .Values.priorityClassName -}}


### PR DESCRIPTION
Fixes #9605

The Linkerd helm templates had an extra blank line which we remove by using `-}}` to strip trailing whitespace.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
