### PR TITLE
Reenable G402 lint check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,7 @@ name: Go
 on:
   pull_request:
     paths:
+      - .golangci.yml
       - .github/workflows/go.yml
       - go.sum
       - '**/*.go'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,14 +88,6 @@ issues:
     - gosec
     text: "G101: Potential hardcoded credentials"
 
-  # Temporarily disable this check until the next golang-ci upgrade (greater
-  # than v1.50.1) which upgrades gosec from v2.13.1 to v2.14.0. The fix is in
-  # this commit, that refers to G404 but it seems it also affects G402:
-  # https://github.com/securego/gosec/commit/dfde579243e1bfe0856ddafc5fc6aebb29c0edf6
-  - linters:
-    - gosec
-    text: "G402: TLS MinVersion too low"
-
   # Flag operations are fallible if the flag does not exist. We assume these
   # exist as they are generally flags we are deprecating or use only for
   # development.


### PR DESCRIPTION
This got disabled in #9693, pending an upgrade to golang-ci that just happened via the dev container upgrade.

I'm also adding `.golangci.yml` to the triggers for the `go.yml` workflow.