### PR TITLE
Add multicluster deployment template annotations and terminationGrace…

### DIFF
--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -74,6 +74,7 @@ Kubernetes: `>=1.21.0-0`
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
 | gateway.UID | int | `2103` | User id under which the gateway shall be ran |
+| gateway.deploymentAnnotations | object | `{}` | Annotations to add to the gateway deployment |
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |
@@ -85,6 +86,7 @@ Kubernetes: `>=1.21.0-0`
 | gateway.replicas | int | `1` | Number of replicas for the gateway pod |
 | gateway.serviceAnnotations | object | `{}` | Annotations to add to the gateway service |
 | gateway.serviceType | string | `"LoadBalancer"` | Service Type of gateway Service |
+| gateway.terminationGracePeriodSeconds | string | `""` | Set terminationGracePeriodSeconds on gateway deployment |
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | imagePullPolicy | string | `"IfNotPresent"` | Docker imagePullPolicy for all multicluster components |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -35,6 +35,7 @@ spec:
         config.linkerd.io/enable-gateway: "true"
         config.linkerd.io/default-inbound-policy: all-authenticated
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        {{- with .Values.gateway.deploymentAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
         app: {{.Values.gateway.name}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
@@ -42,6 +43,9 @@ spec:
       {{- $_ := set $tree "component" .Values.gateway.name -}}
       {{- $_ := set $tree "label" "app" -}}
       {{- include "linkerd.affinity" $tree | nindent 6 }}
+      {{- if .Values.gateway.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{.Values.gateway.terminationGracePeriodSeconds}}
+      {{- end }}
       containers:
         - name: pause
           image: {{ .Values.gateway.pauseImage }}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -23,8 +23,12 @@ gateway:
     seconds: 3
   # -- Annotations to add to the gateway service
   serviceAnnotations: {}
+  # -- Annotations to add to the gateway deployment
+  deploymentAnnotations: {}
   # -- Set loadBalancerIP on gateway service
   loadBalancerIP: ""
+  # -- Set terminationGracePeriodSeconds on gateway deployment
+  terminationGracePeriodSeconds: ""
 
   # -- The pause container to use
   pauseImage: "gcr.io/google_containers/pause:3.2"


### PR DESCRIPTION
Hi,

I have created this MR following the issue #10120 I have opened sooner today.

This MR is adding 2 new parameters to the linkerd-multicluster chart: 

- `deploymentAnnotations`
- `terminationGracePeriodSeconds`

Signed-off-by: Arnaud Beun <arnaud.beun@sorare.com>
