### PR TITLE
policy: Use ClusterInfo in outbound indexer

### DIFF
--- a/policy-controller/core/src/http_route.rs
+++ b/policy-controller/core/src/http_route.rs
@@ -8,8 +8,7 @@ pub use http::{
     Method, StatusCode,
 };
 use regex::Regex;
-use std::net::IpAddr;
-use std::num::NonZeroU16;
+use std::{net::IpAddr, num::NonZeroU16};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InboundHttpRoute {
@@ -54,7 +53,7 @@ pub struct OutboundHttpRouteRule {
 pub enum Backend {
     Addr(WeightedAddr),
     Dst(WeightedDst),
-    InvalidDst(WeightedDst),
+    InvalidDst { weight: u32 },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/policy-controller/core/src/http_route.rs
+++ b/policy-controller/core/src/http_route.rs
@@ -53,7 +53,7 @@ pub struct OutboundHttpRouteRule {
 pub enum Backend {
     Addr(WeightedAddr),
     Dst(WeightedDst),
-    InvalidDst { weight: u32 },
+    InvalidDst { weight: u32, message: String },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -763,7 +763,7 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
                 filters: Default::default(),
             }),
         },
-        Backend::InvalidDst { weight } => outbound::http_route::WeightedRouteBackend {
+        Backend::InvalidDst { weight, message } => outbound::http_route::WeightedRouteBackend {
             weight,
             backend: Some(outbound::http_route::RouteBackend {
                 backend: None,
@@ -771,7 +771,7 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
                     kind: Some(outbound::http_route::filter::Kind::FailureInjector(
                         api::http_route::HttpFailureInjector {
                             status: 500,
-                            message: "backend is invalid".to_string(),
+                            message,
                             ratio: None,
                         },
                     )),

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -725,6 +725,7 @@ fn convert_outbound_http_route(
 fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRouteBackend {
     match backend {
         Backend::Addr(addr) => outbound::http_route::WeightedRouteBackend {
+            weight: addr.weight,
             backend: Some(outbound::http_route::RouteBackend {
                 backend: Some(outbound::Backend {
                     metadata: None,
@@ -739,9 +740,9 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
                 }),
                 filters: Default::default(),
             }),
-            weight: addr.weight,
         },
         Backend::Dst(dst) => outbound::http_route::WeightedRouteBackend {
+            weight: dst.weight,
             backend: Some(outbound::http_route::RouteBackend {
                 backend: Some(outbound::Backend {
                     metadata: None,
@@ -761,43 +762,28 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
                 }),
                 filters: Default::default(),
             }),
-            weight: dst.weight,
         },
-        Backend::InvalidDst(dst) => outbound::http_route::WeightedRouteBackend {
+        Backend::InvalidDst { weight } => outbound::http_route::WeightedRouteBackend {
+            weight,
             backend: Some(outbound::http_route::RouteBackend {
-                backend: Some(outbound::Backend {
-                    metadata: None,
-                    queue: Some(default_queue_config()),
-                    kind: Some(outbound::backend::Kind::Balancer(
-                        outbound::backend::BalanceP2c {
-                            discovery: Some(outbound::backend::EndpointDiscovery {
-                                kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
-                                    outbound::backend::endpoint_discovery::DestinationGet {
-                                        path: dst.authority.clone(),
-                                    },
-                                )),
-                            }),
-                            load: Some(default_balancer_config()),
-                        },
-                    )),
-                }),
+                backend: None,
                 filters: vec![outbound::http_route::Filter {
                     kind: Some(outbound::http_route::filter::Kind::FailureInjector(
                         api::http_route::HttpFailureInjector {
                             status: 500,
-                            message: format!("backend {} is invalid", dst.authority),
+                            message: "backend is invalid".to_string(),
                             ratio: None,
                         },
                     )),
                 }],
             }),
-            weight: dst.weight,
         },
     }
 }
 
 fn default_http_backend(outbound: &OutboundPolicy) -> outbound::http_route::WeightedRouteBackend {
     outbound::http_route::WeightedRouteBackend {
+        weight: 1,
         backend: Some(outbound::http_route::RouteBackend {
             backend: Some(outbound::Backend {
                 metadata: Some(Metadata {
@@ -819,7 +805,6 @@ fn default_http_backend(outbound: &OutboundPolicy) -> outbound::http_route::Weig
             }),
             filters: Default::default(),
         }),
-        weight: 1,
     }
 }
 
@@ -879,6 +864,7 @@ fn default_queue_config() -> outbound::Queue {
     }
 }
 
+// TODO(ver) this conversion should be made in the api crate.
 fn convert_tcp_address(ip_addr: IpAddr, port: NonZeroU16) -> TcpAddress {
     let ip = match ip_addr {
         IpAddr::V4(ipv4) => Ip::Ipv4(ipv4.into()),

--- a/policy-controller/k8s/index/src/cluster_info.rs
+++ b/policy-controller/k8s/index/src/cluster_info.rs
@@ -1,0 +1,55 @@
+use std::num::NonZeroU16;
+
+use crate::{pod::PortSet, DefaultPolicy};
+use linkerd_policy_controller_core::IpNet;
+use tokio::time;
+
+/// Holds cluster metadata.
+#[derive(Clone, Debug)]
+pub struct ClusterInfo {
+    /// Networks including PodIPs in this cluster.
+    ///
+    /// Unfortunately, there's no way to discover this at runtime.
+    pub networks: Vec<IpNet>,
+
+    /// The namespace where the linkerd control plane is deployed
+    pub control_plane_ns: String,
+
+    /// E.g. "cluster.local"
+    pub dns_domain: String,
+
+    /// The cluster's mesh identity trust domain.
+    pub identity_domain: String,
+
+    /// The cluster-wide default policy.
+    pub default_policy: DefaultPolicy,
+
+    /// The cluster-wide default protocol detection timeout.
+    pub default_detect_timeout: time::Duration,
+
+    /// The default set of ports to be marked opaque.
+    pub default_opaque_ports: PortSet,
+
+    /// The networks that probes are expected to be from.
+    pub probe_networks: Vec<IpNet>,
+}
+
+impl ClusterInfo {
+    pub(crate) fn service_account_identity(&self, ns: &str, sa: &str) -> String {
+        format!(
+            "{}.{}.serviceaccount.identity.{}.{}",
+            sa, ns, self.control_plane_ns, self.identity_domain
+        )
+    }
+
+    pub(crate) fn namespace_identity(&self, ns: &str) -> String {
+        format!(
+            "*.{}.serviceaccount.identity.{}.{}",
+            ns, self.control_plane_ns, self.identity_domain
+        )
+    }
+
+    pub(crate) fn service_dns_authority(&self, ns: &str, svc: &str, port: NonZeroU16) -> String {
+        format!("{}.{}.svc.{}:{port}", svc, ns, self.dns_domain)
+    }
+}

--- a/policy-controller/k8s/index/src/lib.rs
+++ b/policy-controller/k8s/index/src/lib.rs
@@ -24,6 +24,7 @@
 #![forbid(unsafe_code)]
 
 pub mod authorization_policy;
+mod cluster_info;
 mod defaults;
 pub mod http_route;
 mod index;
@@ -37,51 +38,9 @@ mod server_authorization;
 #[cfg(test)]
 mod tests;
 
-use linkerd_policy_controller_core::IpNet;
-use std::time;
-
 pub use self::{
+    cluster_info::ClusterInfo,
     defaults::DefaultPolicy,
     index::{Index, SharedIndex},
     pod::{parse_portset, PortSet},
 };
-
-/// Holds cluster metadata.
-#[derive(Clone, Debug)]
-pub struct ClusterInfo {
-    /// Networks including PodIPs in this cluster.
-    ///
-    /// Unfortunately, there's no way to discover this at runtime.
-    pub networks: Vec<IpNet>,
-
-    /// The namespace where the linkerd control plane is deployed
-    pub control_plane_ns: String,
-
-    /// The cluster's mesh identity trust domain.
-    pub identity_domain: String,
-
-    /// The cluster-wide default policy.
-    pub default_policy: DefaultPolicy,
-
-    /// The cluster-wide default protocol detection timeout.
-    pub default_detect_timeout: time::Duration,
-
-    /// The networks that probes are expected to be from.
-    pub probe_networks: Vec<IpNet>,
-}
-
-impl ClusterInfo {
-    fn service_account_identity(&self, ns: &str, sa: &str) -> String {
-        format!(
-            "{}.{}.serviceaccount.identity.{}.{}",
-            sa, ns, self.control_plane_ns, self.identity_domain
-        )
-    }
-
-    fn namespace_identity(&self, ns: &str) -> String {
-        format!(
-            "*.{}.serviceaccount.identity.{}.{}",
-            ns, self.control_plane_ns, self.identity_domain
-        )
-    }
-}

--- a/policy-controller/k8s/index/src/outbound_index.rs
+++ b/policy-controller/k8s/index/src/outbound_index.rs
@@ -195,9 +195,9 @@ impl Namespace {
         tracing::debug!(?outbound_route);
 
         for parent_ref in route.spec.inner.parent_refs.iter().flatten() {
-            // TODO(ver) we should check the group, too. Nothing stops `Service`
-            // from existing outside of the `core` group.
             if !is_parent_service(parent_ref) {
+                // XXX(ver) This is likely to fire whenever we process routes
+                // that only target inbound resources.
                 tracing::warn!(
                     parent_kind = parent_ref.kind.as_deref(),
                     "ignoring parent_ref with non-Service kind"

--- a/policy-controller/k8s/index/src/outbound_index.rs
+++ b/policy-controller/k8s/index/src/outbound_index.rs
@@ -362,7 +362,7 @@ fn convert_backend(
         if !services.contains_key(&name) {
             return Backend::InvalidDst {
                 weight: weight.into(),
-                message: format!("service not found {name}"),
+                message: format!("Service not found {name}"),
             };
         }
 

--- a/policy-controller/k8s/index/src/outbound_index.rs
+++ b/policy-controller/k8s/index/src/outbound_index.rs
@@ -334,7 +334,7 @@ fn convert_backend(
                 message: format!(
                     "unsupported backend type {group} {kind}",
                     group = backend.inner.group.as_deref().unwrap_or("core"),
-                    kind = backend.inner.kind.as_deref().unwrap_or("core"),
+                    kind = backend.inner.kind.as_deref().unwrap_or("<empty>"),
                 ),
             };
         }
@@ -387,10 +387,12 @@ fn is_backend_service(backend: &BackendObjectReference) -> bool {
 fn is_service(group: Option<&str>, kind: Option<&str>) -> bool {
     group
         .map(|g| g.eq_ignore_ascii_case("core"))
+        // If the group is not specified, assume it's 'core'.
         .unwrap_or(true)
         && kind
             .map(|k| k.eq_ignore_ascii_case("Service"))
-            .unwrap_or(false)
+            // If the kind is not specified, assume it's a Service.
+            .unwrap_or(true)
 }
 
 impl ServiceRoutes {

--- a/policy-controller/k8s/index/src/tests.rs
+++ b/policy-controller/k8s/index/src/tests.rs
@@ -199,8 +199,10 @@ impl TestConfig {
             networks: vec![cluster_net],
             control_plane_ns: "linkerd".to_string(),
             identity_domain: "cluster.example.com".into(),
+            dns_domain: "cluster.example.com".into(),
             default_policy,
             default_detect_timeout: detect_timeout,
+            default_opaque_ports: Default::default(),
             probe_networks,
         };
         let index = Index::shared(cluster.clone());

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -11,7 +11,7 @@ use linkerd_policy_controller::{
 };
 use linkerd_policy_controller_k8s_index::parse_portset;
 use linkerd_policy_controller_k8s_status::{self as status};
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 use tokio::{sync::mpsc, time::Duration};
 use tonic::transport::Server;
 use tracing::{info, info_span, instrument, Instrument};
@@ -118,18 +118,21 @@ async fn main() -> Result<()> {
     let probe_networks = probe_networks.map(|IpNets(nets)| nets).unwrap_or_default();
 
     let default_opaque_ports = parse_portset(&default_opaque_ports)?;
-
-    // Build the index data structure, which will be used to process events from all watches
-    // The lookup handle is used by the gRPC server.
-    let index = Index::shared(ClusterInfo {
+    let cluster_info = Arc::new(ClusterInfo {
         networks: cluster_networks.clone(),
         identity_domain,
         control_plane_ns: control_plane_namespace.clone(),
+        dns_domain: cluster_domain,
         default_policy,
         default_detect_timeout: DETECT_TIMEOUT,
+        default_opaque_ports,
         probe_networks,
     });
-    let outbound_index = outbound_index::Index::shared(cluster_domain, default_opaque_ports);
+
+    // Build the index data structure, which will be used to process events from all watches
+    // The lookup handle is used by the gRPC server.
+    let index = Index::shared(cluster_info.clone());
+    let outbound_index = outbound_index::Index::shared(cluster_info);
     let indexes = IndexPair::shared(index.clone(), outbound_index.clone());
 
     // Spawn resource indexers that update the index and publish lookups for the gRPC server.


### PR DESCRIPTION
We have a `ClusterInfo` type that includes all cluster-level configuration. The outbound indexer does not use this type and, instead, passes around individual configuration values.

This change updates the outbound indexer to use the ClusterInfo configuration type. It also moves the type to its own module.

This is largely a reorganization PR, though there is one notable change:
InvalidDst response no longer reference a backend. Instead, the backend
is left empty, since it's not possible to route requests to it.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
