### PR TITLE
Properly passing annotation changes for Inject (#10231)

### DIFF
--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -166,8 +166,6 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 		return nil, nil, errors.New("--manual must be set when injecting control plane components")
 	}
 
-	reports := []inject.Report{*report}
-
 	if conf.IsService() {
 		opaquePorts, ok := rt.overrideAnnotations[k8s.ProxyOpaquePortsAnnotation]
 		if ok {
@@ -175,12 +173,12 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 			bytes, err = conf.AnnotateService(annotations)
 			report.Annotated = true
 		}
-		return bytes, reports, err
+		return bytes, []inject.Report{*report}, err
 	}
 	if rt.allowNsInject && conf.IsNamespace() {
 		bytes, err = conf.AnnotateNamespace(rt.overrideAnnotations)
 		report.Annotated = true
-		return bytes, reports, err
+		return bytes, []inject.Report{*report}, err
 	}
 	if conf.HasPodTemplate() {
 		conf.AppendPodAnnotations(rt.overrideAnnotations)
@@ -189,9 +187,9 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 
 	if ok, _ := report.Injectable(); !ok {
 		if errs := report.ThrowInjectError(); len(errs) > 0 {
-			return bytes, reports, fmt.Errorf("failed to inject %s%s%s: %w", report.Kind, slash, report.Name, concatErrors(errs, ", "))
+			return bytes, []inject.Report{*report}, fmt.Errorf("failed to inject %s%s%s: %w", report.Kind, slash, report.Name, concatErrors(errs, ", "))
 		}
-		return bytes, reports, nil
+		return bytes, []inject.Report{*report}, nil
 	}
 
 	if rt.injectProxy {
@@ -210,7 +208,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	}
 
 	if len(patchJSON) == 0 {
-		return bytes, reports, nil
+		return bytes, []inject.Report{*report}, nil
 	}
 	log.Infof("patch generated for: %s", report.ResName())
 	log.Debugf("patch: %s", patchJSON)
@@ -230,7 +228,7 @@ func (rt resourceTransformerInject) transform(bytes []byte) ([]byte, []inject.Re
 	if err != nil {
 		return nil, nil, err
 	}
-	return injectedYAML, reports, nil
+	return injectedYAML, []inject.Report{*report}, nil
 }
 
 func (resourceTransformerInject) generateReport(reports []inject.Report, output io.Writer) {

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr
@@ -1,3 +1,4 @@
 
+deployment "nginx" annotated
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.stderr.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "nginx" annotated
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr
@@ -1,6 +1,8 @@
 
+deployment "redis" annotated
 deployment "redis" injected
 
 
+deployment "nginx" annotated
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.stderr.verbose
@@ -6,6 +6,7 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "redis" annotated
 deployment "redis" injected
 
 
@@ -16,5 +17,6 @@ deployment "redis" injected
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "nginx" annotated
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr
@@ -1,3 +1,4 @@
 
+deployment "redis" annotated
 deployment "redis" injected
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.stderr.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "redis" annotated
 deployment "redis" injected
 

--- a/cli/cmd/testdata/inject_contour.report
+++ b/cli/cmd/testdata/inject_contour.report
@@ -1,3 +1,4 @@
 
+deployment "contour" annotated
 deployment "contour" injected
 

--- a/cli/cmd/testdata/inject_contour.report.verbose
+++ b/cli/cmd/testdata/inject_contour.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "contour" annotated
 deployment "contour" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report
@@ -1,6 +1,10 @@
 
+deployment "web1" annotated
 deployment "web1" injected
+deployment "web2" annotated
 deployment "web2" injected
+deployment "web3" annotated
 deployment "web3" injected
+deployment "web4" annotated
 deployment "web4" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.report.verbose
@@ -6,8 +6,12 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web1" annotated
 deployment "web1" injected
+deployment "web2" annotated
 deployment "web2" injected
+deployment "web3" annotated
 deployment "web3" injected
+deployment "web4" annotated
 deployment "web4" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_cronjob.report
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob.report
@@ -1,3 +1,4 @@
 
+cronjob "hello" annotated
 cronjob "hello" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_cronjob.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_cronjob.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+cronjob "hello" annotated
 cronjob "hello" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report
@@ -1,3 +1,4 @@
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.stderr
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.stderr
@@ -1,3 +1,4 @@
 
+deployment "nginx" annotated
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.stderr.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.stderr.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "nginx" annotated
 deployment "nginx" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report
@@ -1,4 +1,6 @@
 
+deployment "controller" annotated
 deployment "controller" injected
+deployment "not-controller" annotated
 deployment "not-controller" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.report.verbose
@@ -6,6 +6,8 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "controller" annotated
 deployment "controller" injected
+deployment "not-controller" annotated
 deployment "not-controller" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report
@@ -1,3 +1,4 @@
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_default_inbound_policy.golden.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.report
@@ -1,4 +1,5 @@
 
+deployment "web" annotated
 deployment "web" injected
 document missing "kind" field, skipped
 document missing "kind" field, skipped

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.report.verbose
@@ -6,6 +6,7 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
 document missing "kind" field, skipped
 document missing "kind" field, skipped

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report
@@ -1,3 +1,4 @@
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.report
@@ -1,5 +1,5 @@
 
 ‼ "linkerd.io/inject: disabled" annotation set on deployment/web
 
-deployment "web" skipped
+deployment "web" annotated
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_injectDisabled.report.verbose
@@ -6,5 +6,5 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
-deployment "web" skipped
+deployment "web" annotated
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.report
@@ -1,3 +1,4 @@
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report
@@ -1,5 +1,6 @@
 
 ‼ deployment/web uses "protocol: UDP"
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.report.verbose
@@ -6,5 +6,6 @@
 ‼ deployment/web uses "protocol: UDP"
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_list.report
+++ b/cli/cmd/testdata/inject_emojivoto_list.report
@@ -1,4 +1,6 @@
 
+deployment "web" annotated
 deployment "web" injected
+deployment "emoji" annotated
 deployment "emoji" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_list.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_list.report.verbose
@@ -6,6 +6,8 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
+deployment "emoji" annotated
 deployment "emoji" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.report
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.report
@@ -1,5 +1,7 @@
 
+deployment "web" annotated
 deployment "web" injected
+deployment "emoji" annotated
 deployment "emoji" injected
 document missing "kind" field, skipped
 document missing "kind" field, skipped

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.report.verbose
@@ -6,7 +6,9 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "web" annotated
 deployment "web" injected
+deployment "emoji" annotated
 deployment "emoji" injected
 document missing "kind" field, skipped
 document missing "kind" field, skipped

--- a/cli/cmd/testdata/inject_emojivoto_namespace_good.golden.report
+++ b/cli/cmd/testdata/inject_emojivoto_namespace_good.golden.report
@@ -1,3 +1,3 @@
 
-namespace "emojivoto" skipped
+namespace "emojivoto" annotated
 

--- a/cli/cmd/testdata/inject_emojivoto_namespace_good.golden.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_namespace_good.golden.report.verbose
@@ -6,5 +6,5 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
-namespace "emojivoto" skipped
+namespace "emojivoto" annotated
 

--- a/cli/cmd/testdata/inject_emojivoto_pod.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report
@@ -1,3 +1,4 @@
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report
@@ -1,3 +1,4 @@
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_default_inbound_policy.golden.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.report
@@ -1,3 +1,4 @@
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report
@@ -1,3 +1,4 @@
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+pod "vote-bot" annotated
 pod "vote-bot" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report
@@ -1,3 +1,4 @@
 
+statefulset "web" annotated
 statefulset "web" injected
 

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+statefulset "web" annotated
 statefulset "web" injected
 

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr
@@ -1,4 +1,6 @@
 
+deployment "get-test-deploy-injected-1" annotated
 deployment "get-test-deploy-injected-1" injected
+deployment "get-test-deploy-injected-2" annotated
 deployment "get-test-deploy-injected-2" injected
 

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.stderr.verbose
@@ -6,6 +6,8 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "get-test-deploy-injected-1" annotated
 deployment "get-test-deploy-injected-1" injected
+deployment "get-test-deploy-injected-2" annotated
 deployment "get-test-deploy-injected-2" injected
 

--- a/cli/cmd/testdata/inject_tap_deployment_debug.report
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.report
@@ -1,3 +1,4 @@
 
+deployment "linkerd-tap" annotated
 deployment "linkerd-tap" injected
 

--- a/cli/cmd/testdata/inject_tap_deployment_debug.report.verbose
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.report.verbose
@@ -6,5 +6,6 @@
 √ pod specs do not include UDP ports
 √ pods do not have automountServiceAccountToken set to "false" or service account token projection is enabled
 
+deployment "linkerd-tap" annotated
 deployment "linkerd-tap" injected
 


### PR DESCRIPTION
Namespaces and services passed to `linkerd inject` are annotated properly but print "skipped" to stderr.

This fix makes sure that changes to `report` when transforming input are appropriately applied to the resulting Go slice. Previously, changes were not being properly propogated to the `reports` slice: this change makes sure that changes to the `Annotated` field are properly made. Returning the slice inline makes it explicit that just one `report` is being returned in the slice and that the changes to `report` are being passed.

Fixes #10231

For example testing, run: `kubectl get ns <namespace> -o yaml | linkerd inject -`

<img width="802" alt="Screen Shot 2023-02-02 at 5 42 43 PM" src="https://user-images.githubusercontent.com/24928296/216478255-860f09ac-512b-4857-89a5-e98bfb1dfe2f.png">

Signed-off-by: Scott Tran <scotttran@utexas.edu>