### PR TITLE
Update Helm chart docs with external issuer info

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -39,7 +39,7 @@ Issuer certificates **must** live in a `Secret` named
 install namespace. In order to use an existing CA, Linkerd needs to be
 installed with `identity.externalCA=true`. To use an existing issuer
 certificate, Linkerd should be installed with
-`identity.issuer.scheme=kubernetes.io/tls`. 
+`identity.issuer.scheme=kubernetes.io/tls`.
 
 A more comprehensive description is in the [automatic certificate rotation
 guide](https://linkerd.io/2.12/tasks/automatically-rotating-control-plane-tls-credentials/#a-note-on-third-party-cert-management-solutions).

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -31,6 +31,19 @@ generate these automatically). You can provide your own, or follow [these
 instructions](https://linkerd.io/2/tasks/generate-certificates/) to generate new
 ones.
 
+Alternatively, both trust anchor and identity issuer certificates may be
+derived from in-cluster resources. Existing CA (trust anchor) certificates
+**must** live in a `ConfigMap` resource named `linkerd-identity-trust-roots`.
+Issuer certificates **must** live in a `Secret` named
+`linkerd-identity-issuer`. Both resources should exist in the control-plane's
+install namespace. In order to use an existing CA, Linkerd needs to be
+installed with `identity.externalCA=true`. To use an existing issuer
+certificate, Linkerd should be installed with
+`identity.issuer.scheme=kubernetes.io/tls`. 
+
+A more comprehensive description is in the [automatic certificate rotation
+guide](https://linkerd.io/2.12/tasks/automatically-rotating-control-plane-tls-credentials/#a-note-on-third-party-cert-management-solutions).
+
 Note that the provided certificates must be ECDSA certificates.
 
 ## Adding Linkerd's Helm repository

--- a/charts/linkerd-control-plane/README.md.gotmpl
+++ b/charts/linkerd-control-plane/README.md.gotmpl
@@ -29,6 +29,19 @@ generate these automatically). You can provide your own, or follow [these
 instructions](https://linkerd.io/2/tasks/generate-certificates/) to generate new
 ones.
 
+Alternatively, both trust anchor and identity issuer certificates may be
+derived from in-cluster resources. Existing CA (trust anchor) certificates
+**must** live in a `ConfigMap` resource named `linkerd-identity-trust-roots`.
+Issuer certificates **must** live in a `Secret` named
+`linkerd-identity-issuer`. Both resources should exist in the control-plane's
+install namespace. In order to use an existing CA, Linkerd needs to be
+installed with `identity.externalCA=true`. To use an existing issuer
+certificate, Linkerd should be installed with
+`identity.issuer.scheme=kubernetes.io/tls`.  
+
+A more comprehensive description is in the [automatic certificate rotation
+guide](https://linkerd.io/2.12/tasks/automatically-rotating-control-plane-tls-credentials/#a-note-on-third-party-cert-management-solutions).
+
 Note that the provided certificates must be ECDSA certificates.
 
 ## Adding Linkerd's Helm repository

--- a/charts/linkerd-control-plane/README.md.gotmpl
+++ b/charts/linkerd-control-plane/README.md.gotmpl
@@ -37,7 +37,7 @@ Issuer certificates **must** live in a `Secret` named
 install namespace. In order to use an existing CA, Linkerd needs to be
 installed with `identity.externalCA=true`. To use an existing issuer
 certificate, Linkerd should be installed with
-`identity.issuer.scheme=kubernetes.io/tls`.  
+`identity.issuer.scheme=kubernetes.io/tls`.
 
 A more comprehensive description is in the [automatic certificate rotation
 guide](https://linkerd.io/2.12/tasks/automatically-rotating-control-plane-tls-credentials/#a-note-on-third-party-cert-management-solutions).


### PR DESCRIPTION
Visibility into our documentation should be improved around the usage of an external CA and/or an external issuer. To some of our users it is not clear that an external issuer, for example, may be used, by changing the identity issuer's scheme.

To make it more visible, this PR updates the Helm chart docs for `linkerd-control-plane`. A short explainer is given on how Linkerd may be installed without explicitly passing in any certificate resources. A more comprehensive explanation is linked (our docs on Automating Certificate Rotation should serve as a more thorough walkthrough).

Closes #10229 

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
