### PR TITLE
Remove parent ref validation from policy admission

### DIFF
--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -6,12 +6,10 @@ use crate::k8s::{
         NetworkAuthentication, NetworkAuthenticationSpec, Server, ServerAuthorization,
         ServerAuthorizationSpec, ServerSpec,
     },
-    Service,
 };
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, bail, Result};
 use futures::future;
 use hyper::{body::Buf, http, Body, Request, Response};
-use k8s_gateway_api::ParentReference;
 use k8s_openapi::api::core::v1::{Namespace, ServiceAccount};
 use kube::{core::DynamicObject, Resource, ResourceExt};
 use linkerd_policy_controller_core as core;
@@ -465,18 +463,6 @@ impl Validate<HttpRouteSpec> for Admission {
             }
         }
 
-        // Ensure that the `HTTPRoute` targets a `Server` or `Service` as its parent ref
-        let all_valid_targets = spec
-            .inner
-            .parent_refs
-            .iter()
-            .flatten()
-            .all(parent_ref_kind_is_valid);
-        ensure!(
-            all_valid_targets,
-            "policy.linkerd.io HTTPRoutes must target only Server or Service resources"
-        );
-
         // Validate the rules in this spec.
         // This is essentially equivalent to the indexer's conversion function
         // from `HttpRouteSpec` to `InboundRouteBinding`, except that we don't
@@ -496,9 +482,4 @@ impl Validate<HttpRouteSpec> for Admission {
 
         Ok(())
     }
-}
-
-fn parent_ref_kind_is_valid(parent_ref: &ParentReference) -> bool {
-    httproute::parent_ref_targets_kind::<Server>(parent_ref)
-        || httproute::parent_ref_targets_kind::<Service>(parent_ref)
 }

--- a/policy-test/tests/admit_http_route.rs
+++ b/policy-test/tests/admit_http_route.rs
@@ -22,40 +22,6 @@ async fn accepts_valid() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn rejects_non_server_parent_ref() {
-    admission::rejects(|ns| HttpRoute {
-        metadata: meta(&ns),
-        spec: HttpRouteSpec {
-            inner: CommonRouteSpec {
-                parent_refs: Some(vec![non_server_parent_ref(ns)]),
-            },
-            hostnames: None,
-            rules: Some(rules()),
-        },
-        status: None,
-    })
-    .await;
-}
-
-/// Tests that an `HTTPRoute` is rejected if it contains *any* parent refs that
-/// target non-`Server` resources, even if it also targets a `Server` resource.
-#[tokio::test(flavor = "current_thread")]
-async fn rejects_mixed_parent_ref() {
-    admission::rejects(|ns| HttpRoute {
-        metadata: meta(&ns),
-        spec: HttpRouteSpec {
-            inner: CommonRouteSpec {
-                parent_refs: Some(vec![server_parent_ref(&ns), non_server_parent_ref(ns)]),
-            },
-            hostnames: None,
-            rules: Some(rules()),
-        },
-        status: None,
-    })
-    .await;
-}
-
-#[tokio::test(flavor = "current_thread")]
 async fn rejects_relative_path_match() {
     admission::rejects(|ns| HttpRoute {
         metadata: meta(&ns),
@@ -121,17 +87,6 @@ fn server_parent_ref(ns: impl ToString) -> ParentReference {
         kind: Some("Server".to_string()),
         namespace: Some(ns.to_string()),
         name: "my-server".to_string(),
-        section_name: None,
-        port: None,
-    }
-}
-
-fn non_server_parent_ref(ns: impl ToString) -> ParentReference {
-    ParentReference {
-        group: Some("foo.bar.bas".to_string()),
-        kind: Some("Gateway".to_string()),
-        namespace: Some(ns.to_string()),
-        name: "my-gateway".to_string(),
         section_name: None,
         port: None,
     }


### PR DESCRIPTION
We remove parent_ref validation for HTTPRoute resources from the policy admission controller.  The validity of inter-resource relationships should be checked on an ongoing basis and reflected in the resource status (e.g. see https://github.com/linkerd/linkerd2/pull/10545) instead of being enforced at resource creation time.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
