### PR TITLE
destination: Avoid sending spurious profile updates

### DIFF
--- a/controller/api/destination/dedup_profile_listener.go
+++ b/controller/api/destination/dedup_profile_listener.go
@@ -1,0 +1,31 @@
+package destination
+
+import (
+	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
+	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
+	log "github.com/sirupsen/logrus"
+)
+
+type dedupProfileListener struct {
+	parent      watcher.ProfileUpdateListener
+	state       *sp.ServiceProfile
+	initialized bool
+	log         *log.Entry
+}
+
+func newDedupProfileListener(
+	parent watcher.ProfileUpdateListener,
+	log *log.Entry,
+) watcher.ProfileUpdateListener {
+	return &dedupProfileListener{parent, nil, false, log}
+}
+
+func (p *dedupProfileListener) Update(profile *sp.ServiceProfile) {
+	if p.initialized && profile == p.state {
+		log.Debug("Skipping redundant update")
+		return
+	}
+	p.parent.Update(profile)
+	p.initialized = true
+	p.state = profile
+}

--- a/controller/api/destination/default_profile_listener.go
+++ b/controller/api/destination/default_profile_listener.go
@@ -1,0 +1,29 @@
+package destination
+
+import (
+	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
+	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
+	log "github.com/sirupsen/logrus"
+)
+
+type defaultProfileListener struct {
+	parent  watcher.ProfileUpdateListener
+	profile *sp.ServiceProfile
+	log     *log.Entry
+}
+
+func newDefaultProfileListener(
+	profile *sp.ServiceProfile,
+	parent watcher.ProfileUpdateListener,
+	log *log.Entry,
+) watcher.ProfileUpdateListener {
+	return &defaultProfileListener{parent, profile, log}
+}
+
+func (p *defaultProfileListener) Update(profile *sp.ServiceProfile) {
+	if profile == nil {
+		log.Debug("Using default profile")
+		profile = p.profile
+	}
+	p.parent.Update(profile)
+}

--- a/controller/api/destination/fallback_profile_listener.go
+++ b/controller/api/destination/fallback_profile_listener.go
@@ -5,99 +5,93 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
+	logging "github.com/sirupsen/logrus"
 )
 
 type fallbackProfileListener struct {
-	underlying watcher.ProfileUpdateListener
-	primary    *primaryProfileListener
-	backup     *backupProfileListener
-	mutex      sync.Mutex
+	primary, backup *childListener
+	parent          watcher.ProfileUpdateListener
+	log             *logging.Entry
+	mutex           sync.Mutex
 }
 
