### PR TITLE
Add lease claims to status controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,11 +951,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fd33a6cfc53c087537f849dc2d34b8f4ea68eca55b417125d41a9c3fe4a1a4"
 dependencies = [
  "ahash",
+ "chrono",
  "clap",
  "drain",
  "futures-core",
  "futures-util",
  "hyper",
+ "k8s-openapi",
  "kube-client",
  "kube-core",
  "kube-runtime",
@@ -963,6 +965,7 @@ dependencies = [
  "pin-project-lite",
  "rustls-pemfile",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-rustls",

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -223,12 +223,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -218,6 +218,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -121,6 +121,16 @@ spec:
       linkerd.io/control-plane-component: destination
 {{- end }}
 ---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+---
 {{- $tree := deepCopy . }}
 {{ $_ := set $tree.Values.proxy "workloadKind" "deployment" -}}
 {{ $_ := set $tree.Values.proxy "component" "linkerd-destination" -}}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1112,6 +1108,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1111,6 +1107,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1111,6 +1107,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1111,6 +1107,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1111,6 +1107,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1102,6 +1098,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1209,6 +1205,15 @@ spec:
   selector:
     matchLabels:
       linkerd.io/control-plane-component: destination
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1209,6 +1205,15 @@ spec:
   selector:
     matchLabels:
       linkerd.io/control-plane-component: destination
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1042,6 +1038,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -204,6 +204,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -209,12 +209,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1086,6 +1082,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd-dev
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd-dev
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -204,6 +204,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -209,12 +209,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1184,6 +1180,15 @@ spec:
   selector:
     matchLabels:
       linkerd.io/control-plane-component: destination
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd-dev
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd-dev
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -204,6 +204,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -209,12 +209,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1192,6 +1188,15 @@ spec:
   selector:
     matchLabels:
       linkerd.io/control-plane-component: destination
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd-dev
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd-dev
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -204,6 +204,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -209,12 +209,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1174,6 +1170,15 @@ spec:
   selector:
     matchLabels:
       linkerd.io/control-plane-component: destination
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd-dev
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd-dev
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1104,6 +1100,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -215,12 +215,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1088,6 +1084,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -210,6 +210,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1111,6 +1107,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -218,12 +218,8 @@ rules:
     resources:
       - leases
     verbs:
-      - create
       - get
-      - list
       - patch
-      - update
-      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1111,6 +1107,15 @@ spec:
   - name: policy-https
     port: 443
     targetPort: policy-https
+---
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: status-controller
+  namespace: linkerd
+  labels:
+    linkerd.io/control-plane-component: destination
+    linkerd.io/control-plane-ns: linkerd
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -213,6 +213,17 @@ rules:
       - httproutes/status
     verbs:
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -47,7 +47,7 @@ features = ["admission", "derive"]
 [dependencies.kubert]
 version = "0.14"
 default-features = false
-features = ["clap", "index", "runtime", "server"]
+features = ["clap", "index", "lease", "runtime", "server"]
 
 [dependencies.tokio]
 version = "1"

--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -9,6 +9,7 @@ pub use k8s_gateway_api as gateway;
 pub use k8s_openapi::{
     api::{
         self,
+        coordination::v1::Lease,
         core::v1::{
             Container, ContainerPort, HTTPGetAction, Namespace, Node, NodeSpec, Pod, PodSpec,
             PodStatus, Probe, Service, ServiceAccount,
@@ -24,6 +25,7 @@ pub use k8s_openapi::{
 };
 pub use kube::{
     api::{Api, ListParams, ObjectMeta, Patch, PatchParams, Resource, ResourceExt},
+    error::ErrorResponse,
     runtime::watcher::Event as WatchEvent,
-    Client,
+    Client, Error,
 };

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -10,7 +10,10 @@ ahash = "0.8"
 anyhow = "1"
 # Fix for https://github.com/chronotope/chrono/issues/602
 chrono = { version = "0.4.23", default-features = false, features = ["clock"] }
-kubert = { version = "0.14", default-features = false, features = ["index"] }
+kubert = { version = "0.14", default-features = false, features = [
+    "index",
+    "lease",
+] }
 linkerd-policy-controller-core = { path = "../../core" }
 linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -19,5 +19,5 @@ linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"
 serde_json = "1.0.91"
 thiserror = "1"
-tokio = "1"
+tokio = { version = "1", features = ["macros"] }
 tracing = "0.1.37"

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -19,5 +19,9 @@ linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"
 serde_json = "1.0.91"
 thiserror = "1"
-tokio = { version = "1", features = ["macros"] }
+tokio = "1"
 tracing = "0.1.37"
+
+[dev-dependencies.tokio]
+version = "1"
+features = ["macros"]

--- a/policy-controller/k8s/status/src/lib.rs
+++ b/policy-controller/k8s/status/src/lib.rs
@@ -1,8 +1,8 @@
 mod http_route;
-pub mod index;
+mod index;
 mod resource_id;
 
 #[cfg(test)]
 mod tests;
 
-pub use self::index::{Controller, Index};
+pub use self::index::{Controller, Index, STATUS_CONTROLLER_NAME};

--- a/policy-controller/k8s/status/src/lib.rs
+++ b/policy-controller/k8s/status/src/lib.rs
@@ -1,5 +1,5 @@
 mod http_route;
-mod index;
+pub mod index;
 mod resource_id;
 
 #[cfg(test)]

--- a/policy-controller/k8s/status/src/tests/http_routes.rs
+++ b/policy-controller/k8s/status/src/tests/http_routes.rs
@@ -6,12 +6,19 @@ use crate::{
 };
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_k8s_api::{self as k8s, gateway, policy::server::Port};
-use tokio::sync::mpsc;
+use std::sync::Arc;
+use tokio::sync::{mpsc, watch};
 
 #[test]
 fn http_route_accepted_after_server_create() {
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let index = Index::shared(tx);
+    let hostname = "test";
+    let claim = kubert::lease::Claim {
+        holder: "holder".to_string(),
+        expiry: chrono::DateTime::<chrono::Utc>::MAX_UTC,
+    };
+    let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
+    let (updates_tx, mut updates_rx) = mpsc::unbounded_channel();
+    let index = Index::shared(hostname, claims_rx, updates_tx);
 
     // Apply the route.
     let http_route = make_route("ns-0", "route-foo", "srv-8080");
@@ -26,7 +33,7 @@ fn http_route_accepted_after_server_create() {
 
     // The first update will be that the HTTPRoute is not accepted because the
     // Server has been created yet.
-    let update = rx.try_recv().unwrap();
+    let update = updates_rx.try_recv().unwrap();
     assert_eq!(id, update.id);
     assert_eq!(patch, update.patch);
 
@@ -49,16 +56,22 @@ fn http_route_accepted_after_server_create() {
 
     // The second update will be that the HTTPRoute is accepted because the
     // Server has been created.
-    let update = rx.try_recv().unwrap();
+    let update = updates_rx.try_recv().unwrap();
     assert_eq!(id, update.id);
     assert_eq!(patch, update.patch);
-    assert!(rx.try_recv().is_err())
+    assert!(updates_rx.try_recv().is_err())
 }
 
 #[test]
 fn http_route_rejected_after_server_delete() {
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let index = Index::shared(tx);
+    let hostname = "test";
+    let claim = kubert::lease::Claim {
+        holder: "holder".to_string(),
+        expiry: chrono::DateTime::<chrono::Utc>::MAX_UTC,
+    };
+    let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
+    let (updates_tx, mut updates_rx) = mpsc::unbounded_channel();
+    let index = Index::shared(hostname, claims_rx, updates_tx);
 
     let server = make_server(
         "ns-0",
@@ -71,7 +84,7 @@ fn http_route_rejected_after_server_delete() {
     index.write().apply(server);
 
     // There should be no update since there are no HTTPRoutes yet.
-    assert!(rx.try_recv().is_err());
+    assert!(updates_rx.try_recv().is_err());
 
     let http_route = make_route("ns-0", "route-foo", "srv-8080");
     index.write().apply(http_route);
@@ -84,7 +97,7 @@ fn http_route_rejected_after_server_delete() {
 
     // The second update will be that the HTTPRoute is accepted because the
     // Server has been created.
-    let update = rx.try_recv().unwrap();
+    let update = updates_rx.try_recv().unwrap();
     assert_eq!(id, update.id);
     assert_eq!(patch, update.patch);
 
@@ -106,10 +119,10 @@ fn http_route_rejected_after_server_delete() {
 
     // The third update will be that the HTTPRoute is not accepted because the
     // Server has been deleted.
-    let update = rx.try_recv().unwrap();
+    let update = updates_rx.try_recv().unwrap();
     assert_eq!(id, update.id);
     assert_eq!(patch, update.patch);
-    assert!(rx.try_recv().is_err());
+    assert!(updates_rx.try_recv().is_err());
 }
 
 fn make_server(
@@ -207,7 +220,7 @@ fn make_parent_status(
             section_name: None,
             port: None,
         },
-        controller_name: STATUS_CONTROLLER_NAME.to_string(),
+        controller_name: format!("{}/{}", POLICY_API_GROUP, STATUS_CONTROLLER_NAME),
         conditions: vec![condition],
     }
 }

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
     let index = Index::shared(ClusterInfo {
         networks: cluster_networks.clone(),
         identity_domain,
-        control_plane_ns: control_plane_namespace,
+        control_plane_ns: control_plane_namespace.clone(),
         default_policy,
         default_detect_timeout: DETECT_TIMEOUT,
         probe_networks,
@@ -160,7 +160,7 @@ async fn main() -> Result<()> {
 
     // Create the lease manager used for trying to claim the status-controller lease.
     // todo: Namespace should be parameterized now
-    let api = k8s::Api::namespaced(runtime.client(), "linkerd");
+    let api = k8s::Api::namespaced(runtime.client(), &control_plane_namespace);
     // todo: Do we need to use LeaseManager::field_manager here?
     let lease = kubert::lease::LeaseManager::init(api, status::STATUS_CONTROLLER_NAME).await?;
     let pod_name =

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -158,8 +158,11 @@ async fn main() -> Result<()> {
         kubert::index::namespaced(index.clone(), http_routes).instrument(info_span!("httproutes")),
     );
 
-    // Create the status controller lease and start trying to claim it.
-    let lease = status::index::create_lease_manager(runtime.client()).await?;
+    // Create the lease manager used for trying to claim the status-controller lease.
+    // todo: Namespace should be parameterized now
+    let api = k8s::Api::namespaced(runtime.client(), "linkerd");
+    // todo: Do we need to use LeaseManager::field_manager here?
+    let lease = kubert::lease::LeaseManager::init(api, status::STATUS_CONTROLLER_NAME).await?;
     let pod_name =
         std::env::var("HOSTNAME").expect("Failed to fetch `HOSTNAME` environment variable");
     // todo: These should probably be configurable or set as consts

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -159,7 +159,6 @@ async fn main() -> Result<()> {
     );
 
     // Create the lease manager used for trying to claim the status-controller lease.
-    // todo: Namespace should be parameterized now
     let api = k8s::Api::namespaced(runtime.client(), &control_plane_namespace);
     // todo: Do we need to use LeaseManager::field_manager here?
     let lease = kubert::lease::LeaseManager::init(api, status::STATUS_CONTROLLER_NAME).await?;

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -158,10 +158,21 @@ async fn main() -> Result<()> {
         kubert::index::namespaced(index.clone(), http_routes).instrument(info_span!("httproutes")),
     );
 
+    // Create the status controller lease and start trying to claim it.
+    let lease = status::index::create_lease_manager(runtime.client()).await?;
+    let pod_name =
+        std::env::var("HOSTNAME").expect("Failed to fetch `HOSTNAME` environment variable");
+    // todo: These should probably be configurable or set as consts
+    let params = kubert::lease::ClaimParams {
+        lease_duration: std::time::Duration::from_secs(30),
+        renew_grace_period: std::time::Duration::from_secs(1),
+    };
+    let (claims, _task) = lease.spawn(pod_name.clone(), params).await?;
+
     // Build the status index which will be used to process updates to policy
     // resources and send to the status controller.
     let (updates_tx, updates_rx) = mpsc::unbounded_channel();
-    let status_index = status::Index::shared(updates_tx);
+    let status_index = status::Index::shared(pod_name, claims, updates_tx);
 
     // Spawn resource indexers that update the status index.
     let http_routes = runtime.watch_all::<k8s::policy::HttpRoute>(ListParams::default());


### PR DESCRIPTION
This adds lease claims to the policy status controller so that upon startup, a status controller attempts to claim the `status-controller` lease in the `linkerd` namespace. With this lease, we can enforce leader election and ensure that only one status controller on a cluster is attempting to patch HTTPRoute’s `status` field.

Upon startup, the status controller now attempts to create the `status-controller` lease — it will handle failure if the lease is already present on the cluster. It then spawns a task for attempting to claim this lease and sends all claim updates to the index `Index`.

Currently, `Index.claims` is not used, but in follow-up changes we can check against the current claim for determining if the status controller is the current leader on the cluster. If it is, we can make decisions about sending updates or not to the controller `Controller`.

### Testing
Currently I’ve only manually tested this, but integration tests will definitely be helpful follow-ups. For manually testing, I’ve asserted that the `status-controller` is claimed when one or more status controllers startup and are running on a cluster. I’ve also asserted that when the current leader is deleted, another status controller claims the lease. Below is the summary of how I tested it

```shell
$ linkerd install --ha |kubectl apply -f -
…

$ kubectl get -n linkerd leases status-controller
NAME                HOLDER                                 AGE
status-controller   linkerd-destination-747b456876-dcwlb   15h

$ kubectl delete -n linkerd pod linkerd-destination-747b456876-dcwlb 
pod "linkerd-destination-747b456876-dcwlb" deleted

$ kubectl get -n linkerd leases status-controller
NAME                HOLDER                                 AGE
status-controller   linkerd-destination-747b456876-5zpwd   15h
```

Signed-off-by: Kevin Leimkuhler <[kleimkuhler@icloud.com](mailto:kleimkuhler@icloud.com)>