### PR TITLE
policy: minor OutboundPolicy gRPC server refactors 

### DIFF
--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -85,8 +85,9 @@ where
             ));
         }
 
-        host = host.trim_end_matches('.');
-        host = host.trim_end_matches(&*self.cluster_domain);
+        host = host
+            .trim_end_matches('.')
+            .trim_end_matches(&*self.cluster_domain);
 
         let mut parts = host.split('.');
         let invalid = {

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -62,7 +62,7 @@ where
             .ok_or_else(|| tonic::Status::invalid_argument("traffic target must have an IP"))?
             .try_into()
             .map_err(|error| {
-                tonic::Status::invalid_argument(format!("failed to parse target addr: {}", error))
+                tonic::Status::invalid_argument(format!("failed to parse target addr: {error}"))
             })?;
 
         self.index
@@ -93,8 +93,7 @@ where
             let domain = &self.cluster_domain;
             move || {
                 tonic::Status::invalid_argument(format!(
-                    "authority must be of the form <name>.<namespace>.svc.{}",
-                    domain
+                    "authority must be of the form <name>.<namespace>.svc.{domain}",
                 ))
             }
         };
@@ -129,7 +128,7 @@ where
             .get_outbound_policy(service)
             .await
             .map_err(|error| {
-                tonic::Status::internal(format!("failed to get outbound policy: {}", error))
+                tonic::Status::internal(format!("failed to get outbound policy: {error}"))
             })?;
 
         if let Some(policy) = policy {
@@ -152,7 +151,7 @@ where
             .index
             .watch_outbound_policy(service)
             .await
-            .map_err(|e| tonic::Status::internal(format!("lookup failed: {}", e)))?
+            .map_err(|e| tonic::Status::internal(format!("lookup failed: {e}",)))?
             .ok_or_else(|| tonic::Status::not_found("unknown server"))?;
         Ok(tonic::Response::new(response_stream(drain, rx)))
     }

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -84,12 +84,10 @@ where
                 "authority must have a host",
             ));
         }
-        if host.ends_with('.') {
-            host = &host[..host.len() - 1];
-        }
-        if host.ends_with(&*self.cluster_domain) {
-            host = &host[..host.len() - self.cluster_domain.len()];
-        }
+
+        host = host.trim_end_matches('.');
+        host = host.trim_end_matches(&*self.cluster_domain);
+
         let mut parts = host.split('.');
         let invalid = {
             let domain = &self.cluster_domain;

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -100,7 +100,7 @@ where
         };
         let name = parts.next().ok_or_else(invalid)?;
         let namespace = parts.next().ok_or_else(invalid)?;
-        if !matches!(parts.next(), Some("svc")) {
+        if parts.next() != Some("svc") {
             return Err(invalid());
         };
 

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -151,7 +151,7 @@ where
             .index
             .watch_outbound_policy(service)
             .await
-            .map_err(|e| tonic::Status::internal(format!("lookup failed: {e}",)))?
+            .map_err(|e| tonic::Status::internal(format!("lookup failed: {e}")))?
             .ok_or_else(|| tonic::Status::not_found("unknown server"))?;
         Ok(tonic::Response::new(response_stream(drain, rx)))
     }


### PR DESCRIPTION
This branch makes a few very minor style tweaks to the OutboundPolicy
API server, primarily in the handling of authority strings in the
`lookup_authority` function. There should be no functional changes in
this branch.