-type fallbackChildListener struct {
+type childListener struct {
 	// state is only referenced from the outer struct primaryProfileListener
 	// or backupProfileListener (e.g. listener.state where listener's type is
 	// _not_ this struct). structcheck issues a false positive for this field
 	// as it does not think it's used.
 	//nolint:structcheck
-	state  *sp.ServiceProfile
-	parent *fallbackProfileListener
+	state       *sp.ServiceProfile
+	initialized bool
+	parent      *fallbackProfileListener
 }
 
-type primaryProfileListener struct {
-	fallbackChildListener
-}
-
-type backupProfileListener struct {
-	fallbackChildListener
-}
-
-// newFallbackProfileListener takes an underlying profileUpdateListener and
-// returns two profileUpdateListeners: a primary and a backup.  Updates to
-// the primary and backup will propagate to the underlying with updates to
-// the primary always taking priority.  If the value in the primary is cleared,
-// the value from the backup is used.
-func newFallbackProfileListener(listener watcher.ProfileUpdateListener) (watcher.ProfileUpdateListener, watcher.ProfileUpdateListener) {
+// newFallbackProfileListener takes a parent ProfileUpdateListener and returns
+// two ProfileUpdateListeners: a primary and a backup.
+//
+// If the primary listener is updated with a non-nil value, it is published to
+// the parent listener.
+//
+// Otherwise, if the backup listener has most recently been updated with a
+// non-nil value, its valeu is published to the parent listener.
+//
+// A nil ServiceProfile is published only when both the primary and backup have
+// been initialized and have nil values.
+func newFallbackProfileListener(
+	parent watcher.ProfileUpdateListener,
+	log *logging.Entry,
+) (watcher.ProfileUpdateListener, watcher.ProfileUpdateListener) {
 	// Primary and backup share a lock to ensure updates are atomic.
 	fallback := fallbackProfileListener{
-		mutex:      sync.Mutex{},
-		underlying: listener,
+		mutex: sync.Mutex{},
+		log:   log,
 	}
 
-	primary := primaryProfileListener{
-		fallbackChildListener{
-			parent: &fallback,
-		},
+	primary := childListener{
+		initialized: false,
+		parent:      &fallback,
 	}
-	backup := backupProfileListener{
-		fallbackChildListener{
-			parent: &fallback,
-		},
+
+	backup := childListener{
+		initialized: false,
+		parent:      &fallback,
 	}
+
+	fallback.parent = parent
 	fallback.primary = &primary
 	fallback.backup = &backup
+
 	return &primary, &backup
 }
 
-// Primary
+func (f *fallbackProfileListener) publish() {
+	if !f.primary.initialized {
+		f.log.Debug("Waiting for primary profile listener to be initialized")
+		return
+	}
 
-func (p *primaryProfileListener) Update(profile *sp.ServiceProfile) {
+	if f.primary.state == nil {
+		if !f.backup.initialized {
+			f.log.Debug("Waiting for backup profile listener to be initialized")
+			return
+		}
+
+		if f.backup.state != nil {
+			f.log.Debug("Publishing backup profile")
+			f.parent.Update(f.backup.state)
+			return
+		}
+	}
+
+	f.log.Debug("Publishing primary profile")
+	f.parent.Update(f.primary.state)
+}
+
+func (p *childListener) Update(profile *sp.ServiceProfile) {
 	p.parent.mutex.Lock()
 	defer p.parent.mutex.Unlock()
 
 	p.state = profile
-
-	if p.state != nil {
-		// We got a value; apply the update.
-		p.parent.underlying.Update(p.state)
-		return
-	}
-	if p.parent.backup != nil {
-		// Our value was cleared; fall back to backup.
-		p.parent.underlying.Update(p.parent.backup.state)
-		return
-	}
-	// Our value was cleared and there is no backup value.
-	p.parent.underlying.Update(nil)
-}
-
-// Backup
-
-func (b *backupProfileListener) Update(profile *sp.ServiceProfile) {
-	b.parent.mutex.Lock()
-	defer b.parent.mutex.Unlock()
-
-	b.state = profile
-
-	if b.parent.primary != nil && b.parent.primary.state != nil {
-		// Primary has a value, so ignore this update.
-		return
-	}
-	if b.state != nil {
-		// We got a value; apply the update.
-		b.parent.underlying.Update(b.state)
-		return
-	}
-	// Our value was cleared and there is no primary value.
-	b.parent.underlying.Update(nil)
+	p.initialized = true
+	p.parent.publish()
 }

--- a/controller/api/destination/fallback_profile_listener.go
+++ b/controller/api/destination/fallback_profile_listener.go
@@ -69,18 +69,15 @@ func (f *fallbackProfileListener) publish() {
 		f.log.Debug("Waiting for primary profile listener to be initialized")
 		return
 	}
+	if !f.backup.initialized {
+		f.log.Debug("Waiting for backup profile listener to be initialized")
+		return
+	}
 
-	if f.primary.state == nil {
-		if !f.backup.initialized {
-			f.log.Debug("Waiting for backup profile listener to be initialized")
-			return
-		}
-
-		if f.backup.state != nil {
-			f.log.Debug("Publishing backup profile")
-			f.parent.Update(f.backup.state)
-			return
-		}
+	if f.primary.state == nil && f.backup.state != nil {
+		f.log.Debug("Publishing backup profile")
+		f.parent.Update(f.backup.state)
+		return
 	}
 
 	f.log.Debug("Publishing primary profile")

--- a/controller/api/destination/fallback_profile_listener_test.go
+++ b/controller/api/destination/fallback_profile_listener_test.go
@@ -42,8 +42,10 @@ func TestFallbackProfileListener(t *testing.T) {
 	}
 
 	t.Run("Primary updated", func(t *testing.T) {
-		primary, _, listener := newListeners()
+		primary, backup, listener := newListeners()
 		primary.Update(&primaryProfile)
+		assertEq(t, listener.received, []*sp.ServiceProfile{})
+		backup.Update(nil)
 		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile})
 	})
 
@@ -82,7 +84,7 @@ func TestFallbackProfileListener(t *testing.T) {
 		primary.Update(&primaryProfile)
 		backup.Update(&backupProfile)
 		backup.Update(nil)
-		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, &primaryProfile, &primaryProfile})
+		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, &primaryProfile})
 	})
 
 	t.Run("Fallback to backup", func(t *testing.T) {
@@ -90,7 +92,7 @@ func TestFallbackProfileListener(t *testing.T) {
 		primary.Update(&primaryProfile)
 		backup.Update(&backupProfile)
 		primary.Update(nil)
-		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, &primaryProfile, &backupProfile})
+		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, &backupProfile})
 	})
 
 }

