### PR TITLE
Otel collector pushes Tags as "host.name" for all formats

### DIFF
--- a/web/app/js/components/JaegerLink.jsx
+++ b/web/app/js/components/JaegerLink.jsx
@@ -7,7 +7,7 @@ function jaegerQuery(name, namespace, resource) {
   if (_isEmpty(namespace)) {
     return `{"linkerd.io/workload-ns"%3A"${name}"}`;
   } else if (resource === 'pod') {
-    return `{"hostname"%3A"${name}"%2C"linkerd.io/workload-ns"%3A"${namespace}"}`;
+    return `{"host.name"%3A"${name}"%2C"linkerd.io/workload-ns"%3A"${namespace}"}`;
   } else {
     return `{"linkerd.io%2Fproxy-${resource}"%3A"${name}"%2C"linkerd.io/workload-ns"%3A"${namespace}"}`;
   }


### PR DESCRIPTION
Subject
Fix Linkerd Viz UI link to pods traces in Jaeger

Problem
It is not possible to use current link Linkerd Viz for Pods - we see empty data in the Jaeger UI

Solution
We are using wrong tag "hostname", which should be "host.name" - propagated by Otel Collector for all formats.

Validation

Fixes #[GitHub issue ID]
no
