### PR TITLE
set allowPrivilegeEscalation to false for template files

### DIFF
--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       restartPolicy: Never
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: namespace-metadata

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -231,6 +231,7 @@ spec:
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.prometheus) | nindent 6 }}
       securityContext:
+        allowPrivilegeEscalation: false
         fsGroup: 65534
       containers:
       {{- if .Values.prometheus.sidecarContainers -}}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -120,6 +120,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap-injector

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -132,6 +132,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -136,6 +136,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: web

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -710,6 +710,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
+        allowPrivilegeEscalation: false
         fsGroup: 65534
       containers:
       - args:
@@ -914,6 +915,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap
@@ -1120,6 +1122,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap-injector
@@ -1196,6 +1199,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP
@@ -1286,6 +1290,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: web

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -710,6 +710,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
+        allowPrivilegeEscalation: false
         fsGroup: 65534
       containers:
       - args:
@@ -914,6 +915,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap
@@ -1120,6 +1122,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap-injector
@@ -1196,6 +1199,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP
@@ -1287,6 +1291,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: web

--- a/viz/cmd/testdata/install_prometheus_disabled.golden
+++ b/viz/cmd/testdata/install_prometheus_disabled.golden
@@ -622,6 +622,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap
@@ -828,6 +829,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap-injector
@@ -904,6 +906,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP
@@ -994,6 +997,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: web

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -710,6 +710,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
+        allowPrivilegeEscalation: false
         fsGroup: 65534
       containers:
       - args:
@@ -914,6 +915,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap
@@ -1120,6 +1122,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap-injector
@@ -1196,6 +1199,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP
@@ -1286,6 +1290,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: web

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -714,6 +714,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
+        allowPrivilegeEscalation: false
         fsGroup: 65534
       containers:
       - args:
@@ -922,6 +923,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap
@@ -1128,6 +1130,7 @@ spec:
           name: tls
           readOnly: true
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: tap-injector
@@ -1204,6 +1207,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP
@@ -1298,6 +1302,7 @@ spec:
           seccompProfile:
             type: RuntimeDefault
       securityContext:
+        allowPrivilegeEscalation: false
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: web


### PR DESCRIPTION
For Current Linked viz deployments showing non-compliant against the Azure Policy. Security Context is set to true by default, to adhere to best security practices allowPrivilegeEscalation has been set to true for the helm chart. It has been done for the control plane.

Fixes #9946 