### PR TITLE
Add metrics to server and service watchers

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -35,9 +35,6 @@ const (
 
 const endpointTargetRefPod = "Pod"
 
-// TODO: prom metrics for all the queues/caches
-// https://github.com/linkerd/linkerd2/issues/2204
-
 type (
 	// Address represents an individual port on a specific endpoint.
 	// This endpoint might be the result of a the existence of a pod

--- a/controller/api/destination/watcher/k8s.go
+++ b/controller/api/destination/watcher/k8s.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
@@ -40,6 +41,11 @@ type (
 		authority string
 	}
 )
+
+// Labels returns the labels for prometheus metrics associated to the service
+func (id ServiceID) Labels() prometheus.Labels {
+	return prometheus.Labels{"namespace": id.Namespace, "name": id.Name}
+}
 
 func (is InvalidService) Error() string {
 	return fmt.Sprintf("Invalid k8s service %s", is.authority)

--- a/controller/api/destination/watcher/opaque_ports_watcher.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher.go
@@ -122,11 +122,15 @@ func (opw *OpaquePortsWatcher) Unsubscribe(id ServiceID, listener OpaquePortsUpd
 		}
 	}
 
-	if len(ss.listeners) == 0 {
+	labels := id.Labels()
+	if len(ss.listeners) > 0 {
+		opw.subscribersGauge.With(labels).Set(float64(len(ss.listeners)))
+	} else {
+		if !opw.subscribersGauge.Delete(labels) {
+			opw.log.Warnf("unable to delete service_subscribers metric with labels %s", labels)
+		}
 		delete(opw.subscriptions, id)
 	}
-
-	opw.subscribersGauge.With(id.Labels()).Set(float64(len(ss.listeners)))
 }
 
 func (opw *OpaquePortsWatcher) addService(obj interface{}) {

--- a/controller/api/destination/watcher/server_watcher.go
+++ b/controller/api/destination/watcher/server_watcher.go
@@ -44,7 +44,7 @@ type ServerUpdateListener interface {
 var serverMetrics = promauto.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "server_port_subscribers",
-		Help: "Number of subscribers to changes to Servers associated to a port in a pod.",
+		Help: "Number of subscribers to Server changes associated with a pod's port.",
 	},
 	[]string{"namespace", "name", "port"},
 )

--- a/controller/api/destination/watcher/server_watcher.go
+++ b/controller/api/destination/watcher/server_watcher.go
@@ -1,10 +1,14 @@
 package watcher
 
 import (
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/linkerd/linkerd2/controller/gen/apis/server/v1beta1"
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	logging "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,9 +21,10 @@ import (
 // update, it only sends updates to listeners if their endpoint's protocol
 // is changed by the Server.
 type ServerWatcher struct {
-	subscriptions map[podPort][]ServerUpdateListener
-	k8sAPI        *k8s.API
-	log           *logging.Entry
+	subscriptions    map[podPort][]ServerUpdateListener
+	k8sAPI           *k8s.API
+	subscribersGauge *prometheus.GaugeVec
+	log              *logging.Entry
 	sync.RWMutex
 }
 
@@ -36,12 +41,21 @@ type ServerUpdateListener interface {
 	UpdateProtocol(bool)
 }
 
+var serverMetrics = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "server_port_subscribers",
+		Help: "Number of subscribers to changes to Servers associated to a port in a pod.",
+	},
+	[]string{"namespace", "name", "port"},
+)
+
 // NewServerWatcher creates a new ServerWatcher.
 func NewServerWatcher(k8sAPI *k8s.API, log *logging.Entry) (*ServerWatcher, error) {
 	sw := &ServerWatcher{
-		subscriptions: make(map[podPort][]ServerUpdateListener),
-		k8sAPI:        k8sAPI,
-		log:           log,
+		subscriptions:    make(map[podPort][]ServerUpdateListener),
+		k8sAPI:           k8sAPI,
+		subscribersGauge: serverMetrics,
+		log:              log,
 	}
 	_, err := k8sAPI.Srv().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    sw.addServer,
@@ -66,11 +80,13 @@ func (sw *ServerWatcher) Subscribe(pod *corev1.Pod, port Port, listener ServerUp
 	}
 	listeners, ok := sw.subscriptions[pp]
 	if !ok {
-		sw.subscriptions[pp] = []ServerUpdateListener{listener}
-		return
+		listeners = []ServerUpdateListener{listener}
+	} else {
+		listeners = append(listeners, listener)
 	}
-	listeners = append(listeners, listener)
 	sw.subscriptions[pp] = listeners
+
+	sw.subscribersGauge.With(serverMetricLabels(pod, port)).Set(float64(len(listeners)))
 }
 
 // Unsubscribe unsubcribes a listener from any Server updates.