--- a/controller/api/destination/fallback_profile_listener_test.go
+++ b/controller/api/destination/fallback_profile_listener_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
+	logging "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,65 +43,54 @@ func TestFallbackProfileListener(t *testing.T) {
 
 	t.Run("Primary updated", func(t *testing.T) {
 		primary, _, listener := newListeners()
-
 		primary.Update(&primaryProfile)
-
 		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile})
 	})
 
 	t.Run("Backup updated", func(t *testing.T) {
-		_, backup, listener := newListeners()
-
+		primary, backup, listener := newListeners()
 		backup.Update(&backupProfile)
-
+		primary.Update(nil)
 		assertEq(t, listener.received, []*sp.ServiceProfile{&backupProfile})
 	})
 
 	t.Run("Primary cleared", func(t *testing.T) {
-		primary, _, listener := newListeners()
-
+		primary, backup, listener := newListeners()
+		backup.Update(nil)
 		primary.Update(&primaryProfile)
 		primary.Update(nil)
-
 		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, nil})
 	})
 
 	t.Run("Backup cleared", func(t *testing.T) {
-		_, backup, listener := newListeners()
-
+		primary, backup, listener := newListeners()
 		backup.Update(&backupProfile)
+		primary.Update(nil)
 		backup.Update(nil)
-
 		assertEq(t, listener.received, []*sp.ServiceProfile{&backupProfile, nil})
 	})
 
 	t.Run("Primary overrides backup", func(t *testing.T) {
 		primary, backup, listener := newListeners()
-
 		backup.Update(&backupProfile)
 		primary.Update(&primaryProfile)
-
-		assertEq(t, listener.received, []*sp.ServiceProfile{&backupProfile, &primaryProfile})
+		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile})
 	})
 
 	t.Run("Backup update ignored", func(t *testing.T) {
 		primary, backup, listener := newListeners()
-
 		primary.Update(&primaryProfile)
 		backup.Update(&backupProfile)
 		backup.Update(nil)
-
-		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile})
+		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, &primaryProfile, &primaryProfile})
 	})
 
 	t.Run("Fallback to backup", func(t *testing.T) {
 		primary, backup, listener := newListeners()
-
 		primary.Update(&primaryProfile)
 		backup.Update(&backupProfile)
 		primary.Update(nil)
-
-		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, &backupProfile})
+		assertEq(t, listener.received, []*sp.ServiceProfile{&primaryProfile, &primaryProfile, &backupProfile})
 	})
 
 }
