### PR TITLE
edge-23.3.4 change notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,9 @@ route outbound traffic, and continues extending the HTTPRoute resource's Status
 field. It also starts integrating circuit-breaking functionality into the proxy,
 which will be configurable in a subsequent iteration.
 
-* Continued iterating over the HTTPRoute's Status field, by extending support
-  for routes parented to Services, and adding a ResolvedRefs condition
-  reflecting the status of BackendRefs
+* Continued iterating on the HTTPRoute's Status field, by extending support for
+  routes parented to Services, and adding a ResolvedRefs condition reflecting
+  the status of BackendRefs
 * Updated the OutboundPolicies API such that only HTTPRoutes with an Accepted
   status of `true` are considered when routing outbound requests
 * Improved handling of invalid backends, allowing the configuration of error

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,24 @@
 # Changes
 
+## edge-23.3.4
+
+This edge release further enhances the OutboundPolicies API used by the proxy to
+route outbound traffic, and continues extending the HTTPRoute resource's Status
+field. It also starts integrating circuit-breaking functionality into the proxy,
+which will be configurable in a subsequent iteration.
+
+* Continued iterating over the HTTPRoute's Status field, by extending support
+  for routes parented to Services, and adding a ResolvedRefs condition
+  reflecting the status of BackendRefs
+* Updated the OutboundPolicies API such that only HTTPRoutes with an Accepted
+  status of `true` are considered when routing outbound requests
+* Improved handling of invalid backends, allowing the configuration of error
+  responses
+* Added new flag `--viz-namespace` which avoids requiring permissions for
+  listing all namespaces in `linkerd viz` subcommands (thanks @danibaeyens!)
+* Among other dependency updates, the no-longer maintained ghodss/yaml library
+  was replaced with sigs.k8s.io/yaml (thanks @Juneezee!)
+
 ## edge-23.3.3
 
 This edge release removes TrafficSplits from the Linkerd dashboard as well as

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.11.8-edge
+version: 1.11.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.11.8-edge](https://img.shields.io/badge/Version-1.11.8--edge-informational?style=flat-square)
+![Version: 1.11.9-edge](https://img.shields.io/badge/Version-1.11.9--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.7.4-edge
+version: 30.7.5-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.7.4-edge](https://img.shields.io/badge/Version-30.7.4--edge-informational?style=flat-square)
+![Version: 30.7.5-edge](https://img.shields.io/badge/Version-30.7.5--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.7.7-edge
+version: 30.7.8-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.7.7-edge](https://img.shields.io/badge/Version-30.7.7--edge-informational?style=flat-square)
+![Version: 30.7.8-edge](https://img.shields.io/badge/Version-30.7.8--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.6.4-edge
+version: 30.6.5-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.6.4-edge](https://img.shields.io/badge/Version-30.6.4--edge-informational?style=flat-square)
+![Version: 30.6.5-edge](https://img.shields.io/badge/Version-30.6.5--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.7.1-edge
+version: 30.7.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.7.1-edge](https://img.shields.io/badge/Version-30.7.1--edge-informational?style=flat-square)
+![Version: 30.7.2-edge](https://img.shields.io/badge/Version-30.7.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.3.4

This edge release further enhances the OutboundPolicies API used by the proxy to
route outbound traffic, and continues extending the HTTPRoute resource's Status
field. It also starts integrating circuit-breaking functionality into the proxy,
which will be configurable in a subsequent iteration.

* Continued iterating on the HTTPRoute's Status field, by extending support for
  routes parented to Services, and adding a ResolvedRefs condition reflecting
  the status of BackendRefs
* Updated the OutboundPolicies API such that only HTTPRoutes with an Accepted
  status of `true` are considered when routing outbound requests
* Improved handling of invalid backends, allowing the configuration of error
  responses
* Added new flag `--viz-namespace` which avoids requiring permissions for
  listing all namespaces in `linkerd viz` subcommands (thanks @danibaeyens!)
* Among other dependency updates, the no-longer maintained ghodss/yaml library
  was replaced with sigs.k8s.io/yaml (thanks @Juneezee!)
