### PR TITLE
Signing digests instead of tags

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -54,6 +54,14 @@ runs:
         fi
         bin/docker-build-${{ inputs.component }}
 
+    - name: Output Image Digest
+      shell: bash
+      id: image_digest
+      run: |
+        image_digest=$(cat metadata-${{ inputs.component }}.json | jq -r '."containerimage.digest"')
+        echo "${image_digest}"
+        echo "DIGEST=${{ inputs.docker-registry }}/${{ inputs.component }}@${image_digest}" >> "$GITHUB_OUTPUT"
+
     # Delete older docker images to prevent cache bloat.
     - run: bin/docker-cache-prune
       shell: bash
@@ -62,3 +70,6 @@ outputs:
   image:
     description: The image that was built
     value: ${{ inputs.docker-registry }}/${{ inputs.component }}:${{ inputs.tag }}
+  digest:
+    description: The image digest
+    value: ${{ steps.image_digest.outputs.DIGEST }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
         component: ${{ matrix.component }}
         tag: ${{ needs.tag.outputs.tag }}
     - uses: sigstore/cosign-installer@v3
-    - run: cosign sign -y '${{ steps.build.outputs.image }}'
+    - run: cosign sign '${{ steps.build.outputs.digest }}'
       env:
-        COSIGN_EXPERIMENTAL: 1
+        COSIGN_YES: true
     - name: Create artifact with CLI
       # windows_static_cli_tests below needs this because it can't create linux containers
       # inside windows

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -52,7 +52,8 @@ docker_repo() {
 }
 
 docker_build() {
-    repo=$(docker_repo "$1")
+    name=$1
+    repo=$(docker_repo "$name")
     shift
 
     tag=$1
@@ -87,6 +88,7 @@ See https://github.com/docker/buildx/issues/59 for more details'
         $output_params \
         -t "$repo:$tag" \
         -f "$file" \
+        --metadata-file metadata-"$name".json \
         "$@"
 
     echo "$repo:$tag"


### PR DESCRIPTION
This change addresses the issue https://github.com/linkerd/linkerd2/issues/10277 a good practice is to sign the digest and not the tag, tags can be mutated and the digest not

Fixes: https://github.com/linkerd/linkerd2/issues/10277

Rehearsal: https://github.com/cpanato/linkerd2/actions/runs/4490598958 check only the image build part :)

cc @vaikas  