### PR TITLE
dev: Always rebuild the CLI in bin/linkerd

### DIFF
--- a/bin/linkerd
+++ b/bin/linkerd
@@ -9,9 +9,8 @@ rootdir=$( cd "$bindir"/.. && pwd )
 
 bin=$rootdir/target/cli/$(os)/linkerd
 
-# build linkerd executable if it does not exist
-if [ ! -f "$bin" ]; then
-  "$bindir"/build-cli-bin >/dev/null
-fi
+# Always rebuild the linkerd CLI binary before running it. This should be
+# relatively fast (<2s) if nothing has changed.
+"$bindir"/build-cli-bin >/dev/null
 
 exec "$bin" "$@"


### PR DESCRIPTION
`bin/linkerd` may use an outdated cached binary. There's no mechanism to invalidate this cache except to manually delete the file. This is cumbersome, and a common source of developer confusion.

This change removes this caching logic so that the binary is always rebuilt. This is relatively quick (<2s) when nothing has changed.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