@@ -110,11 +100,12 @@ func newListeners() (watcher.ProfileUpdateListener, watcher.ProfileUpdateListene
 		received: []*sp.ServiceProfile{},
 	}
 
-	primary, backup := newFallbackProfileListener(listener)
+	primary, backup := newFallbackProfileListener(listener, logging.NewEntry(logging.New()))
 	return primary, backup, listener
 }
 
 func assertEq(t *testing.T, received []*sp.ServiceProfile, expected []*sp.ServiceProfile) {
+	t.Helper()
 	if len(received) != len(expected) {
 		t.Fatalf("Expected %d profile updates, got %d", len(expected), len(received))
 	}

--- a/controller/api/destination/opaque_ports_adaptor.go
+++ b/controller/api/destination/opaque_ports_adaptor.go
@@ -32,10 +32,9 @@ func (opa *opaquePortsAdaptor) UpdateService(ports map[uint32]struct{}) {
 }
 
 func (opa *opaquePortsAdaptor) publish() {
-	merged := sp.ServiceProfile{}
 	if opa.profile != nil {
-		merged = *opa.profile
+		p := *opa.profile
+		p.Spec.OpaquePorts = opa.opaquePorts
+		opa.listener.Update(&p)
 	}
-	merged.Spec.OpaquePorts = opa.opaquePorts
-	opa.listener.Update(&merged)
 }

--- a/controller/api/destination/profile_translator.go
+++ b/controller/api/destination/profile_translator.go
@@ -35,11 +35,13 @@ func newProfileTranslator(stream pb.Destination_GetProfileServer, log *logging.E
 
 func (pt *profileTranslator) Update(profile *sp.ServiceProfile) {
 	if profile == nil {
+		pt.log.Debugf("Sending default profile")
 		if err := pt.stream.Send(pt.defaultServiceProfile()); err != nil {
 			pt.log.Errorf("failed to send default service profile: %s", err)
 		}
 		return
 	}
+
 	destinationProfile, err := pt.createDestinationProfile(profile)
 	if err != nil {
 		pt.log.Error(err)

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -369,6 +369,7 @@ spec:
 		t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
 	}
 	log := logging.WithField("test", t.Name())
+	logging.SetLevel(logging.DebugLevel)
 	defaultOpaquePorts := map[uint32]struct{}{
 		25:    {},
 		443:   {},

--- a/controller/api/destination/watcher/test_util.go
+++ b/controller/api/destination/watcher/test_util.go
@@ -50,6 +50,7 @@ func (bpl *BufferingProfileListener) Update(profile *sp.ServiceProfile) {
 }
 
 func testCompare(t *testing.T, expected interface{}, actual interface{}) {
+	t.Helper()
 	if diff := deep.Equal(expected, actual); diff != nil {
 		t.Fatalf("%v", diff)
 	}


### PR DESCRIPTION
The GetProfile API endpoint does not behave as expected: when a profile watch is established, the API server starts two separate profile watches--a primary watch with the client's namespace and fallback watch ignoring the client's namespace. These watches race to send data back to the client. If the backup watch updates first, it may be sent to clients before being corrected by a subsequent update. If the primary watch updates with an empty value, the default profile may be served before being corrected by an update to the backup watch.

From the proxy's perspective, we'd much prefer that the API provide a single authoritative response when possible. It avoid needless corrective work from distributing across the system on every watch initiation.

To fix this, we modify the fallbackProfileListener to behave predictably: it only emits updates once both its primary and fallback listeners have been updated. This avoids emitting updates based on a partial understanding of the cluster state.

Furthermore, the opaquePortsAdaptor is updated to avoid synthesizing a default serviceprofile (surprising behavior) and, instead, this defaulting logic is moved into a dedicated defaultProfileListener helper. A dedupProfileListener is added to squelch obviously redundant updates.

Finally, this newfound predictability allows us to simplify the API's tests. Many of the API tests are not clear in what they test and sometimes make assertions about the "incorrect" profile updates.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
