### PR TITLE
proxy-injector: Skip Kube API server ports

### DIFF
--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -119,6 +119,11 @@ spec:
       {{ if .Values.cniEnabled -}}
       - {{- include "partials.network-validator" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ else -}}
+      {{- /*
+        The controller needs to connect to the Kubernetes API. There's no reason
+        to put the proxy in the way of that.
+      */}}
+      {{- $_ := set $tree.Values.proxyInit "ignoreOutboundPorts" .Values.proxyInit.kubeAPIServerPorts -}}
       - {{- include "partials.proxy-init" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       {{- if .Values.priorityClassName -}}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1754,7 +1754,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1752,7 +1752,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1752,7 +1752,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: my.custom.registry/linkerd-io/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1752,7 +1752,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1752,7 +1752,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1732,7 +1732,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1916,7 +1916,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1916,7 +1916,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1624,7 +1624,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -1733,7 +1733,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,222"
         - --outbound-ports-to-ignore
-        - "111"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -1897,7 +1897,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,222"
         - --outbound-ports-to-ignore
-        - "111"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1917,7 +1917,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,444"
         - --outbound-ports-to-ignore
-        - "333"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1887,7 +1887,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,222"
         - --outbound-ports-to-ignore
-        - "111"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:test-proxy-init-version
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1730,8 +1730,6 @@ spec:
         - "2102"
         - --inbound-ports-to-ignore
         - "4190,4191"
-        - --outbound-ports-to-ignore
-        - "443"
         image: ProxyInitImageName:ProxyInitVersion
         imagePullPolicy: ImagePullPolicy
         name: linkerd-init

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1752,7 +1752,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
-        - "5432"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1752,7 +1752,7 @@ spec:
         - --inbound-ports-to-ignore
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
-        - "4567,4568"
+        - "443,6443"
         image: cr.l5d.io/linkerd/proxy-init:v2.2.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init


### PR DESCRIPTION
The destination and identity controllers skip ports that are used by the kubernetes API server to avoid startup ordering issues and to ensure that the controllers are able to communicate with the kubernetes API without requiring the control plane for discovery.

To avoid startup issues in the proxy-injector, the same configuration should be applied.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
