### PR TITLE
fix typo with provenance flag

### DIFF
--- a/.github/actions/rust-docker-build/action.yml
+++ b/.github/actions/rust-docker-build/action.yml
@@ -42,7 +42,7 @@ runs:
           -f ./${{ inputs.component-path }}/${{ inputs.arch }}.dockerfile \
           --tag=ghcr.io/${{ github.repository_owner }}/${{ inputs.component }}:${{ inputs.tag }}-${{ inputs.arch }} \
           --cache-from type=local,src=${{ runner.temp }}/.buildx-cache \
-          --cache-to type=local,dest=${{ runner.temp }}/.buildx-cache,mode=max
+          --cache-to type=local,dest=${{ runner.temp }}/.buildx-cache,mode=max \
           --provenance=false
 
 outputs:


### PR DESCRIPTION
A missing `\` caused the `--provenance` flag to be interpreted as a separate command rather than a continuation of the previous one.  This caused the build action to fail.

Add the missing `\` character.

Signed-off-by: Alex Leong <alex@buoyant.io>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
