### PR TITLE
Adds a new global flag for viz to override the default viz namespace autodetection

### DIFF
--- a/viz/cmd/authz.go
+++ b/viz/cmd/authz.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/metrics-api/util"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	pkgUtil "github.com/linkerd/linkerd2/viz/pkg/util"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -56,13 +57,16 @@ func NewCmdAuthz() *cobra.Command {
 
 			// The gRPC client is concurrency-safe, so we can reuse it in all the following goroutines
 			// https://github.com/grpc/grpc-go/issues/682
-			client := api.CheckClientOrExit(healthcheck.Options{
-				ControlPlaneNamespace: controlPlaneNamespace,
-				KubeConfig:            kubeconfigPath,
-				Impersonate:           impersonate,
-				ImpersonateGroup:      impersonateGroup,
-				KubeContext:           kubeContext,
-				APIAddr:               apiAddr,
+			client := api.CheckClientOrExit(hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
 			})
 
 			var resource string

--- a/viz/cmd/check.go
+++ b/viz/cmd/check.go
@@ -71,15 +71,18 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, options *checkOptions
 		return fmt.Errorf("validation error when executing check command: %w", err)
 	}
 
-	hc := vizHealthCheck.NewHealthChecker([]healthcheck.CategoryID{}, &healthcheck.Options{
-		ControlPlaneNamespace: controlPlaneNamespace,
-		KubeConfig:            kubeconfigPath,
-		KubeContext:           kubeContext,
-		Impersonate:           impersonate,
-		ImpersonateGroup:      impersonateGroup,
-		APIAddr:               apiAddr,
-		RetryDeadline:         time.Now().Add(options.wait),
-		DataPlaneNamespace:    options.namespace,
+	hc := vizHealthCheck.NewHealthChecker([]healthcheck.CategoryID{}, &vizHealthCheck.VizOptions{
+		Options: &healthcheck.Options{
+			ControlPlaneNamespace: controlPlaneNamespace,
+			KubeConfig:            kubeconfigPath,
+			KubeContext:           kubeContext,
+			Impersonate:           impersonate,
+			ImpersonateGroup:      impersonateGroup,
+			APIAddr:               apiAddr,
+			RetryDeadline:         time.Now().Add(options.wait),
+			DataPlaneNamespace:    options.namespace,
+		},
+		VizNamespaceOverride: vizNamespace,
 	})
 	err = hc.InitializeKubeAPIClient()
 	if err != nil {
@@ -87,7 +90,7 @@ func configureAndRunChecks(wout io.Writer, werr io.Writer, options *checkOptions
 		os.Exit(1)
 	}
 
-	hc.AppendCategories(hc.VizCategory())
+	hc.AppendCategories(hc.VizCategory(true))
 	if options.proxy {
 		hc.AppendCategories(hc.VizDataPlaneCategory())
 	}

--- a/viz/cmd/dashboard.go
+++ b/viz/cmd/dashboard.go
@@ -10,6 +10,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -83,14 +84,17 @@ func NewCmdDashboard() *cobra.Command {
 			}
 
 			// ensure we can connect to the viz API before starting the proxy
-			api.CheckClientOrRetryOrExit(healthcheck.Options{
-				ControlPlaneNamespace: controlPlaneNamespace,
-				KubeConfig:            kubeconfigPath,
-				Impersonate:           impersonate,
-				ImpersonateGroup:      impersonateGroup,
-				KubeContext:           kubeContext,
-				APIAddr:               apiAddr,
-				RetryDeadline:         time.Now().Add(options.wait),
+			api.CheckClientOrRetryOrExit(hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+					RetryDeadline:         time.Now().Add(options.wait),
+				},
+				VizNamespaceOverride: vizNamespace,
 			}, true)
 
 			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)

--- a/viz/cmd/edges.go
+++ b/viz/cmd/edges.go
@@ -17,6 +17,7 @@ import (
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/metrics-api/util"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	pkgUtil "github.com/linkerd/linkerd2/viz/pkg/util"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
@@ -127,13 +128,16 @@ func NewCmdEdges() *cobra.Command {
 
 			// The gRPC client is concurrency-safe, so we can reuse it in all the following goroutines
 			// https://github.com/grpc/grpc-go/issues/682
-			client := api.CheckClientOrExit(healthcheck.Options{
-				ControlPlaneNamespace: controlPlaneNamespace,
-				KubeConfig:            kubeconfigPath,
-				Impersonate:           impersonate,
-				ImpersonateGroup:      impersonateGroup,
-				KubeContext:           kubeContext,
-				APIAddr:               apiAddr,
+			client := api.CheckClientOrExit(hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
 			})
 
 			c := make(chan indexedEdgeResults, len(reqs))

--- a/viz/cmd/profile.go
+++ b/viz/cmd/profile.go
@@ -20,6 +20,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	"github.com/linkerd/linkerd2/pkg/protohttp"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	vizutil "github.com/linkerd/linkerd2/viz/pkg/util"
 	pb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	"github.com/linkerd/linkerd2/viz/tap/pkg"
@@ -103,13 +104,16 @@ func newCmdProfile() *cobra.Command {
 			return results, cobra.ShellCompDirectiveDefault
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			api.CheckClientOrExit(healthcheck.Options{
-				ControlPlaneNamespace: controlPlaneNamespace,
-				KubeConfig:            kubeconfigPath,
-				Impersonate:           impersonate,
-				ImpersonateGroup:      impersonateGroup,
-				KubeContext:           kubeContext,
-				APIAddr:               apiAddr,
+			api.CheckClientOrExit(hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
 			})
 			if options.namespace == "" {
 				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)

--- a/viz/cmd/root.go
+++ b/viz/cmd/root.go
@@ -39,6 +39,7 @@ var (
 	controlPlaneNamespace string
 	kubeconfigPath        string
 	kubeContext           string
+	vizNamespace          string
 	impersonate           string
 	impersonateGroup      []string
 	verbose               bool
@@ -76,6 +77,7 @@ func NewCmdViz() *cobra.Command {
 	vizCmd.PersistentFlags().StringVar(&impersonate, "as", "", "Username to impersonate for Kubernetes operations")
 	vizCmd.PersistentFlags().StringArrayVar(&impersonateGroup, "as-group", []string{}, "Group to impersonate for Kubernetes operations")
 	vizCmd.PersistentFlags().StringVar(&apiAddr, "api-addr", "", "Override kubeconfig and communicate directly with the control plane at host:port (mostly for testing)")
+	vizCmd.PersistentFlags().StringVar(&vizNamespace, "viz-namespace", "", "Name of the linkerd-viz namespace. If not set, it's automatically detected")
 	vizCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
 	vizCmd.AddCommand(NewCmdAuthz())
 	vizCmd.AddCommand(NewCmdCheck())

--- a/viz/cmd/routes.go
+++ b/viz/cmd/routes.go
@@ -18,6 +18,8 @@ import (
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/metrics-api/util"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
+
 	pkgUtil "github.com/linkerd/linkerd2/viz/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -75,13 +77,16 @@ This command will only display traffic which is sent to a service that has a Ser
 			}
 
 			output, err := requestRouteStatsFromAPI(
-				api.CheckClientOrExit(healthcheck.Options{
-					ControlPlaneNamespace: controlPlaneNamespace,
-					KubeConfig:            kubeconfigPath,
-					Impersonate:           impersonate,
-					ImpersonateGroup:      impersonateGroup,
-					KubeContext:           kubeContext,
-					APIAddr:               apiAddr,
+				api.CheckClientOrExit(hc.VizOptions{
+					Options: &healthcheck.Options{
+						ControlPlaneNamespace: controlPlaneNamespace,
+						KubeConfig:            kubeconfigPath,
+						Impersonate:           impersonate,
+						ImpersonateGroup:      impersonateGroup,
+						KubeContext:           kubeContext,
+						APIAddr:               apiAddr,
+					},
+					VizNamespaceOverride: vizNamespace,
 				}),
 				req,
 				options,

--- a/viz/cmd/stat.go
+++ b/viz/cmd/stat.go
@@ -17,6 +17,7 @@ import (
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/metrics-api/util"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	pkgUtil "github.com/linkerd/linkerd2/viz/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -229,13 +230,16 @@ If no resource name is specified, displays stats about all resources of the spec
 
 			// The gRPC client is concurrency-safe, so we can reuse it in all the following goroutines
 			// https://github.com/grpc/grpc-go/issues/682
-			client := api.CheckClientOrExit(healthcheck.Options{
-				ControlPlaneNamespace: controlPlaneNamespace,
-				KubeConfig:            kubeconfigPath,
-				Impersonate:           impersonate,
-				ImpersonateGroup:      impersonateGroup,
-				KubeContext:           kubeContext,
-				APIAddr:               apiAddr,
+			client := api.CheckClientOrExit(hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
 			})
 
 			c := make(chan indexedResults, len(reqs))

--- a/viz/cmd/tap.go
+++ b/viz/cmd/tap.go
@@ -20,6 +20,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/protohttp"
 	metricsPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	vizutil "github.com/linkerd/linkerd2/viz/pkg/util"
 	tapPb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	"github.com/linkerd/linkerd2/viz/tap/pkg"
@@ -207,13 +208,16 @@ func NewCmdTap() *cobra.Command {
 				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
 			}
 
-			api.CheckClientOrExit(healthcheck.Options{
-				ControlPlaneNamespace: controlPlaneNamespace,
-				KubeConfig:            kubeconfigPath,
-				Impersonate:           impersonate,
-				ImpersonateGroup:      impersonateGroup,
-				KubeContext:           kubeContext,
-				APIAddr:               apiAddr,
+			api.CheckClientOrExit(hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
 			})
 
 			requestParams := pkg.TapRequestParams{

--- a/viz/cmd/top.go
+++ b/viz/cmd/top.go
@@ -19,6 +19,7 @@ import (
 	metricsAPI "github.com/linkerd/linkerd2/viz/metrics-api"
 	metricsPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
 	vizutil "github.com/linkerd/linkerd2/viz/pkg/util"
 	tapPb "github.com/linkerd/linkerd2/viz/tap/gen/tap"
 	"github.com/linkerd/linkerd2/viz/tap/pkg"
@@ -352,13 +353,16 @@ func NewCmdTop() *cobra.Command {
 				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
 			}
 
-			api.CheckClientOrExit(healthcheck.Options{
-				ControlPlaneNamespace: controlPlaneNamespace,
-				KubeConfig:            kubeconfigPath,
-				Impersonate:           impersonate,
-				ImpersonateGroup:      impersonateGroup,
-				KubeContext:           kubeContext,
-				APIAddr:               apiAddr,
+			api.CheckClientOrExit(hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
 			})
 
 			requestParams := pkg.TapRequestParams{

--- a/viz/pkg/api/api.go
+++ b/viz/pkg/api/api.go
@@ -13,7 +13,7 @@ import (
 // CheckClientOrExit builds a new Viz API client and executes default status
 // checks to determine if the client can successfully perform cli commands. If the
 // checks fail, then CLI will print an error and exit.
-func CheckClientOrExit(hcOptions healthcheck.Options) pb.ApiClient {
+func CheckClientOrExit(hcOptions vizHealthCheck.VizOptions) pb.ApiClient {
 	hcOptions.RetryDeadline = time.Time{}
 	return CheckClientOrRetryOrExit(hcOptions, false)
 }
@@ -22,7 +22,7 @@ func CheckClientOrExit(hcOptions healthcheck.Options) pb.ApiClient {
 // checks to determine if the client can successfully connect to the API. If the
 // checks fail, then CLI will print an error and exit. If the hcOptions.retryDeadline
 // param is specified, then the CLI will print a message to stderr and retry.
-func CheckClientOrRetryOrExit(hcOptions healthcheck.Options, apiChecks bool) pb.ApiClient {
+func CheckClientOrRetryOrExit(hcOptions vizHealthCheck.VizOptions, apiChecks bool) pb.ApiClient {
 	checks := []healthcheck.CategoryID{
 		healthcheck.KubernetesAPIChecks,
 	}
@@ -33,7 +33,7 @@ func CheckClientOrRetryOrExit(hcOptions healthcheck.Options, apiChecks bool) pb.
 
 	hc := vizHealthCheck.NewHealthChecker(checks, &hcOptions)
 
-	hc.AppendCategories(hc.VizCategory())
+	hc.AppendCategories(hc.VizCategory(false))
 
 	hc.RunChecks(exitOnError)
 	return hc.VizAPIClient()


### PR DESCRIPTION
Overriding the namespace autodetection by setting a known one also makes viz client to skip most of the healthchecks. This is useful for permission restricted environments.

As a healthcheck, it confirms that the user has permissions to get the namespace (checking the linkerd extension label) and instantiate the apiclient. The namespace check is also used to print the anchor to a doc section.

When the user has this set of permissions on linkerd-viz namespace, he can use linkerd viz commands:
```
- apiGroups:
  - rbac.authorization.k8s.io
  resourceNames:
  - linkerd-linkerd-viz-metrics-api
  - linkerd-linkerd-viz-tap
  - linkerd-linkerd-viz-tap-admin
  - linkerd-tap-injector
  resources:
  - clusterroles
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - rbac.authorization.k8s.io
  resourceNames:
  - linkerd-linkerd-viz-tap
  - linkerd-linkerd-viz-metrics-api
  - linkerd-linkerd-viz-tap-auth-delegator
  - linkerd-tap-inkector
  resources:
  - clusterrolebindings
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apps
  resources:
  - replicasets
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - pods
  - namespaces
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - pods/portforward
  verbs:
  - get
  - list
  - watch
  - create
```

To get tap permissions, the user needs:
```
- apiGroups:
  - tap.linkerd.io
  resources:
  - '*'
  verbs:
  - watch
```
on his own namespace.

This is an idea which could fix #10207 

Fully open to discuss it and I can change anything after discussion.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
