### PR TITLE
Fix deleteEndpointSlice when there are multiple EndpointSlices

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -1017,8 +1017,14 @@ func (pp *portPublisher) deleteEndpointSlice(es *discovery.EndpointSlice) {
 		listener.Remove(addrSet)
 	}
 
-	svcExists := len(pp.addresses.Addresses) > 0
-	pp.noEndpoints(svcExists)
+	if len(pp.addresses.Addresses) == 0 {
+		pp.noEndpoints(false)
+	} else {
+		pp.exists = true
+		pp.metrics.incUpdates()
+		pp.metrics.setPods(len(pp.addresses.Addresses))
+		pp.metrics.setExists(true)
+	}
 }
 
 func (pp *portPublisher) noEndpoints(exists bool) {

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -1520,33 +1520,77 @@ status:
   phase: Running
   podIP: 172.17.0.12`}
 
+	k8sConfigWithMultipleES := append(k8sConfigsWithES, []string{`
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 172.17.0.13
+  conditions:
+    ready: true
+  targetRef:
+    kind: Pod
+    name: name1-2
+    namespace: ns
+  topology:
+    kubernetes.io/hostname: node-1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: name1
+  name: name1-live
+  namespace: ns
+ports:
+- name: ""
+  port: 8989`, `apiVersion: v1
+kind: Pod
+metadata:
+  name: name1-2
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.13`}...)
+
 	for _, tt := range []struct {
-		serviceType      string
-		k8sConfigs       []string
-		id               ServiceID
-		hostname         string
-		port             Port
-		objectToDelete   interface{}
-		deletingServices bool
-		hasSliceAccess   bool
+		serviceType       string
+		k8sConfigs        []string
+		id                ServiceID
+		hostname          string
+		port              Port
+		objectToDelete    interface{}
+		deletingServices  bool
+		hasSliceAccess    bool
+		noEndpointsCalled bool
 	}{
 		{
-			serviceType:    "can delete EndpointSlices",
-			k8sConfigs:     k8sConfigsWithES,
-			id:             ServiceID{Name: "name1", Namespace: "ns"},
-			port:           8989,
-			hostname:       "name1-1",
-			objectToDelete: createTestEndpointSlice(),
-			hasSliceAccess: true,
+			serviceType:       "can delete an EndpointSlice",
+			k8sConfigs:        k8sConfigsWithES,
+			id:                ServiceID{Name: "name1", Namespace: "ns"},
+			port:              8989,
+			hostname:          "name1-1",
+			objectToDelete:    createTestEndpointSlice(),
+			hasSliceAccess:    true,
+			noEndpointsCalled: true,
 		},
 		{
-			serviceType:    "can delete EndpointSlices when wrapped in a DeletedFinalStateUnknown",
-			k8sConfigs:     k8sConfigsWithES,
-			id:             ServiceID{Name: "name1", Namespace: "ns"},
-			port:           8989,
-			hostname:       "name1-1",
-			objectToDelete: createTestEndpointSlice(),
-			hasSliceAccess: true,
+			serviceType:       "can delete an EndpointSlice when wrapped in a DeletedFinalStateUnknown",
+			k8sConfigs:        k8sConfigsWithES,
+			id:                ServiceID{Name: "name1", Namespace: "ns"},
+			port:              8989,
+			hostname:          "name1-1",
+			objectToDelete:    createTestEndpointSlice(),
+			hasSliceAccess:    true,
+			noEndpointsCalled: true,
+		},
+		{
+			serviceType:       "can delete an EndpointSlice when there are multiple ones",
+			k8sConfigs:        k8sConfigWithMultipleES,
+			id:                ServiceID{Name: "name1", Namespace: "ns"},
+			port:              8989,
+			hostname:          "name1-1",
+			objectToDelete:    createTestEndpointSlice(),
+			hasSliceAccess:    true,
+			noEndpointsCalled: false,
 		},
 	} {
 		tt := tt // pin
@@ -1578,8 +1622,9 @@ status:
 
 			watcher.deleteEndpointSlice(tt.objectToDelete)
 
-			if !listener.endpointsAreNotCalled() {
-				t.Fatal("Expected NoEndpoints to be Called")
+			if listener.endpointsAreNotCalled() != tt.noEndpointsCalled {
+				t.Fatalf("Expected noEndpointsCalled to be [%t], got [%t]",
+					tt.noEndpointsCalled, listener.endpointsAreNotCalled())
 			}
 		})
 	}


### PR DESCRIPTION
### Problem

When an EndpointSlice slice is deleted for a given service but there are other existing EndpointSlices for this service, the destination controller is currently notifying listeners that there are no more endpoints which I think is wrong.  This typically happens when a service has more than 100 endpoints/pods as per the default `--max-endpoints-per-slice` kube-controller-manager flag.

To repro:
- Create a meshed service with 2 EndpointSlices
- Send a request to this service from a meshed pod so that a listener subscribes to this endpoint
- Delete one EndpointSlice
- Linkerd proxies get "NoEndpoint" and are unable to reach the service until something updates the endpoints list again  :boom:

### Solution

This PR fixes it by only notifying subscribers with "NoEndpoint" if the service has no more endpoints at all after an EndpointSlice deletion.
