### PR TITLE
increase memory limit for no-op container to 25 mebibytes

### DIFF
--- a/charts/partials/templates/_noop.tpl
+++ b/charts/partials/templates/_noop.tpl
@@ -6,10 +6,10 @@ name: noop
 resources:
   limits:
     cpu: "50m"
-    memory: "10Mi"
+    memory: "25Mi"
   requests:
     cpu: "50m"
-    memory: "10Mi"
+    memory: "25Mi"
 securityContext:
   runAsUser: {{ .Values.proxyInit.runAsUser | int | eq 0 | ternary 65534 .Values.proxyInit.runAsUser }}
 {{- end -}}

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -171,10 +171,10 @@ spec:
         resources:
           limits:
             cpu: 50m
-            memory: 10Mi
+            memory: 25Mi
           requests:
             cpu: 50m
-            memory: 10Mi
+            memory: 25Mi
         securityContext:
           runAsUser: 65534
       volumes:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -746,7 +746,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -911,10 +911,10 @@ spec:
         resources:
           limits:
             cpu: "50m"
-            memory: "10Mi"
+            memory: "25Mi"
           requests:
             cpu: "50m"
-            memory: "10Mi"
+            memory: "25Mi"
         securityContext:
           runAsUser: 65534
       serviceAccountName: linkerd-identity
@@ -1074,7 +1074,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1308,10 +1308,10 @@ spec:
         resources:
           limits:
             cpu: "50m"
-            memory: "10Mi"
+            memory: "25Mi"
           requests:
             cpu: "50m"
-            memory: "10Mi"
+            memory: "25Mi"
         securityContext:
           runAsUser: 65534
       serviceAccountName: linkerd-destination
@@ -1426,7 +1426,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1591,10 +1591,10 @@ spec:
         resources:
           limits:
             cpu: "50m"
-            memory: "10Mi"
+            memory: "25Mi"
           requests:
             cpu: "50m"
-            memory: "10Mi"
+            memory: "25Mi"
         securityContext:
           runAsUser: 65534
       serviceAccountName: linkerd-proxy-injector


### PR DESCRIPTION
This change increases the memory limit for the no-op init container to 25 mebibytes (roughly 26Mb) for a new release in the 2.12 series.
