### PR TITLE
Add brute force backendRef

### DIFF
--- a/policy-controller/k8s/api/src/policy/httproute.rs
+++ b/policy-controller/k8s/api/src/policy/httproute.rs
@@ -1,3 +1,4 @@
+use k8s_gateway_api::HttpBackendRef;
 pub use k8s_gateway_api::{
     CommonRouteSpec, Hostname, HttpHeader, HttpHeaderMatch, HttpHeaderName, HttpMethod,
     HttpPathMatch, HttpPathModifier, HttpQueryParamMatch, HttpRequestHeaderFilter,
@@ -19,7 +20,7 @@ pub use k8s_gateway_api::{
 )]
 #[kube(
     group = "policy.linkerd.io",
-    version = "v1alpha1",
+    version = "v1beta2",
     kind = "HTTPRoute",
     struct = "HttpRoute",
     status = "HttpRouteStatus",
@@ -126,6 +127,34 @@ pub struct HttpRouteRule {
     ///
     /// Support: Core
     pub filters: Option<Vec<HttpRouteFilter>>,
+
+    /// BackendRefs defines the backend(s) where matching requests should be
+    /// sent.
+    ///
+    /// A 500 status code MUST be returned if there are no BackendRefs or
+    /// filters specified that would result in a response being sent.
+    ///
+    /// A BackendRef is considered invalid when it refers to:
+    ///
+    /// * an unknown or unsupported kind of resource
+    /// * a resource that does not exist
+    /// * a resource in another namespace when the reference has not been
+    ///   explicitly allowed by a ReferencePolicy (or equivalent concept).
+    ///
+    /// When a BackendRef is invalid, 500 status codes MUST be returned for
+    /// requests that would have otherwise been routed to an invalid backend. If
+    /// multiple backends are specified, and some are invalid, the proportion of
+    /// requests that would otherwise have been routed to an invalid backend
+    /// MUST receive a 500 status code.
+    ///
+    /// When a BackendRef refers to a Service that has no ready endpoints, it is
+    /// recommended to return a 503 status code.
+    ///
+    /// Support: Core for Kubernetes Service
+    /// Support: Custom for any other resource
+    ///
+    /// Support for weight: Core
+    pub backend_refs: Option<Vec<HttpBackendRef>>,
 }
 
 /// HTTPRouteFilter defines processing steps that must be completed during the

