### PR TITLE
Add changes for edge-22.12.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,13 +10,13 @@ components so that they can communicate with the Kubernetes API before their
 proxies are running.
 
 Additionally, a potential panic and false warning have been fixed in the
-destination component.
+destination controller.
 
-* Updated linkerd-jaeger's collector component to expose port 4318 in order
+* Updated linkerd-jaeger's collector to expose port 4318 in order
   support HTTP alongside gRPC (thanks @uralsemih!)
 * Introduced the `privileged` configuration which allows the `proxy-init`
   container to run as privileged without also running as root
-* Fixed a potential panic in the destination component caused by concurrent
+* Fixed a potential panic in the destination controller caused by concurrent
   writes when dealing with Endpoint updates
 * Fixed false warning when looking up HostPort mappings on Pods
 * Added static and dynamic port overrides for CNI eBPF to work with socket-level

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,10 +12,10 @@ proxies are running.
 Additionally, a potential panic and false warning have been fixed in the
 destination controller.
 
-* Updated linkerd-jaeger's collector to expose port 4318 in order
-  support HTTP alongside gRPC (thanks @uralsemih!)
-* Introduced the `privileged` configuration which allows the `proxy-init`
-  container to run as privileged without also running as root
+* Updated linkerd-jaeger's collector to expose port 4318 in order support HTTP
+  alongside gRPC (thanks @uralsemih!)
+* Added a `proxyInit.privileged` setting to control whether the `proxy-init`
+  initContainer runs as a privileged process
 * Fixed a potential panic in the destination controller caused by concurrent
   writes when dealing with Endpoint updates
 * Fixed false warning when looking up HostPort mappings on Pods

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # Changes
 
+## edge-22.12.1
+
+This edge release introduces static and dynamic port overrides for CNI eBPF
+socket-level load balancing. In certain installations when CNI plugins run in
+eBPF mode, socket-level load balancing rewrites packet destinations to port
+6443; as with 443 already, this port is now skipped as well on control plane
+components so that they can communicate with the Kubernetes API before their
+proxies are running.
+
+Additionally, a potential panic and false warning have been fixed in the
+destination component.
+
+* Updated linkerd-jaeger's collector component to expose port 4318 in order
+  support HTTP alongside gRPC (thanks @uralsemih!)
+* Introduced the `privileged` configuration which allows the `proxy-init`
+  container to run as privileged without also running as root
+* Fixed a potential panic in the destination component caused by concurrent
+  writes when dealing with Endpoint updates
+* Fixed false warning when looking up HostPort mappings on Pods
+* Added static and dynamic port overrides for CNI eBPF to work with socket-level
+  load balancing
+
 ## edge-22.11.3
 
 This edge release fixes connection errors to pods that use `hostPort`

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.10.5-edge
+version: 1.11.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.10.5-edge](https://img.shields.io/badge/Version-1.10.5--edge-informational?style=flat-square)
+![Version: 1.11.0-edge](https://img.shields.io/badge/Version-1.11.0--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.5.0-edge
+version: 30.5.1-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.5.0-edge](https://img.shields.io/badge/Version-30.5.0--edge-informational?style=flat-square)
+![Version: 30.5.1-edge](https://img.shields.io/badge/Version-30.5.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.5.5-edge
+version: 30.6.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.5.5-edge](https://img.shields.io/badge/Version-30.5.5--edge-informational?style=flat-square)
+![Version: 30.6.0-edge](https://img.shields.io/badge/Version-30.6.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.5-edge
+version: 30.3.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.3.5-edge](https://img.shields.io/badge/Version-30.3.5--edge-informational?style=flat-square)
+![Version: 30.3.6-edge](https://img.shields.io/badge/Version-30.3.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.5-edge
+version: 30.4.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.4.5-edge](https://img.shields.io/badge/Version-30.4.5--edge-informational?style=flat-square)
+![Version: 30.4.6-edge](https://img.shields.io/badge/Version-30.4.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
linkerd-control-plane chart: Minor bump after introduction of `proxyInit.privileged`
linkerd-jaeger chart: Minor bump after charts changed to expose new port and add additional Server

## edge-22.12.1

This edge release introduces static and dynamic port overrides for CNI eBPF
socket-level load balancing. In certain installations when CNI plugins run in
eBPF mode, socket-level load balancing rewrites packet destinations to port
6443; as with 443 already, this port is now skipped as well on control plane
components so that they can communicate with the Kubernetes API before their
proxies are running.

Additionally, a potential panic and false warning have been fixed in the
destination component.

* Updated linkerd-jaeger's collector component to expose port 4318 in order
  support HTTP alongside gRPC (thanks @uralsemih!)
* Introduced the `privileged` configuration which allows the `proxy-init`
  container to run as privileged without also running as root
* Fixed a potential panic in the destination component caused by concurrent
  writes when dealing with Endpoint updates
* Fixed false warning when looking up HostPort mappings on Pods
* Added static and dynamic port overrides for CNI eBPF to work with socket-level
  load balancing

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
