### PR TITLE
Fix memory leak in Server listeners

### DIFF
--- a/controller/api/destination/watcher/server_watcher.go
+++ b/controller/api/destination/watcher/server_watcher.go
@@ -94,7 +94,12 @@ func (sw *ServerWatcher) Unsubscribe(pod *corev1.Pod, port Port, listener Server
 			listeners = listeners[:n-1]
 		}
 	}
-	sw.subscriptions[pp] = listeners
+
+	if len(listeners) > 0 {
+		sw.subscriptions[pp] = listeners
+	} else {
+		delete(sw.subscriptions, pp)
+	}
 }
 
 func (sw *ServerWatcher) addServer(obj interface{}) {


### PR DESCRIPTION
Fixes #8270

When a listener unsubscribes to port updates in Servers, we were removing the listener for the `ServerWatcher.subscriptions` map, leaving the map's key (`podPort` with holds the pod object and port) with an empty value. In clusters where there's a lot of pod churn, those keys with empty values were getting accumulated, so this change cleans that up.

The repro (basically constantly rolling emojivoto) is described in #9947.

A followup will be up shortly adding metrics to track these metrics, along with similar missing metrics from other parts of Destination.