### PR TITLE
policy: Return Service metadata in OutboundPolicy responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -536,17 +536,6 @@ dependencies = [
  "errno-dragonfly",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1232,7 +1221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
 dependencies = [
  "bindgen",
- "errno 0.2.8",
+ "errno",
  "libc",
 ]
 
@@ -2006,12 +1995,12 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.12"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0af200a3324fa5bcd922e84e9b55a298ea9f431a489f01961acdebc6e908f25"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
- "errno 0.3.0",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.8.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=9efe50fd769cf8fbba4f0eedf95fa8ca896d7355#9efe50fd769cf8fbba4f0eedf95fa8ca896d7355"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#afca924a6df2434196e85a265ffb7c15a547a8fa"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
 
 [profile.release]
 lto = "thin"
+
+[patch.crates-io]
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main" }

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -21,6 +21,7 @@ pub type OutboundPolicyStream = Pin<Box<dyn Stream<Item = OutboundPolicy> + Send
 pub struct OutboundPolicy {
     pub http_routes: HashMap<String, HttpRoute>,
     pub authority: String,
+    pub name: String,
     pub namespace: String,
     pub opaque: bool,
 }

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -12,12 +12,15 @@ http = "0.2"
 drain = "0.1"
 hyper = { version = "0.14", features = ["http2", "server", "tcp"] }
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { features = [
-    "inbound",
-    "outbound",
-], git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "9efe50fd769cf8fbba4f0eedf95fa8ca896d7355" }
 linkerd-policy-controller-core = { path = "../core" }
 maplit = "1"
 tokio = { version = "1", features = ["macros"] }
 tonic = { version = "0.8", default-features = false }
 tracing = "0.1"
+
+[dependencies.linkerd2-proxy-api]
+version = "0.8"
+features = [
+    "inbound",
+    "outbound",
+]

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -15,8 +15,9 @@ use std::{net::SocketAddr, num::NonZeroU16, sync::Arc, time};
 
 #[derive(Clone, Debug)]
 pub struct OutboundPolicyServer<T> {
-    cluster_domain: Arc<str>,
     index: T,
+    // Used to parse named addresses into <svc>.<ns>.svc.<cluster-domain>.
+    cluster_domain: Arc<str>,
     drain: drain::Watch,
 }
 
@@ -238,15 +239,28 @@ fn to_service(outbound: OutboundPolicy) -> outbound::OutboundPolicy {
                 }),
                 http1: Some(outbound::proxy_protocol::Http1 {
                     routes: http_routes.clone(),
+                    failure_accrual: None,
                 }),
                 http2: Some(outbound::proxy_protocol::Http2 {
                     routes: http_routes,
+                    failure_accrual: None,
                 }),
             },
         )
     };
 
+    let metadata = Metadata {
+        kind: Some(metadata::Kind::Resource(api::meta::Resource {
+            group: "core".to_string(),
+            kind: "Service".to_string(),
+            namespace: outbound.namespace,
+            name: outbound.name,
+            ..Default::default()
+        })),
+    };
+
     outbound::OutboundPolicy {
+        metadata: Some(metadata),
         protocol: Some(outbound::ProxyProtocol { kind: Some(kind) }),
     }
 }

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -240,6 +240,7 @@ impl Namespace {
             let (sender, _) = watch::channel(OutboundPolicy {
                 http_routes: Default::default(),
                 authority,
+                name: sp.service.clone(),
                 namespace: self.namespace.to_string(),
                 opaque,
             });

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -14,7 +14,6 @@ k8s-gateway-api = "0.11"
 k8s-openapi = { version = "0.17", features = ["v1_20"] }
 linkerd-policy-controller-core = { path = "../policy-controller/core" }
 linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
-linkerd2-proxy-api = { features = ["inbound", "outbound"], git="https://github.com/linkerd/linkerd2-proxy-api", rev = "9efe50fd769cf8fbba4f0eedf95fa8ca896d7355" }
 maplit = "1"
 rand = "0.8"
 serde = "1"
@@ -29,6 +28,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 version = "0.80"
 default-features = false
 features = ["client", "openssl-tls", "runtime", "ws"]
+
+[dependencies.linkerd2-proxy-api]
+version = "0.8"
+features = [
+    "inbound",
+    "outbound",
+]
 
 [dev-dependencies]
 tokio-test = "0.4"


### PR DESCRIPTION
When the OutboundPolicy API returns a policy for a `Service`, it should include the service's metadata (for metrics, etc).

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
