### PR TITLE
policy status: don't iterate all servers for each HTTPRoute

### DIFF
--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -183,10 +183,7 @@ impl Index {
 
                 // Is this parent in the list of parents which accept
                 // the route?
-                let accepted = self
-                    .servers
-                    .iter()
-                    .any(|server| server == parent_reference_id);
+                let accepted = self.servers.contains(parent_reference_id);
                 let condition = if accepted {
                     k8s::Condition {
                         last_transition_time: k8s::Time(timestamp),


### PR DESCRIPTION
Currently, the policy status controller checks whether an HTTPRoute should have the Accepted status by iterating over its `HashSet` of Servers and checking each server against the HTTPRoute's parent reference. This is inefficient: the Server resource IDs are stored in a `HashSet`, so we can instead use `HashSet::contains` to test if that parent ref is present. This is an O(1) operation, while the current implementation is an O(_servers_) operation. This check is performed for each parent reference on an HTTPRoute, so the status controller currently performs iterates over all servers once for each parent reference on each HTTPRoute every 10 seconds.

This commit simply changes the status controller to check whether a parent reference exists by using the `HashSet`'s `contains` operation, rather than iterating over all Servers.