### PR TITLE
policy: Include ports in OutboundPolicies service references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 [[package]]
 name = "kubert"
 version = "0.15.0"
-source = "git+https://github.com/olix0r/kubert?rev=8c582e42b6ae4aec76ac3af54e6742945d452207#8c582e42b6ae4aec76ac3af54e6742945d452207"
+source = "git+https://github.com/olix0r/kubert?branch=main#8c582e42b6ae4aec76ac3af54e6742945d452207"
 dependencies = [
  "ahash 0.8.3",
  "chrono",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.8.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#afca924a6df2434196e85a265ffb7c15a547a8fa"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#ad750d839ceb18294406e0f118527122be56cf66"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ members = [
 lto = "thin"
 
 [patch.crates-io]
+kubert = { git = "https://github.com/olix0r/kubert", branch = "main" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main" }
-kubert = { git = "https://github.com/olix0r/kubert", rev = "8c582e42b6ae4aec76ac3af54e6742945d452207" }

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -23,6 +23,7 @@ pub struct OutboundPolicy {
     pub authority: String,
     pub name: String,
     pub namespace: String,
+    pub port: NonZeroU16,
     pub opaque: bool,
 }
 
@@ -62,4 +63,5 @@ pub struct WeightedService {
     pub authority: String,
     pub name: String,
     pub namespace: String,
+    pub port: NonZeroU16,
 }

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -255,6 +255,7 @@ fn to_service(outbound: OutboundPolicy) -> outbound::OutboundPolicy {
             kind: "Service".to_string(),
             namespace: outbound.namespace,
             name: outbound.name,
+            port: u16::from(outbound.port).into(),
             ..Default::default()
         })),
     };
@@ -359,6 +360,7 @@ fn convert_http_backend(backend: Backend) -> outbound::http_route::WeightedRoute
                             name: svc.name,
                             namespace: svc.namespace,
                             section: Default::default(),
+                            port: u16::from(svc.port).into(),
                         })),
                     }),
                     queue: Some(default_queue_config()),

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -242,6 +242,7 @@ impl Namespace {
                 authority,
                 name: sp.service.clone(),
                 namespace: self.namespace.to_string(),
+                port: sp.port,
                 opaque,
             });
             ServiceRoutes {
@@ -350,6 +351,7 @@ fn convert_backend(
             authority: cluster.service_dns_authority(ns, &name, port),
             name,
             namespace: ns.to_string(),
+            port,
         })
     })
 }

--- a/policy-test/tests/outbound_api.rs
+++ b/policy-test/tests/outbound_api.rs
@@ -489,13 +489,7 @@ fn route_backends_random_available(
 #[track_caller]
 fn route_name(route: &grpc::outbound::HttpRoute) -> &str {
     match route.metadata.as_ref().unwrap().kind.as_ref().unwrap() {
-        grpc::meta::metadata::Kind::Resource(grpc::meta::Resource {
-            group: _,
-            kind: _,
-            ref name,
-            namespace: _,
-            section: _,
-        }) => name,
+        grpc::meta::metadata::Kind::Resource(grpc::meta::Resource { ref name, .. }) => name,
         _ => panic!("route must be a resource kind"),
     }
 }


### PR DESCRIPTION
Service references always include ports. This information should be passed to the proxy with API responses.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
