### PR TITLE
policy: return `NotFound` for valid non-Service authorities

### DIFF
--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -94,7 +94,7 @@ where
         let invalid = {
             let domain = &self.cluster_domain;
             move || {
-                tonic::Status::invalid_argument(format!(
+                tonic::Status::not_found(format!(
                     "authority must be of the form <name>.<namespace>.svc.{}",
                     domain
                 ))


### PR DESCRIPTION
Currently, the OutboundPolicies API returns the gRPC status code `InvalidArgument` when a target authority is valid but is not a Kubernetes Service. In the proxy, the `NotFound` status is handled by synthesizing a policy from a ServiceProfile, as it is used to indicate that a target is potentially valid but not known to the policy controller. Other gRPC status codes, such as `InvalidArgument`, are treated as fatal, as they indicate that the proxy did something wrong. Multicluster gateway proxies may perform lookups for Pod DNS names (rather than Service DNS names), and those lookups should return `NotFound`, so that the proxy knows to synthesize a policy for that target, rather than failing after receiving `InvalidArgument`.

This branch changes the OutboundPolicies API to return `NotFound` when a target authority is a valid DNS name that is not a Service.