### PR TITLE
Optional AuthorizationPolicy for Grafana

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -35,6 +35,16 @@ relevant, and have it link to the appropriate Grafana dashboard, make sure you
 have a proper location set up in the `grafana.url` setting in Linkerd Viz's
 `values.yaml`.
 
+## Granting access
+
+As of linkerd `stable-2.13.0` (or `edge-23.1.1`), the access to Linkerd Viz'
+Prometheus instance has been restricted through the `prometheus-admin`
+AuthorizationPolicy, granting access only to the `metrics-api` ServiceAccount.
+In order to grant access to Grafana, you need to add an AuthorizationPolicy
+pointing to its ServiceAccount. You can apply
+[authzpolicy-grafana.yaml](grafana/authzpolicy-grafana.yaml) which grants permission for the
+`grafana` ServiceAccount.
+
 ## Note to developers
 
 The `grafana/dashboards` directory contains the same dashboard definitions

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -42,8 +42,8 @@ Prometheus instance has been restricted through the `prometheus-admin`
 AuthorizationPolicy, granting access only to the `metrics-api` ServiceAccount.
 In order to grant access to Grafana, you need to add an AuthorizationPolicy
 pointing to its ServiceAccount. You can apply
-[authzpolicy-grafana.yaml](grafana/authzpolicy-grafana.yaml) which grants permission for the
-`grafana` ServiceAccount.
+[authzpolicy-grafana.yaml](grafana/authzpolicy-grafana.yaml) which grants
+permission for the `grafana` ServiceAccount.
 
 ## Note to developers
 

--- a/grafana/authzpolicy-grafana.yaml
+++ b/grafana/authzpolicy-grafana.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  namespace: linkerd-viz
+  name: grafana
+spec:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: prometheus-admin
+  requiredAuthenticationRefs:
+    - kind: ServiceAccount
+      name: grafana
+      namespace: grafana
+


### PR DESCRIPTION
Now that Prometheus access is restricted to just the metrics-api ServiceAccount, we provide here an optional AuthorizationPolicy to grant access to Grafana, and relevant instructions in the Grafana README.