### PR TITLE
Added mirrored service name template to customize local names of mirrored services

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -32,6 +32,7 @@ Kubernetes: `>=1.21.0-0`
 | enablePSP | bool | `false` | Create RoleBindings to associate ServiceAccount of target cluster Service Mirror to the control plane PSP resource. This requires that `enabledPSP` is set to true on the extension and control plane install. Note PSP has been deprecated since k8s v1.21 |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
+| mirroredServiceNameTemplate | string | `"{{.remoteName}}-{{.targetClusterName}}"` | Go template string specifying the local name of mirrored services. |
 | nodeSelector | object | `{}` | Node selectors for the Service mirror pod |
 | podLabels | object | `{}` | Additional labels to add to all pods |
 | resources | object | `{}` | Resources for the Service mirror container |

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -118,6 +118,9 @@ spec:
         {{- if .Values.enableHeadlessServices }}
         - -enable-headless-services
         {{- end }}
+        {{- if .Values.mirroredServiceNameTemplate }}
+        - -mirrored-service-name-template={{.Values.mirroredServiceNameTemplate}}
+        {{- end }}
         - -enable-pprof={{.Values.enablePprof | default false}}
         - {{.Values.targetClusterName}}
         image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion}}

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -9,6 +9,8 @@ podLabels: {}
 commonLabels: {}
 # -- Toggle support for mirroring headless services
 enableHeadlessServices: false
+# -- Go template string specifying the local name of mirrored services.
+mirroredServiceNameTemplate: "{{.remoteName}}-{{.targetClusterName}}"
 gateway:
   probe:
     # -- The port used for liveliness probing


### PR DESCRIPTION
The local names of mirrored services used a hard-coded format string, containing the target cluster name. Users who don't want to deal with cluster names had no ability to change this behavior.

Changed from Sprintf to go templates.
Named fields allow for more readable format strings. A new command line flag has been added to the service-mirror command. The link helm chart also has a new value to make use of this flag.

Mirroring tests were enhanced to support tests for custom names.

Fixes #10275.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
