### PR TITLE
Add changes for edge-23.2.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ ReplicaSets. For all other resources it tracks, it uses additional information
 so continues to use the API as before.
 
 * Added colliding Server in the policy controller's admission webhook validation
-* Upated wording for linkerd-multicluster cluster when it fails to probe a
+* Updated wording for linkerd-multicluster cluster when it fails to probe a
   remote gateway mirror
 * Removed unnecessary Namespaces access from the destination controller RBAC
 * Added Kubernetes metadata API in the destination controller for watching Nodes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # Changes
 
+## edge-23.2.2
+
+This edge release adds the policy status controller which writes the `status`
+field to HTTPRoutes when a parent reference Server accepts or rejects the
+HTTPRoute. This field is currently not consumed by the policy controller, but
+acts as the first step for considering HTTPRoute `status` when serving policy.
+
+Additionally, the destination controller now uses the Kubernetes metadata API
+for resources which it only needs to track the metadata for — Nodes and
+ReplicaSets. For all other resources it tracks, it uses additional information
+so continues to use the API as before.
+
+* Added colliding Server in the policy controller's admission webhook validation
+* Upated wording for linkerd-multicluster cluster when it fails to probe a
+  remote gateway mirror
+* Removed unnecessary Namespaces access from the destination controller RBAC
+* Added Kubernetes metadata API in the destination controller for watching Nodes
+  and ReplicaSets
+* Fixed QueryParamMatch parsing for HTTPRoutes
+* Added the policy status controller which writes the `status` field to
+  HTTPRoutes when a parent reference Server accepts or rejects it
+
 ## edge-23.2.1
 
 This edge release sees the `linkerd-cni` plugin moved to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@ for resources which it only needs to track the metadata for — Nodes and
 ReplicaSets. For all other resources it tracks, it uses additional information
 so continues to use the API as before.
 
-* Added colliding Server in the policy controller's admission webhook validation
+* Fixed error message to include the colliding Server in the policy controller's
+  admission webhook validation
 * Updated wording for linkerd-multicluster cluster when it fails to probe a
   remote gateway mirror
 * Removed unnecessary Namespaces access from the destination controller RBAC

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.11.3-edge
+version: 1.11.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.11.3-edge](https://img.shields.io/badge/Version-1.11.3--edge-informational?style=flat-square)
+![Version: 1.11.4-edge](https://img.shields.io/badge/Version-1.11.4--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.7.0-edge
+version: 30.7.1-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.7.0-edge](https://img.shields.io/badge/Version-30.7.0--edge-informational?style=flat-square)
+![Version: 30.7.1-edge](https://img.shields.io/badge/Version-30.7.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.6.3-edge
+version: 30.6.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.6.3-edge](https://img.shields.io/badge/Version-30.6.3--edge-informational?style=flat-square)
+![Version: 30.6.4-edge](https://img.shields.io/badge/Version-30.6.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.5.0-edge
+version: 30.5.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.5.0-edge](https://img.shields.io/badge/Version-30.5.0--edge-informational?style=flat-square)
+![Version: 30.5.1-edge](https://img.shields.io/badge/Version-30.5.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.4.9-edge
+version: 30.4.10-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.4.9-edge](https://img.shields.io/badge/Version-30.4.9--edge-informational?style=flat-square)
+![Version: 30.4.10-edge](https://img.shields.io/badge/Version-30.4.10--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.2.2

This edge release adds the policy status controller which writes the `status`
field to HTTPRoutes when a parent reference Server accepts or rejects the
HTTPRoute. This field is currently not consumed by the policy controller, but
acts as the first step for considering HTTPRoute `status` when serving policy.

Additionally, the destination controller now uses the Kubernetes metadata API
for resources which it only needs to track the metadata for — Nodes and
ReplicaSets. For all other resources it tracks, it uses additional information
so continues to use the API as before.

* Fixed error message to include the colliding Server in the policy controller's
  admission webhook validation
* Updated wording for linkerd-multicluster cluster when it fails to probe a
  remote gateway mirror
* Removed unnecessary Namespaces access from the destination controller RBAC
* Added Kubernetes metadata API in the destination controller for watching Nodes
  and ReplicaSets
* Fixed QueryParamMatch parsing for HTTPRoutes
* Added the policy status controller which writes the `status` field to
  HTTPRoutes when a parent reference Server accepts or rejects it

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
