### PR TITLE
Take seconds from TapEvents into account

### DIFF
--- a/viz/cmd/tap.go
+++ b/viz/cmd/tap.go
@@ -381,7 +381,7 @@ func renderTapEvent(event *tapPb.TapEvent) string {
 			ev.ResponseInit.GetId().GetStream(),
 			flow,
 			ev.ResponseInit.GetHttpStatus(),
-			ev.ResponseInit.GetSinceRequestInit().GetNanos()/1000,
+			ev.ResponseInit.GetSinceRequestInit().AsDuration().Microseconds(),
 		)
 
 	case *tapPb.TapEvent_Http_ResponseEnd_:
@@ -393,7 +393,7 @@ func renderTapEvent(event *tapPb.TapEvent) string {
 				ev.ResponseEnd.GetId().GetStream(),
 				flow,
 				codes.Code(eos.GrpcStatusCode),
-				ev.ResponseEnd.GetSinceResponseInit().GetNanos()/1000,
+				ev.ResponseEnd.GetSinceResponseInit().AsDuration().Microseconds(),
 				ev.ResponseEnd.GetResponseBytes(),
 			)
 
@@ -404,7 +404,7 @@ func renderTapEvent(event *tapPb.TapEvent) string {
 				ev.ResponseEnd.GetId().GetStream(),
 				flow,
 				eos.ResetErrorCode,
-				ev.ResponseEnd.GetSinceResponseInit().GetNanos()/1000,
+				ev.ResponseEnd.GetSinceResponseInit().AsDuration().Microseconds(),
 				ev.ResponseEnd.GetResponseBytes(),
 			)
 
@@ -413,7 +413,7 @@ func renderTapEvent(event *tapPb.TapEvent) string {
 				ev.ResponseEnd.GetId().GetBase(),
 				ev.ResponseEnd.GetId().GetStream(),
 				flow,
-				ev.ResponseEnd.GetSinceResponseInit().GetNanos()/1000,
+				ev.ResponseEnd.GetSinceResponseInit().AsDuration().Microseconds(),
 				ev.ResponseEnd.GetResponseBytes(),
 			)
 		}

--- a/viz/cmd/tap_test.go
+++ b/viz/cmd/tap_test.go
@@ -311,13 +311,13 @@ func TestEventToString(t *testing.T) {
 		event := toTapEvent(&tapPb.TapEvent_Http{
 			Event: &tapPb.TapEvent_Http_ResponseInit_{
 				ResponseInit: &tapPb.TapEvent_Http_ResponseInit{
-					SinceRequestInit: &duration.Duration{Nanos: 999000},
+					SinceRequestInit: &duration.Duration{Seconds: 9, Nanos: 999000},
 					HttpStatus:       http.StatusOK,
 				},
 			},
 		})
 
-		expectedOutput := "rsp id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :status=200 latency=999µs"
+		expectedOutput := "rsp id=7:8 proxy=out src=1.2.3.4:5555 dst=2.3.4.5:6666 tls= :status=200 latency=9000999µs"
 		output := renderTapEvent(event)
 		if output != expectedOutput {
 			t.Fatalf("Expecting command output to be [%s], got [%s]", expectedOutput, output)

--- a/viz/cmd/testdata/tap_busy_output.golden
+++ b/viz/cmd/testdata/tap_busy_output.golden
@@ -1,2 +1,2 @@
 req id=1:0 proxy=out src=0.0.0.1:0 dst=[ff01::1]:0 tls=true :method=GET :authority=localhost :path=/some/path
-end id=1:0 proxy=out src=0.0.0.1:0 dst=[ff01::1]:0 tls= grpc-status=Code(666) duration=0µs response-length=1337B
+end id=1:0 proxy=out src=0.0.0.1:0 dst=[ff01::1]:0 tls= grpc-status=Code(666) duration=100000000µs response-length=1337B

--- a/viz/cmd/testdata/tap_busy_output_wide.golden
+++ b/viz/cmd/testdata/tap_busy_output_wide.golden
@@ -1,2 +1,2 @@
 req id=1:0 proxy=out src=0.0.0.1:0 dst=[ff01::1]:0 tls=true :method=GET :authority=localhost :path=/some/path dst_pod=my-pod dst_tls=true
-end id=1:0 proxy=out src=0.0.0.1:0 dst=[ff01::1]:0 tls= grpc-status=Code(666) duration=0µs response-length=1337B
+end id=1:0 proxy=out src=0.0.0.1:0 dst=[ff01::1]:0 tls= grpc-status=Code(666) duration=100000000µs response-length=1337B


### PR DESCRIPTION
The output of `linkerd viz tap` cli command has wrong values for latency/duration fields. This happens with default output format and with `-o wide` option, but works well with `-o json`, dashboard also shows proper values.

The solution is to display duration with `AsDuration().Microseconds()`.

Updated existing test + fixed couple of golden ones.

Fixes: #9878

Signed-off-by: Oleg Vorobev <olegy2008@ya.ru>