### PR TITLE
Implement the k8s metadata API in the Destination controller

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -668,12 +668,18 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), false)
+			metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+			if err != nil {
+				t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+			}
+
+			watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), false)
 			if err != nil {
 				t.Fatalf("can't create Endpoints watcher: %s", err)
 			}
 
 			k8sAPI.Sync(nil)
+			metadataAPI.Sync(nil)
 
 			listener := newBufferingEndpointListener()
 
@@ -1290,12 +1296,18 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), true)
+			metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+			if err != nil {
+				t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+			}
+
+			watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), true)
 			if err != nil {
 				t.Fatalf("can't create Endpoints watcher: %s", err)
 			}
 
 			k8sAPI.Sync(nil)
+			metadataAPI.Sync(nil)
 
 			listener := newBufferingEndpointListener()
 
@@ -1414,12 +1426,18 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), false)
+			metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+			if err != nil {
+				t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+			}
+
+			watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), false)
 			if err != nil {
 				t.Fatalf("can't create Endpoints watcher: %s", err)
 			}
 
 			k8sAPI.Sync(nil)
+			metadataAPI.Sync(nil)
 
 			listener := newBufferingEndpointListener()
 
@@ -1538,12 +1556,18 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), true)
+			metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+			if err != nil {
+				t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+			}
+
+			watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), true)
 			if err != nil {
 				t.Fatalf("can't create Endpoints watcher: %s", err)
 			}
 
 			k8sAPI.Sync(nil)
+			metadataAPI.Sync(nil)
 
 			listener := newBufferingEndpointListener()
 
@@ -1768,12 +1792,18 @@ subsets:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), tt.enableEndpointSlices)
+			metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+			if err != nil {
+				t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+			}
+
+			watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), tt.enableEndpointSlices)
 			if err != nil {
 				t.Fatalf("can't create Endpoints watcher: %s", err)
 			}
 
 			k8sAPI.Sync(nil)
+			metadataAPI.Sync(nil)
 
 			listener := newBufferingEndpointListener()
 
@@ -1931,12 +1961,18 @@ subsets:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), false)
+			metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+			if err != nil {
+				t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+			}
+
+			watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), false)
 			if err != nil {
 				t.Fatalf("can't create Endpoints watcher: %s", err)
 			}
 
 			k8sAPI.Sync(nil)
+			metadataAPI.Sync(nil)
 
 			listener := newBufferingEndpointListener()
 
@@ -2057,12 +2093,18 @@ status:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), false)
+			metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+			if err != nil {
+				t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+			}
+
+			watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), false)
 			if err != nil {
 				t.Fatalf("can't create Endpoints watcher: %s", err)
 			}
 
 			k8sAPI.Sync(nil)
+			metadataAPI.Sync(nil)
 
 			listener := newBufferingEndpointListenerWithResVersion()
 
@@ -2153,12 +2195,18 @@ status:
 		t.Fatalf("NewFakeAPI returned an error: %s", err)
 	}
 
-	watcher, err := NewEndpointsWatcher(k8sAPI, logging.WithField("test", t.Name()), true)
+	metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+	if err != nil {
+		t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+	}
+
+	watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), true)
 	if err != nil {
 		t.Fatalf("can't create Endpoints watcher: %s", err)
 	}
 
 	k8sAPI.Sync(nil)
+	metadataAPI.Sync(nil)
 
 	listener := newBufferingEndpointListener()
 

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -97,6 +97,8 @@ func toPartialObjectMetadata(obj runtime.Object) (*metav1.PartialObjectMetadata,
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       u.GetNamespace(),
 			Name:            u.GetName(),
+			Annotations:     u.GetAnnotations(),
+			Labels:          u.GetLabels(),
 			OwnerReferences: u.GetOwnerReferences(),
 		},
 	}, nil


### PR DESCRIPTION
Fixes #9986

After reviewing the k8s API calls in Destination, it was concluded we could only swap out the calls to the Node and RS resources to use the metadata API, as all the other resources (Endpoints, EndpointSlices, Services, Pod, ServiceProfiles, Server) required fields other than those found in their metadata section.

This also required completing the `NewFakeAPI` implementation by adding the missing annotations and labels entries.

## Testing Memory Consumption

The gains here aren't as big as in #9650. In order to test this we need to push hard and create 4000 RS:

``` bash
for i in {0..4000}; do kubectl create deployment test-pod-$i --image=nginx; done
```

In edge-23.2.1 the destination pod's memory consumption goes from 40Mi to 160Mi after all the RS were created. With this change, it went from 37Mi to 140Mi.