### PR TITLE
edge-23.3.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,16 +14,12 @@ introduces support for header-based routing.
 * Proxy
   * Utilize new OutboundPolices API, supporting Gateway API-style routes
     in the outbound proxy
-  * Proxies in ingress and gateway configurations may now
-    discover policies by name instead of network address
 
 * Policy Controller
-  * Utilize `policy-controller-write` Lease to avoid multiple writers
-    when patching HTTPRoutes
+  * Support highly available Policy Controller by utilizing
+   `policy-controller-write` Lease when patching HTTPRoutes
   * Consider the `status` field and filter out HTTPRoutes which have not
     been accepted
-  * Controller name value has been renamed from
-    `policy.linkerd.io/status-controller` to `linkerd.io/policy-controller`
 
 * Added KubeAPI server ports to `ignoreOutboundPorts` of `proxy-injector`
 * Updated HTTPRoute version from `v1alpha1` to `v1beta2`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ This edge release continues to improve dynamic Policy statuses and
 introduces support for header-based routing.
 
 * Destination Controller
-  * Added OutboundPolices API, for use by `linkerd-proxy` to route
+  * Added OutboundPolicies API, for use by `linkerd-proxy` to route
     outbound traffic
   * Improved diagnostic log messages
   * Fixed sending of spurious profile updates

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ introduces support for header-based routing.
   * Fixed sending of spurious profile updates
 
 * Proxy
-  * Utilize new OutboundPolices API, supporting Gateway API-style routes
+  * Use the new OutboundPolicies API, supporting Gateway API-style routes
     in the outbound proxy
 
 * Policy Controller

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,36 @@
 # Changes
 
+## edge-23.3.2
+
+This edge release continues to improve dynamic Policy statuses and
+introduces support for header-based routing.
+
+* Destination Controller
+  * Added OutboundPolices API, for use by `linkerd-proxy` to route
+    outbound traffic
+  * Improved diagnostic log messages
+  * Fixed sending of spurious profile updates
+
+* Proxy
+  * Utilize new OutboundPolices API, supporting Gateway API-style routes
+    in the outbound proxy
+  * Proxies in ingress and gateway configurations may now
+    discover policies by name instead of network address
+
+* Policy Controller
+  * Utilize `policy-controller-write` Lease to avoid multiple writers
+    when patching HTTPRoutes
+  * Consider the `status` field and filter out HTTPRoutes which have not
+    been accepted
+  * Controller name value has been renamed from
+    `policy.linkerd.io/status-controller` to `linkerd.io/policy-controller`
+
+* Added KubeAPI server ports to `ignoreOutboundPorts` of `proxy-injector`
+* Updated HTTPRoute version from `v1alpha1` to `v1beta2`
+* Updated `network-validator` helm charts to use `proxy-init` resources
+* Fixed Grafana regular expression, enabling monitoring of filesystem
+  usage (thanks @h-dav!)
+
 ## edge-23.3.1
 
 This edge release continues to build support under the hood for the upcoming

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.11.6-edge
+version: 1.11.7-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.11.6-edge](https://img.shields.io/badge/Version-1.11.6--edge-informational?style=flat-square)
+![Version: 1.11.7-edge](https://img.shields.io/badge/Version-1.11.7--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.7.2-edge
+version: 30.7.3-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.7.2-edge](https://img.shields.io/badge/Version-30.7.2--edge-informational?style=flat-square)
+![Version: 30.7.3-edge](https://img.shields.io/badge/Version-30.7.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.7.5-edge
+version: 30.7.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.7.5-edge](https://img.shields.io/badge/Version-30.7.5--edge-informational?style=flat-square)
+![Version: 30.7.6-edge](https://img.shields.io/badge/Version-30.7.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.6.2-edge
+version: 30.6.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.6.2-edge](https://img.shields.io/badge/Version-30.6.2--edge-informational?style=flat-square)
+![Version: 30.6.3-edge](https://img.shields.io/badge/Version-30.6.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.6.0-edge
+version: 30.7.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.6.0-edge](https://img.shields.io/badge/Version-30.6.0--edge-informational?style=flat-square)
+![Version: 30.7.0-edge](https://img.shields.io/badge/Version-30.7.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.3.2

This edge release continues to improve dynamic Policy statuses and
introduces support for header-based routing.

* Destination Controller
  * Added OutboundPolicies API, for use by `linkerd-proxy` to route
    outbound traffic
  * Improved diagnostic log messages
  * Fixed sending of spurious profile updates

* Proxy
  * Use the new OutboundPolicies API, supporting Gateway API-style routes
    in the outbound proxy

* Policy Controller
  * Support highly available Policy Controller by utilizing
   `policy-controller-write` Lease when patching HTTPRoutes
  * Consider the `status` field and filter out HTTPRoutes which have not
    been accepted

* Added KubeAPI server ports to `ignoreOutboundPorts` of `proxy-injector`
* Updated HTTPRoute version from `v1alpha1` to `v1beta2`
* Updated `network-validator` helm charts to use `proxy-init` resources
* Fixed Grafana regular expression, enabling monitoring of filesystem
  usage (thanks @h-dav!)
