### PR TITLE
test: Cleanup trafficsplit, improve diagnostics

### DIFF
--- a/test/integration/deep/norelay/norelay_test.go
+++ b/test/integration/deep/norelay/norelay_test.go
@@ -130,7 +130,10 @@ func getDeployments(t *testing.T) map[string]string {
 	}
 
 	// server-relay is injected in ingress mode, manually
-	deploys["server-relay"], err = TestHelper.LinkerdRun("inject", "--manual", "--ingress", "--proxy-log-level=linkerd=debug,info", "testdata/server-relay.yml")
+	deploys["server-relay"], err = TestHelper.LinkerdRun(
+		"inject", "--manual", "--ingress",
+		"--proxy-log-level=linkerd=debug,info",
+		"testdata/server-relay.yml")
 	if err != nil {
 		testutil.AnnotatedFatal(t, "unexpected error", err)
 	}
@@ -138,7 +141,8 @@ func getDeployments(t *testing.T) map[string]string {
 	// client is not injected
 	deploys["client"], err = testutil.ReadFile("testdata/client.yml")
 	if err != nil {
-		testutil.AnnotatedFatalf(t, "failed to read 'client.yml'", "failed to read 'client.yml': %s", err)
+		testutil.AnnotatedFatalf(t, "failed to read 'client.yml'",
+			"failed to read 'client.yml': %s", err)
 	}
 
 	return deploys
@@ -152,7 +156,7 @@ func getPodIp(t *testing.T, ns, selector string) string {
 	)
 	if err != nil {
 		testutil.AnnotatedFatalf(t, "failed to retrieve pod IP",
-			"failed to retrieve pod IP: %s\n%s", err, ip)
+			"failed to retrieve pod IP: %s", err)
 	}
 	return strings.Trim(ip, "'")
 }

--- a/test/integration/deep/norelay/norelay_test.go
+++ b/test/integration/deep/norelay/norelay_test.go
@@ -90,28 +90,10 @@ func TestRelay(t *testing.T) {
 				)
 			}
 		}
+		waitForPods(t, ctx, ns, deployments)
+		relayIP := getPodIp(t, ns, "app=server-relay")
 
