### PR TITLE
Introduce support for non-cluster "CLI Checks"

### DIFF
--- a/pkg/healthcheck/healthcheck_output_test.go
+++ b/pkg/healthcheck/healthcheck_output_test.go
@@ -1,0 +1,112 @@
+package healthcheck
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"k8s.io/utils/exec"
+	fakeexec "k8s.io/utils/exec/testing"
+)
+
+func TestSuffixes(t *testing.T) {
+	testCases := []*struct {
+		testName  string
+		cliChecks CLIChecks
+		exp       map[string]struct{}
+	}{
+		{
+			"empty",
+			CLIChecks{},
+			map[string]struct{}{},
+		},
+		{
+			"empty name",
+			CLIChecks{
+				CheckCLIOutput{Name: ""}: "",
+			},
+			map[string]struct{}{
+				"": {},
+			},
+		},
+		{
+			"one check",
+			CLIChecks{
+				CheckCLIOutput{Name: "linkerd-foo"}: "filepath",
+			},
+			map[string]struct{}{
+				"foo": {},
+			},
+		},
+		{
+			"two checks",
+			CLIChecks{
+				CheckCLIOutput{Name: "linkerd-foo"}:    "filepath",
+				CheckCLIOutput{Name: "linker-bar-baz"}: "filepath",
+			},
+			map[string]struct{}{
+				"foo": {},
+				"baz": {},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc // pin
+		t.Run(tc.testName, func(t *testing.T) {
+			result := tc.cliChecks.Suffixes()
+			if !reflect.DeepEqual(tc.exp, result) {
+				t.Fatalf("Expected [%+v] Got [%+v]", tc.exp, result)
+			}
+		})
+	}
+}
+
+func TestGetCLIChecks(t *testing.T) {
+	fakeGlob := func(path string) ([]string, error) {
+		dir, _ := filepath.Split(path)
+		return []string{
+			filepath.Join(dir, "linkerd-foo"),
+			filepath.Join(dir, "linkerd-bar"),
+			filepath.Join(dir, "linkerd-baz"),
+		}, nil
+	}
+
+	fcmd := fakeexec.FakeCmd{
+		RunScript: []fakeexec.FakeAction{
+			func() ([]byte, []byte, error) { return []byte(`{"name":"linkerd-foo-no-match"}`), nil, nil },
+			func() ([]byte, []byte, error) {
+				return []byte(`{"name":"linkerd-bar"}`), nil, errors.New("fake-error")
+			},
+			func() ([]byte, []byte, error) { return []byte(`{"name":"linkerd-baz"}`), nil, nil },
+
+			func() ([]byte, []byte, error) { return []byte(`{"name":"linkerd-foo"}`), nil, nil },
+			func() ([]byte, []byte, error) { return []byte(`{"name":"linkerd-bar"}`), nil, nil },
+			func() ([]byte, []byte, error) { return []byte(`{"name":"linkerd-baz"}`), nil, nil },
+		},
+	}
+
+	fexec := &fakeexec.FakeExec{
+		CommandScript: []fakeexec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+		LookPathFunc: func(cmd string) (string, error) { return cmd, nil },
+	}
+
+	cliChecks := GetCLIChecks("/path1:/this/is/a/fake/path2", fakeGlob, fexec)
+
+	exp := CLIChecks{
+		CheckCLIOutput{Name: "linkerd-baz"}: "/path1/linkerd-baz",
+		CheckCLIOutput{Name: "linkerd-bar"}: "/this/is/a/fake/path2/linkerd-bar",
+		CheckCLIOutput{Name: "linkerd-foo"}: "/this/is/a/fake/path2/linkerd-foo",
+	}
+
+	if !reflect.DeepEqual(exp, cliChecks) {
+		t.Errorf("Expected [%+v] Got [%+v]", exp, cliChecks)
+	}
+}


### PR DESCRIPTION
The existing `linkerd check` command runs extension checks based on extension namespaces already on-cluster. This approach does not permit running extension checks without cluster-side components.

Introduce "CLI Checks". These extensions run as part of `linkerd check`, if they satisfy the following criteria:
1) executable in PATH
2) prefixed by `linkerd-`
3) supports a `check-cli` subcommand, that outputs self-identifying
   JSON, for example:
   ```
   $ linkerd-foo check-cli
   { "name": "linkerd-foo" }
   ```
4) The `name` value from `check-cli` must match the filename.

If a CLI Check is found that also would have run as an on-cluster extension check, it is run as a CLI Check only.

Fixes #10544

# Validation

Save this file as `linkerd-foo`, set it executable, and place it in your PATH:
```bash
#!/usr/bin/env bash

if [[ "$#" < 1 ]]; then
  exit 1
fi

if [[ "$1" == "check-cli" ]]; then
cat << EOF
{
  "name": "linkerd-foo"
}
EOF

elif [[ "$1" == "check" ]]; then
sleep 2
cat << EOF
{
  "success": true,
  "categories": [
    {
      "categoryName": "foo cli checks",
      "checks": [
        {
          "description": "foo can run a check",
          "result": "success"
        },
        {
          "description": "foo throws a warning",
          "hint": "https://example.com/foo",
          "error": "this is the foo warning message",
          "result": "warning"
        }
      ]
    }
  ]
}
EOF

else
  exit 1
fi
```

Test `linkerd-foo` to ensure it's working:
```bash
$ linkerd-foo
$ linkerd-foo check-cli
{
  "name": "linkerd-foo"
}
$ linkerd-foo check
{
  "success": true,
  "categories": [
    {
      "categoryName": "foo cli checks",
      "checks": [
        {
          "description": "foo can run a check",
          "result": "success"
        },
        {
          "description": "foo throws a warning",
          "hint": "https://example.com/foo",
          "error": "this is the foo warning message",
          "result": "warning"
        }
      ]
    }
  ]
}
```

Create a local cluster, install linkerd, check out this branch, and run `bin/go-run cli check`. you should see `linkerd-foo` get executed.

```bash
$ bin/go-run cli check

Linkerd core checks
===================

kubernetes-api
--------------
√ can initialize the client
...
foo cli checks
--------------
√ foo can run a check
‼ foo throws a warning
    this is the foo warning message
    see https://example.com/foo for hints
```