### PR TITLE
Correct `identity.issuer.externalCA` to `identity.externalCA`

### DIFF
--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -241,7 +241,7 @@ func makeInstallFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) 
 
 		flag.NewBoolFlag(installOnlyFlags, "identity-external-ca", false,
 			"Whether to use an external CA provider (default false)", func(values *l5dcharts.Values, value bool) error {
-				values.Identity.Issuer.ExternalCA = value
+				values.Identity.ExternalCA = value
 				return nil
 			}),
 	}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -937,7 +937,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1132,7 +1132,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1384,7 +1384,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1540,7 +1540,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -936,7 +936,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1131,7 +1131,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1382,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,7 +1538,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -936,7 +936,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1131,7 +1131,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1382,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,7 +1538,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -936,7 +936,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1131,7 +1131,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1382,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,7 +1538,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -936,7 +936,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1131,7 +1131,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1382,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,7 +1538,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -934,7 +934,7 @@ spec:
         - mountPath: /var/run/linkerd/identity/end-entity
           name: linkerd-identity-end-entity
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1122,7 +1122,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1371,7 +1371,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1520,7 +1520,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -448,9 +448,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -1018,7 +1018,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1510,7 +1510,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -448,9 +448,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: true
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -1018,7 +1018,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1510,7 +1510,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -361,9 +361,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -697,7 +697,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -867,7 +867,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1062,7 +1062,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1313,7 +1313,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1413,7 +1413,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -431,9 +431,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -739,7 +739,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -909,7 +909,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1107,7 +1107,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1358,7 +1358,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1519,7 +1519,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -449,9 +449,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -991,7 +991,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1486,7 +1486,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -449,9 +449,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -999,7 +999,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1498,7 +1498,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -444,9 +444,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -981,7 +981,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1476,7 +1476,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -1118,7 +1118,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1512,7 +1512,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -423,9 +423,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -742,7 +742,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -914,7 +914,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1104,7 +1104,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1363,7 +1363,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1515,7 +1515,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -936,7 +936,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1131,7 +1131,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1382,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,7 +1538,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -430,9 +430,9 @@ data:
     heartbeatSchedule: 1 2 3 4 5
     highAvailability: false
     identity:
+      externalCA: false
       issuer:
         clockSkewAllowance: 20s
-        externalCA: false
         issuanceLifetime: 24h0m0s
         scheme: linkerd.io/tls
         tls:
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - args:
         - identity
@@ -936,7 +936,7 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1131,7 +1131,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1382,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      
+
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,7 +1538,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      
+
       containers:
       - env:
         - name: _pod_name

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -224,13 +224,13 @@ type (
 	// Identity contains the fields to set the identity variables in the proxy
 	// sidecar container
 	Identity struct {
+		ExternalCA                    bool    `json:"externalCA"`
 		ServiceAccountTokenProjection bool    `json:"serviceAccountTokenProjection"`
 		Issuer                        *Issuer `json:"issuer"`
 	}
 
 	// Issuer has the Helm variables of the identity issuer
 	Issuer struct {
-		ExternalCA         bool       `json:"externalCA"`
 		Scheme             string     `json:"scheme"`
 		ClockSkewAllowance string     `json:"clockSkewAllowance"`
 		IssuanceLifetime   string     `json:"issuanceLifetime"`


### PR DESCRIPTION
Helm chart has `identity.externalCA` value.
CLI code sets `identity.issuer.externalCA` and fails to produce the desired configuration. This change aligns everything to `identity.externalCA`.

Signed-off-by: Dmitry Mikhaylov <anoxape@gmail.com>
