### PR TITLE
Fail controller readiness checks until caches are synced

### DIFF
--- a/controller/webhook/launcher.go
+++ b/controller/webhook/launcher.go
@@ -24,6 +24,16 @@ func Launch(
 	kubeconfig string,
 	enablePprof bool,
 ) {
+	ready := false
+	adminServer := admin.NewServer(metricsAddr, enablePprof, &ready)
+
+	go func() {
+		log.Infof("starting admin server on %s", metricsAddr)
+		if err := adminServer.ListenAndServe(); err != nil {
+			log.Errorf("failed to start webhook admin server: %s", err)
+		}
+	}()
+
 	stop := make(chan os.Signal, 1)
 	defer close(stop)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
@@ -56,14 +66,7 @@ func Launch(
 
 	metadataAPI.Sync(nil)
 
-	adminServer := admin.NewServer(metricsAddr, enablePprof)
-
-	go func() {
-		log.Infof("starting admin server on %s", metricsAddr)
-		if err := adminServer.ListenAndServe(); err != nil {
-			log.Errorf("failed to start webhook admin server: %s", err)
-		}
-	}()
+	ready = true
 
 	<-stop
 	log.Info("shutting down webhook server")

--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -13,13 +13,15 @@ import (
 type handler struct {
 	promHandler http.Handler
 	enablePprof bool
+	ready       *bool
 }
 
 // NewServer returns an initialized `http.Server`, configured to listen on an address.
-func NewServer(addr string, enablePprof bool) *http.Server {
+func NewServer(addr string, enablePprof bool, ready *bool) *http.Server {
 	h := &handler{
 		promHandler: promhttp.Handler(),
 		enablePprof: enablePprof,
+		ready:       ready,
 	}
 
 	return &http.Server{
@@ -63,5 +65,10 @@ func (h *handler) servePing(w http.ResponseWriter) {
 }
 
 func (h *handler) serveReady(w http.ResponseWriter) {
-	w.Write([]byte("ok\n"))
+	if *h.ready {
+		w.Write([]byte("ok\n"))
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("not ready\n"))
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/10036

The Linkerd control plane components written in go serve liveness and readiness probes endpoint on their admin server.  However, the admin server is not started until k8s informer caches are synced, which can take a long time on large clusters.  This means that liveness checks can time out causing the controller to be restarted.

We start the admin server before attempting to sync caches so that we can respond to liveness checks immediately.  We fail readiness probes until the caches are synced.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
