### PR TITLE
Binary util to annotate extension namespaces

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,7 @@ on:
       - go.sum
       - justfile
       - multicluser/**
+      - ns-labeler/**
       - policy-controller/**
       - policy-test/**
       - viz/**
@@ -223,6 +224,7 @@ jobs:
         component:
           - jaeger-webhook
           - metrics-api
+          - ns-labeler
           - tap
           - web
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         - cli-bin
         - cni-plugin
         - controller
+        - ns-labeler
         - policy-controller
         - debug
         - jaeger-webhook

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ on:
       - justfile
       - deny.toml
       - '**/*.rs'
+      - ns-annotator/Dockerfile
       - policy-*/Dockerfile
       - rust-toolchain
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,7 +789,19 @@ checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
 dependencies = [
  "serde",
  "serde_json",
- "treediff",
+ "treediff 3.0.2",
+]
+
+[[package]]
+name = "json-patch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "treediff 4.0.2",
 ]
 
 [[package]]
@@ -803,8 +821,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5aff351861fa8aef1329a3eae6512ead291e58e478b293e20dfa8104965fb8"
 dependencies = [
- "k8s-openapi",
- "kube",
+ "k8s-openapi 0.16.0",
+ "kube 0.76.0",
  "schemars",
  "serde",
  "serde_json",
@@ -816,7 +834,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "http",
@@ -829,16 +847,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-openapi"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
+dependencies = [
+ "base64 0.20.0",
+ "bytes",
+ "chrono",
+ "http",
+ "percent-encoding",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "kube"
 version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf241a3a42bca4a2d1c21f2f34a659655032a7858270c7791ad4433aa8d79cb"
 dependencies = [
- "k8s-openapi",
- "kube-client",
- "kube-core",
+ "k8s-openapi 0.16.0",
+ "kube-client 0.76.0",
+ "kube-core 0.76.0",
  "kube-derive",
  "kube-runtime",
+]
+
+[[package]]
+name = "kube"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ee2ba94546e32a5aef943e5831c6ac25592ff8dcfa8b2a06e0aaea90c69188"
+dependencies = [
+ "k8s-openapi 0.17.0",
+ "kube-client 0.78.0",
+ "kube-core 0.78.0",
 ]
 
 [[package]]
@@ -847,7 +893,7 @@ version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e442b4e6d55c4b3d0c0c70d79a8865bf17e2c33725f9404bfcb8a29ee002ffe"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "dirs-next",
@@ -860,8 +906,8 @@ dependencies = [
  "hyper-rustls",
  "hyper-timeout",
  "jsonpath_lib",
- "k8s-openapi",
- "kube-core",
+ "k8s-openapi 0.16.0",
+ "kube-core 0.76.0",
  "openssl",
  "pem",
  "pin-project",
@@ -882,6 +928,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "kube-client"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9ca1f597bd48ed26f45f601bf2fa3aaa0933b8d1652d883b8444519b72af4a"
+dependencies = [
+ "base64 0.20.0",
+ "bytes",
+ "chrono",
+ "dirs-next",
+ "either",
+ "futures",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-openssl",
+ "hyper-timeout",
+ "jsonpath_lib",
+ "k8s-openapi 0.17.0",
+ "kube-core 0.78.0",
+ "openssl",
+ "pem",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.0",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
 name = "kube-core"
 version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,10 +971,27 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "http",
- "json-patch",
- "k8s-openapi",
+ "json-patch 0.2.7",
+ "k8s-openapi 0.16.0",
  "once_cell",
  "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f2c6d1a2d1584859499eb05a41c5a44713818041621fa7515cfdbdf4769ea7"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http",
+ "json-patch 0.3.0",
+ "k8s-openapi 0.17.0",
+ "once_cell",
  "serde",
  "serde_json",
  "thiserror",
@@ -922,9 +1020,9 @@ dependencies = [
  "backoff",
  "derivative",
  "futures",
- "json-patch",
- "k8s-openapi",
- "kube-client",
+ "json-patch 0.2.7",
+ "k8s-openapi 0.16.0",
+ "kube-client 0.76.0",
  "parking_lot",
  "pin-project",
  "serde",
@@ -948,8 +1046,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hyper",
- "kube-client",
- "kube-core",
+ "kube-client 0.76.0",
+ "kube-core 0.76.0",
  "kube-runtime",
  "parking_lot",
  "pin-project-lite",
@@ -959,6 +1057,18 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "kubert"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d457fb44f5e08044ce60f0fab24396ed03dff6a5dca106e86d560356573c7ca"
+dependencies = [
+ "thiserror",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1012,15 +1122,15 @@ dependencies = [
  "ipnet",
  "jemallocator",
  "k8s-gateway-api",
- "k8s-openapi",
- "kube",
- "kubert",
+ "k8s-openapi 0.16.0",
+ "kube 0.76.0",
+ "kubert 0.12.0",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-grpc",
  "linkerd-policy-controller-k8s-api",
  "linkerd-policy-controller-k8s-index",
- "openssl",
  "linkerd-policy-controller-k8s-status",
+ "openssl",
  "parking_lot",
  "serde",
  "serde_json",
@@ -1067,8 +1177,8 @@ version = "0.1.0"
 dependencies = [
  "ipnet",
  "k8s-gateway-api",
- "k8s-openapi",
- "kube",
+ "k8s-openapi 0.16.0",
+ "kube 0.76.0",
  "schemars",
  "serde",
  "serde_json",
@@ -1087,7 +1197,7 @@ dependencies = [
  "chrono",
  "futures",
  "k8s-gateway-api",
- "kubert",
+ "kubert 0.12.0",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",
  "maplit",
@@ -1107,7 +1217,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "chrono",
- "kubert",
+ "kubert 0.12.0",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",
  "parking_lot",
@@ -1126,8 +1236,8 @@ dependencies = [
  "hyper",
  "ipnet",
  "k8s-gateway-api",
- "k8s-openapi",
- "kube",
+ "k8s-openapi 0.16.0",
+ "kube 0.76.0",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",
  "linkerd2-proxy-api",
@@ -1207,6 +1317,25 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "ns-labeler"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "json-patch 0.3.0",
+ "k8s-openapi 0.17.0",
+ "kube 0.78.0",
+ "kubert 0.13.0",
+ "openssl",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1359,7 +1488,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1608,7 +1737,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2039,7 +2168,7 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2079,7 +2208,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "futures-core",
@@ -2191,6 +2320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "treediff"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,7 +2340,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "ns-labeler",
     "policy-controller",
     "policy-controller/core",
     "policy-controller/grpc",

--- a/bin/docker-build-ns-labeler
+++ b/bin/docker-build-ns-labeler
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ $# -ne 0 ]; then
+    echo "no arguments allowed for ${0##*/}, given: $*" >&2
+    exit 64
+fi
+
+bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+
+# shellcheck source=_docker.sh
+. "$bindir"/_docker.sh
+# shellcheck source=_tag.sh
+. "$bindir"/_tag.sh
+# shellcheck source=_os.sh
+. "$bindir"/_os.sh
+
+dir=$( cd "$bindir"/../ns-labeler && pwd )
+docker_build ns-labeler v0.1.0 "$dir/Dockerfile"

--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -46,31 +46,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         args:
-        - -c
-        - |
-          ops=''
-          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          ns=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
-
-          if ! echo "$ns" | grep -q 'labels'; then
-            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
-          fi
-
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"jaeger\"},"
-
-          # grab the latest occurence of cniEnabled in linkerd-config, to
-          # discard value in the last-applied-configuration annotation
-          cniEnabled=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Values.linkerdNamespace}}/configmaps/linkerd-config" | \
-            sed -r -n 's/.*cniEnabled: (\w+).*/\1/gp' | tail -1)
-
-          level="privileged"
-          if [ "$cniEnabled" = "true" ]; then
-            level="restricted"
-          fi
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/pod-security.kubernetes.io~1enforce\", \"value\": \"$level\"}"
-
-          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
-            -d "[$ops]" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"
+        - --extension
+        - jaeger
+        - --namespace
+        - {{.Release.Namespace}}
+        - --linkerd-namespace
+        - {{.Values.linkerdNamespace}}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -152,11 +152,11 @@ linkerdVersion: &linkerd_version linkerdVersionValue
 namespaceMetadata:
   image:
     # -- Docker registry for the namespace-metadata instance
-    registry: curlimages
+    registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: curl
+    name: ns-labeler
     # -- Docker image tag for the namespace-metadata instance
-    tag: 7.78.0
+    tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance
     # @default -- imagePullPolicy
     pullPolicy: ""

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -34,7 +34,6 @@ spec:
       - name: namespace-metadata
         image: {{.Values.namespaceMetadata.image.registry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
         imagePullPolicy: {{.Values.namespaceMetadata.image.pullPolicy | default .Values.imagePullPolicy}}
-        command: ["/bin/sh"]
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -45,31 +44,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         args:
-        - -c
-        - |
-          ops=''
-          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          ns=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
-
-          if ! echo "$ns" | grep -q 'labels'; then
-            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
-          fi
-
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"multicluster\"},"
-
-          # grab the latest occurence of cniEnabled in linkerd-config, to
-          # discard value in the last-applied-configuration annotation
-          cniEnabled=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Values.linkerdNamespace}}/configmaps/linkerd-config" | \
-            sed -r -n 's/.*cniEnabled: (\w+).*/\1/gp' | tail -1)
-
-          level="privileged"
-          if [ "$cniEnabled" = "true" ]; then
-            level="restricted"
-          fi
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/pod-security.kubernetes.io~1enforce\", \"value\": \"$level\"}"
-
-          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
-            -d "[$ops]" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"
+        - --extension
+        - multicluster
+        - --namespace
+        - {{.Release.Namespace}}
+        - --linkerd-namespace
+        - {{.Values.linkerdNamespace}}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -65,11 +65,11 @@ identityTrustDomain: cluster.local
 namespaceMetadata:
   image:
     # -- Docker registry for the namespace-metadata instance
-    registry: curlimages
+    registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: curl
+    name: ns-labeler
     # -- Docker image tag for the namespace-metadata instance
-    tag: 7.78.0
+    tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance
     # @default -- imagePullPolicy
     pullPolicy: ""

--- a/ns-labeler/Cargo.toml
+++ b/ns-labeler/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "ns-labeler"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[features]
+default = ["openssl-tls", "openssl-vendored"]
+openssl-tls = ["kube/openssl-tls"]
+# Vendor openssl to statically link lib
+openssl-vendored = ["openssl/vendored"]
+
+[dependencies]
+anyhow = "1"
+json-patch = "0.3"
+kubert = { version = "0.13", features = ["log"] }
+openssl = { version = "0.10", optional = true }
+serde = "1"
+serde_json = "1"
+serde_yaml = "0.8"
+thiserror = "1"
+tracing = "0.1"
+
+[dependencies.clap]
+version = "4"
+default-features = false
+features = ["derive", "help", "usage", "env", "std"]
+
+[dependencies.kube]
+version = "0.78"
+default-features = false
+features = ["client", "jsonpatch"]
+
+[dependencies.k8s-openapi]
+version = "0.17"
+features = ["v1_21"]
+
+[dependencies.tokio]
+version = "1"
+features = ["macros"]

--- a/ns-labeler/Dockerfile
+++ b/ns-labeler/Dockerfile
@@ -1,10 +1,10 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v39-rust-musl as controller
+FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v39-rust as builder
 ARG BUILD_TYPE="release"
 WORKDIR /build
 RUN mkdir -p target/bin
 COPY Cargo.toml Cargo.lock .
-# required for cargo fetch
 COPY ns-labeler ns-labeler
+# required for cargo fetch
 COPY policy-controller policy-controller
 RUN cargo new policy-test --lib
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -18,9 +18,9 @@ RUN --mount=type=cache,target=target \
         arm) echo armv7-unknown-linux-musleabihf ;; \
         *) echo "unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
     esac) && \
-    just-cargo profile=$BUILD_TYPE target=$target build --package=linkerd-policy-controller && \
-    mv "target/$target/$BUILD_TYPE/linkerd-policy-controller" /tmp/
+    just-cargo profile=$BUILD_TYPE target=$target build --package=ns-labeler && \
+    mv "target/$target/$BUILD_TYPE/ns-labeler" /tmp/
 
 FROM scratch as runtime
-COPY --from=controller /tmp/linkerd-policy-controller /bin/
-ENTRYPOINT ["/bin/linkerd-policy-controller"]
+COPY --from=builder /tmp/ns-labeler /bin/
+ENTRYPOINT ["/bin/ns-labeler"]

--- a/ns-labeler/src/main.rs
+++ b/ns-labeler/src/main.rs
@@ -1,0 +1,245 @@
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use json_patch::{AddOperation, PatchOperation::Add};
+use k8s_openapi::api::core::v1::{ConfigMap, Namespace};
+use kube::{
+    api::{Api, Patch, PatchParams},
+    Client,
+};
+use serde::Deserialize;
+use thiserror::Error;
+use tokio::time;
+use tracing::{debug, info};
+
+/// Add metadata to extension namespaces
+///
+/// The added metadata is used by the Linkerd CLI to recognize the extensions installed in the
+/// cluster.
+/// Note that this is only required when installing extensions via Helm.
+#[derive(Parser)]
+#[clap(version, about)]
+struct Args {
+    #[clap(long, env = "LINKERD_NS_LABELER_LOG_LEVEL", default_value = "info")]
+    log_level: kubert::LogFilter,
+
+    #[clap(long, env = "LINKERD_NS_LABELER_LOG_FORMAT", default_value = "plain")]
+    log_format: kubert::LogFormat,
+
+    /// Extension name (e.g. viz, multicluster, jaeger)
+    #[clap(long)]
+    extension: String,
+
+    /// Namespace where the extension is installed
+    #[clap(long, short = 'n')]
+    namespace: String,
+
+    /// Namespace where the Linkerd control-plane is installed
+    #[clap(long)]
+    linkerd_namespace: String,
+
+    /// URL of external Prometheus instance, if any (only used by the viz
+    /// extension)
+    #[clap(long)]
+    prometheus_url: Option<String>,
+}
+
+#[derive(Debug, Error)]
+enum Error {
+    #[error("data not found")]
+    DataNotFound,
+    #[error("values not found")]
+    ValuesNotFound,
+}
+
+#[derive(Deserialize)]
+struct ConfigValues {
+    #[serde(rename = "cniEnabled")]
+    cni_enabled: bool,
+}
+
+const LINKERD_CONFIG_CM: &str = "linkerd-config";
+const WRITE_TIMEOUT: time::Duration = time::Duration::from_secs(10);
+const FIELD_MANAGER: &str = "kubectl-label";
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let Args {
+        log_level,
+        log_format,
+        extension,
+        namespace,
+        linkerd_namespace,
+        prometheus_url,
+    } = Args::parse();
+
+    log_format
+        .try_init(log_level)
+        .expect("must configure logging");
+
+    info!("patching namespace {}", namespace);
+
+    let client = Client::try_default().await?;
+    let namespaces: Api<Namespace> = Api::all(client.clone());
+    let ns = namespaces.get(&namespace).await?;
+
+    let add_annotations_root = ns.metadata.annotations.filter(|x| !x.is_empty()).is_none();
+    let add_labels_root = ns.metadata.labels.filter(|x| !x.is_empty()).is_none();
+    let cni_enabled = get_cni_enabled(client, &linkerd_namespace).await?;
+    let patch = get_patch(
+        &extension,
+        prometheus_url,
+        cni_enabled,
+        add_annotations_root,
+        add_labels_root,
+    );
+    let params: PatchParams = PatchParams::apply(FIELD_MANAGER);
+    time::timeout(
+        WRITE_TIMEOUT,
+        namespaces.patch(namespace.as_str(), &params, &Patch::Json::<()>(patch)),
+    )
+    .await?
+    .map(|_| info!("successfully patched namespace"))
+    .map_err(|e| {
+        tracing::error!("failed patching namespace: {}", e);
+        anyhow!("failed patching namespace")
+    })
+}
+
+fn get_patch(
+    extension: &str,
+    prometheus_url: Option<String>,
+    cni_enabled: bool,
+    add_annotations_root: bool,
+    add_labels_root: bool,
+) -> json_patch::Patch {
+    let mut patches = Vec::new();
+
+    if add_annotations_root {
+        patches.push(Add(AddOperation {
+            path: "/metadata/annotations".to_string(),
+            value: serde_json::json!({}),
+        }));
+    }
+
+    if add_labels_root {
+        patches.push(Add(AddOperation {
+            path: "/metadata/labels".to_string(),
+            value: serde_json::json!({}),
+        }));
+    }
+
+    prometheus_url.into_iter().for_each(|url| {
+        patches.push(Add(AddOperation {
+            path: "/metadata/annotations/viz.linkerd.io~1external-prometheus".to_string(),
+            value: serde_json::Value::String(url),
+        }));
+    });
+
+    patches.push(Add(AddOperation {
+        path: "/metadata/labels/linkerd.io~1extension".to_string(),
+        value: serde_json::Value::String(extension.to_string()),
+    }));
+
+    let level = if cni_enabled {
+        "restricted"
+    } else {
+        "privileged"
+    };
+
+    patches.push(Add(AddOperation {
+        path: "/metadata/labels/pod-security.kubernetes.io~1enforce".to_string(),
+        value: serde_json::Value::String(level.to_string()),
+    }));
+
+    debug!("patch to apply: {:?}", patches);
+
+    json_patch::Patch(patches)
+}
+
+async fn get_cni_enabled(client: Client, ns: &str) -> Result<bool> {
+    let cm_api: Api<ConfigMap> = Api::namespaced(client, ns);
+    let cm = cm_api.get(LINKERD_CONFIG_CM).await?;
+    let data = cm.data.ok_or(Error::DataNotFound)?;
+    let values = data.get("values").ok_or(Error::ValuesNotFound)?;
+    let config_values: ConfigValues = serde_yaml::from_str(&values)?;
+    Ok(config_values.cni_enabled)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::get_patch;
+    use anyhow::Result;
+
+    #[test]
+    fn multicluster() -> Result<()> {
+        let patch = get_patch("multicluster", None, false, false, true);
+        let patch_str = serde_json::to_string(&patch)?;
+        assert_eq!(
+            patch_str,
+            r#"
+[
+    {
+        "op": "add",
+        "path": "/metadata/labels",
+        "value": {}
+    },
+    {
+        "op": "add",
+        "path": "/metadata/labels/linkerd.io~1extension",
+        "value": "multicluster"
+    },
+    {
+        "op": "add",
+        "path": "/metadata/labels/pod-security.kubernetes.io~1enforce",
+        "value": "privileged"
+    }
+]
+"#
+            .replace("\n", "")
+            .replace(" ", "")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn viz() -> Result<()> {
+        let patch = get_patch(
+            "viz",
+            Some("prometheus.obs.svc.cluster.local:9090".to_string()),
+            true,
+            true,
+            false,
+        );
+        let patch_str = serde_json::to_string(&patch)?;
+        assert_eq!(
+            patch_str,
+            r#"
+[
+    {
+        "op": "add",
+        "path": "/metadata/annotations",
+        "value": {}
+    },
+    {
+        "op": "add",
+        "path": "/metadata/annotations/viz.linkerd.io~1external-prometheus",
+        "value": "prometheus.obs.svc.cluster.local:9090"
+    },
+    {
+        "op": "add",
+        "path": "/metadata/labels/linkerd.io~1extension",
+        "value": "viz"
+    },
+    {
+        "op": "add",
+        "path": "/metadata/labels/pod-security.kubernetes.io~1enforce",
+        "value": "restricted"
+    }
+]
+"#
+            .replace("\n", "")
+            .replace(" ", "")
+        );
+        Ok(())
+    }
+}

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -34,7 +34,6 @@ spec:
       - name: namespace-metadata
         image: {{.Values.namespaceMetadata.image.registry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
         imagePullPolicy: {{.Values.namespaceMetadata.image.pullPolicy | default .Values.defaultImagePullPolicy}}
-        command: ["/bin/sh"]
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -46,37 +45,16 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         args:
-        - -c
-        - |
-          ops=''
-          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          ns=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
-
-          if ! echo "$ns" | grep -q 'labels'; then
-            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
-          fi
-          if ! echo "$ns" | grep -q 'annotations'; then
-            ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {}},"
-          fi
-
-          {{- if .Values.prometheusUrl }}
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations/viz.linkerd.io~1external-prometheus\", \"value\": \"{{.Values.prometheusUrl}}\"},"
-          {{- end }}
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"viz\"},"
-
-          # grab the latest occurence of cniEnabled in linkerd-config, to
-          # discard value in the last-applied-configuration annotation
-          cniEnabled=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Values.linkerdNamespace}}/configmaps/linkerd-config" | \
-            sed -r -n 's/.*cniEnabled: (\w+).*/\1/gp' | tail -1)
-
-          level="privileged"
-          if [ "$cniEnabled" = "true" ]; then
-            level="restricted"
-          fi
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/pod-security.kubernetes.io~1enforce\", \"value\": \"$level\"}"
-
-          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
-            -d "[$ops]" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"
+        - --log-format
+        - {{.Values.defaultLogFormat}}
+        - --log-level
+        - {{.Values.defaultLogLevel}}
+        - --extension
+        - viz
+        - --namespace
+        - {{.Release.Namespace}}
+        - --linkerd-namespace
+        - {{.Values.linkerdNamespace}}
+        {{- with .Values.prometheusUrl }}
+        - {{.}}
+        {{- end }}

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -375,11 +375,11 @@ dashboard:
 namespaceMetadata:
   image:
     # -- Docker registry for the namespace-metadata instance
-    registry: curlimages
+    registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: curl
+    name: ns-labeler
     # -- Docker image tag for the namespace-metadata instance
-    tag: 7.78.0
+    tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""


### PR DESCRIPTION
Fixes #9985

When installing extensions via Helm, the `namespace-metadata` job adds the following metadata to its extension namespace:
- `linkerd.io/extension` label to have `linkerd check` identify the extension
- `pod-security.kubernetes.io/enforce` label Pod Security Admission, depending on whether linkerd-cni is enabled
- for viz only, the `viz.linkerd.io/1external-prometheus` annotation, if using an external Prometheus instance

The job uses a `curlimages/curl` docker image and performs those mutations through an inline shell script, which has two downsides:
- Security scanner warnings are sometimges triggered because of outdated binaries in there that we're not using
- The limitations of the shell environment don't allow to have a clear and maintainable script

The current change replaces that with a binary `ns-labeler`, shipped into its own image whose tag is currently fixed at `v0.1.0`.

Note that integration tests will fail until the image gets published.