### PR TITLE
Do not include attestations in policy controller docker manifests

### DIFF
--- a/.github/actions/rust-docker-build/action.yml
+++ b/.github/actions/rust-docker-build/action.yml
@@ -43,6 +43,7 @@ runs:
           --tag=ghcr.io/${{ github.repository_owner }}/${{ inputs.component }}:${{ inputs.tag }}-${{ inputs.arch }} \
           --cache-from type=local,src=${{ runner.temp }}/.buildx-cache \
           --cache-to type=local,dest=${{ runner.temp }}/.buildx-cache,mode=max
+          --provenance=false
 
 outputs:
   image:


### PR DESCRIPTION
Github actions has upgraded from `docker buildx 0.9.1+azure-2` to `buildx 0.10.0+azure-1` which by default adds provenance attestation to manifests (https://github.com/docker/buildx/releases/tag/v0.10.0).  This means that our platform specific images now contain multiple manifests because the attestation counts as a manifest:

```console
> docker buildx imagetools inspect ghcr.io/linkerd/policy-controller:edge-23.1.2-amd64 --format "{{ json .Manifest.Manifests }}"
[
  {
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "digest": "sha256:1abeb519e76c71c7285b4435a3f85dd73f9c1982905a5a2ca59e0abb279f09aa",
    "size": 1055,
    "platform": {
      "architecture": "amd64",
      "os": "linux"
    }
  },
  {
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "digest": "sha256:1254d52f1bd4ffd1c17688f39e01a6796b85bbcaf07bf83bdeb1c88ebe5b4657",
    "size": 566,
    "annotations": {
      "vnd.docker.reference.digest": "sha256:1abeb519e76c71c7285b4435a3f85dd73f9c1982905a5a2ca59e0abb279f09aa",
      "vnd.docker.reference.type": "attestation-manifest"
    },
    "platform": {
      "architecture": "unknown",
      "os": "unknown"
    }
  }
]
```

This causes the creation of our multi-arch image to fail because the `docker manifest create` command expects each of the constituent images to contain a single manifest each.

We set `--provenance=false` to skip adding the attestation manifest.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
