### PR TITLE
edge-23.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,11 +7,9 @@ This edge release sees the `linkerd-cni` plugin moved to
 improvement to `linkerd-cni` and `proxy-init` is the main focus. Other
 minor fixes are also included.
 
-* Upgraded `linkerd-cni` to v1.0.0 which is now published from
-  `linkerd2-proxy-init` and makes iptables rules idempotent (thanks @jim-minter!)
-  as well as minor logging improvements
-* Upgraded `proxy-init` from v2.1.0 to v2.2.0 which makes `iptables` rules
-  idempotent (thanks @jim-minter!)
+* Changed `proxy-init` iptables rules to be idempotent upon init pod
+  restart (thanks @jim-minter!)
+* Improved logging in `proxy-init` and `linkerd-cni`
 * Added the server_port_subscribers metric to track the number of subscribers
   to Server changes associated with a pod's port
 * Added the service_subscribers metric to track the number of subscribers to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,17 +7,23 @@ This edge release sees the `linkerd-cni` plugin moved to
 improvement to `linkerd-cni` and `proxy-init` is the main focus. Other
 minor fixes are also included.
 
-* Upgrades `linkerd-cni` to v1.0.0 which is now published from
+* Upgraded `linkerd-cni` to v1.0.0 which is now published from
   `linkerd2-proxy-init` and makes iptables rules idempotent (thanks @jim-minter!)
+  as well as minor logging improvements.
 * Upgraded `proxy-init` from v2.1.0 to v2.2.0 which makes `iptables` rules
-  idempotent (thanks @jim-minter!)
-* Add `server_port_subscribers` metrics to server and service watchers
-* Don't apply `waitBeforeExitSeconds` to control-plane pods
-* Added support for the `internalTrafficPolicy` of a service (thanks @yc185050!)
-* Added `limits` and `requests` to network-validator for ResourceQuota interop
-* Adds block chomping to strip trailing new lines in ConfigMap (thanks @avdicl!)
-* Added multicluster gateway `nodeSelector` and `tolerations` helm parameters
-* Added protection against nil dereference in resources helm template
+  idempotent (thanks @jim-minter!).
+* Added the server_port_subscribers metric to track the number of subscribers
+  to Server changes associated with a pod's port.
+* Added the service_subscribers metric to track the number of subscribers to
+  Service changes.
+* Fixed a small memory leak in the opaque ports watcher.
+* No longer apply `waitBeforeExitSeconds` to control plane, viz and jager
+  extension pods.
+* Added support for the `internalTrafficPolicy` of a service (thanks @yc185050!).
+* Added `limits` and `requests` to network-validator for ResourceQuota interop.
+* Added block chomping to strip trailing new lines in ConfigMap (thanks @avdicl!)
+* Added multicluster gateway `nodeSelector` and `tolerations` helm parameters.
+* Added protection against nil dereference in resources helm template.
 
 ## edge-23.1.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Changes
 
+## edge-23.2.1
+
+This edge release sees the `linkerd-cni` plugin moved to
+`linkerd2-proxy-init` and released from that repository. An iptables
+improvement to `linkerd-cni` and `proxy-init` is the main focus. Other
+minor fixes are also included.
+
+* Upgrades `linkerd-cni` to v1.0.0 which is now published from
+  `linkerd2-proxy-init` and makes iptables rules idempotent (thanks @jim-minter!)
+* Upgraded `proxy-init` from v2.1.0 to v2.2.0 which makes `iptables` rules
+  idempotent (thanks @jim-minter!)
+* Add `server_port_subscribers` metrics to server and service watchers
+* Don't apply `waitBeforeExitSeconds` to control-plane pods
+* Added support for the `internalTrafficPolicy` of a service (thanks @yc185050!)
+* Added `limits` and `requests` to network-validator for ResourceQuota interop
+* Adds block chomping to strip trailing new lines in ConfigMap (thanks @avdicl!)
+* Added multicluster gateway `nodeSelector` and `tolerations` helm parameters
+* Added protection against nil dereference in resources helm template
+
 ## edge-23.1.2
 
 This edge release fixes a memory leak in the Linkerd control plane that could

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,21 +9,21 @@ minor fixes are also included.
 
 * Upgraded `linkerd-cni` to v1.0.0 which is now published from
   `linkerd2-proxy-init` and makes iptables rules idempotent (thanks @jim-minter!)
