### PR TITLE
Fix GitHub Actions deprecation warnings

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -39,8 +39,8 @@ runs:
         key: ${{ runner.os }}-buildx-${{ inputs.component }}-${{ inputs.tag }}
         restore-keys: ${{ runner.os }}-buildx-${{ inputs.component }}-
 
-    - uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
-    - uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+    - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
+    - uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
     - name: Run bin/docker-build-${{ inputs.component }}
       env:
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - run: echo "::set-output name=tag::$(CI_FORCE_CLEAN=1 bin/root-tag)"
+      - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_OUTPUT
         id: tag
     outputs:
       tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_OUTPUT
+      - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> "$GITHUB_OUTPUT"
         id: tag
     outputs:
       tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_OUTPUT
+      - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> "$GITHUB_OUTPUT"
         id: tag
     outputs:
       tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - run: echo "::set-output name=tag::$(CI_FORCE_CLEAN=1 bin/root-tag)"
+      - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> $GITHUB_OUTPUT
         id: tag
     outputs:
       tag: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
GitHub Actions will deprecate `::set-output` and `::save-state`. This syntax should be replaced with evars (or Environment Files as they call it). Instead of something like:

```
::set-output name={name}::{value}
```

We should simply append to the GITHUB_OUTPUT evar

```
echo {name}={value} >> $GITHUB_OUTPUT
````

Additionally, this change also replaces the versions of `setup-buildx` action and `qemu` actions. Both generate NodeJS 12 deprecation warnings; they have not received the usual bumps, presumably because they are in a different directory.


---

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

```
[tag](https://github.com/linkerd/linkerd2/actions/runs/4254430427/jobs/7400665718#step:3:9)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

[Docker build (debug)](https://github.com/linkerd/linkerd2/actions/runs/4254430427/jobs/7400669709)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480, docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```



<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:




```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
