### PR TITLE
Fix service `exists` when endpoints are deleted

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -1018,7 +1018,7 @@ func (pp *portPublisher) deleteEndpointSlice(es *discovery.EndpointSlice) {
 	}
 
 	if len(pp.addresses.Addresses) == 0 {
-		pp.noEndpoints(false)
+		pp.noEndpoints(true)
 	} else {
 		pp.exists = true
 		pp.metrics.incUpdates()

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -1561,6 +1561,7 @@ status:
 		deletingServices  bool
 		hasSliceAccess    bool
 		noEndpointsCalled bool
+		noEndpointsExists bool
 	}{
 		{
 			serviceType:       "can delete an EndpointSlice",
@@ -1571,6 +1572,7 @@ status:
 			objectToDelete:    createTestEndpointSlice(),
 			hasSliceAccess:    true,
 			noEndpointsCalled: true,
+			noEndpointsExists: true,
 		},
 		{
 			serviceType:       "can delete an EndpointSlice when wrapped in a DeletedFinalStateUnknown",
@@ -1581,6 +1583,7 @@ status:
 			objectToDelete:    createTestEndpointSlice(),
 			hasSliceAccess:    true,
 			noEndpointsCalled: true,
+			noEndpointsExists: true,
 		},
 		{
 			serviceType:       "can delete an EndpointSlice when there are multiple ones",
@@ -1591,6 +1594,9 @@ status:
 			objectToDelete:    createTestEndpointSlice(),
 			hasSliceAccess:    true,
 			noEndpointsCalled: false,
+			// NoEndpoints is never called, so there is never any reason to
+			// set `exists = false`
+			noEndpointsExists: false,
 		},
 	} {
 		tt := tt // pin
@@ -1625,6 +1631,9 @@ status:
 			if listener.endpointsAreNotCalled() != tt.noEndpointsCalled {
 				t.Fatalf("Expected noEndpointsCalled to be [%t], got [%t]",
 					tt.noEndpointsCalled, listener.endpointsAreNotCalled())
+			}
+			if listener.endpointsDoNotExist() != tt.noEndpointsExists {
+				t.Fatalf("Expected service to exist")
 			}
 		})
 	}


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/pull/10370 fixed an issue where `NoEndpoints` was being called for services that still had endpoints. However, there is still an issue where `NoEndpoints` is called with `exists = false` for services that don’t have endpoints, but do still exist. In these situations, `exists = true` because the service still exists on the cluster. For more explanation read the API documentation [^1].

This fixes the `NoEndpoints` call to indicate that the service still exists and asserts the tests check for the proper values.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>

[^1]: https://github.com/linkerd/linkerd2-proxy-api/blob/main/proto/destination.proto#L18-L26