-  as well as minor logging improvements.
+  as well as minor logging improvements
 * Upgraded `proxy-init` from v2.1.0 to v2.2.0 which makes `iptables` rules
-  idempotent (thanks @jim-minter!).
+  idempotent (thanks @jim-minter!)
 * Added the server_port_subscribers metric to track the number of subscribers
-  to Server changes associated with a pod's port.
+  to Server changes associated with a pod's port
 * Added the service_subscribers metric to track the number of subscribers to
-  Service changes.
-* Fixed a small memory leak in the opaque ports watcher.
-* No longer apply `waitBeforeExitSeconds` to control plane, viz and jager
-  extension pods.
-* Added support for the `internalTrafficPolicy` of a service (thanks @yc185050!).
-* Added `limits` and `requests` to network-validator for ResourceQuota interop.
+  Service changes
+* Fixed a small memory leak in the opaque ports watcher
+* No longer apply `waitBeforeExitSeconds` to control plane, viz and jaeger
+  extension pods
+* Added support for the `internalTrafficPolicy` of a service (thanks @yc185050!)
+* Added `limits` and `requests` to network-validator for ResourceQuota interop
 * Added block chomping to strip trailing new lines in ConfigMap (thanks @avdicl!)
-* Added multicluster gateway `nodeSelector` and `tolerations` helm parameters.
-* Added protection against nil dereference in resources helm template.
+* Added multicluster gateway `nodeSelector` and `tolerations` helm parameters
+* Added protection against nil dereference in resources helm template
 
 ## edge-23.1.2
 

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.11.2-edge
+version: 1.11.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.11.2-edge](https://img.shields.io/badge/Version-1.11.2--edge-informational?style=flat-square)
+![Version: 1.11.3-edge](https://img.shields.io/badge/Version-1.11.3--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.6.1-edge
+version: 30.7.0-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.6.1-edge](https://img.shields.io/badge/Version-30.6.1--edge-informational?style=flat-square)
+![Version: 30.7.0-edge](https://img.shields.io/badge/Version-30.7.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.6.2-edge
+version: 30.6.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.6.2-edge](https://img.shields.io/badge/Version-30.6.2--edge-informational?style=flat-square)
+![Version: 30.6.3-edge](https://img.shields.io/badge/Version-30.6.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.0-edge
+version: 30.5.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.4.0-edge](https://img.shields.io/badge/Version-30.4.0--edge-informational?style=flat-square)
+![Version: 30.5.0-edge](https://img.shields.io/badge/Version-30.5.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.8-edge
+version: 30.4.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.4.8-edge](https://img.shields.io/badge/Version-30.4.8--edge-informational?style=flat-square)
+![Version: 30.4.9-edge](https://img.shields.io/badge/Version-30.4.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release sees the `linkerd-cni` plugin moved to
`linkerd2-proxy-init` and released from that repository. An iptables
improvement to `linkerd-cni` and `proxy-init` is the main focus. Other
minor fixes are also included.

* Upgraded `linkerd-cni` to v1.0.0 which is now published from
  `linkerd2-proxy-init` and makes iptables rules idempotent (thanks @jim-minter!)
  as well as minor logging improvements.
* Upgraded `proxy-init` from v2.1.0 to v2.2.0 which makes `iptables` rules
  idempotent (thanks @jim-minter!).
* Added the server_port_subscribers metric to track the number of subscribers
  to Server changes associated with a pod's port.
* Added the service_subscribers metric to track the number of subscribers to
  Service changes.
* Fixed a small memory leak in the opaque ports watcher.
* No longer apply `waitBeforeExitSeconds` to control plane, viz and jager
  extension pods.
* Added support for the `internalTrafficPolicy` of a service (thanks @yc185050!).
* Added `limits` and `requests` to network-validator for ResourceQuota interop.
* Added block chomping to strip trailing new lines in ConfigMap (thanks @avdicl!)
* Added multicluster gateway `nodeSelector` and `tolerations` helm parameters.
* Added protection against nil dereference in resources helm template.