### PR TITLE
update network-validator to use proxy-init resources for limits

### DIFF
--- a/charts/partials/templates/_network-validator.tpl
+++ b/charts/partials/templates/_network-validator.tpl
@@ -2,13 +2,7 @@
 name: linkerd-network-validator
 image: {{.Values.proxy.image.name}}:{{.Values.proxy.image.version | default .Values.linkerdVersion }}
 imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPolicy}}
-resources:
-  limits:
-    cpu: "50m"
-    memory: "10Mi"
-  requests:
-    cpu: "50m"
-    memory: "10Mi"
+{{ include "partials.resources" .Values.proxyInit.resources }}
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -185,11 +185,11 @@ spec:
         name: linkerd-network-validator
         resources:
           limits:
-            cpu: 50m
-            memory: 10Mi
+            cpu: 100m
+            memory: 20Mi
           requests:
-            cpu: 50m
-            memory: 10Mi
+            cpu: 100m
+            memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -947,11 +947,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: "50m"
-            memory: "10Mi"
+            cpu: "100m"
+            memory: "20Mi"
           requests:
-            cpu: "50m"
-            memory: "10Mi"
+            cpu: "100m"
+            memory: "20Mi"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1390,11 +1390,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: "50m"
-            memory: "10Mi"
+            cpu: "100m"
+            memory: "20Mi"
           requests:
-            cpu: "50m"
-            memory: "10Mi"
+            cpu: "100m"
+            memory: "20Mi"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1716,11 +1716,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: "50m"
-            memory: "10Mi"
+            cpu: "100m"
+            memory: "20Mi"
           requests:
-            cpu: "50m"
-            memory: "10Mi"
+            cpu: "100m"
+            memory: "20Mi"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Increase memory resource and limit for network-validator. We will reuse proxy-init's resources and limits.
