### PR TITLE
Remove duplicate SecurityContext entry in prometheus manifest

### DIFF
--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -230,8 +230,6 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.prometheus) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.prometheus) | nindent 6 }}
-      securityContext:
-        fsGroup: 65534
       containers:
       {{- if .Values.prometheus.sidecarContainers -}}
       {{- toYaml .Values.prometheus.sidecarContainers | trim | nindent 6 }}
@@ -292,6 +290,7 @@ spec:
           subPath: prometheus.yml
           readOnly: true
       securityContext:
+        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: prometheus

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -709,8 +709,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      securityContext:
-        fsGroup: 65534
       containers:
       - args:
         - --log.level=info
@@ -756,6 +754,7 @@ spec:
           subPath: prometheus.yml
           readOnly: true
       securityContext:
+        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: prometheus
@@ -1196,6 +1195,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -709,8 +709,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      securityContext:
-        fsGroup: 65534
       containers:
       - args:
         - --log.level=debug
@@ -756,6 +754,7 @@ spec:
           subPath: prometheus.yml
           readOnly: true
       securityContext:
+        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: prometheus
@@ -1196,6 +1195,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -709,8 +709,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      securityContext:
-        fsGroup: 65534
       containers:
       - args:
         - --log.format=logfmt
@@ -756,6 +754,7 @@ spec:
           subPath: prometheus.yml
           readOnly: true
       securityContext:
+        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: prometheus
@@ -1196,6 +1195,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -713,8 +713,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      securityContext:
-        fsGroup: 65534
       containers:
       - args:
         - --log.level=info
@@ -760,6 +758,7 @@ spec:
           subPath: prometheus.yml
           readOnly: true
       securityContext:
+        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: prometheus
@@ -1204,6 +1203,7 @@ metadata:
     namespace: linkerd-viz
   annotations:
     linkerd.io/created-by: linkerd/helm dev-undefined
+    
     linkerd.io/inject: enabled
 spec:
   type: ClusterIP


### PR DESCRIPTION
Ref #10208

This resulted in incomplete SecurityContext entries. This wasn't getting flagged by `helm lint` but it was by kustomize's helm inflator.