### PR TITLE
ci: increase timeout for `build-core`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -92,7 +92,7 @@ jobs:
           - controller
           - policy-controller
           - proxy
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: ./.github/actions/docker-build


### PR DESCRIPTION
Policy controller docker builds seem to keep hitting the 15-minute timeout for this job (see e.g. [this comment][1]). We should probably try to figure out if there's anything we can do to make that build faster, but for now, this PR bumps the timeout up by 5 minutes. Hopefully this is enough to get CI passing reliably, although we could bump it up by 10 if it's not...

[1]: https://github.com/linkerd/linkerd2/pull/10547#issuecomment-1472393611