### PR TITLE
Replace curl script with linkerd-extension-init

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -46,31 +46,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         args:
-        - -c
-        - |
-          ops=''
-          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          ns=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
-
-          if ! echo "$ns" | grep -q 'labels'; then
-            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
-          fi
-
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"jaeger\"},"
-
-          # grab the latest occurence of cniEnabled in linkerd-config, to
-          # discard value in the last-applied-configuration annotation
-          cniEnabled=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Values.linkerdNamespace}}/configmaps/linkerd-config" | \
-            sed -r -n 's/.*cniEnabled: (\w+).*/\1/gp' | tail -1)
-
-          level="privileged"
-          if [ "$cniEnabled" = "true" ]; then
-            level="restricted"
-          fi
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/pod-security.kubernetes.io~1enforce\", \"value\": \"$level\"}"
-
-          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
-            -d "[$ops]" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"
+        - --extension
+        - jaeger
+        - --namespace
+        - {{.Release.Namespace}}
+        - --linkerd-namespace
+        - {{.Values.linkerdNamespace}}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -154,7 +154,7 @@ namespaceMetadata:
     # -- Docker registry for the namespace-metadata instance
     registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: linkerd-extension-init
+    name: extension-init
     # -- Docker image tag for the namespace-metadata instance
     tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -152,11 +152,11 @@ linkerdVersion: &linkerd_version linkerdVersionValue
 namespaceMetadata:
   image:
     # -- Docker registry for the namespace-metadata instance
-    registry: curlimages
+    registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: curl
+    name: linkerd-extension-init
     # -- Docker image tag for the namespace-metadata instance
-    tag: 7.78.0
+    tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance
     # @default -- imagePullPolicy
     pullPolicy: ""

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -34,7 +34,6 @@ spec:
       - name: namespace-metadata
         image: {{.Values.namespaceMetadata.image.registry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
         imagePullPolicy: {{.Values.namespaceMetadata.image.pullPolicy | default .Values.imagePullPolicy}}
-        command: ["/bin/sh"]
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -45,31 +44,9 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         args:
-        - -c
-        - |
-          ops=''
-          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          ns=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
-
-          if ! echo "$ns" | grep -q 'labels'; then
-            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
-          fi
-
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"multicluster\"},"
-
-          # grab the latest occurence of cniEnabled in linkerd-config, to
-          # discard value in the last-applied-configuration annotation
-          cniEnabled=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Values.linkerdNamespace}}/configmaps/linkerd-config" | \
-            sed -r -n 's/.*cniEnabled: (\w+).*/\1/gp' | tail -1)
-
-          level="privileged"
-          if [ "$cniEnabled" = "true" ]; then
-            level="restricted"
-          fi
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/pod-security.kubernetes.io~1enforce\", \"value\": \"$level\"}"
-
-          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
-            -d "[$ops]" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"
+        - --extension
+        - multicluster
+        - --namespace
+        - {{.Release.Namespace}}
+        - --linkerd-namespace
+        - {{.Values.linkerdNamespace}}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -65,11 +65,11 @@ identityTrustDomain: cluster.local
 namespaceMetadata:
   image:
     # -- Docker registry for the namespace-metadata instance
-    registry: curlimages
+    registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: curl
+    name: linkerd-extension-init
     # -- Docker image tag for the namespace-metadata instance
-    tag: 7.78.0
+    tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance
     # @default -- imagePullPolicy
     pullPolicy: ""

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -67,7 +67,7 @@ namespaceMetadata:
     # -- Docker registry for the namespace-metadata instance
     registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: linkerd-extension-init
