### PR TITLE
Provide additional shortnames for resources

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -20,8 +20,10 @@ const (
 	Endpoints             = "endpoints"
 	EndpointSlices        = "endpointslices"
 	Job                   = "job"
+	MeshTLSAuthentication = "meshtlsauthentication"
 	MutatingWebhookConfig = "mutatingwebhookconfig"
 	Namespace             = "namespace"
+	NetworkAuthentication = "networkauthentication"
 	Pod                   = "pod"
 	ReplicationController = "replicationcontroller"
 	ReplicaSet            = "replicaset"
@@ -117,16 +119,24 @@ var resourceNames = []resourceName{
 	{"ds", "daemonset", "daemonsets"},
 	{"deploy", "deployment", "deployments"},
 	{"job", "job", "jobs"},
+	{"meshtlsauthn", "meshtlsauthentication", "meshtlsauthentications"},
 	{"ns", "namespace", "namespaces"},
+	{"netauthn", "networkauthentication", "networkauthentications"},
+	{"networkauthn", "networkauthentication", "networkauthentications"},
 	{"po", "pod", "pods"},
 	{"rc", "replicationcontroller", "replicationcontrollers"},
 	{"rs", "replicaset", "replicasets"},
 	{"svc", "service", "services"},
 	{"sp", "serviceprofile", "serviceprofiles"},
 	{"saz", "serverauthorization", "serverauthorizations"},
+	{"serverauthz", "serverauthorization", "serverauthorizations"},
+	{"srvauthz", "serverauthorization", "serverauthorizations"},
 	{"srv", "server", "servers"},
 	{"ap", "authorizationpolicy", "authorizationpolicies"},
+	{"authzpolicy", "authorizationpolicy", "authorizationpolicies"},
 	{"route", "httproute", "httproutes"},
+	{"httprt", "httproute", "httproutes"},
+	{"rt", "httproute", "httproutes"},
 	{"sts", "statefulset", "statefulsets"},
 	{"ln", "link", "links"},
 	{"all", "all", "all"},
@@ -206,8 +216,9 @@ func ShortNameFromCanonicalResourceName(canonicalName string) string {
 
 // KindToL5DLabel converts a Kubernetes `kind` to a Linkerd label.
 // For example:
-//   `pod` -> `pod`
-//   `job` -> `k8s_job`
+//
+//	`pod` -> `pod`
+//	`job` -> `k8s_job`
 func KindToL5DLabel(k8sKind string) string {
 	if k8sKind == Job {
 		return l5dJob

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -28,14 +28,22 @@ func TestGetConfig(t *testing.T) {
 func TestCanonicalResourceNameFromFriendlyName(t *testing.T) {
 	t.Run("Returns canonical name for all known variants", func(t *testing.T) {
 		expectations := map[string]string{
-			"po":          Pod,
-			"pod":         Pod,
-			"deployment":  Deployment,
-			"deployments": Deployment,
-			"au":          Authority,
-			"authorities": Authority,
-			"cj":          CronJob,
-			"cronjob":     CronJob,
+			"po":           Pod,
+			"pod":          Pod,
+			"deployment":   Deployment,
+			"deployments":  Deployment,
+			"au":           Authority,
+			"authorities":  Authority,
+			"cj":           CronJob,
+			"cronjob":      CronJob,
+			"serverauthz":  ServerAuthorization,
+			"srvauthz":     ServerAuthorization,
+			"authzpolicy":  AuthorizationPolicy,
+			"meshtlsauthn": MeshTLSAuthentication,
+			"networkauthn": NetworkAuthentication,
+			"netauthn":     NetworkAuthentication,
+			"httprt":       HTTPRoute,
+			"rt":           HTTPRoute,
 		}
 
 		for input, expectedName := range expectations {


### PR DESCRIPTION
This change expands on existing shortnames while adding others for various policy resources. This improves the user experience when issuing commands via kubectl.

Fixes #9322

Signed-off-by: Paul Balogh <javaducky@gmail.com>
