### PR TITLE
edge-23.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,50 @@
 # Changes
 
+## edge-23.1.1
+
+This edge release introduces a number of different fixes changes to the proxy.
+The proxy has been updated to initialize routes lazily, which means service
+profile routes will now only show up in the metrics when a route is used. In
+the extensions, old (`ServerAuthorization`) resources have been converted to
+`AuthorizationPolicy` -- as part of this change, redundant policy resources
+have been cleaned up. A bug in the destination controller that could
+potentially lead to stale pods being considered in the load balancer has been
+fixed; operations that could previously result in this behavior are now
+infallible. Support has been added for `Pod Security Admission`, used instead
+of `Pod Security Policy`, as part of this change, some of the extension charts
+have been modified to include a `cniEnabled` flag that will impact the policy
+used. 
+
+Finally, this edge release contains a number of fixes and improvements
+from our contributors.
+
+* Converted `ServerAuthorization` resources to `AuthorizationPolicy` resources
+  in Linkerd extensions
+* Removed policy resources bound to admin servers in extensions (previously
+  these resources were used to authorize probes but now are authorized by
+  default)
+* Added a `resources` field in the linkerd-cni chart (thanks @jcogilvie!)
+* Fixed an issue in the CLI where `--identity-external-ca` would set an
+  incorrect field (thanks @anoxape!)
+* Fixed an issue in the destination controller that could result in stale
+  endpoints when using EndpointSlice objects. Logic that previously resulted in
+  undefined behavior is now infallible and endpoints will no longer be skipped
+  during removal
+* Added namespace to namespace-metadata resources in Helm (thanks @joebowbeer!)
+* Added support for Pod Security Admission (superseedes PSPs); through this
+  change extensions now have a `cniEnabled` value in their charts that will
+  directly influence which PSA policy to use
+* Changed routes to be initialized lazily. Service Profile routes will no
+  longer show up in metrics until the route is used (default routes are always
+  available when no Service Profile is defined for a service)
+* Changed the proxy's behavior when traffic splitting so that only services
+  that are not in failfast are used. This will enable the proxy to manage
+  failover without external coordination
+* Updated tokio (async runtime) in the proxy which should reduce CPU usage,
+  especially for proxy's pod local (i.e in the same network namespace)
+  communication
+
+
 ## edge-22.12.1
 
 This edge release introduces static and dynamic port overrides for CNI eBPF

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,21 +7,18 @@ deprecated policy resources, and introduces several changes to how the proxy
 works.
 
 A bug in the destination controller that could potentially lead to stale pods
-being considered in the load balancer has been fixed; operations that could
-previously result in this behavior are now infallible.
+being considered in the load balancer has been fixed.
 
 Several Linkerd extensions were still using the now deprecated
 ServerAuthorization resource. These instances have now been converted to using
-AuthorizationPolicy. Additionally, there were several policy resources that
-authenticated probes, but these became redundant after a previous change that
-automatically authenticates probes; those resources have been removed.
+AuthorizationPolicy. Additionally, removed several policy resources that
+authenticated probes, since probes are now authenticated by default.
 
-As part of ongoing policy work in the proxy, there are several changes with how
-the proxy works. There were several places that we were able to remove
-unnecessary caching and buffering. Routes are now lazily initialized so that
-service profile routes will not show up in metrics until the route is used.
-Furthermore, the proxy’s traffic splitting behavior has changed so that only
-available resources are used, resulting in less failfast errors.
+As part of ongoing policy work, there are several changes with how the proxy
+works. Routes are now lazily initialized so that service profile routes will
+not show up in metrics until the route is used. Furthermore, the proxy’s
+traffic splitting behavior has changed so that only available resources are
+used, resulting in less failfast errors.
 
 Finally, this edge release contains a number of fixes and improvements from our
 contributors.
@@ -34,14 +31,11 @@ contributors.
 * Added a `resources` field in the linkerd-cni chart (thanks @jcogilvie!)
 * Fixed an issue in the CLI where `--identity-external-ca` would set an
   incorrect field (thanks @anoxape!)
-* Fixed an issue in the destination controller that could result in stale
-  endpoints when using EndpointSlice objects. Logic that previously resulted in
-  undefined behavior is now infallible and endpoints will no longer be skipped
-  during removal
+* Fixed an issue in the destination controller's cache that could result in
+  stale endpoints when using EndpointSlice objects
 * Added namespace to namespace-metadata resources in Helm (thanks @joebowbeer!)
-* Added support for Pod Security Admission (superseedes PSPs); through this
-  change extensions now have a `cniEnabled` value in their charts that will
-  directly influence which PSA policy to use
+* Added support for Pod Security Admission (Pod Security Policy resources are
+  still supported but disabled by default)
 * Changed routes to be initialized lazily. Service Profile routes will no
   longer show up in metrics until the route is used (default routes are always
   available when no Service Profile is defined for a service)
@@ -51,7 +45,8 @@ contributors.
 * Updated tokio (async runtime) in the proxy which should reduce CPU usage,
   especially for proxy's pod local (i.e in the same network namespace)
   communication
-
+* Fixed an issue where `linkerd viz tap` would display wrong latency/duration
+  value (thanks @olegy2008!)
 
 ## edge-22.12.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,21 +2,29 @@
 
 ## edge-23.1.1
 
