### PR TITLE
Add support for customizable ignore headers list in Linkerd Tap

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -160,6 +160,7 @@ Kubernetes: `>=1.21.0-0`
 | tap.caBundle | string | `""` | Bundle of CA certificates for tap. If not provided nor injected with cert-manager, then Helm will use the certificate generated for `tap.crtPEM`. If `tap.externalSecret` is set to true, this value, injectCaFrom, or injectCaFromSecret must be set, as no certificate will be generated. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector) for more information. |
 | tap.crtPEM | string | `""` | Certificate for the Tap component. If not provided and not using an external secret then Helm will generate one. |
 | tap.externalSecret | bool | `false` | Do not create a secret resource for the Tap component. If this is set to `true`, the value `tap.caBundle` must be set or the ca bundle must injected with cert-manager ca injector using `tap.injectCaFrom` or `tap.injectCaFromSecret` (see below). |
+| tap.ignoredHeaders | string | `""` | Comma-separated list of headers to be ignored by Linkerd Tap. Ignore auth tokens written in plain text or irrelevant cookies.
 | tap.image.name | string | `"tap"` | Docker image name for the tap instance |
 | tap.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the tap component |
 | tap.image.registry | string | defaultRegistry | Docker registry for the tap instance |

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -90,6 +90,9 @@ spec:
         {{- if .Values.grafana.uidPrefix }}
         - -grafana-prefix={{.Values.grafana.uidPrefix}}
         {{- end}}
+        {{- if .Values.tap.ignoredHeaders }}
+        - -tap-ignored-headers={{.Values.tap.ignoredHeaders}}
+        {{- end}}        
         {{- if .Values.jaegerUrl }}
         - -jaeger-addr={{.Values.jaegerUrl}}
         {{- end}}

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -131,6 +131,8 @@ metricsAPI:
 
 # tap configuration
 tap:
+  # Headers that will be ignored for web Linkerd Tap
+  ignoredHeaders: ""
     # -- Number of tap component replicas
   replicas: 1
   # -- log level of the tap component

