### PR TITLE
Fixes HostPort mapping lookup that was generating a false warning

### DIFF
--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -720,7 +720,7 @@ func getPodSkippedInboundPortsAnnotations(pod *corev1.Pod) (map[uint32]struct{},
 // Given a list of PodIP, determine is `targetIP` is a member
 func containsIP(podIPs []corev1.PodIP, targetIP string) bool {
 	for _, ip := range podIPs {
-		if ip.String() == targetIP {
+		if ip.IP == targetIP {
 			return true
 		}
 	}

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -55,6 +55,8 @@ metadata:
 status:
   phase: Running
   podIP: 172.17.0.12
+  podIPs:
+  - ip: 172.17.0.12
 spec:
   containers:
     - env:
@@ -69,7 +71,9 @@ metadata:
   namespace: ns
 status:
   phase: Succeeded
-  podIP: 172.17.0.13`,
+  podIP: 172.17.0.13
+  podIPs:
+  - ip: 172.17.0.13`,
 		`
 apiVersion: v1
 kind: Pod
@@ -78,7 +82,9 @@ metadata:
   namespace: ns
 status:
   phase: Failed
-  podIP: 172.17.0.13`,
+  podIP: 172.17.0.13
+  podIPs:
+  - ip: 172.17.0.13`,
 		`
 apiVersion: v1
 kind: Pod
@@ -87,7 +93,9 @@ metadata:
   namespace: ns
   deletionTimestamp: 2021-01-01T00:00:00Z
 status:
-  podIP: 172.17.0.13`,
+  podIP: 172.17.0.13
+  podIPs:
+  - ip: 172.17.0.13`,
 		`
 apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
@@ -125,7 +133,9 @@ metadata:
   namespace: ns
 status:
   phase: Running
-  podIP: 172.17.0.13`
+  podIP: 172.17.0.13
+  podIPs:
+  - ip: 172.17.0.13`
 
 	meshedOpaquePodResources := []string{
 		`
@@ -167,6 +177,8 @@ metadata:
 status:
   phase: Running
   podIP: 172.17.0.14
+  podIPs:
+  - ip: 172.17.0.14
 spec:
   containers:
     - env:
@@ -226,6 +238,8 @@ metadata:
 status:
   phase: Running
   podIP: 172.17.0.15
+  podIPs:
+  - ip: 172.17.0.15
 spec:
   containers:
     - env:
@@ -272,7 +286,9 @@ metadata:
   namespace: ns
 status:
   phase: Running
-  podIP: 172.17.13.15`,
+  podIP: 172.17.13.15
+  podIPs:
+  - ip: 172.17.13.15`,
 	}
 
 	policyResources := []string{
@@ -288,6 +304,8 @@ metadata:
 status:
   phase: Running
   podIP: 172.17.0.16
+  podIPs:
+  - ip: 172.17.0.16
 spec:
   containers:
     - name: linkerd-proxy
@@ -324,6 +342,8 @@ status:
   phase: Running
   hostIP: 192.168.1.20
   podIP: 172.17.0.17
+  podIPs:
+  - ip: 172.17.0.17
 spec:
   containers:
   - name: nginx


### PR DESCRIPTION
When performing the HostPort mapping introduced in #9819, the `containsIP` iterates through the pod IPs searching for a match against `targetIP` using `ip.String()`, but that returns something like `&PodIP{IP: xxx}`. Fixed that to just use `ip.IP`, and also completed the text fixtures to include both `PodIP` and `PodIPs` in the pods manifests.

Note this wasn't affecting the end result, it was just producing an extra warning as shown below, that this change eliminates:

```bash
$ go test -v ./controller/api/destination/... -run TestGetProfiles
=== RUN   TestGetProfiles
...
=== RUN   TestGetProfiles/Return_profile_with_endpoint_when_using_pod_DNS
time="2022-11-29T09:38:48-05:00" level=info msg="waiting for caches to sync"
time="2022-11-29T09:38:49-05:00" level=info msg="caches synced"
time="2022-11-29T09:38:49-05:00" level=warning msg="unable to find container port as host (172.17.13.15) matches neither PodIP nor HostIP (&Pod{ObjectMeta:{pod-0  ns    0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[linkerd.io/control-plane-ns:linkerd] map[] [] [] []},Spec:PodSpec{Volumes:[]Volume{},Containers:[]Container{},RestartPolicy:,TerminationGracePeriodSeconds:nil,ActiveDeadlineSeconds:nil,DNSPolicy:,NodeSelector:map[string]string{},ServiceAccountName:,DeprecatedServiceAccount:,NodeName:,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:nil,ImagePullSecrets:[]LocalObjectReference{},Hostname:,Subdomain:,Affinity:nil,SchedulerName:,InitContainers:[]Container{},AutomountServiceAccountToken:nil,Tolerations:[]Toleration{},HostAliases:[]HostAlias{},PriorityClassName:,Priority:nil,DNSConfig:nil,ShareProcessNamespace:nil,ReadinessGates:[]PodReadinessGate{},RuntimeClassName:nil,EnableServiceLinks:nil,PreemptionPolicy:nil,Overhead:ResourceList{},TopologySpreadConstraints:[]TopologySpreadConstraint{},EphemeralContainers:[]EphemeralContainer{},SetHostnameAsFQDN:nil,OS:nil,HostUsers:nil,},Status:PodStatus{Phase:Running,Conditions:[]PodCondition{},Message:,Reason:,HostIP:,PodIP:172.17.13.15,StartTime:<nil>,ContainerStatuses:[]ContainerStatus{},QOSClass:,InitContainerStatuses:[]ContainerStatus{},NominatedNodeName:,PodIPs:[]PodIP{},EphemeralContainerStatuses:[]ContainerStatus{},},})" test=TestGetProfiles/Return_profile_with_endpoint_when_using_pod_DNS
```
