### PR TITLE
network-validator: use limits and requests for ResourceQuota interop

### DIFF
--- a/charts/partials/templates/_network-validator.tpl
+++ b/charts/partials/templates/_network-validator.tpl
@@ -2,6 +2,13 @@
 name: linkerd-network-validator
 image: {{.Values.proxy.image.name}}:{{.Values.proxy.image.version | default .Values.linkerdVersion }}
 imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPolicy}}
+resources:
+  limits:
+    cpu: "50m"
+    memory: "10Mi"
+  requests:
+    cpu: "50m"
+    memory: "10Mi"
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -183,6 +183,13 @@ spec:
         image: cr.l5d.io/linkerd/proxy:test-inject-proxy-version
         imagePullPolicy: IfNotPresent
         name: linkerd-network-validator
+        resources:
+          limits:
+            cpu: 50m
+            memory: 10Mi
+          requests:
+            cpu: 50m
+            memory: 10Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -939,6 +939,13 @@ spec:
       - name: linkerd-network-validator
         image: cr.l5d.io/linkerd/proxy:install-proxy-version
         imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: "50m"
+            memory: "10Mi"
+          requests:
+            cpu: "50m"
+            memory: "10Mi"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1375,6 +1382,13 @@ spec:
       - name: linkerd-network-validator
         image: cr.l5d.io/linkerd/proxy:install-proxy-version
         imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: "50m"
+            memory: "10Mi"
+          requests:
+            cpu: "50m"
+            memory: "10Mi"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1694,6 +1708,13 @@ spec:
       - name: linkerd-network-validator
         image: cr.l5d.io/linkerd/proxy:install-proxy-version
         imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: "50m"
+            memory: "10Mi"
+          requests:
+            cpu: "50m"
+            memory: "10Mi"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
In order for the network-validator to operate properly in clusters with ResourceQuotas, we need to specify `limits` or `requests`

Signed-off-by: Steve Jenson <stevej@buoyant.io>
