### PR TITLE
Remove viz dependency in multicluster tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -372,7 +372,7 @@ jobs:
           bin/scurl -v "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | bash
       - name: Load docker images
         run: |
-          for img in controller policy-controller proxy web metrics-api tap jaeger-webhook; do
+          for img in controller policy-controller proxy; do
             docker load <"image-archives/${img}.tar"
           done
       - run: docker image ls

--- a/justfile
+++ b/justfile
@@ -484,7 +484,7 @@ mc-target-k3d-delete:
             k3d-delete
     fi
 
-_mc-load: _k3d-init linkerd-load linkerd-viz-load
+_mc-load: _k3d-init linkerd-load
 
 _mc-target-load:
     @{{ just_executable() }} \

--- a/test/integration/multicluster/install_test.go
+++ b/test/integration/multicluster/install_test.go
@@ -211,7 +211,7 @@ func TestCheckMulticluster(t *testing.T) {
 	if err := TestHelper.SwitchContext(ctx); err != nil {
 		testutil.AnnotatedFatalf(t, "failed to rebuild helper clientset with new context", "failed to rebuild helper clientset with new context [%s]: %v", ctx, err)
 	}
-	if err := TestHelper.TestCheck("--context", ctx); err != nil {
+	if err := TestHelper.TestCheckMc("--context", ctx); err != nil {
 		t.Fatalf("'linkerd check' command failed: %s", err)
 	}
 }

--- a/test/integration/multicluster/install_test.go
+++ b/test/integration/multicluster/install_test.go
@@ -109,6 +109,8 @@ func TestInstall(t *testing.T) {
 	cmd = []string{
 		"install",
 		"--controller-log-level", "debug",
+		"--set", "proxyInit.image.name=ghcr.io/linkerd/proxy-init",
+		"--set", "proxyInit.image.version=v2.2.0",
 		"--set", fmt.Sprintf("proxy.image.version=%s", TestHelper.GetVersion()),
 		"--set", "heartbeatSchedule=1 2 3 4 5",
 		"--identity-trust-anchors-file", rootPath,

--- a/test/integration/multicluster/install_test.go
+++ b/test/integration/multicluster/install_test.go
@@ -202,37 +202,6 @@ func TestLinkClusters(t *testing.T) {
 
 }
 
-// TestInstallViz will install the viz extension, needed to verify whether the
-// gateway probe succeeded.
-// TODO (matei): can the dependency on viz be removed?
-func TestInstallViz(t *testing.T) {
-	for _, ctx := range contexts {
-		cmd := []string{
-			"--context=" + ctx,
-			"viz",
-			"install",
-			"--set", fmt.Sprintf("namespace=%s", TestHelper.GetVizNamespace()),
-		}
-
-		out, err := TestHelper.LinkerdRun(cmd...)
-		if err != nil {
-			testutil.AnnotatedFatal(t, "'linkerd viz install' command failed", err)
-		}
-
-		out, err = TestHelper.KubectlApplyWithContext(out, ctx, "-f", "-")
-		if err != nil {
-			testutil.AnnotatedFatalf(t, "'kubectl apply' command failed",
-				"'kubectl apply' command failed\n%s", out)
-		}
-
-	}
-
-	// Allow viz to be installed in parallel and then block until viz is ready.
-	for _, ctx := range contexts {
-		TestHelper.WaitRolloutWithContext(t, testutil.LinkerdVizDeployReplicas, ctx)
-	}
-}
-
 func TestCheckMulticluster(t *testing.T) {
 	// Check resources after link were created successfully in source cluster
 	ctx := contexts[testutil.SourceContextKey]

--- a/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
+++ b/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
@@ -64,12 +64,6 @@ func TestMain(m *testing.M) {
 	// Block until gateway & service mirror deploys are running successfully in
 	// source cluster.
 	TestHelper.WaitUntilDeployReady(testutil.MulticlusterSourceReplicas)
-	// Switch back to target context to commence test
-	if err := TestHelper.SwitchContext(targetCtx); err != nil {
-		out := fmt.Sprintf("Error running test: failed to switch Kubernetes client to context [%s]: %s\n", targetCtx, err)
-		os.Stderr.Write([]byte(out))
-		os.Exit(1)
-	}
 	os.Exit(m.Run())
 }
 
@@ -141,7 +135,7 @@ func TestCheckGatewayAfterRepairEndpoints(t *testing.T) {
 			contexts[testutil.SourceContextKey], err)
 	}
 	time.Sleep(time.Minute + 5*time.Second)
-	if err := TestHelper.TestCheck("--context", contexts[testutil.SourceContextKey]); err != nil {
+	if err := TestHelper.TestCheckMc("--context", contexts[testutil.SourceContextKey]); err != nil {
 		t.Fatalf("'linkerd check' command failed: %s", err)
 	}
 }

--- a/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
+++ b/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
@@ -77,7 +77,6 @@ func TestMain(m *testing.M) {
 // three emojivoto services in target cluster and asserting the output against
 // the source cluster.
 func TestGateways(t *testing.T) {
-	t.Log("Starting")
 	t.Run("install resources in target cluster", func(t *testing.T) {
 		// Create namespace in source cluster
 		out, err := TestHelper.KubectlWithContext("", contexts[testutil.SourceContextKey], "create", "namespace", "linkerd-nginx-gateway-deploy")

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -98,6 +98,14 @@ var MulticlusterDeployReplicas = map[string]DeploySpec{
 	"linkerd-gateway": {"linkerd-multicluster", 1},
 }
 
+// MulticlusterSourceReplicas is a map containing the number of replicas for the
+// Gateway and Service Mirror component; components that we'd only expect in the
+// source cluster.
+var MulticlusterSourceReplicas = map[string]DeploySpec{
+	"linkerd-service-mirror-target": {Namespace: "linkerd-multicluster", Replicas: 1},
+	"linkerd-gateway":               {Namespace: "linkerd-multicluster", Replicas: 1},
+}
+
 // ExternalVizDeployReplicas has an external prometheus instance that's in a
 // separate namespace
 var ExternalVizDeployReplicas = map[string]DeploySpec{

--- a/testutil/test_helper_check.go
+++ b/testutil/test_helper_check.go
@@ -55,8 +55,7 @@ func (h *TestHelper) TestCheck(extraArgs ...string) error {
 func (h *TestHelper) TestCheckMc(extraArgs ...string) error {
 	cmd := []string{"check", "--output", "json", "--wait", "5m"}
 	cmd = append(cmd, extraArgs...)
-	categories := append(coreCategories, "linkerd-multicluster")
-	return h.testCheck(cmd, categories)
+	return h.testCheck(cmd, coreCategories)
 }
 
 // TestCheckProxy runs validates the output of `linkerd check --proxy`

--- a/testutil/test_helper_check.go
+++ b/testutil/test_helper_check.go
@@ -51,6 +51,14 @@ func (h *TestHelper) TestCheck(extraArgs ...string) error {
 	return h.testCheck(cmd, categories)
 }
 
+// TestCheckMc validates the output of `linkerd check` and `linkerd mc check`
+func (h *TestHelper) TestCheckMc(extraArgs ...string) error {
+	cmd := []string{"check", "--output", "json", "--wait", "5m"}
+	cmd = append(cmd, extraArgs...)
+	categories := append(coreCategories, "linkerd-multicluster")
+	return h.testCheck(cmd, categories)
+}
+
 // TestCheckProxy runs validates the output of `linkerd check --proxy`
 func (h *TestHelper) TestCheckProxy(expectedVersion, namespace string) error {
 	cmd := []string{"check", "--proxy", "--expected-version", expectedVersion,

--- a/testutil/test_helper_check.go
+++ b/testutil/test_helper_check.go
@@ -53,6 +53,8 @@ func (h *TestHelper) TestCheck(extraArgs ...string) error {
 
 // TestCheckMc validates the output of `linkerd check` and `linkerd mc check`
 func (h *TestHelper) TestCheckMc(extraArgs ...string) error {
+	// TODO (matei): expose multicluster healthchecks in a public library so
+	// they can be consumed here, similar to what viz is doing.
 	cmd := []string{"check", "--output", "json", "--wait", "5m"}
 	cmd = append(cmd, extraArgs...)
 	return h.testCheck(cmd, coreCategories)


### PR DESCRIPTION
Our multicluster integration tests used to depend on viz. Viz was used to check the state of the gateways (`linkerd multicluster gateways` required it). Since this is no longer the case, we can remove this dependency to get back a few seconds of execution times (multicluster tests are famously slow).

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