--- a/policy-controller/k8s/index/src/http_route.rs
+++ b/policy-controller/k8s/index/src/http_route.rs
@@ -95,9 +95,11 @@ impl TryFrom<policy::HttpRoute> for InboundRouteBinding {
             .rules
             .into_iter()
             .flatten()
-            .map(|policy::HttpRouteRule { matches, filters }| {
-                Self::try_rule(matches, filters, Self::try_policy_filter)
-            })
+            .map(
+                |policy::HttpRouteRule {
+                     matches, filters, ..
+                 }| { Self::try_rule(matches, filters, Self::try_policy_filter) },
+            )
             .collect::<Result<_>>()?;
 
         Ok(InboundRouteBinding {

--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -1,5 +1,5 @@
 use crate::{
-    http_route::{self, ParentReference},
+    http_route::{self, BackendReference, ParentReference},
     resource_id::ResourceId,
 };
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
@@ -25,7 +25,9 @@ pub struct Index {
     updates: UnboundedSender<Update>,
 
     http_routes: HashMap<ResourceId, Vec<ParentReference>>,
+    route_backends: HashMap<ResourceId, Vec<BackendReference>>,
     servers: HashSet<ResourceId>,
+    services: HashSet<ResourceId>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -60,13 +62,15 @@ impl Index {
         Arc::new(RwLock::new(Self {
             updates,
             http_routes: HashMap::new(),
+            route_backends: HashMap::new(),
             servers: HashSet::new(),
+            services: HashSet::new(),
         }))
     }
 
     // If the route is new or its parents have changed, return true so that a
     // patch is generated; otherwise return false.
-    fn update_http_route(&mut self, id: ResourceId, parents: Vec<ParentReference>) -> bool {
+    fn update_http_route_parents(&mut self, id: ResourceId, parents: Vec<ParentReference>) -> bool {
         match self.http_routes.entry(id) {
             Entry::Vacant(entry) => {
                 entry.insert(parents);
@@ -77,7 +81,28 @@ impl Index {
                 }
                 entry.insert(parents);
             }
-        }
+        };
+
+        true
+    }
+
+    fn update_http_route_backends(
+        &mut self,
+        id: ResourceId,
+        backends: Vec<BackendReference>,
+    ) -> bool {
+        match self.route_backends.entry(id) {
+            Entry::Vacant(entry) => {
+                entry.insert(backends);
+            }
+            Entry::Occupied(mut entry) => {
+                if *entry.get() == backends {
+                    return false;
+                }
+                entry.insert(backends);
+            }
+        };
+
         true
     }
 
@@ -85,8 +110,9 @@ impl Index {
         &self,
         id: &ResourceId,
         parents: &[ParentReference],
+        backends: &[BackendReference],
     ) -> k8s::Patch<serde_json::Value> {
-        let parent_statuses = parents
+        let conditions = parents
             .iter()
             .map(|parent| {
                 let ParentReference::Server(parent_reference_id) = parent;
@@ -102,7 +128,7 @@ impl Index {
                     .servers
                     .iter()
                     .any(|server| server == parent_reference_id);
-                let condition = if accepted {
+                let cond = if accepted {
                     k8s::Condition {
                         last_transition_time: k8s::Time(timestamp),
                         message: "".to_string(),
@@ -121,20 +147,72 @@ impl Index {
                         type_: "Accepted".to_string(),
                     }
                 };
-                gateway::RouteParentStatus {
-                    parent_ref: gateway::ParentReference {
-                        group: Some(POLICY_API_GROUP.to_string()),
-                        kind: Some("Server".to_string()),
-                        namespace: Some(parent_reference_id.namespace.clone()),
-                        name: parent_reference_id.name.clone(),
-                        section_name: None,
-                        port: None,
-                    },
-                    controller_name: STATUS_CONTROLLER_NAME.to_string(),
-                    conditions: vec![condition],
-                }
+                (parent_reference_id, cond)
             })
-            .collect();
+            .collect::<Vec<(&ResourceId, k8s::Condition)>>();
+
+        // For a route to have a successful backendRef condition, it means that
+        // all backend_references in _all_ of a route's rules **must**
+        // successfully resolve.
+        // At the moment, this means that all of the backend_references _exist_ (in our cache).
+        // https://gateway-api.sigs.k8s.io/geps/gep-1364/#all-conditions-positive
+        let mut resolved_all = true;
+        for backend in backends.into_iter() {
+            // For each route <-> backendRef group binding
+            // check if _all_ of the backendRefs exist in the cache
+            // a From trait would be good here so we could contains(backend.into())
+            let BackendReference::Service(backend_reference_id) = backend;
+            if !self.services.contains(backend_reference_id) {
+                tracing::info!(?self.services, ?backend_reference_id, "ResolvedAll false");
+                resolved_all = false;
+                break;
+            }
+        }
+
+        #[cfg(not(test))]
+        let timestamp = Utc::now();
+        #[cfg(test)]
+        let timestamp = chrono::DateTime::<chrono::Utc>::MIN_UTC;
+        let resolved_refs_cond = if resolved_all {
+            k8s::Condition {
+                last_transition_time: k8s::Time(timestamp),
+                type_: "ResolvedRefs".to_string(),
+                status: "True".to_string(),
+                reason: "ResolvedRefs".to_string(),
+                observed_generation: None,
+                message: "".to_string(),
+            }
+        } else {
+            k8s::Condition {
+                last_transition_time: k8s::Time(timestamp),
+                type_: "ResolvedRefs".to_string(),
+                status: "False".to_string(),
+                reason: "BackendDoesNotExist".to_string(),
+                observed_generation: None,
+                message: "".to_string(),
+            }
+        };
+
+        // Each parent status indicates whether the parent is valid. All parents
+        // share the same backendRefs since they are part of the route itself.
+        // As a result, append condition to all statuses when creating status
+        let mut parent_statuses = Vec::new();
+        for (p_ref_id, cond) in conditions.into_iter() {
+            let status = gateway::RouteParentStatus {
+                parent_ref: gateway::ParentReference {
+                    group: Some(POLICY_API_GROUP.to_string()),
+                    kind: Some("Server".to_string()),
+                    namespace: Some(p_ref_id.namespace.clone()),
+                    name: p_ref_id.name.clone(),
+                    section_name: None,
+                    port: None,
+                },
+                controller_name: STATUS_CONTROLLER_NAME.to_string(),
+                conditions: vec![cond, resolved_refs_cond.clone()],
+            };
+            parent_statuses.push(status);
+        }
+
         let status = gateway::HttpRouteStatus {
             inner: gateway::RouteStatus {
                 parents: parent_statuses,
@@ -145,7 +223,24 @@ impl Index {
 
     fn apply_server_update(&self) {
         for (id, parents) in self.http_routes.iter() {
-            let patch = self.make_http_route_patch(id, parents);
+            // Bad to unwrap but if a route is in we can hint at there being a
+            // route that's been processed. We should be more flexible here and
+            // handle this properly.
+            let backends = self.route_backends.get(id).unwrap();
+            let patch = self.make_http_route_patch(id, parents, backends);
+            if let Err(error) = self.updates.send(Update {
+                id: id.clone(),
+                patch,
+            }) {
+                tracing::error!(%id.namespace, %id.name, %error, "Failed to send HTTPRoute patch")
+            }
+        }
+    }
+
+    fn apply_service_update(&self) {
+        for (id, parents) in self.http_routes.iter() {
+            let backends = self.route_backends.get(id).unwrap();
+            let patch = self.make_http_route_patch(id, parents, backends);
             if let Err(error) = self.updates.send(Update {
                 id: id.clone(),
                 patch,
@@ -167,20 +262,32 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute> for Index {
         // Create the route parents and insert it into the index. If the
         // HTTPRoute is already in the index and it hasn't changed, skip
         // creating a patch.
-        let parents = match http_route::make_parents(resource) {
+        let parents = match http_route::make_parents(resource.clone()) {
             Ok(parents) => parents,
             Err(error) => {
                 tracing::info!(%namespace, %name, %error, "Ignoring HTTPRoute");
                 return;
             }
         };
-        if !self.update_http_route(id.clone(), parents.clone()) {
+
+        // Create backendRefs
+        let backends = match http_route::make_backends(resource) {
+            Ok(backends) => backends,
+            Err(error) => {
+                tracing::info!(%namespace, %name, %error, "Ignoring HTTPRoute");
+                return;
+            }
+        };
+
+        let should_update_parents = self.update_http_route_parents(id.clone(), parents.clone());
+        let should_update_backends = self.update_http_route_backends(id.clone(), backends.clone());
+        if !should_update_parents && !should_update_backends {
             return;
         }
 
         // Create a patch for the HTTPRoute and send it to the controller so
         // that it is applied.
-        let patch = self.make_http_route_patch(&id, &parents);
+        let patch = self.make_http_route_patch(&id, &parents, &backends);
         if let Err(error) = self.updates.send(Update {
             id: id.clone(),
             patch,
@@ -200,9 +307,7 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute> for Index {
 
 impl kubert::index::IndexNamespacedResource<k8s::policy::Server> for Index {
     fn apply(&mut self, resource: k8s::policy::Server) {
-        let namespace = resource
-            .namespace()
-            .expect("HTTPRoute must have a namespace");
+        let namespace = resource.namespace().expect("Server must have a namespace");
         let name = resource.name_unchecked();
         let id = ResourceId::new(namespace, name);
 
@@ -215,6 +320,30 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::Server> for Index {
 
         self.servers.remove(&id);
         self.apply_server_update();
+    }
+
+    // Since apply only reindexes a single Server at a time, there's no need
+    // to handle resets specially.
+}
+
+impl kubert::index::IndexNamespacedResource<k8s::Service> for Index {
+    fn apply(&mut self, resource: k8s::Service) {
+        let namespace = resource.namespace().expect("Service must have a namespace");
+        // Don't process kube-system Service objects
+        let name = resource.name_unchecked();
+        let id = ResourceId::new(namespace, name);
+
+        if id.namespace != "kube-system" {
+            self.services.insert(id);
+            self.apply_service_update();
+        }
+    }
+
+    fn delete(&mut self, namespace: String, name: String) {
+        let id = ResourceId::new(namespace, name);
+
+        self.services.remove(&id);
+        self.apply_service_update();
     }
 
     // Since apply only reindexes a single Server at a time, there's no need

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -481,7 +481,10 @@ impl Validate<HttpRouteSpec> for Admission {
         // This is essentially equivalent to the indexer's conversion function
         // from `HttpRouteSpec` to `InboundRouteBinding`, except that we don't
         // actually allocate stuff in order to return an `InboundRouteBinding`.
-        for httproute::HttpRouteRule { filters, matches } in spec.rules.into_iter().flatten() {
+        for httproute::HttpRouteRule {
+            filters, matches, ..
+        } in spec.rules.into_iter().flatten()
+        {
             for m in matches.into_iter().flatten() {
                 validate_match(m)?;
             }

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -175,6 +175,12 @@ async fn main() -> Result<()> {
         kubert::index::namespaced(status_index.clone(), servers).instrument(info_span!("servers")),
     );
 
+    let services = runtime.watch_all::<k8s::Service>(ListParams::default());
+    tokio::spawn(
+        kubert::index::namespaced(status_index.clone(), services)
+            .instrument(info_span!("services")),
+    );
+
     // Run the gRPC server, serving results by looking up against the index handle.
     tokio::spawn(grpc(
         grpc_addr,


### PR DESCRIPTION
WIP: will update description soon.

This is just a bruteforce way of hooking backendReferences up to the status controller.

Spec states:

```
BackendRef is a reference to a backend to forward matched requests to.

A BackendRef can be invalid for the following reasons. In all cases, the implementation MUST ensure the ResolvedRefs Condition on the Route is set to status: False, with a Reason and Message that indicate what is the cause of the error.

A BackendRef is invalid if:

It refers to an unknown or unsupported kind of resource. In this case, the Reason must be set to InvalidKind and Message of the Condition must explain which kind of resource is unknown or unsupported.

It refers to a resource that does not exist. In this case, the Reason must be set to BackendNotFound and the Message of the Condition must explain which resource does not exist.

It refers a resource in another namespace when the reference has not been explicitly allowed by a ReferenceGrant (or equivalent concept). In this case, the Reason must be set to RefNotPermitted and the Message of the Condition must explain which cross-namespace reference is not allowed.

Support: Core for Kubernetes Service

Support: Implementation-specific for any other resource

Support for weight: Core
```

[ref#1](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPBackendRef)
[ref#2](https://gateway-api.sigs.k8s.io/geps/gep-1364/#new-and-updated-conditions)

Testing resources:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      annotations:
        linkerd.io/inject: "enabled"
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: nginx-svc
spec:
  selector:
    app: nginx
  ports:
    - name: http
      protocol: TCP
      port: 80
---
apiVersion: policy.linkerd.io/v1beta2
kind: HTTPRoute
metadata:
  name: nginx-route
spec:
  parentRefs:
    - name: nginx-srv
      kind: Server
      group: policy.linkerd.io
  rules:
    - matches:
      - path:
          value: "/"
        method: GET
      backendRefs:
        - name: nginx-svc
          weight: 100
          port: 80
---
apiVersion: policy.linkerd.io/v1beta1
kind: Server
metadata:
  name: nginx-srv
spec:
  podSelector:
    matchLabels:
      app: nginx
  port: 80
```

My own manual test:

```
:; k get httproutes.policy.linkerd.io nginx-route -o yaml | rg 'status' -A 10 -B 10
    - group: ""
      kind: Service
      name: nginx-svc
      port: 80
      weight: 100
    matches:
    - method: GET
      path:
        type: PathPrefix
        value: /
status:
  parents:
  - conditions:
    - lastTransitionTime: "2023-03-07T16:34:34Z"
      message: ""
      reason: Accepted
      status: "True"
      type: Accepted
    - lastTransitionTime: "2023-03-07T16:34:34Z"
      message: ""
      reason: ResolvedRefs
      status: "True"
      type: ResolvedRefs
    controllerName: policy.linkerd.io/status-controller
    parentRef:
      group: policy.linkerd.io
      kind: Server
      name: nginx-srv
      namespace: default

```

After deleting service

```
:; k get httproutes.policy.linkerd.io nginx-route -o yaml | rg 'status' -A 10 -B 10
    - group: ""
      kind: Service
      name: nginx-svc
      port: 80
      weight: 100
    matches:
    - method: GET
      path:
        type: PathPrefix
        value: /
status:
  parents:
  - conditions:
    - lastTransitionTime: "2023-03-07T16:49:41Z"
      message: ""
      reason: Accepted
      status: "True"
      type: Accepted
    - lastTransitionTime: "2023-03-07T16:49:41Z"
      message: ""
      reason: BackendDoesNotExist
      status: "False"
      type: ResolvedRefs
    controllerName: policy.linkerd.io/status-controller
    parentRef:
      group: policy.linkerd.io
      kind: Server
      name: nginx-srv
      namespace: default
```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
