### PR TITLE
Fix PSP

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -342,6 +342,9 @@ spec:
       {{- if .Values.priorityClassName -}}
       priorityClassName: {{ .Values.priorityClassName }}
       {{ end -}}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -47,6 +47,9 @@ spec:
           {{- include "linkerd.tolerations" . | nindent 10 }}
           {{- end -}}
           {{- include "linkerd.node-selector" . | nindent 10 }}
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -227,6 +227,9 @@ spec:
       {{- if .Values.priorityClassName -}}
       priorityClassName: {{ .Values.priorityClassName }}
       {{ end -}}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -123,6 +123,9 @@ spec:
       {{- if .Values.priorityClassName -}}
       priorityClassName: {{ .Values.priorityClassName }}
       {{ end -}}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/charts/linkerd-control-plane/templates/psp.yaml
+++ b/charts/linkerd-control-plane/templates/psp.yaml
@@ -7,6 +7,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-{{.Release.Namespace}}-control-plane
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "runtime/default"
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -46,6 +46,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: linkerd-{{.Release.Namespace}}-cni
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "runtime/default"
   labels:
     linkerd.io/cni-resource: "true"
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -210,6 +212,9 @@ spec:
       {{- include "linkerd.node-affinity" . | nindent 8 }}
       {{- end }}
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -71,6 +71,8 @@ securityContext:
   runAsUser: {{ .Values.proxyInit.runAsUser | int | eq 0 | ternary 65534 .Values.proxyInit.runAsUser }}
   {{- end }}
   readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
 terminationMessagePolicy: FallbackToLogsOnError
 {{- if or (not .Values.cniEnabled) .Values.proxyInit.saMountPath }}
 volumeMounts:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -187,6 +187,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -187,6 +187,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
@@ -394,6 +396,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -187,6 +187,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -227,6 +227,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -198,6 +198,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
@@ -416,6 +418,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
@@ -634,6 +638,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
@@ -852,6 +858,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -198,6 +198,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -201,6 +201,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -190,6 +190,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -214,6 +214,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -215,6 +215,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -198,6 +198,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
@@ -416,6 +418,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -203,6 +203,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -198,6 +198,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -199,6 +199,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -199,6 +199,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -199,6 +199,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -200,6 +200,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -200,6 +200,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -200,6 +200,8 @@ items:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           - mountPath: /run
@@ -412,6 +414,8 @@ items:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -200,6 +200,8 @@ items:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           - mountPath: /run
@@ -412,6 +414,8 @@ items:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
           - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -182,6 +182,8 @@ spec:
       readOnlyRootFilesystem: true
       runAsNonRoot: true
       runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -185,6 +185,8 @@ spec:
       readOnlyRootFilesystem: true
       runAsNonRoot: true
       runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -184,6 +184,8 @@ spec:
       readOnlyRootFilesystem: true
       runAsNonRoot: true
       runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -193,6 +193,8 @@ spec:
       readOnlyRootFilesystem: true
       runAsNonRoot: true
       runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
     terminationMessagePolicy: FallbackToLogsOnError
     volumeMounts:
     - mountPath: /run

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -199,6 +199,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -200,6 +200,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
@@ -420,6 +422,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -252,6 +252,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -109,6 +109,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       containers:
       # This container installs the linkerd CNI binaries

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -109,6 +109,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       priorityClassName: system-node-critical
       containers:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -109,6 +109,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       priorityClassName: system-node-critical
       containers:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -109,6 +109,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       priorityClassName: system-node-critical
       containers:

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -110,6 +110,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       containers:
       # This container installs the linkerd CNI binaries

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -102,6 +102,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       containers:
       # This container installs the linkerd CNI binaries

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -102,6 +102,9 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-cni
       priorityClassName: system-node-critical
       containers:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -937,7 +937,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -965,14 +964,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1132,7 +1136,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1384,7 +1388,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1412,14 +1415,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1473,6 +1481,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1540,7 +1551,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1737,14 +1748,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -936,7 +936,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -964,14 +963,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1131,7 +1135,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1386,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1410,14 +1413,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1471,6 +1479,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1538,7 +1549,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1735,14 +1746,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -936,7 +936,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -964,14 +963,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1131,7 +1135,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1386,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1410,14 +1413,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1471,6 +1479,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1538,7 +1549,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1735,14 +1746,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -936,7 +936,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -964,14 +963,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1131,7 +1135,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1386,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1410,14 +1413,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1471,6 +1479,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1538,7 +1549,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1735,14 +1746,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -936,7 +936,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -964,14 +963,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1131,7 +1135,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1386,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1410,14 +1413,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1471,6 +1479,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1538,7 +1549,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1735,14 +1746,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -934,7 +934,6 @@ spec:
         - mountPath: /var/run/linkerd/identity/end-entity
           name: linkerd-identity-end-entity
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -962,14 +961,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1122,7 +1126,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1371,7 +1375,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1399,14 +1402,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1453,6 +1461,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1520,7 +1531,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1715,14 +1726,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1018,7 +1018,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1046,14 +1045,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1510,7 +1514,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,14 +1541,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1599,6 +1607,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1899,14 +1910,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1018,7 +1018,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1046,14 +1045,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1510,7 +1514,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1538,14 +1541,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1599,6 +1607,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1899,14 +1910,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -697,7 +697,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -867,7 +867,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -895,14 +894,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1062,7 +1066,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1313,7 +1317,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1341,14 +1344,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1413,7 +1421,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1610,14 +1618,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -739,7 +739,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -909,7 +909,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -937,14 +936,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1107,7 +1111,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1358,7 +1362,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1386,14 +1389,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1449,6 +1457,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1519,7 +1530,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1716,14 +1727,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -991,7 +991,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1019,14 +1018,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1486,7 +1490,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1514,14 +1517,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1577,6 +1585,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1880,14 +1891,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -999,7 +999,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1027,14 +1026,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1498,7 +1502,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1526,14 +1529,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1593,6 +1601,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1900,14 +1911,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -981,7 +981,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1009,14 +1008,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1476,7 +1480,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1504,14 +1507,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1567,6 +1575,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1870,14 +1881,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -961,6 +961,9 @@ spec:
           - 0.0.0.0:4140
           - --timeout
           - 10s
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1118,7 +1121,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1394,6 +1397,9 @@ spec:
           - 0.0.0.0:4140
           - --timeout
           - 10s
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1445,6 +1451,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1512,7 +1521,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1707,6 +1716,9 @@ spec:
           - 0.0.0.0:4140
           - --timeout
           - 10s
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -742,7 +742,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -914,7 +914,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -940,15 +939,20 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
       priorityClassName: PriorityClassName
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1104,7 +1108,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1363,7 +1367,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1389,15 +1392,20 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
       priorityClassName: PriorityClassName
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1452,6 +1460,9 @@ spec:
           priorityClassName: PriorityClassName
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1515,7 +1526,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1714,15 +1725,20 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
       priorityClassName: PriorityClassName
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -936,7 +936,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -964,14 +963,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1131,7 +1135,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1386,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1410,14 +1413,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1471,6 +1479,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1538,7 +1549,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1735,14 +1746,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -766,7 +766,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -936,7 +936,6 @@ spec:
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -964,14 +963,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-identity
       volumes:
       - name: identity-issuer