-This edge release introduces a number of different fixes changes to the proxy.
-The proxy has been updated to initialize routes lazily, which means service
-profile routes will now only show up in the metrics when a route is used. In
-the extensions, old (`ServerAuthorization`) resources have been converted to
-`AuthorizationPolicy` -- as part of this change, redundant policy resources
-have been cleaned up. A bug in the destination controller that could
-potentially lead to stale pods being considered in the load balancer has been
-fixed; operations that could previously result in this behavior are now
-infallible. Support has been added for `Pod Security Admission`, used instead
-of `Pod Security Policy`, as part of this change, some of the extension charts
-have been modified to include a `cniEnabled` flag that will impact the policy
-used. 
+This edge release fixes a caching issue in the destination controller, converts
+deprecated policy resources, and introduces several changes to how the proxy
+works.
 
-Finally, this edge release contains a number of fixes and improvements
-from our contributors.
+A bug in the destination controller that could potentially lead to stale pods
+being considered in the load balancer has been fixed; operations that could
+previously result in this behavior are now infallible.
+
+Several Linkerd extensions were still using the now deprecated
+ServerAuthorization resource. These instances have now been converted to using
+AuthorizationPolicy. Additionally, there were several policy resources that
+authenticated probes, but these became redundant after a previous change that
+automatically authenticates probes; those resources have been removed.
+
+As part of ongoing policy work in the proxy, there are several changes with how
+the proxy works. There were several places that we were able to remove
+unnecessary caching and buffering. Routes are now lazily initialized so that
+service profile routes will not show up in metrics until the route is used.
+Furthermore, the proxy’s traffic splitting behavior has changed so that only
+available resources are used, resulting in less failfast errors.
+
+Finally, this edge release contains a number of fixes and improvements from our
+contributors.
 
 * Converted `ServerAuthorization` resources to `AuthorizationPolicy` resources
   in Linkerd extensions

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.12.0-edge
+version: 1.11.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.11.0-edge
+version: 1.12.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.11.0-edge](https://img.shields.io/badge/Version-1.11.0--edge-informational?style=flat-square)
+![Version: 1.12.0-edge](https://img.shields.io/badge/Version-1.12.0--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.12.0-edge](https://img.shields.io/badge/Version-1.12.0--edge-informational?style=flat-square)
+![Version: 1.11.1-edge](https://img.shields.io/badge/Version-1.11.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.5.1-edge
+version: 30.6.0-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.5.1-edge](https://img.shields.io/badge/Version-30.5.1--edge-informational?style=flat-square)
+![Version: 30.6.0-edge](https://img.shields.io/badge/Version-30.6.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.7.0-edge
+version: 30.6.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.6.0-edge
+version: 30.7.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.6.0-edge](https://img.shields.io/badge/Version-30.6.0--edge-informational?style=flat-square)
+![Version: 30.7.0-edge](https://img.shields.io/badge/Version-30.7.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.7.0-edge](https://img.shields.io/badge/Version-30.7.0--edge-informational?style=flat-square)
+![Version: 30.6.1-edge](https://img.shields.io/badge/Version-30.6.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.0-edge
+version: 30.3.7-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.3.6-edge
+version: 30.4.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.3.6-edge](https://img.shields.io/badge/Version-30.3.6--edge-informational?style=flat-square)
+![Version: 30.4.0-edge](https://img.shields.io/badge/Version-30.4.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.4.0-edge](https://img.shields.io/badge/Version-30.4.0--edge-informational?style=flat-square)
+![Version: 30.3.7-edge](https://img.shields.io/badge/Version-30.3.7--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.5.0-edge
+version: 30.4.7-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.6-edge
+version: 30.5.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.5.0-edge](https://img.shields.io/badge/Version-30.5.0--edge-informational?style=flat-square)
+![Version: 30.4.7-edge](https://img.shields.io/badge/Version-30.4.7--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.4.6-edge](https://img.shields.io/badge/Version-30.4.6--edge-informational?style=flat-square)
+![Version: 30.5.0-edge](https://img.shields.io/badge/Version-30.5.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release introduces a number of different fixes changes to the proxy. The proxy has been updated to initialize routes lazily, which means service profile routes will now only show up in the metrics when a route is used. In the extensions, old (`ServerAuthorization`) resources have been converted to `AuthorizationPolicy` -- as part of this change, redundant policy resources have been cleaned up. A bug in the destination controller that could potentially lead to stale pods being considered in the load balancer has been fixed; operations that could previously result in this behavior are now infallible. Support has been added for `Pod Security Admission`, used instead of `Pod Security Policy`, as part of this change, some of the extension charts have been modified to include a `cniEnabled` flag that will impact the policy used.

Finally, this edge release contains a number of fixes and improvements from our contributors.

* Converted `ServerAuthorization` resources to `AuthorizationPolicy` resources in Linkerd extensions
* Removed policy resources bound to admin servers in extensions (previously these resources were used to authorize probes but now are authorized by default)
* Added a `resources` field in the linkerd-cni chart (thanks @jcogilvie!)
* Fixed an issue in the CLI where `--identity-external-ca` would set an incorrect field (thanks @anoxape!)
* Fixed an issue in the destination controller that could result in stale endpoints when using EndpointSlice objects. Logic that previously resulted in undefined behavior is now infallible and endpoints will no longer be skipped during removal
* Added namespace to namespace-metadata resources in Helm (thanks @joebowbeer!)
* Added support for Pod Security Admission (superseedes PSPs); through this change extensions now have a `cniEnabled` value in their charts that will directly influence which PSA policy to use
* Changed routes to be initialized lazily. Service Profile routes will no longer show up in metrics until the route is used (default routes are always available when no Service Profile is defined for a service)
* Changed the proxy's behavior when traffic splitting so that only services that are not in failfast are used. This will enable the proxy to manage failover without external coordination
* Updated tokio (async runtime) in the proxy which should reduce CPU usage, especially for proxy's pod local (i.e in the same network namespace) communication

Signed-off-by: Matei David <matei@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