+    name: extension-init
     # -- Docker image tag for the namespace-metadata instance
     tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -34,7 +34,6 @@ spec:
       - name: namespace-metadata
         image: {{.Values.namespaceMetadata.image.registry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
         imagePullPolicy: {{.Values.namespaceMetadata.image.pullPolicy | default .Values.defaultImagePullPolicy}}
-        command: ["/bin/sh"]
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -46,37 +45,16 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         args:
-        - -c
-        - |
-          ops=''
-          token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          ns=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}")
-
-          if ! echo "$ns" | grep -q 'labels'; then
-            ops="$ops{\"op\": \"add\",\"path\": \"/metadata/labels\",\"value\": {}},"
-          fi
-          if ! echo "$ns" | grep -q 'annotations'; then
-            ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {}},"
-          fi
-
-          {{- if .Values.prometheusUrl }}
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/annotations/viz.linkerd.io~1external-prometheus\", \"value\": \"{{.Values.prometheusUrl}}\"},"
-          {{- end }}
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/linkerd.io~1extension\", \"value\": \"viz\"},"
-
-          # grab the latest occurence of cniEnabled in linkerd-config, to
-          # discard value in the last-applied-configuration annotation
-          cniEnabled=$(curl -kfv -H "Authorization: Bearer $token" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Values.linkerdNamespace}}/configmaps/linkerd-config" | \
-            sed -r -n 's/.*cniEnabled: (\w+).*/\1/gp' | tail -1)
-
-          level="privileged"
-          if [ "$cniEnabled" = "true" ]; then
-            level="restricted"
-          fi
-          ops="$ops{\"op\": \"add\", \"path\": \"/metadata/labels/pod-security.kubernetes.io~1enforce\", \"value\": \"$level\"}"
-
-          curl -kfv -XPATCH -H "Content-Type: application/json-patch+json" -H "Authorization: Bearer $token" \
-            -d "[$ops]" \
-            "https://kubernetes.default.svc/api/v1/namespaces/{{.Release.Namespace}}?fieldManager=kubectl-label"
+        - --log-format
+        - {{.Values.defaultLogFormat}}
+        - --log-level
+        - {{.Values.defaultLogLevel}}
+        - --extension
+        - viz
+        - --namespace
+        - {{.Release.Namespace}}
+        - --linkerd-namespace
+        - {{.Values.linkerdNamespace}}
+        {{- with .Values.prometheusUrl }}
+        - {{.}}
+        {{- end }}

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -56,5 +56,6 @@ spec:
         - --linkerd-namespace
         - {{.Values.linkerdNamespace}}
         {{- with .Values.prometheusUrl }}
+        - -- prometheus-url
         - {{.}}
         {{- end }}

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -375,11 +375,11 @@ dashboard:
 namespaceMetadata:
   image:
     # -- Docker registry for the namespace-metadata instance
-    registry: curlimages
+    registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: curl
+    name: linkerd-extension-init
     # -- Docker image tag for the namespace-metadata instance
-    tag: 7.78.0
+    tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -377,7 +377,7 @@ namespaceMetadata:
     # -- Docker registry for the namespace-metadata instance
     registry: cr.l5d.io/linkerd
     # -- Docker image name for the namespace-metadata instance
-    name: linkerd-extension-init
+    name: extension-init
     # -- Docker image tag for the namespace-metadata instance
     tag: v0.1.0
     # -- Pull policy for the namespace-metadata instance


### PR DESCRIPTION
Fixes #9985

When installing extensions via Helm, the `namespace-metadata` job adds the following metadata to its extension namespace:
- `linkerd.io/extension` label to have `linkerd check` identify the extension
- `pod-security.kubernetes.io/enforce` label Pod Security Admission, depending on whether linkerd-cni is enabled
- for viz only, the `viz.linkerd.io/1external-prometheus` annotation, if using an external Prometheus instance

The job uses a `curlimages/curl` docker image and performs those mutations through an inline shell script, which has two downsides:
- Security scanner warnings are sometimges triggered because of outdated binaries in there that we're not using
- The limitations of the shell environment don't allow to have a clear and maintainable script

This change replaces the `curlimage/curl` image in the `namespace-metadata` jobs with the new image for
`linkerd-extension-init` currently worked on
linkerd/linkerd-extension-init#2.