-		for name := range deployments {
-			err := TestHelper.CheckPods(ctx, ns, name, 1)
-			if err != nil {
-				//nolint:errorlint
-				if rce, ok := err.(*testutil.RestartCountError); ok {
-					testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
-				} else {
-					testutil.AnnotatedError(t, "CheckPods timed-out", err)
-				}
-			}
-		}
-
-		ip, err := TestHelper.Kubectl(
-			"", "-n", ns, "get", "po", "-l", "app=server-relay",
-			"-o", "jsonpath='{range .items[*]}{@.status.podIP}{end}'",
-		)
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "failed to retrieve server-relay IP",
-				"failed to retrieve server-relay IP: %s\n%s", err, ip)
-		}
-		relayIP := strings.Trim(ip, "'")
+		// Send a request to the outbound proxy port with a header that should route internally.
 		o, err := TestHelper.Kubectl(
 			"", "-n", ns, "exec", "deploy/client",
 			"--", "curl", "-fsv", "-H", "l5d-dst-override: server-hello."+ns+".svc.cluster.local:8080", "http://"+relayIP+":4140",
@@ -122,6 +104,7 @@ func TestRelay(t *testing.T) {
 				"-n", ns,
 				"-l", "app=server-relay",
 				"-c", "linkerd-proxy",
+				"--tail=1000",
 			)
 			if err != nil {
 				log = fmt.Sprintf("failed to retrieve server-relay logs: %s", err)
@@ -159,4 +142,32 @@ func getDeployments(t *testing.T) map[string]string {
 	}
 
 	return deploys
+}
+
+func getPodIp(t *testing.T, ns, selector string) string {
+	t.Helper()
+	ip, err := TestHelper.Kubectl(
+		"", "-n", ns, "get", "po", "-l", selector,
+		"-o", "jsonpath='{range .items[*]}{@.status.podIP}{end}'",
+	)
+	if err != nil {
+		testutil.AnnotatedFatalf(t, "failed to retrieve pod IP",
+			"failed to retrieve pod IP: %s\n%s", err, ip)
+	}
+	return strings.Trim(ip, "'")
+}
+
+func waitForPods(t *testing.T, ctx context.Context, ns string, deployments map[string]string) {
+	t.Helper()
+	for name := range deployments {
+		err := TestHelper.CheckPods(ctx, ns, name, 1)
+		if err != nil {
+			//nolint:errorlint
+			if rce, ok := err.(*testutil.RestartCountError); ok {
+				testutil.AnnotatedWarn(t, "CheckPods timed-out", rce)
+			} else {
+				testutil.AnnotatedError(t, "CheckPods timed-out", err)
+			}
+		}
+	}
 }

--- a/test/integration/viz/trafficsplit/trafficsplit_test.go
+++ b/test/integration/viz/trafficsplit/trafficsplit_test.go
@@ -54,37 +54,41 @@ func parseStatRows(out string, expectedRowCount, expectedColumnCount int) ([]*te
 	return statRows, nil
 }
 
-func TestTrafficSplitCliWithSP(t *testing.T) {
-
-	version := "sp"
+func TestServiceProfileDstOverrides(t *testing.T) {
 	ctx := context.Background()
-	TestHelper.WithDataPlaneNamespace(ctx, fmt.Sprintf("trafficsplit-test-%s", version), map[string]string{}, t, func(t *testing.T, prefixedNs string) {
-		out, err := TestHelper.LinkerdRun("inject", "--manual", "testdata/applications-at-diff-ports.yaml")
+	TestHelper.WithDataPlaneNamespace(ctx, "trafficsplit-test-sp", map[string]string{}, t, func(t *testing.T, prefixedNs string) {
+		// First, create a `ServiceProfile`.
+		initialSP := `---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local
+spec:
+  dstOverrides:
+    - authority: backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local
+      weight: 1
+    - authority: failing-svc.linkerd-trafficsplit-test-sp.svc.cluster.local:8081
+      weight: 0
+...`
+		out, err := TestHelper.KubectlApply(initialSP, prefixedNs)
+		if err != nil {
+			testutil.AnnotatedFatalf(t, "Failed to apply ServiceProfile",
+				"Failed to apply ServiceProfile\n%s", out)
+		}
+
+		// Deploy an application that will route traffic to the `backend-svc`.
+		out, err = TestHelper.LinkerdRun("inject", "--manual",
+			"--proxy-log-level=linkerd=debug,linkerd_service_profiles::client=trace,info",
+			"testdata/applications-at-diff-ports.yaml")
 		if err != nil {
 			testutil.AnnotatedFatal(t, "'linkerd inject' command failed", err)
 		}
-
 		out, err = TestHelper.KubectlApply(out, prefixedNs)
 		if err != nil {
 			testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
 				"'kubectl apply' command failed\n%s", out)
 		}
-
-		TsResourceFile := fmt.Sprintf("testdata/%s/traffic-split-leaf-weights.yaml", version)
-		TsResource, err := testutil.ReadFile(TsResourceFile)
-
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "cannot read updated traffic split resource",
-				"cannot read updated traffic split resource: %s, %s", TsResource, err)
-		}
-
-		out, err = TestHelper.KubectlApply(TsResource, prefixedNs)
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "failed to update traffic split resource",
-				"failed to update traffic split resource: %s\n %s", err, out)
-		}
-
-		// wait for deployments to start
+		// Wait for all of its pods to be ready.
 		for _, deploy := range []string{"backend", "failing", "slow-cooker"} {
 			if err := TestHelper.CheckPods(ctx, prefixedNs, deploy, 1); err != nil {
 				//nolint:errorlint
@@ -96,92 +100,102 @@ func TestTrafficSplitCliWithSP(t *testing.T) {
 			}
 		}
 
-		t.Run(fmt.Sprintf("ensure traffic is sent to one backend only for %s", version), func(t *testing.T) {
+		t.Run("ensure traffic is sent to one backend only", func(t *testing.T) {
 			timeout := 40 * time.Second
+			expectedRows := []*testutil.RowStat{
+				{
+					Name:               "backend",
+					Meshed:             "1/1",
+					Success:            "100.00%",
+					TCPOpenConnections: "1",
+				},
+			}
 			err := testutil.RetryFor(timeout, func() error {
-				out, err := TestHelper.LinkerdRun("viz", "stat", "deploy", "--namespace", prefixedNs, "--from", "deploy/slow-cooker", "-t", "30s")
+				out, err := TestHelper.LinkerdRun("viz", "stat", "deploy", "--namespace", prefixedNs,
+					"--from", "deploy/slow-cooker", "-t", "30s")
 				if err != nil {
 					return err
 				}
-
 				rows, err := parseStatRows(out, 1, 8)
 				if err != nil {
 					return err
 				}
-
-				expectedRows := []*testutil.RowStat{
-					{
-						Name:               "backend",
-						Meshed:             "1/1",
-						Success:            "100.00%",
-						TCPOpenConnections: "1",
-					},
-				}
-
 				if err := validateRowStats(expectedRows, rows); err != nil {
 					return err
 				}
 				return nil
 			})
-
 			if err != nil {
 				testutil.AnnotatedFatal(t, fmt.Sprintf("timed-out ensuring traffic is sent to one backend only (%s)", timeout), err)
 			}
 		})
 
-		t.Run(fmt.Sprintf("update traffic split resource with equal weights for %s", version), func(t *testing.T) {
-
-			updatedTsResourceFile := fmt.Sprintf("testdata/%s/updated-traffic-split-leaf-weights.yaml", version)
-			updatedTsResource, err := testutil.ReadFile(updatedTsResourceFile)
-
+		t.Run("update traffic split resource with equal weights", func(t *testing.T) {
+			updatedSP := `---
+apiVersion: linkerd.io/v1alpha2
+kind: ServiceProfile
+metadata:
+  name: backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local
+spec:
+  dstOverrides:
+    - authority: backend-svc.linkerd-trafficsplit-test-sp.svc.cluster.local
+      weight: 1
+    - authority: failing-svc.linkerd-trafficsplit-test-sp.svc.cluster.local:8081
+      weight: 1
+...`
+			out, err := TestHelper.KubectlApply(updatedSP, prefixedNs)
 			if err != nil {
-				testutil.AnnotatedFatalf(t, "cannot read updated traffic split resource",
-					"cannot read updated traffic split resource: %s, %s", updatedTsResource, err)
-			}
-
-			out, err := TestHelper.KubectlApply(updatedTsResource, prefixedNs)
-			if err != nil {
-				testutil.AnnotatedFatalf(t, "failed to update traffic split resource",
-					"failed to update traffic split resource: %s\n %s", err, out)
+				testutil.AnnotatedFatalf(t, "failed to update ServiceProfile",
+					"failed to update ServiceProfile: %s\n %s", err, out)
 			}
 		})
 
-		t.Run(fmt.Sprintf("ensure traffic is sent to both backends for %s", version), func(t *testing.T) {
+		t.Run("ensure traffic is sent to both backends", func(t *testing.T) {
 			timeout := 40 * time.Second
+			expectedRows := []*testutil.RowStat{
+				{
+					Name:               "backend",
+					Meshed:             "1/1",
+					Success:            "100.00%",
+					TCPOpenConnections: "1",
+				},
+				{
+					Name:               "failing",
+					Meshed:             "1/1",
+					Success:            "0.00%",
+					TCPOpenConnections: "1",
+				},
+			}
 			err := testutil.RetryFor(timeout, func() error {
-
-				out, err := TestHelper.LinkerdRun("viz", "stat", "deploy", "-n", prefixedNs, "--from", "deploy/slow-cooker", "-t", "30s")
+				out, err := TestHelper.LinkerdRun("viz", "stat", "deploy", "-n", prefixedNs,
+					"--from", "deploy/slow-cooker", "-t", "30s")
 				if err != nil {
 					return err
 				}
-
 				rows, err := parseStatRows(out, 2, 8)
 				if err != nil {
 					return err
 				}
-
-				expectedRows := []*testutil.RowStat{
-					{
-						Name:               "backend",
-						Meshed:             "1/1",
-						Success:            "100.00%",
-						TCPOpenConnections: "1",
-					},
-					{
-						Name:               "failing",
-						Meshed:             "1/1",
-						Success:            "0.00%",
-						TCPOpenConnections: "1",
-					},
-				}
-
 				if err := validateRowStats(expectedRows, rows); err != nil {
 					return err
 				}
 				return nil
 			})
-
 			if err != nil {
+				out, lerr := TestHelper.LinkerdRun("viz", "stat", "deploy", "-n", prefixedNs,
+					"--from", "deploy/slow-cooker", "-t", "30s")
+				if lerr == nil {
+					fmt.Fprintf(os.Stderr, "----------- linkerd viz stat\n")
+					fmt.Fprintf(os.Stderr, "%s", out)
+				}
+				out, lerr = TestHelper.Kubectl("", "logs", "--tail=1000", "-n", prefixedNs,
+					"-l", "app=slow-cooker", "-c", "linkerd-proxy")
+				if lerr != nil {
+					fmt.Fprintf(os.Stderr, "Failed to run kubectl logs: %s", lerr)
+				} else {
+					fmt.Fprintf(os.Stderr, "----------- kubectl logs\n")
+					fmt.Fprintf(os.Stderr, "%s", out)
+				}
 				testutil.AnnotatedFatal(t, fmt.Sprintf("timed-out ensuring traffic is sent to both backends (%s)", timeout), err)
 			}
 		})
@@ -189,11 +203,9 @@ func TestTrafficSplitCliWithSP(t *testing.T) {
 }
 
 func validateRowStats(expectedRowStats, actualRowStats []*testutil.RowStat) error {
-
 	if len(expectedRowStats) != len(actualRowStats) {
 		return fmt.Errorf("Expected number of rows to be %d, but found %d", len(expectedRowStats), len(actualRowStats))
 	}
-
 	for i := 0; i < len(expectedRowStats); i++ {
 		err := compareRowStat(expectedRowStats[i], actualRowStats[i])
 		if err != nil {
@@ -204,46 +216,37 @@ func validateRowStats(expectedRowStats, actualRowStats []*testutil.RowStat) erro
 }
 
 func compareRowStat(expectedRow, actualRow *testutil.RowStat) error {
-
 	if actualRow.Name != expectedRow.Name {
 		return fmt.Errorf("Expected name to be '%s', got '%s'",
 			expectedRow.Name, actualRow.Name)
 	}
-
 	if actualRow.Meshed != expectedRow.Meshed {
 		return fmt.Errorf("Expected meshed to be '%s', got '%s'",
 			expectedRow.Meshed, actualRow.Meshed)
 	}
-
 	if !strings.HasSuffix(actualRow.Rps, "rps") {
 		return fmt.Errorf("Unexpected rps for [%s], got [%s]",
 			actualRow.Name, actualRow.Rps)
 	}
-
 	if !strings.HasSuffix(actualRow.P50Latency, "ms") {
 		return fmt.Errorf("Unexpected p50 latency for [%s], got [%s]",
 			actualRow.Name, actualRow.P50Latency)
 	}
-
 	if !strings.HasSuffix(actualRow.P95Latency, "ms") {
 		return fmt.Errorf("Unexpected p95 latency for [%s], got [%s]",
 			actualRow.Name, actualRow.P95Latency)
 	}
-
 	if !strings.HasSuffix(actualRow.P99Latency, "ms") {
 		return fmt.Errorf("Unexpected p99 latency for [%s], got [%s]",
 			actualRow.Name, actualRow.P99Latency)
 	}
-
 	if actualRow.Success != expectedRow.Success {
 		return fmt.Errorf("Expected success to be '%s', got '%s'",
 			expectedRow.Success, actualRow.Success)
 	}
-
 	if actualRow.TCPOpenConnections != expectedRow.TCPOpenConnections {
 		return fmt.Errorf("Expected tcp to be '%s', got '%s'",
 			expectedRow.TCPOpenConnections, actualRow.TCPOpenConnections)
 	}
-
 	return nil
 }


### PR DESCRIPTION
While integrating a new proxy version, we needed to make a few test changes to improve diagnostics. These changes are probably worthwhile in general:

1. We have unused test resources in the trafficsplit tests. These can be removed.
2. We can simply inline our ServiceProfile configurations in the trafficsplit tests. There's not a lot of value in having that decoupled from the test.
3. We now enable verbose proxy logs and emit proxy logs when the trafficsplit test fails
4. The norelay test is also updated for clarity and to include additional proxy logs on failure.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
