### PR TITLE
HTTPRoute should not accept parent Services without clusterIPs

### DIFF
--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -237,7 +237,7 @@ impl Index {
 
                 Some(gateway::RouteParentStatus {
                     parent_ref: gateway::ParentReference {
-                        group: None,
+                        group: Some("core".to_string()),
                         kind: Some("Service".to_string()),
                         namespace: Some(service.namespace.clone()),
                         name: service.name.clone(),

--- a/policy-controller/k8s/status/src/lib.rs
+++ b/policy-controller/k8s/status/src/lib.rs
@@ -1,6 +1,7 @@
 mod http_route;
 mod index;
 mod resource_id;
+mod service;
 
 #[cfg(test)]
 mod tests;

--- a/policy-controller/k8s/status/src/service.rs
+++ b/policy-controller/k8s/status/src/service.rs
@@ -1,0 +1,26 @@
+use linkerd_policy_controller_k8s_api as k8s;
+
+#[derive(Default)]
+pub(crate) struct Service {
+    cluster_ip: Option<String>,
+    type_: Option<String>,
+}
+
+impl Service {
+    pub(crate) fn valid_parent_service(&self) -> bool {
+        let cluster_ip = self.cluster_ip.is_some();
+        let external_name = self.type_.as_deref() == Some("ExternalName");
+        cluster_ip && !external_name
+    }
+}
+
+impl From<k8s::Service> for Service {
+    fn from(svc: k8s::Service) -> Self {
+        svc.spec
+            .map(|spec| Self {
+                cluster_ip: spec.cluster_ip,
+                type_: spec.type_,
+            })
+            .unwrap_or_default()
+    }
+}

--- a/policy-controller/k8s/status/src/service.rs
+++ b/policy-controller/k8s/status/src/service.rs
@@ -8,7 +8,11 @@ pub(crate) struct Service {
 
 impl Service {
     pub(crate) fn valid_parent_service(&self) -> bool {
-        let cluster_ip = self.cluster_ip.is_some();
+        let cluster_ip = self
+            .cluster_ip
+            .as_ref()
+            .filter(|cip| !cip.eq_ignore_ascii_case("none"))
+            .is_some();
         let external_name = self.type_.as_deref() == Some("ExternalName");
         cluster_ip && !external_name
     }

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -213,6 +213,40 @@ pub fn mk_service(ns: &str, name: &str, port: i32) -> k8s::Service {
     }
 }
 
+pub fn mk_route(
+    ns: &str,
+    name: &str,
+    parent_refs: Option<Vec<k8s::policy::httproute::ParentReference>>,
+) -> k8s::policy::HttpRoute {
+    use k8s::policy::httproute as api;
+    api::HttpRoute {
+        metadata: kube::api::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        spec: api::HttpRouteSpec {
+            inner: api::CommonRouteSpec { parent_refs },
+            hostnames: None,
+            rules: Some(vec![]),
+        },
+        status: None,
+    }
+}
+
+pub fn find_route_condition(
+    statuses: impl IntoIterator<Item = k8s_gateway_api::RouteParentStatus>,
+    parent_name: &str,
+) -> Option<k8s::Condition> {
+    statuses
+        .into_iter()
+        .find(|route_status| route_status.parent_ref.name == parent_name)
+        .expect("route must have at least one status set")
+        .conditions
+        .into_iter()
+        .find(|cond| cond.type_ == "Accepted")
+}
+
 /// Runs a test with a random namespace that is deleted on test completion
 pub async fn with_temp_ns<F, Fut>(test: F)
 where

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -1,0 +1,152 @@
+use kube::ResourceExt;
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_test::{
+    await_route_status, create, find_route_condition, mk_route, with_temp_ns,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn accepted_parent() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent Service
+        let svc = k8s::Service {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some("test-service".to_string()),
+                ..Default::default()
+            },
+            spec: Some(k8s::ServiceSpec {
+                cluster_ip: Some("10.96.1.1".to_string()),
+                type_: Some("ClusterIP".to_string()),
+                ports: Some(vec![k8s::ServicePort {
+                    port: 80,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..k8s::Service::default()
+        };
+        let svc = create(&client, svc).await;
+        let svc_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("core".to_string()),
+            kind: Some("Service".to_string()),
+            namespace: svc.namespace(),
+            name: svc.name_unchecked(),
+            section_name: None,
+            port: None,
+        }];
+
+        // Create a route that references the Service resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+        // Wait until route is updated with a status
+        let statuses = await_route_status(&client, &ns, "test-route").await.parents;
+
+        let route_status = statuses
+            .clone()
+            .into_iter()
+            .find(|route_status| route_status.parent_ref.name == svc.name_unchecked())
+            .expect("must have at least one parent status");
+
+        // Check status references to parent we have created
+        assert_eq!(route_status.parent_ref.group.as_deref(), Some("core"));
+        assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Service"));
+
+        // Check status is accepted with a status of 'True'
+        let cond = find_route_condition(statuses, &svc.name_unchecked())
+            .expect("must have at least one 'Accepted' condition for accepted servuce");
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason, "Accepted")
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn no_cluster_ip() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent Service
+        let svc = k8s::Service {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some("test-service".to_string()),
+                ..Default::default()
+            },
+            spec: Some(k8s::ServiceSpec {
+                cluster_ip: None,
+                type_: Some("ClusterIP".to_string()),
+                ports: Some(vec![k8s::ServicePort {
+                    port: 80,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..k8s::Service::default()
+        };
+        let svc = create(&client, svc).await;
+        let svc_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("core".to_string()),
+            kind: Some("Service".to_string()),
+            namespace: svc.namespace(),
+            name: svc.name_unchecked(),
+            section_name: None,
+            port: None,
+        }];
+
+        // Create a route that references the Service resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+        // Wait until route is updated with a status
+        let cond = find_route_condition(
+            await_route_status(&client, &ns, "test-route").await.parents,
+            "test-server",
+        )
+        .expect("must have at least one 'Accepted' condition set for parent");
+        // Parent with no ClusterIP should not match.
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "NoMatchingParent");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn external_name() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent Service
+        let svc = k8s::Service {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some("test-service".to_string()),
+                ..Default::default()
+            },
+            spec: Some(k8s::ServiceSpec {
+                cluster_ip: None,
+                type_: Some("ExternalName".to_string()),
+                ports: Some(vec![k8s::ServicePort {
+                    port: 80,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..k8s::Service::default()
+        };
+        let svc = create(&client, svc).await;
+        let svc_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("core".to_string()),
+            kind: Some("Service".to_string()),
+            namespace: svc.namespace(),
+            name: svc.name_unchecked(),
+            section_name: None,
+            port: None,
+        }];
+
+        // Create a route that references the Service resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+        // Wait until route is updated with a status
+        let cond = find_route_condition(
+            await_route_status(&client, &ns, "test-route").await.parents,
+            "test-server",
+        )
+        .expect("must have at least one 'Accepted' condition set for parent");
+        // Parent with ExternalName should not match.
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "NoMatchingParent");
+    })
+    .await;
+}

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -15,7 +15,6 @@ async fn accepted_parent() {
                 ..Default::default()
             },
             spec: Some(k8s::ServiceSpec {
-                cluster_ip: Some("10.96.1.1".to_string()),
                 type_: Some("ClusterIP".to_string()),
                 ports: Some(vec![k8s::ServicePort {
                     port: 80,
@@ -116,7 +115,6 @@ async fn external_name() {
                 ..Default::default()
             },
             spec: Some(k8s::ServiceSpec {
-                cluster_ip: None,
                 type_: Some("ExternalName".to_string()),
                 external_name: Some("linkerd.io".to_string()),
                 ports: Some(vec![k8s::ServicePort {

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -32,7 +32,7 @@ async fn accepted_parent() {
             namespace: svc.namespace(),
             name: svc.name_unchecked(),
             section_name: None,
-            port: None,
+            port: Some(80),
         }];
 
         // Create a route that references the Service resource.
@@ -70,7 +70,7 @@ async fn no_cluster_ip() {
                 ..Default::default()
             },
             spec: Some(k8s::ServiceSpec {
-                cluster_ip: None,
+                cluster_ip: Some("None".to_string()),
                 type_: Some("ClusterIP".to_string()),
                 ports: Some(vec![k8s::ServicePort {
                     port: 80,
@@ -87,7 +87,7 @@ async fn no_cluster_ip() {
             namespace: svc.namespace(),
             name: svc.name_unchecked(),
             section_name: None,
-            port: None,
+            port: Some(80),
         }];
 
         // Create a route that references the Service resource.
@@ -95,7 +95,7 @@ async fn no_cluster_ip() {
         // Wait until route is updated with a status
         let cond = find_route_condition(
             await_route_status(&client, &ns, "test-route").await.parents,
-            "test-server",
+            "test-service",
         )
         .expect("must have at least one 'Accepted' condition set for parent");
         // Parent with no ClusterIP should not match.
@@ -118,6 +118,7 @@ async fn external_name() {
             spec: Some(k8s::ServiceSpec {
                 cluster_ip: None,
                 type_: Some("ExternalName".to_string()),
+                external_name: Some("linkerd.io".to_string()),
                 ports: Some(vec![k8s::ServicePort {
                     port: 80,
                     ..Default::default()
@@ -133,7 +134,7 @@ async fn external_name() {
             namespace: svc.namespace(),
             name: svc.name_unchecked(),
             section_name: None,
-            port: None,
+            port: Some(80),
         }];
 
         // Create a route that references the Service resource.
@@ -141,7 +142,7 @@ async fn external_name() {
         // Wait until route is updated with a status
         let cond = find_route_condition(
             await_route_status(&client, &ns, "test-route").await.parents,
-            "test-server",
+            "test-service",
         )
         .expect("must have at least one 'Accepted' condition set for parent");
         // Parent with ExternalName should not match.


### PR DESCRIPTION
The provisional [xRoutes GEP](https://gateway-api.sigs.k8s.io/geps/gep-1426/#allowed-service-types) says that implementations should support ClusterIP Service types as a parentRef (with or without selectors) but should not support headless services, since they do not have a "frontend" functionality (e.g an IP or DNS hostname that consumers may use). It is unclear to me whether this extends to backendRefs, but I would assume so (since there are no endpoints to send to).

Additionally, ExternalName Service types should not allowed at all, either as backendRefs or parentRefs since they pose a security threat. Last but not least LoadBalancer and NodePort types are apparently supported since they still provision a cluster IP.

We update the policy-controller to only accept a parent Service if it has a ClusterIP.