### PR TITLE
Add multicluster gateway nodeSelector and tolerations helm parameters

### DIFF
--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -78,6 +78,7 @@ Kubernetes: `>=1.21.0-0`
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |
+| gateway.nodeSelector | object | `{}` | Node selectors for the gateway pod |
 | gateway.pauseImage | string | `"gcr.io/google_containers/pause:3.2"` | The pause container to use |
 | gateway.port | int | `4143` | The port on which all the gateway will accept incoming traffic |
 | gateway.probe.path | string | `"/ready"` | The path that will be used by remote clusters for determining whether the gateway is alive |
@@ -87,6 +88,7 @@ Kubernetes: `>=1.21.0-0`
 | gateway.serviceAnnotations | object | `{}` | Annotations to add to the gateway service |
 | gateway.serviceType | string | `"LoadBalancer"` | Service Type of gateway Service |
 | gateway.terminationGracePeriodSeconds | string | `""` | Set terminationGracePeriodSeconds on gateway deployment |
+| gateway.tolerations | list | `[]` | Tolerations for the gateway pod |
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | imagePullPolicy | string | `"IfNotPresent"` | Docker imagePullPolicy for all multicluster components |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -59,6 +59,12 @@ spec:
             seccompProfile:
               type: RuntimeDefault
       serviceAccountName: {{.Values.gateway.name}}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations: {{ toYaml . | nindent 6 }}
+      {{- end }}
 {{- if .Values.enablePodAntiAffinity }}
 ---
 kind: PodDisruptionBudget

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -29,6 +29,10 @@ gateway:
   loadBalancerIP: ""
   # -- Set terminationGracePeriodSeconds on gateway deployment
   terminationGracePeriodSeconds: ""
+  # -- Node selectors for the gateway pod
+  nodeSelector: {}
+  # -- Tolerations for the gateway pod
+  tolerations: []
 
   # -- The pause container to use
   pauseImage: "gcr.io/google_containers/pause:3.2"


### PR DESCRIPTION
To be able to move gateway pods to different kube nodes.

Signed-off-by: Arnaud Beun [arnaud.beun@sorare.com](mailto:arnaud.beun@sorare.com)