### PR TITLE
Support service internal traffic policy

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -31,6 +31,7 @@ type endpointTranslator struct {
 	identityTrustDomain string
 	enableH2Upgrade     bool
 	nodeTopologyZone    string
+	nodeName            string
 	defaultOpaquePorts  map[uint32]struct{}
 
 	availableEndpoints watcher.AddressSet
@@ -70,6 +71,7 @@ func newEndpointTranslator(
 		identityTrustDomain,
 		enableH2Upgrade,
 		nodeTopologyZone,
+		srcNodeName,
 		defaultOpaquePorts,
 		availableEndpoints,
 		filteredSnapshot,
@@ -103,8 +105,9 @@ func (et *endpointTranslator) Remove(set watcher.AddressSet) {
 
 func (et *endpointTranslator) sendFilteredUpdate(set watcher.AddressSet) {
 	et.availableEndpoints = watcher.AddressSet{
-		Addresses: et.availableEndpoints.Addresses,
-		Labels:    set.Labels,
+		Addresses:          et.availableEndpoints.Addresses,
+		Labels:             set.Labels,
+		LocalTrafficPolicy: set.LocalTrafficPolicy,
 	}
 
 	filtered := et.filterAddresses()
@@ -124,8 +127,26 @@ func (et *endpointTranslator) sendFilteredUpdate(set watcher.AddressSet) {
 // topology zone. The client will only receive endpoints with the same
 // consumption zone as the node. An endpoints consumption zone is set
 // by its Hints field and can be different than its actual Topology zone.
+// when service.pec.internalTrafficPolicy is set to local, Topology Aware
+// Hints are not used.
 func (et *endpointTranslator) filterAddresses() watcher.AddressSet {
 	filtered := make(map[watcher.ID]watcher.Address)
+	// If service.pec.internalTrafficPolicy is set to local, filter and return the addresses
+	// for local node only
+	if et.availableEndpoints.LocalTrafficPolicy {
+		et.log.Debugf("Filtering through addresses that should be consumed by node %s", et.nodeName)
+		for id, address := range et.availableEndpoints.Addresses {
+			if address.Pod.Spec.NodeName == et.nodeName {
+				filtered[id] = address
+			}
+		}
+		et.log.Debugf("Filtered from %d to %d addresses", len(et.availableEndpoints.Addresses), len(filtered))
+		return watcher.AddressSet{
+			Addresses:          filtered,
+			Labels:             et.availableEndpoints.Labels,
+			LocalTrafficPolicy: et.availableEndpoints.LocalTrafficPolicy,
+		}
+	}
 	// If any address does not have a hint, then all hints are ignored and all
 	// available addresses are returned. This replicates kube-proxy behavior
 	// documented in the KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/2433-topology-aware-hints/README.md#kube-proxy
@@ -135,8 +156,9 @@ func (et *endpointTranslator) filterAddresses() watcher.AddressSet {
 				filtered[k] = v
 			}
 			return watcher.AddressSet{
-				Addresses: filtered,
-				Labels:    et.availableEndpoints.Labels,
+				Addresses:          filtered,
+				Labels:             et.availableEndpoints.Labels,
+				LocalTrafficPolicy: et.availableEndpoints.LocalTrafficPolicy,
 			}
 		}
 	}
@@ -154,8 +176,9 @@ func (et *endpointTranslator) filterAddresses() watcher.AddressSet {
 	if len(filtered) > 0 {
 		et.log.Debugf("Filtered from %d to %d addresses", len(et.availableEndpoints.Addresses), len(filtered))
 		return watcher.AddressSet{
-			Addresses: filtered,
-			Labels:    et.availableEndpoints.Labels,
+			Addresses:          filtered,
+			Labels:             et.availableEndpoints.Labels,
+			LocalTrafficPolicy: et.availableEndpoints.LocalTrafficPolicy,
 		}
 	}
 
@@ -165,8 +188,9 @@ func (et *endpointTranslator) filterAddresses() watcher.AddressSet {
 		filtered[k] = v
 	}
 	return watcher.AddressSet{
-		Addresses: filtered,
-		Labels:    et.availableEndpoints.Labels,
+		Addresses:          filtered,
+		Labels:             et.availableEndpoints.Labels,
+		LocalTrafficPolicy: et.availableEndpoints.LocalTrafficPolicy,
 	}
 }
 

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -136,7 +136,7 @@ func (et *endpointTranslator) filterAddresses() watcher.AddressSet {
 	if et.availableEndpoints.LocalTrafficPolicy {
 		et.log.Debugf("Filtering through addresses that should be consumed by node %s", et.nodeName)
 		for id, address := range et.availableEndpoints.Addresses {
-			if address.Pod.Spec.NodeName == et.nodeName {
+			if address.Pod != nil && address.Pod.Spec.NodeName == et.nodeName {
 				filtered[id] = address
 			}
 		}

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -20,10 +20,11 @@ import (
 )
 
 type bufferingEndpointListener struct {
-	added             []string
-	removed           []string
-	noEndpointsCalled bool
-	noEndpointsExist  bool
+	added              []string
+	removed            []string
+	localTrafficPolicy bool
+	noEndpointsCalled  bool
+	noEndpointsExist   bool
 	sync.Mutex
 }
 
@@ -78,6 +79,7 @@ func (bel *bufferingEndpointListener) Add(set AddressSet) {
 	for _, address := range set.Addresses {
 		bel.added = append(bel.added, addressString(address))
 	}
+	bel.localTrafficPolicy = set.LocalTrafficPolicy
 }
 
 func (bel *bufferingEndpointListener) Remove(set AddressSet) {
@@ -86,6 +88,7 @@ func (bel *bufferingEndpointListener) Remove(set AddressSet) {
 	for _, address := range set.Addresses {
 		bel.removed = append(bel.removed, addressString(address))
 	}
+	bel.localTrafficPolicy = set.LocalTrafficPolicy
 }
 
 func (bel *bufferingEndpointListener) NoEndpoints(exists bool) {
@@ -708,6 +711,7 @@ func TestEndpointsWatcherWithEndpointSlices(t *testing.T) {
 		expectedNoEndpoints              bool
 		expectedNoEndpointsServiceExists bool
 		expectedError                    bool
+		expectedLocalTrafficPolicy       bool
 	}{
 		{
 			serviceType: "local services with EndpointSlice",
@@ -738,7 +742,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 8989`,
+  - port: 8989
+  internalTrafficPolicy: Local`,
 				`
 addressType: IPv4
 apiVersion: discovery.k8s.io/v1
@@ -836,6 +841,7 @@ status:
 			expectedNoEndpoints:              false,
 			expectedNoEndpointsServiceExists: false,
 			expectedError:                    false,
+			expectedLocalTrafficPolicy:       true,
 		},
 		{
 			serviceType: "local services with missing addresses and EndpointSlice",
@@ -1299,6 +1305,10 @@ status:
 			}
 			if !tt.expectedError && err != nil {
 				t.Fatalf("Expected no error, got [%s]", err)
+			}
+
+			if listener.localTrafficPolicy != tt.expectedLocalTrafficPolicy {
+				t.Fatalf("Expected localTrafficPolicy [%v], got [%v]", tt.expectedLocalTrafficPolicy, listener.localTrafficPolicy)
 			}
 
 			listener.ExpectAdded(tt.expectedAddresses, t)


### PR DESCRIPTION
Addresses https://github.com/linkerd/linkerd2/discussions/10130

https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
1. Update endpoints watcher to include additional field `localTrafficPolicy`. Set to true when `.spec.internalTrafficPolicy` is set to `Local`
2. Update endpoints translater to filter by node when `localTrafficPolicy` is set to true. Topology Aware Hints are not used when `service.pec.internalTrafficPolicy` is set to local

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