@@ -1131,7 +1135,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1382,7 +1386,6 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-
       - args:
         - --incoming-proxy-port
         - "4143"
@@ -1410,14 +1413,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-destination
       volumes:
       - name: sp-tls
@@ -1471,6 +1479,9 @@ spec:
         spec:
           nodeSelector:
             kubernetes.io/os: linux
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: linkerd-heartbeat
           restartPolicy: Never
           containers:
@@ -1538,7 +1549,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1735,14 +1746,19 @@ spec:
             add:
             - NET_ADMIN
             - NET_RAW
+          privileged: false
           runAsNonRoot: true
           runAsUser: 65534
-          privileged: false
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /run
           name: linkerd-proxy-init-xtables-lock
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-proxy-injector
       volumes:
       - configMap:

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -82,7 +82,10 @@
         "privileged": false,
         "runAsNonRoot": true,
         "runAsUser": 65534,
-        "readOnlyRootFilesystem": true
+        "readOnlyRootFilesystem": true,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+		}
       },
       "terminationMessagePolicy": "FallbackToLogsOnError",
       "volumeMounts": [

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -92,7 +92,10 @@
         "privileged": false,
         "runAsNonRoot": true,
         "runAsUser": 65534,
-        "readOnlyRootFilesystem": true
+        "readOnlyRootFilesystem": true,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+		}
       },
       "terminationMessagePolicy": "FallbackToLogsOnError",
       "volumeMounts": [

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -82,7 +82,10 @@
         "privileged": false,
         "runAsNonRoot": true,
         "runAsUser": 65534,
-        "readOnlyRootFilesystem": true
+        "readOnlyRootFilesystem": true,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+		}
       },
       "terminationMessagePolicy": "FallbackToLogsOnError",
       "volumeMounts": [

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -78,6 +78,9 @@ spec:
         {{- if .Values.webhook.resources -}}
         {{- include "partials.resources" .Values.webhook.resources | nindent 8 }}
         {{- end }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jaeger-injector
       volumes:
       - name: tls

--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -27,6 +27,9 @@ spec:
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       restartPolicy: Never
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: namespace-metadata
       containers:
       - name: namespace-metadata

--- a/jaeger/charts/linkerd-jaeger/templates/psp.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/psp.yaml
@@ -41,4 +41,7 @@ subjects:
   name: jaeger
   namespace: {{.Release.Namespace}}
 {{ end -}}
+- kind: ServiceAccount
+  name: namespace-metadata
+  namespace: {{.Release.Namespace}}
 {{ end -}}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -138,6 +138,9 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: collector-config-val
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: collector
       volumes:
       - configMap:
@@ -237,5 +240,8 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       dnsPolicy: ClusterFirst
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jaeger
 {{ end -}}

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -80,6 +80,9 @@ spec:
           name: tls
           readOnly: true
         resources:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jaeger-injector
       volumes:
       - name: tls
@@ -152,7 +155,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # Ideally, this should be restricted to the actual set of IPs the kube-api
   # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
@@ -306,4 +309,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       dnsPolicy: ClusterFirst
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jaeger

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -80,6 +80,9 @@ spec:
           name: tls
           readOnly: true
         resources:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jaeger-injector
       volumes:
       - name: tls
@@ -152,7 +155,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # Ideally, this should be restricted to the actual set of IPs the kube-api
   # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
@@ -394,6 +397,9 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: collector-config-val
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: collector
       volumes:
       - configMap:
@@ -482,6 +488,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       dnsPolicy: ClusterFirst
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jaeger
 ---
 apiVersion: policy.linkerd.io/v1beta1

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -80,6 +80,9 @@ spec:
           name: tls
           readOnly: true
         resources:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: jaeger-injector
       volumes:
       - name: tls
@@ -152,7 +155,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
 spec:
-  # Ideally, this should be restricted to the actual set of IPs the kubelet API
+  # Ideally, this should be restricted to the actual set of IPs the kube-api
   # server uses for webhooks in a cluster. This can't easily be discovered.
   networks:
   - cidr: "0.0.0.0/0"
@@ -385,6 +388,9 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: collector-config-val
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: collector
       volumes:
       - configMap:

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -137,6 +137,9 @@ spec:
         {{- with .Values.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-service-mirror-{{.Values.targetClusterName}}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -58,6 +58,9 @@ spec:
             runAsUser: {{.Values.gateway.UID}}
             seccompProfile:
               type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: {{.Values.gateway.name}}
 {{- if .Values.enablePodAntiAffinity }}
 ---

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -26,6 +26,9 @@ spec:
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       restartPolicy: Never
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: namespace-metadata
       containers:
       - name: namespace-metadata

--- a/multicluster/charts/linkerd-multicluster/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/psp.yaml
@@ -32,4 +32,7 @@ subjects:
 - kind: ServiceAccount
   name: {{.Values.gateway.name}}
   namespace: {{.Release.Namespace}}
+- kind: ServiceAccount
+  name: namespace-metadata
+  namespace: {{.Release.Namespace}}
 {{ end -}}

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -50,6 +50,9 @@ spec:
             runAsUser: 2103
             seccompProfile:
               type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-gateway
 ---
 apiVersion: v1

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -72,6 +72,9 @@ spec:
             runAsUser: 2103
             seccompProfile:
               type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-gateway
 ---
 kind: PodDisruptionBudget
@@ -251,6 +254,9 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-gateway
+  namespace: linkerd-multicluster
+- kind: ServiceAccount
+  name: namespace-metadata
   namespace: linkerd-multicluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -50,6 +50,9 @@ spec:
             runAsUser: 2103
             seccompProfile:
               type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-gateway
 ---
 apiVersion: v1
@@ -214,6 +217,9 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: linkerd-gateway
+  namespace: linkerd-multicluster
+- kind: ServiceAccount
+  name: namespace-metadata
   namespace: linkerd-multicluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/multicluster/cmd/testdata/serivce_mirror_default.golden
+++ b/multicluster/cmd/testdata/serivce_mirror_default.golden
@@ -38,9 +38,9 @@ metadata:
   name: linkerd-service-mirror-read-remote-creds-test-cluster
   namespace: test
   labels:
-      linkerd.io/extension: multicluster
-      component: service-mirror
-      mirror.linkerd.io/cluster-name: test-cluster
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -56,9 +56,9 @@ metadata:
   name: linkerd-service-mirror-read-remote-creds-test-cluster
   namespace: test
   labels:
-      linkerd.io/extension: multicluster
-      component: service-mirror
-      mirror.linkerd.io/cluster-name: test-cluster
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -124,6 +124,9 @@ spec:
         ports:
         - containerPort: 9999
           name: admin-http
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: linkerd-service-mirror-test-cluster
 ---
 apiVersion: v1

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -117,4 +117,7 @@ spec:
           runAsUser: {{.Values.metricsAPI.UID | default .Values.defaultUID}}
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: metrics-api

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -26,6 +26,9 @@ spec:
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       restartPolicy: Never
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: namespace-metadata
       containers:
       - name: namespace-metadata

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -290,6 +290,9 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus
       volumes:
     {{- range .Values.prometheus.ruleConfigMapMounts }}

--- a/viz/charts/linkerd-viz/templates/psp.yaml
+++ b/viz/charts/linkerd-viz/templates/psp.yaml
@@ -46,4 +46,7 @@ subjects:
 - kind: ServiceAccount
   name: tap-injector
   namespace: {{.Release.Namespace}}
+- kind: ServiceAccount
+  name: namespace-metadata
+  namespace: {{.Release.Namespace}}
 {{ end -}}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -117,6 +117,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap-injector
       volumes:
       - name: tls

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -129,6 +129,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap
       volumes:
       - name: tls

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -133,4 +133,7 @@ spec:
           runAsUser: {{.Values.dashboard.UID | default .Values.defaultUID}}
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: web

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -455,6 +455,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: metrics-api
 ---
 apiVersion: policy.linkerd.io/v1beta1
@@ -750,6 +753,9 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus
       volumes:
       - name: data
@@ -904,6 +910,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap
       volumes:
       - name: tls
@@ -1106,6 +1115,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap-injector
       volumes:
       - name: tls
@@ -1268,6 +1280,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: web
 ---
 apiVersion: linkerd.io/v1alpha2

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -455,6 +455,9 @@ spec:
           runAsUser: 1234
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: metrics-api
 ---
 apiVersion: policy.linkerd.io/v1beta1
@@ -750,6 +753,9 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus
       volumes:
       - name: data
@@ -904,6 +910,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap
       volumes:
       - name: tls
@@ -1106,6 +1115,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap-injector
       volumes:
       - name: tls
@@ -1269,6 +1281,9 @@ spec:
           runAsUser: 1234
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: web
 ---
 apiVersion: linkerd.io/v1alpha2

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -415,6 +415,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: metrics-api
 ---
 apiVersion: policy.linkerd.io/v1beta1
@@ -616,6 +619,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap
       volumes:
       - name: tls
@@ -818,6 +824,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap-injector
       volumes:
       - name: tls
@@ -980,6 +989,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: web
 ---
 apiVersion: linkerd.io/v1alpha2

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -455,6 +455,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: metrics-api
 ---
 apiVersion: policy.linkerd.io/v1beta1
@@ -750,6 +753,9 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus
       volumes:
       - name: data
@@ -904,6 +910,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap
       volumes:
       - name: tls
@@ -1106,6 +1115,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap-injector
       volumes:
       - name: tls
@@ -1268,6 +1280,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: web
 ---
 apiVersion: linkerd.io/v1alpha2

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -455,6 +455,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: metrics-api
 ---
 apiVersion: policy.linkerd.io/v1beta1
@@ -754,6 +757,9 @@ spec:
           name: prometheus-config
           subPath: prometheus.yml
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: prometheus
       volumes:
       - name: data
@@ -912,6 +918,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap
       volumes:
       - name: tls
@@ -1114,6 +1123,9 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: tls
           readOnly: true
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: tap-injector
       volumes:
       - name: tls
@@ -1280,6 +1292,9 @@ spec:
           runAsUser: 2103
           seccompProfile:
             type: RuntimeDefault
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: web
 ---
 apiVersion: linkerd.io/v1alpha2


### PR DESCRIPTION
Fixes #10150

When we added PodSecurityAdmission in #9719 (and included in edge-23.1.1), we added the entry `seccompProfile.type=RuntimeDefault` to the containers SecurityContext.

For PSP to accept that we require to add the annotation `seccomp.security.alpha.kubernetes.io/allowedProfileNames: "runtime/default"` into the PSP resource, which also implies we require to add the entry `seccompProfile.type=RuntimeDefault` to the pod's SecurityContext as well, not just the container's.

It also turns out the `namespace-metadata` Jobs used by extensions for the helm installation method didn't have their ServiceAccount properly bound to the PSP resource. This resulted in the `helm install` command failing, and although the extensions resources did get deployed, they were not being discoverable by `linkerd check`. This change fixes that as well, that has been broken since 2.12.0!