### PR TITLE
Add block chomping indicator to strip trailing new lines in config map

### DIFF
--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -34,7 +34,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
-  ca-bundle.crt: |{{.Values.identityTrustAnchorsPEM | trim | nindent 4}}
+  ca-bundle.crt: |-{{.Values.identityTrustAnchorsPEM | trim | nindent 4}}
 {{- end}}
 ---
 kind: Service


### PR DESCRIPTION
When using ArgoCD and Azure Key Vault Plugin to manage Linkerd via Helm, the identityTrustAnchorsPEM value gets passed from Azure Key Vault with a trailing new line. This trailing new line makes its way into the config map linkerd-identity-trust-roots causing Linkerd control plane to crash upon deployment. There aren't any other alternatives when using Azure Key Vault due to how multi-line secrets are created. Azure forces this trailing new line.

The solution is to add a block chomping indicator to strip trailing new lines in the config map.

More on block chomping indicators: https://yaml-multiline.info/

Fixes: #10012

Signed-off-by: Alexander Di Clemente <diclemea@gmail.com>