### PR TITLE
Add Service backend metadata to outbound policy API

### DIFF
--- a/policy-controller/core/src/http_route.rs
+++ b/policy-controller/core/src/http_route.rs
@@ -53,7 +53,7 @@ pub struct OutboundHttpRouteRule {
 pub enum Backend {
     Addr(WeightedAddr),
     Service(WeightedService),
-    InvalidDst { weight: u32, message: String },
+    Invalid { weight: u32, message: String },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/policy-controller/core/src/http_route.rs
+++ b/policy-controller/core/src/http_route.rs
@@ -52,7 +52,7 @@ pub struct OutboundHttpRouteRule {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Backend {
     Addr(WeightedAddr),
-    Dst(WeightedDst),
+    Service(WeightedService),
     InvalidDst { weight: u32, message: String },
 }
 
@@ -64,9 +64,11 @@ pub struct WeightedAddr {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct WeightedDst {
+pub struct WeightedService {
     pub weight: u32,
     pub authority: String,
+    pub name: String,
+    pub namespace: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -759,7 +759,7 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
                 filters: Default::default(),
             }),
         },
-        Backend::InvalidDst { weight, message } => outbound::http_route::WeightedRouteBackend {
+        Backend::Invalid { weight, message } => outbound::http_route::WeightedRouteBackend {
             weight,
             backend: Some(outbound::http_route::RouteBackend {
                 backend: None,

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -729,18 +729,26 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
                 }),
             }
         }
-        Backend::Dst(dst) => outbound::http_route::WeightedRouteBackend {
-            weight: dst.weight,
+        Backend::Service(svc) => outbound::http_route::WeightedRouteBackend {
+            weight: svc.weight,
             backend: Some(outbound::http_route::RouteBackend {
                 backend: Some(outbound::Backend {
-                    metadata: None,
+                    metadata: Some(Metadata {
+                        kind: Some(metadata::Kind::Resource(api::meta::Resource {
+                            group: "core".to_string(),
+                            kind: "Service".to_string(),
+                            name: svc.name,
+                            namespace: svc.namespace,
+                            section: String::default(),
+                        })),
+                    }),
                     queue: Some(default_queue_config()),
                     kind: Some(outbound::backend::Kind::Balancer(
                         outbound::backend::BalanceP2c {
                             discovery: Some(outbound::backend::EndpointDiscovery {
                                 kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
                                     outbound::backend::endpoint_discovery::DestinationGet {
-                                        path: dst.authority,
+                                        path: svc.authority,
                                     },
                                 )),
                             }),

--- a/policy-controller/k8s/index/src/outbound_index.rs
+++ b/policy-controller/k8s/index/src/outbound_index.rs
@@ -7,7 +7,7 @@ use ahash::AHashMap as HashMap;
 use anyhow::Result;
 use k8s_gateway_api::{BackendObjectReference, HttpBackendRef, ParentReference};
 use linkerd_policy_controller_core::{
-    http_route::{Backend, OutboundHttpRoute, OutboundHttpRouteRule, WeightedDst},
+    http_route::{Backend, OutboundHttpRoute, OutboundHttpRouteRule, WeightedService},
     OutboundPolicy,
 };
 use linkerd_policy_controller_k8s_api::{
@@ -357,9 +357,11 @@ fn convert_backend(
             };
         }
 
-        Backend::Dst(WeightedDst {
+        Backend::Service(WeightedService {
             weight: weight.into(),
             authority: cluster.service_dns_authority(ns, &name, port),
+            name,
+            namespace: ns.to_string(),
         })
     })
 }

--- a/policy-controller/k8s/index/src/outbound_index.rs
+++ b/policy-controller/k8s/index/src/outbound_index.rs
@@ -320,7 +320,7 @@ fn convert_backend(
 ) -> Option<Backend> {
     backend.backend_ref.map(|backend| {
         if !is_backend_service(&backend.inner) {
-            return Backend::InvalidDst {
+            return Backend::Invalid {
                 weight: backend.weight.unwrap_or(1).into(),
                 message: format!(
                     "unsupported backend type {group} {kind}",
@@ -343,7 +343,7 @@ fn convert_backend(
         {
             Some(port) => port,
             None => {
-                return Backend::InvalidDst {
+                return Backend::Invalid {
                     weight: weight.into(),
                     message: format!("missing port for backend Service {name}"),
                 }
@@ -351,7 +351,7 @@ fn convert_backend(
         };
 
         if !services.contains_key(&name) {
-            return Backend::InvalidDst {
+            return Backend::Invalid {
                 weight: weight.into(),
                 message: format!("Service not found {name}"),
             };


### PR DESCRIPTION
When the outbound policy API was returning backends which corresponded to Service resources, those backends were missing metadata information.  

We update the policy controller to populate Service metadata for those backends.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
