### PR TITLE
Send queue config even when outbound backend service is missing

### DIFF
--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -338,7 +338,15 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
             weight: svc.weight,
             backend: Some(outbound::http_route::RouteBackend {
                 backend: Some(outbound::Backend {
-                    metadata: None,
+                    metadata: Some(Metadata {
+                        kind: Some(metadata::Kind::Resource(api::meta::Resource {
+                            group: "core".to_string(),
+                            kind: "Service".to_string(),
+                            name: svc.name,
+                            namespace: svc.namespace,
+                            section: Default::default(),
+                        })),
+                    }),
                     queue: Some(default_queue_config()),
                     kind: Some(outbound::backend::Kind::Balancer(
                         outbound::backend::BalanceP2c {
@@ -359,7 +367,11 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
         Backend::Invalid { weight, message } => outbound::http_route::WeightedRouteBackend {
             weight,
             backend: Some(outbound::http_route::RouteBackend {
-                backend: None,
+                backend: Some(outbound::Backend {
+                    metadata: None,
+                    queue: Some(default_queue_config()),
+                    kind: None,
+                }),
                 filters: vec![outbound::http_route::Filter {
                     kind: Some(outbound::http_route::filter::Kind::FailureInjector(
                         api::http_route::HttpFailureInjector {

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -368,7 +368,9 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
             weight,
             backend: Some(outbound::http_route::RouteBackend {
                 backend: Some(outbound::Backend {
-                    metadata: None,
+                    metadata: Some(Metadata {
+                        kind: Some(metadata::Kind::Default("invalid".to_string())),
+                    }),
                     queue: Some(default_queue_config()),
                     kind: None,
                 }),


### PR DESCRIPTION
When an HTTPRoute references a backend service which does not exist, the outbound policy API returns an FailureInjector filter and no backend.  However, since the proxy still needs to do queuing for this synthetic backend, we still need to send a queue config to the proxy.

We populate the queue config for this backend, even when it does not exist.

As an unrelated but nearby fix, we also populate metadata for service backends.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
