### PR TITLE
policy: Update HTTPRoute type to v1beta2

### DIFF
--- a/policy-controller/k8s/api/src/policy/httproute.rs
+++ b/policy-controller/k8s/api/src/policy/httproute.rs
@@ -19,7 +19,7 @@ pub use k8s_gateway_api::{
 )]
 #[kube(
     group = "policy.linkerd.io",
-    version = "v1alpha1",
+    version = "v1beta2",
     kind = "HTTPRoute",
     struct = "HttpRoute",
     status = "HttpRouteStatus",

--- a/policy-test/tests/e2e_authorization_policy.rs
+++ b/policy-test/tests/e2e_authorization_policy.rs
@@ -4,7 +4,6 @@ use linkerd_policy_controller_k8s_api::{
     policy::{LocalTargetRef, NamespacedTargetRef},
 };
 use linkerd_policy_test::{create, create_ready_pod, curl, web, with_temp_ns, LinkerdInject};
-use std::num::NonZeroU16;
 
 #[tokio::test(flavor = "current_thread")]
 async fn meshtls() {
@@ -63,25 +62,10 @@ async fn targets_route() {
         );
         // Create a route which matches the /allowed path.
         let (root_route, _roux_route) = tokio::join!(
+            create(&client, http_route("root", &ns, &srv.name_unchecked(), "/"),),
             create(
                 &client,
-                http_route(
-                    "root",
-                    &ns,
-                    &srv.name_unchecked(),
-                    "/",
-                    NonZeroU16::new(80).unwrap(),
-                ),
-            ),
-            create(
-                &client,
-                http_route(
-                    "roux",
-                    &ns,
-                    &srv.name_unchecked(),
-                    "/roux",
-                    NonZeroU16::new(80).unwrap(),
-                )
+                http_route("roux", &ns, &srv.name_unchecked(), "/roux")
             )
         );
         // Create a policy which allows all authenticated clients
@@ -637,13 +621,7 @@ fn allow_ips(
     }
 }
 
-fn http_route(
-    name: &str,
-    ns: &str,
-    server_name: &str,
-    path: &str,
-    port: NonZeroU16,
-) -> k8s::policy::HttpRoute {
+fn http_route(name: &str, ns: &str, server_name: &str, path: &str) -> k8s::policy::HttpRoute {
     k8s::policy::HttpRoute {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
@@ -658,7 +636,7 @@ fn http_route(
                     namespace: Some(ns.to_string()),
                     name: server_name.to_string(),
                     section_name: None,
-                    port: Some(port.into()),
+                    port: None,
                 }]),
             },
             hostnames: None,


### PR DESCRIPTION
The policy controller uses the v1alpha1 HTTPRoute type as its internal representation of HTTPRoute resources. This change updates the resource version to v1beta2 in anticipation of adding outbound policy support.

To do so, we need to update the e2e tests to create HTTPRoute resources properly. They currently include a `port` value, though it is not allowed by our validator. The older resource type does not support this field and so it was silently ignored.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