--- a/web/app/js/components/Tap.jsx
+++ b/web/app/js/components/Tap.jsx
@@ -31,6 +31,7 @@ class Tap extends React.Component {
     this.loadFromServer = this.loadFromServer.bind(this);
 
     this.state = {
+      tapIgnoredHeaders: this.tapIgnoredHeaders,
       tapResultsById: this.tapResultsById,
       error: null,
       resourcesByNs: {},
@@ -292,7 +293,7 @@ class Tap extends React.Component {
   };
 
   render() {
-    const { tapResultsById, tapRequestInProgress, tapIsClosing, resourcesByNs, authoritiesByNs, query, showTapEnabledWarning, error } = this.state;
+    const { tapResultsById, tapRequestInProgress, tapIsClosing, resourcesByNs, authoritiesByNs, query, showTapEnabledWarning, tapIgnoredHeaders, error } = this.state;
     const tableRows = _orderBy(_values(tapResultsById), r => r.lastUpdated, 'desc');
 
     return (
@@ -320,6 +321,7 @@ class Tap extends React.Component {
         {!showTapEnabledWarning &&
           <TapEventTable
             resource={query.resource}
+            tapIgnoredHeaders={tapIgnoredHeaders}
             tableRows={tableRows} />
         }
       </div>

--- a/web/app/js/components/TapEventHeadersTable.jsx
+++ b/web/app/js/components/TapEventHeadersTable.jsx
@@ -2,6 +2,7 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -12,10 +13,14 @@ const headersStyles = {
   },
 };
 
-const HeadersContentBase = function({ headers, classes }) {
+const HeadersContentBase = function({ headers, classes, tapIgnoredHeaders }) {
+  const ignoredHeaders = new Set(tapIgnoredHeaders.split(','));
   return (
     <React.Fragment>
       {headers.map(header => {
+        if (ignoredHeaders.has(header.name)) {
+          return null;
+        }
         return (
           <React.Fragment key={`${header.name}_${header.valueStr}`}>
             <Typography
@@ -33,6 +38,7 @@ const HeadersContentBase = function({ headers, classes }) {
           </React.Fragment>
         );
       })}
+
     </React.Fragment>
   );
 };
@@ -42,11 +48,12 @@ HeadersContentBase.propTypes = {
     name: PropTypes.string.isRequired,
     valueStr: PropTypes.string.isRequired,
   })).isRequired,
+  tapIgnoredHeaders: PropTypes.string.isRequired,
 };
 
 const HeadersContentDisplay = withStyles(headersStyles)(HeadersContentBase);
 
-export const headersDisplay = (title, value) => {
+export const headersDisplay = (title, value, tapIgnoredHeaders) => {
   if (!value) {
     return null;
   }
@@ -55,7 +62,7 @@ export const headersDisplay = (title, value) => {
     <ListItem disableGutters>
       <ListItemText
         primary={title}
-        secondary={'headers' in value ? <HeadersContentDisplay headers={value.headers} /> : '-'} />
+        secondary={'headers' in value ? <HeadersContentDisplay headers={value.headers} tapIgnoredHeaders={tapIgnoredHeaders} /> : '-'} />
     </ListItem>
   );
 };

--- a/web/app/js/components/TapEventTable.jsx
+++ b/web/app/js/components/TapEventTable.jsx
@@ -138,77 +138,78 @@ const itemDisplay = (title, value) => {
   );
 };
 
-const requestInitSection = d => (
-  <React.Fragment>
-    <Typography variant="subtitle2"><Trans>tableTitleRequestInit</Trans></Typography>
-    <br />
-    <List dense>
-      {itemDisplay(<Trans>formAuthority</Trans>, _get(d, 'requestInit.http.requestInit.authority'))}
-      {itemDisplay(<Trans>formPath</Trans>, _get(d, 'requestInit.http.requestInit.path'))}
-      {itemDisplay(<Trans>formScheme</Trans>, _get(d, 'requestInit.http.requestInit.scheme.registered'))}
-      {itemDisplay(<Trans>formMethod</Trans>, _get(d, 'requestInit.http.requestInit.method.registered'))}
-      {headersDisplay(<Trans>formHeaders</Trans>, _get(d, 'requestInit.http.requestInit.headers'))}
-    </List>
-  </React.Fragment>
-);
+const expandedRowRender = (d, expandedWrapStyle, tapIgnoredHeaders) => {
+  const requestInitSection = () => (
+    <React.Fragment>
+      <Typography variant="subtitle2"><Trans>tableTitleRequestInit</Trans></Typography>
+      <br />
+      <List dense>
+        {itemDisplay(<Trans>formAuthority</Trans>, _get(d, 'requestInit.http.requestInit.authority'))}
+        {itemDisplay(<Trans>formPath</Trans>, _get(d, 'requestInit.http.requestInit.path'))}
+        {itemDisplay(<Trans>formScheme</Trans>, _get(d, 'requestInit.http.requestInit.scheme.registered'))}
+        {itemDisplay(<Trans>formMethod</Trans>, _get(d, 'requestInit.http.requestInit.method.registered'))}
+        {headersDisplay(<Trans>formHeaders</Trans>, _get(d, 'requestInit.http.requestInit.headers'), tapIgnoredHeaders)}
+      </List>
+    </React.Fragment>
+  );
 
-const responseInitSection = d => _isEmpty(d.responseInit) ? null : (
-  <React.Fragment>
-    <Typography variant="subtitle2"><Trans>tableTitleResponseInit</Trans></Typography>
-    <br />
-    <List dense>
-      {itemDisplay(<Trans>formHTTPStatus</Trans>, _get(d, 'responseInit.http.responseInit.httpStatus'))}
-      {itemDisplay(<Trans>formLatency</Trans>, formatTapLatency(_get(d, 'responseInit.http.responseInit.sinceRequestInit')))}
-      {headersDisplay(<Trans>formHeaders</Trans>, _get(d, 'responseInit.http.responseInit.headers'))}
-    </List>
-  </React.Fragment>
-);
+  const responseInitSection = () => _isEmpty(d.responseInit) ? null : (
+    <React.Fragment>
+      <Typography variant="subtitle2"><Trans>tableTitleResponseInit</Trans></Typography>
+      <br />
+      <List dense>
+        {itemDisplay(<Trans>formHTTPStatus</Trans>, _get(d, 'responseInit.http.responseInit.httpStatus'))}
+        {itemDisplay(<Trans>formLatency</Trans>, formatTapLatency(_get(d, 'responseInit.http.responseInit.sinceRequestInit')))}
+        {headersDisplay(<Trans>formHeaders</Trans>, _get(d, 'responseInit.http.responseInit.headers'), tapIgnoredHeaders)}
+      </List>
+    </React.Fragment>
+  );
 
-const responseEndSection = d => _isEmpty(d.responseEnd) ? null : (
-  <React.Fragment>
-    <Typography variant="subtitle2"><Trans>tableTitleResponseEnd</Trans></Typography>
-    <br />
+  const responseEndSection = () => _isEmpty(d.responseEnd) ? null : (
+    <React.Fragment>
+      <Typography variant="subtitle2"><Trans>tableTitleResponseEnd</Trans></Typography>
+      <br />
 
-    <List dense>
-      {itemDisplay(<Trans>formGRPCStatus</Trans>, _isNull(_get(d, 'responseEnd.http.responseEnd.eos')) ? 'N/A' : grpcStatusCodes[_get(d, 'responseEnd.http.responseEnd.eos.grpcStatusCode')])}
-      {itemDisplay(<Trans>formLatency</Trans>, formatTapLatency(_get(d, 'responseEnd.http.responseEnd.sinceResponseInit')))}
-      {itemDisplay(<Trans>formResponseLengthB</Trans>, formatWithComma(_get(d, 'responseEnd.http.responseEnd.responseBytes')))}
-    </List>
-  </React.Fragment>
-);
+      <List dense>
+        {itemDisplay(<Trans>formGRPCStatus</Trans>, _isNull(_get(d, 'responseEnd.http.responseEnd.eos')) ? 'N/A' : grpcStatusCodes[_get(d, 'responseEnd.http.responseEnd.eos.grpcStatusCode')])}
+        {itemDisplay(<Trans>formLatency</Trans>, formatTapLatency(_get(d, 'responseEnd.http.responseEnd.sinceResponseInit')))}
+        {itemDisplay(<Trans>formResponseLengthB</Trans>, formatWithComma(_get(d, 'responseEnd.http.responseEnd.responseBytes')))}
+      </List>
+    </React.Fragment>
+  );
 
-// hide verbose information
-const expandedRowRender = (d, expandedWrapStyle) => {
   return (
     <Grid container spacing={2} className={expandedWrapStyle}>
       <Grid item xs={4}>
         <Card elevation={3}>
-          <CardContent>{requestInitSection(d)}</CardContent>
+          <CardContent>{requestInitSection()}</CardContent>
         </Card>
       </Grid>
       <Grid item xs={4}>
         <Card elevation={3}>
-          <CardContent>{responseInitSection(d)}</CardContent>
+          <CardContent>{responseInitSection()}</CardContent>
         </Card>
       </Grid>
       <Grid item xs={4}>
         <Card elevation={3}>
-          <CardContent>{responseEndSection(d)}</CardContent>
+          <CardContent>{responseEndSection()}</CardContent>
         </Card>
       </Grid>
     </Grid>
   );
 };
 
-const TapEventTable = function({ tableRows, resource, api }) {
+const TapEventTable = function({ tableRows, resource, api, tapIgnoredHeaders }) {
   const resourceType = resource.split('/')[0];
   const columns = tapColumns(resourceType, api.ResourceLink);
+  expandedRowRender.tapIgnoredHeaders = tapIgnoredHeaders;
 
   return (
     <ExpandableTable
       tableRows={tableRows}
       tableColumns={columns}
-      expandedRowRender={expandedRowRender}
+      // expandedRowRender={expandedRowRender}
+      expandedRowRender={(d, expandedWrapStyle) => expandedRowRender(d, expandedWrapStyle, tapIgnoredHeaders)}
       tableClassName="metric-table" />
   );
 };
@@ -219,9 +220,11 @@ TapEventTable.propTypes = {
   }).isRequired,
   resource: PropTypes.string,
   tableRows: PropTypes.arrayOf(PropTypes.shape({})),
+  tapIgnoredHeaders: PropTypes.string,
 };
 
 TapEventTable.defaultProps = {
+  tapIgnoredHeaders: '',
   resource: '',
   tableRows: [],
 };

--- a/web/main.go
+++ b/web/main.go
@@ -33,6 +33,7 @@ func main() {
 	grafanaExternalAddr := cmd.String("grafana-external-addr", "", "address of the external grafana service")
 	grafanaPrefix := cmd.String("grafana-prefix", "", "prefix for Grafana dashboard UID's")
 	jaegerAddr := cmd.String("jaeger-addr", "", "address of the jaeger service")
+	tapIgnoredHeaders := cmd.String("tap-ignored-headers", "", "comma-separated list of ignored headers displayed in linkerd tap")
 	templateDir := cmd.String("template-dir", "templates", "directory to search for template files")
 	staticDir := cmd.String("static-dir", "app/dist", "directory to search for static files")
 	reload := cmd.Bool("reload", true, "reloading set to true or false")
@@ -107,7 +108,13 @@ func main() {
 		log.Fatalf("invalid --enforced-host parameter: %s", err)
 	}
 
-	server := srv.NewServer(*addr, *grafanaAddr, *grafanaExternalAddr, *grafanaPrefix, *jaegerAddr, *templateDir, *staticDir, uuid, version,
+	commaSeperatedPattern := regexp.MustCompile(`^[-\w]+(,[-\w]+)*$`)
+	if !commaSeperatedPattern.MatchString(*tapIgnoredHeaders) {
+		log.Fatalf("invalid --tap-ignored-headers parameter: %s no white-space, comma seperated values only", *tapIgnoredHeaders)
+
+	}
+
+	server := srv.NewServer(*addr, *grafanaAddr, *grafanaExternalAddr, *grafanaPrefix, *tapIgnoredHeaders, *jaegerAddr, *templateDir, *staticDir, uuid, version,
 		*controllerNamespace, *clusterDomain, *reload, reHost, client, k8sAPI, hc)
 
 	go func() {

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -30,6 +30,7 @@ type (
 		grafana             string
 		grafanaExternalURL  string
 		grafanaPrefix       string
+		tapIgnoredHeaders   string
 		jaeger              string
 		grafanaProxy        *reverseProxy
 		jaegerProxy         *reverseProxy
@@ -53,6 +54,7 @@ func (h *handler) handleIndex(w http.ResponseWriter, req *http.Request, p httpro
 		Grafana:             h.grafana,
 		GrafanaExternalURL:  h.grafanaExternalURL,
 		GrafanaPrefix:       h.grafanaPrefix,
+		TapIgnoredHeaders:   h.tapIgnoredHeaders,
 		Jaeger:              h.jaeger,
 	}
 

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -55,6 +55,7 @@ type (
 		Grafana             string
 		GrafanaExternalURL  string
 		GrafanaPrefix       string
+		TapIgnoredHeaders   string
 	}
 
 	healthChecker interface {
@@ -87,6 +88,7 @@ func NewServer(
 	grafanaAddr string,
 	grafanaExternalAddr string,
 	grafanaPrefix string,
+	tapIgnoredHeaders string,
 	jaegerAddr string,
 	templateDir string,
 	staticDir string,
@@ -125,6 +127,7 @@ func NewServer(
 		grafana:             grafanaAddr,
 		grafanaExternalURL:  grafanaExternalAddr,
 		grafanaPrefix:       grafanaPrefix,
+		tapIgnoredHeaders:   tapIgnoredHeaders,
 		jaeger:              jaegerAddr,
 		hc:                  hc,
 		statCache:           cache.New(statExpiration, statCleanupInterval),


### PR DESCRIPTION
Currently, Linkerd Tap displays all headers by default, which can contain irrelevant or sensitive information that users may want to exclude from being displayed. Therefore, there is a need for a feature that allows users to set their own ignore headers list, so that they can choose which headers to exclude from the output of Linkerd Tap on the dashboard.

This commit adds a new helm value, `tap.ignoredHeaders`, to the Linkerd-viz chart. This value allows users to specify a comma-separated list of headers to be ignored by Linkerd Tap. The default list includes commonly irrelevant and sensitive headers such as authorization tokens and cookies.

Once merged, every comma-seperated value in `tap.ignoredHeaders` will be removed from the headers in the Tap Dashboard when expanding a request headers result.

Fixes #10389

Signed-off-by: Ryan Hristovski <ryan.hristovski@docker.com>

---

This is my first time contributing to this repo so I am sure refinement or even a different approach may be suggested which I'm open to.

I understand `tap` itself will need to be updated as well which I can do if this gets a positive signal. As of right now the headers will still be visible when running the cli

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
