### PR TITLE
policy: Support lookups of named services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "async-trait",
  "drain",
  "futures",
+ "http",
  "hyper",
  "linkerd-policy-controller-core",
  "linkerd2-proxy-api",

--- a/policy-controller/core/src/lib.rs
+++ b/policy-controller/core/src/lib.rs
@@ -104,7 +104,7 @@ pub trait DiscoverOutboundPolicy<T> {
 
     async fn watch_outbound_policy(&self, target: T) -> Result<Option<OutboundPolicyStream>>;
 
-    fn service_lookup(&self, addr: IpAddr, port: NonZeroU16) -> Option<T>;
+    fn lookup_ip(&self, addr: IpAddr, port: NonZeroU16) -> Option<T>;
 }
 
 pub type OutboundPolicyStream = Pin<Box<dyn Stream<Item = OutboundPolicy> + Send + Sync + 'static>>;

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -8,10 +8,14 @@ publish = false
 [dependencies]
 async-stream = "0.3"
 async-trait = "0.1"
+http = "0.2"
 drain = "0.1"
 hyper = { version = "0.14", features = ["http2", "server", "tcp"] }
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { features = ["inbound", "outbound"], git="https://github.com/linkerd/linkerd2-proxy-api", rev = "9efe50fd769cf8fbba4f0eedf95fa8ca896d7355" }
+linkerd2-proxy-api = { features = [
+    "inbound",
+    "outbound",
+], git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "9efe50fd769cf8fbba4f0eedf95fa8ca896d7355" }
 linkerd-policy-controller-core = { path = "../core" }
 maplit = "1"
 tokio = { version = "1", features = ["macros"] }

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -38,6 +38,7 @@ pub struct InboundPolicyServer<T> {
 
 #[derive(Clone, Debug)]
 pub struct OutboundPolicyServer<T> {
+    cluster_domain: Arc<str>,
     index: T,
     drain: drain::Watch,
 }
@@ -139,9 +140,10 @@ impl<T> OutboundPolicyServer<T>
 where
     T: DiscoverOutboundPolicy<(String, String, NonZeroU16)> + Send + Sync + 'static,
 {
-    pub fn new(discover: T, drain: drain::Watch) -> Self {
+    pub fn new(discover: T, cluster_domain: impl Into<Arc<str>>, drain: drain::Watch) -> Self {
         Self {
             index: discover,
+            cluster_domain: cluster_domain.into(),
             drain,
         }
     }
@@ -150,19 +152,17 @@ where
         OutboundPoliciesServer::new(self)
     }
 
-    fn service_lookup(
+    fn lookup(
         &self,
-        traffic_spec: outbound::TrafficSpec,
+        spec: outbound::TrafficSpec,
     ) -> Result<(String, String, NonZeroU16), tonic::Status> {
-        let target = traffic_spec
+        let target = spec
             .target
             .ok_or_else(|| tonic::Status::invalid_argument("target is required"))?;
         let target = match target {
             outbound::traffic_spec::Target::Addr(target) => target,
-            outbound::traffic_spec::Target::Authority(_) => {
-                return Err(tonic::Status::unimplemented(
-                    "getting policy by authority is not supported",
-                ))
+            outbound::traffic_spec::Target::Authority(auth) => {
+                return self.lookup_authority(&*auth)
             }
         };
 
@@ -182,8 +182,52 @@ where
             })?;
 
         self.index
-            .service_lookup(addr, port)
+            .lookup_ip(addr, port)
             .ok_or_else(|| tonic::Status::not_found("No such service"))
+    }
+
+    fn lookup_authority(
+        &self,
+        authority: &str,
+    ) -> Result<(String, String, NonZeroU16), tonic::Status> {
+        let auth = authority
+            .parse::<http::uri::Authority>()
+            .map_err(|_| tonic::Status::invalid_argument("invalid authority"))?;
+
+        let mut host = auth.host();
+        if host.is_empty() {
+            return Err(tonic::Status::invalid_argument(
+                "authority must have a host",
+            ));
+        }
+        if host.ends_with('.') {
+            host = &host[..host.len() - 1];
+        }
+        if host.ends_with(&*self.cluster_domain) {
+            host = &host[..host.len() - self.cluster_domain.len()];
+        }
+        let mut parts = host.split('.');
+        let invalid = {
+            let domain = &self.cluster_domain;
+            move || {
+                tonic::Status::invalid_argument(format!(
+                    "authority must be of the form <name>.<namespace>.svc.{}",
+                    domain
+                ))
+            }
+        };
+        let name = parts.next().ok_or_else(invalid)?;
+        let namespace = parts.next().ok_or_else(invalid)?;
+        if !matches!(parts.next(), Some("svc")) {
+            return Err(invalid());
+        };
+
+        let port = auth
+            .port_u16()
+            .and_then(|p| NonZeroU16::try_from(p).ok())
+            .unwrap_or_else(|| 80.try_into().unwrap());
+
+        Ok((namespace.to_string(), name.to_string(), port))
     }
 }
 
@@ -196,7 +240,7 @@ where
         &self,
         req: tonic::Request<outbound::TrafficSpec>,
     ) -> Result<tonic::Response<outbound::OutboundPolicy>, tonic::Status> {
-        let service = self.service_lookup(req.into_inner())?;
+        let service = self.lookup(req.into_inner())?;
 
         let policy = self
             .index
@@ -219,7 +263,7 @@ where
         &self,
         req: tonic::Request<outbound::TrafficSpec>,
     ) -> Result<tonic::Response<BoxWatchServiceStream>, tonic::Status> {
-        let service = self.service_lookup(req.into_inner())?;
+        let service = self.lookup(req.into_inner())?;
         let drain = self.drain.clone();
 
         let rx = self

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -92,11 +92,7 @@ impl DiscoverOutboundPolicy<(String, String, NonZeroU16)> for OutboundDiscover {
         }
     }
 
-    fn service_lookup(
-        &self,
-        addr: IpAddr,
-        port: NonZeroU16,
-    ) -> Option<(String, String, NonZeroU16)> {
+    fn lookup_ip(&self, addr: IpAddr, port: NonZeroU16) -> Option<(String, String, NonZeroU16)> {
         self.0
             .read()
             .lookup_service(addr)


### PR DESCRIPTION
Proxies in ingress and gateway configurations may discover policies by name instead of network address.

This change updates the policy controller to parse service names from lookups.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
