### PR TITLE
Updated wording for multicluster check

### DIFF
--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -201,7 +201,7 @@ func multiclusterCategory(hc *healthChecker, wait time.Duration) *healthcheck.Ca
 				return hc.checkServiceMirrorController(ctx)
 			}))
 	checkers = append(checkers,
-		*healthcheck.NewChecker("all gateway mirrors are healthy").
+		*healthcheck.NewChecker("Probe service able to communicate with all gateway mirrors").
 			WithHintAnchor("l5d-multicluster-gateways-endpoints").
 			WithCheck(func(ctx context.Context) error {
 				return hc.checkIfGatewayMirrorsHaveEndpoints(ctx, wait)

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -201,7 +201,7 @@ func multiclusterCategory(hc *healthChecker, wait time.Duration) *healthcheck.Ca
 				return hc.checkServiceMirrorController(ctx)
 			}))
 	checkers = append(checkers,
-		*healthcheck.NewChecker("Probe service able to communicate with all gateway mirrors").
+		*healthcheck.NewChecker("probe service able to communicate with all gateway mirrors").
 			WithHintAnchor("l5d-multicluster-gateways-endpoints").
 			WithCheck(func(ctx context.Context) error {
 				return hc.checkIfGatewayMirrorsHaveEndpoints(ctx, wait)

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -201,7 +201,7 @@ func multiclusterCategory(hc *healthChecker, wait time.Duration) *healthcheck.Ca
 				return hc.checkServiceMirrorController(ctx)
 			}))
 	checkers = append(checkers,
-		*healthcheck.NewChecker("probe service able to communicate with all gateway mirrors").
+		*healthcheck.NewChecker("probe services able to communicate with all gateway mirrors").
 			WithHintAnchor("l5d-multicluster-gateways-endpoints").
 			WithCheck(func(ctx context.Context) error {
 				return hc.checkIfGatewayMirrorsHaveEndpoints(ctx, wait)


### PR DESCRIPTION
The wording for `linkerd multicluster check` when it failed to probe the remote gateway mirror was confusing.

Fixes #10212

Signed-off-by: Steve Jenson <stevej@buoyant.io>
