### PR TITLE
Avoid busy looping after losing lease watch

### DIFF
--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -132,17 +132,10 @@ impl Index {
 
         loop {
             tokio::select! {
-                res = claims.changed() => match res {
-                    Ok(()) => {
-                        tracing::debug!("Lease holder has changed");
-                    },
-                    Err(error) => {
-                        tracing::error!(%error, "Failed to get lease status");
-                        // If we have lost the claims watch, we won't ever be
-                        // able to recover.
-                        panic!("Claims watch lost");
-                    },
-                },
+                res = claims.changed() => {
+                    res.expect("Claims watch must not be dropped");
+                    tracing::debug!("Lease holder has changed");
+                }
                 _ = time::sleep(Duration::from_secs(10)) => {}
             }
 

--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -83,7 +83,7 @@ impl Controller {
         loop {
             tokio::select! {
                 biased;
-                res = claims.changed() => {
+                res = self.claims.changed() => {
                     res.expect("Claims watch must not be dropped");
                     tracing::debug!("Lease holder has changed");
                     let claim = self.claims.borrow_and_update();


### PR DESCRIPTION
Transient API errors can cause the policy controller's claim watch to die (see https://github.com/olix0r/kubert/issues/134).  In this case, the policy controller enters a busy loop and consumes large amounts of CPU.

Ideally, the Kubert lease module should handle errors internally and present an infallible interface.  In absence of that, it's better for us to panic when we lose the watch and let Kubernetes restart the container, rather than busy looping.

![](https://i.imgflip.com/7f7wyu.jpg)