### PR TITLE
Add block chomping and update golden files

### DIFF
--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -34,7 +34,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
-  ca-bundle.crt: |{{.Values.identityTrustAnchorsPEM | trim | nindent 4}}
+  ca-bundle.crt: |-{{.Values.identityTrustAnchorsPEM | trim | nindent 4}}
 {{- end}}
 ---
 kind: Service

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -710,7 +710,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -710,7 +710,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -605,7 +605,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -658,7 +658,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     test-trust-anchor
 ---
 kind: Service

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -694,7 +694,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     test-trust-anchor
 ---
 kind: Service

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -698,7 +698,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     test-trust-anchor
 ---
 kind: Service

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -684,7 +684,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/helm linkerd-version
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     test-trust-anchor
 ---
 kind: Service

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -654,7 +654,7 @@ metadata:
   annotations:
     linkerd.io/created-by: CliVersion
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -674,7 +674,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
 data:
-  ca-bundle.crt: |
+  ca-bundle.crt: |-
     -----BEGIN CERTIFICATE-----
     MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
     JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4


### PR DESCRIPTION
> When using ArgoCD and Azure Key Vault Plugin to manage Linkerd via Helm, the
> identityTrustAnchorsPEM value gets passed from Azure Key Vault with a trailing
> new line. This trailing new line makes its way into the config map
> linkerd-identity-trust-roots causing Linkerd control plane to crash upon
> deployment. There aren't any other alternatives when using Azure Key Vault due
> to how multi-line secrets are created. Azure forces this trailing new line.
>
> The solution is to add a block chomping indicator to strip trailing new lines in
> the config map.
> 
> More on block chomping indicators: https://yaml-multiline.info/
> 
> Fixes: #10012

The original PR #10059 has staled out, but it's worth getting this change in.

Signed-off-by: Alexander Di Clemente <diclemea@gmail.com>
Co-authored-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
