### PR TITLE
rust: downgrade yanked versions of `thread_local`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,11 +1848,10 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.6"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f297120ff9d4efe680df143d5631bba9c75fa371992b7fcb33eb3453cb0a07"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
- "cfg-if",
  "once_cell",
 ]
 


### PR DESCRIPTION
Our lockfile currently depends on v1.1.6 of the `thread_local` crate, which has been [yanked from crates.io][yanked] due to Amanieu/thread_local-rs#47. Our `cargo deny` CI job is currently [failing] due to the dependency on a yanked version of a crate.

This branch downgrades the dependency on `thread_local` to the latest non-yanked version. This should fix the failing CI job.

[yanked]: https://crates.io/crates/thread_local/1.1.6
[failing]: https://github.com/linkerd/linkerd2/actions/runs/4148333422/jobs/7176219624