@@ -95,9 +111,14 @@ func (sw *ServerWatcher) Unsubscribe(pod *corev1.Pod, port Port, listener Server
 		}
 	}
 
+	labels := serverMetricLabels(pod, port)
 	if len(listeners) > 0 {
+		sw.subscribersGauge.With(labels).Set(float64(len(listeners)))
 		sw.subscriptions[pp] = listeners
 	} else {
+		if !sw.subscribersGauge.Delete(labels) {
+			sw.log.Warnf("unable to delete server_port_subscribers metric with labels %s", labels)
+		}
 		delete(sw.subscriptions, pp)
 	}
 }
@@ -156,5 +177,14 @@ func (sw *ServerWatcher) updateServer(server *v1beta1.Server, selector labels.Se
 				}
 			}
 		}
+	}
+}
+
+func serverMetricLabels(pod *corev1.Pod, port Port) prometheus.Labels {
+	podName, _, _ := strings.Cut(pod.Name, "-")
+	return prometheus.Labels{
+		"namespace": pod.Namespace,
+		"name":      podName,
+		"port":      strconv.FormatUint(uint64(port), 10),
 	}
 }


### PR DESCRIPTION
# Update

Closes #10202 and completes #2204

As a followup to #10201, I'm adding the following metric in `server_watcher.go`:

- `server_port_subscribers`: This tracks the number of subscribers to changes to Servers associated to a port in a pod. The metric's label identify the namespace and name of the pod, and its targeted port.

Additionally, `opaque_ports.go` was missing metrics as well. I added `service_subscribers` which tracks the number of subscribers to a given Service, labeled by the Service's namespace and name.

`opaque_ports.go` was also leaking the subscriber's map key, so that got fixed as well.

---

# Original description

Closes #10202 and completes #2204

As a followup to #10201, I'm adding two metrics in `server_watcher.go`:

- `server_subscribers`: This tracks the total number of subscribers to Server changes, regardless of the Pod/Port the subscribers are interested in, so it doesn't have any labels. I could have added labels for the subscribers Pod/Port, but I was afraid of the cardinality this might imply in large clusters, so I went with a global metric. The next metric gives us an idea though of that cardinality. Anyway I'm open to suggestions on alternative approaches!
- `server_subscribers_port`: This is the number of keys of the map backing the subscriptions, so it's the number of Pod/Ports tied to the listeners.

Additionally, `opaque_ports.go` was missing metrics as well. I added `service_subscribers` which tracks the number of subscribers to a given Service, labeled by the Service's namespace and name.

`opaque_ports.go` was also leaking the subscriber's map key, so that got fixed as well.

## How to test

Values for the `service_subscribers` can be seen incremented as soon as core+viz+emoji are installed. The Server metrics can be checked with the following:

```bash
# port-forward the destination port
$ k -n linkerd port-forward linkerd-destination-54cf7d779-4h87b 8086 &

# check that there isn't any subscribers
$ linkerd diagnostics controller-metrics|grep 'server_subscribers'
# HELP server_subscribers Number of subscribers to any Server changes.
# TYPE server_subscribers gauge
server_subscribers 0
# HELP server_subscribers_port Number of pod ports targeted by Server subscribers.
# TYPE server_subscribers_port gauge
server_subscribers_port 0

# call getProfile() on viz' metrics-api pod IP
$ go run ./controller/script/destination-client --addr localhost:8086 --method getProfile --path 10.42.0.6:80 &

# check that the subscriber was added
$ linkerd diagnostics controller-metrics|grep 'server_subscribers'
# HELP server_subscribers Number of subscribers to any Server changes.
# TYPE server_subscribers gauge
server_subscribers 1
# HELP server_subscribers_port Number of pod ports targeted by Server subscribers.
# TYPE server_subscribers_port gauge
server_subscribers_port 1
```