### PR TITLE
Add policy status controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -515,7 +518,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1025,6 +1028,7 @@ dependencies = [
  "linkerd-policy-controller-grpc",
  "linkerd-policy-controller-k8s-api",
  "linkerd-policy-controller-k8s-index",
+ "linkerd-policy-controller-k8s-status-controller",
  "parking_lot",
  "serde",
  "serde_json",
@@ -1096,12 +1100,23 @@ dependencies = [
  "linkerd-policy-controller-k8s-api",
  "maplit",
  "parking_lot",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "linkerd-policy-controller-k8s-status-controller"
+version = "0.1.0"
+dependencies = [
+ "linkerd-policy-controller-k8s-api",
+ "linkerd-policy-controller-k8s-index",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1192,7 +1207,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
 
@@ -1864,6 +1879,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,6 +2301,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -230,3 +230,38 @@ subjects:
   - kind: ServiceAccount
     name: linkerd-destination
     namespace: {{.Release.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: linkerd-policy-status
+  labels:
+    app.kubernetes.io/part-of: Linkerd
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+rules:
+  - apiGroups:
+      - policy.linkerd.io
+    resources:
+      - httproutes/status
+    verbs:
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linkerd-destination-policy-status
+  labels:
+    app.kubernetes.io/part-of: Linkerd
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-policy-status
+subjects:
+  - kind: ServiceAccount
+    name: linkerd-destination
+    namespace: {{.Release.Namespace}}

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -22,6 +22,7 @@ ipnet = { version = "2", default-features = false }
 linkerd-policy-controller-core = { path = "./core" }
 linkerd-policy-controller-grpc = { path = "./grpc" }
 linkerd-policy-controller-k8s-index = { path = "./k8s/index" }
+linkerd-policy-controller-k8s-status-controller = { path = "./k8s/status-controller" }
 linkerd-policy-controller-k8s-api = { path = "./k8s/api" }
 parking_lot = "0.12"
 serde = "1"

--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -5,20 +5,25 @@ pub mod labels;
 pub mod policy;
 
 pub use self::labels::Labels;
+pub use k8s_gateway_api as gateway;
 pub use k8s_openapi::{
     api::{
         self,
         core::v1::{
             Container, ContainerPort, HTTPGetAction, Namespace, Node, NodeSpec, Pod, PodSpec,
-            PodStatus, Probe, ServiceAccount,
+            PodStatus, Probe, Service, ServiceAccount,
         },
     },
     apimachinery::{
         self,
-        pkg::{apis::meta::v1::Time, util::intstr::IntOrString},
+        pkg::{
+            apis::meta::v1::{Condition, Time},
+            util::intstr::IntOrString,
+        },
     },
 };
 pub use kube::{
-    api::{ObjectMeta, Resource, ResourceExt},
+    api::{Api, ObjectMeta, Patch, PatchParams, Resource, ResourceExt},
     runtime::watcher::Event as WatchEvent,
+    Client,
 };

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -8,12 +8,14 @@ publish = false
 [dependencies]
 ahash = "0.8"
 anyhow = "1"
+chrono = "0.4"
 futures = { version = "0.3", default-features = false }
 k8s-gateway-api = "0.8"
 kubert = { version = "0.12", default-features = false, features = ["index"] }
 linkerd-policy-controller-core = { path = "../../core" }
 linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"
+serde_json = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tracing = "0.1"

--- a/policy-controller/k8s/index/src/lib.rs
+++ b/policy-controller/k8s/index/src/lib.rs
@@ -20,7 +20,8 @@
 //! these resources cannot reference resources in other namespaces. This scoping helps to narrow the
 //! search space when processing updates and linking resources.
 
-#![deny(warnings, rust_2018_idioms)]
+// #![deny(warnings, rust_2018_idioms)]
+#![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
 pub mod authorization_policy;
@@ -41,7 +42,7 @@ use std::time;
 
 pub use self::{
     defaults::DefaultPolicy,
-    index::{Index, SharedIndex},
+    index::{Index, Patch, SharedIndex},
 };
 
 /// Holds cluster metadata.

--- a/policy-controller/k8s/index/src/tests.rs
+++ b/policy-controller/k8s/index/src/tests.rs
@@ -18,7 +18,7 @@ use linkerd_policy_controller_k8s_api::{
     ResourceExt,
 };
 use maplit::*;
-use tokio::time;
+use tokio::{sync::mpsc, time};
 
 #[test]
 fn pod_must_exist_for_lookup() {
@@ -203,7 +203,8 @@ impl TestConfig {
             default_detect_timeout: detect_timeout,
             probe_networks,
         };
-        let index = Index::shared(cluster.clone());
+        let (rx, _) = mpsc::unbounded_channel();
+        let index = Index::shared(cluster.clone(), rx);
         Self {
             index,
             cluster,

--- a/policy-controller/k8s/status-controller/Cargo.toml
+++ b/policy-controller/k8s/status-controller/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "linkerd-policy-controller-k8s-status-controller"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+linkerd-policy-controller-k8s-api = { path = "../api" }
+linkerd-policy-controller-k8s-index = { path = "../index" }
+tokio = "1"
+tracing = "0.1"

--- a/policy-controller/k8s/status-controller/src/lib.rs
+++ b/policy-controller/k8s/status-controller/src/lib.rs
@@ -1,0 +1,25 @@
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_controller_k8s_index as index;
+use tokio::sync::mpsc;
+
+pub async fn process_patches(
+    client: k8s::Client,
+    mut patches_rx: mpsc::UnboundedReceiver<index::Patch>,
+) {
+    let patch_params = k8s::PatchParams::apply("policy.linkerd.io");
+    while let Some(patch) = patches_rx.recv().await {
+        let index::Patch {
+            name,
+            namespace,
+            value,
+        } = patch;
+        tracing::info!(%value, "Patching HTTPRoute");
+        let api = k8s::Api::<k8s::policy::HttpRoute>::namespaced(client.clone(), &namespace);
+        if let Err(error) = api
+            .patch_status(&name, &patch_params, &k8s::Patch::Merge(&value))
+            .await
+        {
+            tracing::info!(%error)
+        }
+    }
+}


### PR DESCRIPTION
The following is a WIP for adding a policy status controller for adding the `status` field to policy resources. Currently, the status controller handles HTTPRoute updates and validates that the parent references are Servers that currently exist on the cluster.

  The status controller is implemented as a separate task that is spawned when the policy controller starts and reads patches sent via a channel from the policy controller. For each patch that it receives, it applies the patch to the specified resource. The policy controller creates and sends the patches so that we can reuse the index for handling resource updates as well as checking when certain resources exist in the cluster.

  When an HTTPRoute fails validation because the parent reference does not exist on the cluster, the policy controller will not index the route so that it is not served to policy clients. It also only validates that HTTPRoutes targets Servers, no other resource kinds, and does not handle backend references since those are not part of Linkerd’s HTTPRoute CRD yet.

  As ongoing work, the status controller (and policy controller index) needs to handle Server creation/deletion and update the routes that have the updated Server as a parent reference. Therefore, the index needs a way to check which HTTPRoutes have the updated Server as a parent reference and update them accordingly. Since we currently do not index HTTPRoutes when they are invalid, this means that when Servers are updated we may need to use the k8s API to check for any HTTPRoutes that are on the cluster that may not have been previously indexed. This may not be ideal, and I’m exploring if it makes sense to still index invalid resources and have a flag for serving them to clients or not.