### PR TITLE
Bump linkerd2-proxy-init packages

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -21,7 +21,8 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version) $TARGETARCH) && \
 ARG LINKERD_AWAIT_VERSION=v0.2.6
 RUN bin/scurl -o linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 ARG LINKERD_VALIDATOR_VERSION=v0.1.2
-RUN bin/scurl -o linkerd-network-validator https://github.com/linkerd/linkerd2-proxy-init/releases/download/validator%2F${LINKERD_VALIDATOR_VERSION}/linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH} && chmod +x linkerd-network-validator
+RUN bin/scurl -O https://github.com/linkerd/linkerd2-proxy-init/releases/download/validator%2F${LINKERD_VALIDATOR_VERSION}/linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}.tgz
+RUN tar -zxvf linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}.tgz && mv linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}/linkerd-network-validator .
 
 ## compile proxy-identity agent
 FROM go-deps as golang

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -20,7 +20,7 @@ RUN (proxy=$(bin/fetch-proxy $(cat proxy-version) $TARGETARCH) && \
     mv "$proxy" linkerd2-proxy)
 ARG LINKERD_AWAIT_VERSION=v0.2.6
 RUN bin/scurl -o linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
-ARG LINKERD_VALIDATOR_VERSION=v0.1.1
+ARG LINKERD_VALIDATOR_VERSION=v0.1.2
 RUN bin/scurl -o linkerd-network-validator https://github.com/linkerd/linkerd2-proxy-init/releases/download/validator%2F${LINKERD_VALIDATOR_VERSION}/linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH} && chmod +x linkerd-network-validator
 
 ## compile proxy-identity agent

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -253,7 +253,7 @@ Kubernetes: `>=1.21.0-0`
 | proxyInit.ignoreOutboundPorts | string | `"4567,4568"` | Default set of outbound ports to skip via iptables - Galera (4567,4568) |
 | proxyInit.image.name | string | `"cr.l5d.io/linkerd/proxy-init"` | Docker image for the proxy-init container |
 | proxyInit.image.pullPolicy | string | imagePullPolicy | Pull policy for the proxy-init container Docker image |
-| proxyInit.image.version | string | `"v2.2.0"` | Tag for the proxy-init container Docker image |
+| proxyInit.image.version | string | `"v2.2.1"` | Tag for the proxy-init container Docker image |
 | proxyInit.iptablesMode | string | `"legacy"` | Variant of iptables that will be used to configure routing. Currently, proxy-init can be run either in 'nft' or in 'legacy' mode. The mode will control which utility binary will be called. The host must support whichever mode will be used |
 | proxyInit.kubeAPIServerPorts | string | `"443,6443"` | Default set of ports to skip via iptables for control plane components so they can communicate with the Kubernetes API Server |
 | proxyInit.logFormat | string | plain | Log format (`plain` or `json`) for the proxy-init |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -211,7 +211,7 @@ proxyInit:
     # @default -- imagePullPolicy
     pullPolicy: ""
     # -- Tag for the proxy-init container Docker image
-    version: v2.2.0
+    version: v2.2.1
   resources:
     cpu:
       # -- Maximum amount of CPU units that the proxy-init container can use

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -31,7 +31,7 @@ Kubernetes: `>=1.21.0-0`
 | ignoreOutboundPorts | string | `""` | Default set of outbound ports to skip via iptables |
 | image.name | string | `"cr.l5d.io/linkerd/cni-plugin"` | Docker image for the CNI plugin |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the linkerd-cni container |
-| image.version | string | `"v1.0.0"` | Tag for the CNI container Docker image |
+| image.version | string | `"v1.1.0"` | Tag for the CNI container Docker image |
 | imagePullSecrets | string | `nil` |  |
 | inboundProxyPort | int | `4143` | Inbound port for the proxy container |
 | logLevel | string | `"info"` | Log level for the CNI plugin |

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -53,7 +53,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.0.0"
+  version: "v1.1.0"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -14,7 +14,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 
 	image := cniPluginImage{
 		name:       "my-docker-registry.io/awesome/cni-plugin-test-image",
-		version:    "v1.0.0",
+		version:    "v1.1.0",
 		pullPolicy: nil,
 	}
 	fullyConfiguredOptions := &cniPluginOptions{

--- a/cli/cmd/install_cni_helm_test.go
+++ b/cli/cmd/install_cni_helm_test.go
@@ -35,7 +35,7 @@ func TestRenderCniHelm(t *testing.T) {
   			"logLevel": "debug",
 			"image": {
 				"name": "cr.l5d.io/linkerd/cni-plugin",
-				"version": "v1.0.0"
+				"version": "v1.1.0"
 			},
   			"proxyUID": 1111,
   			"destCNINetDir": "/etc/cni/net.d-test",

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -167,7 +167,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -167,7 +167,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -376,7 +376,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -167,7 +167,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -207,7 +207,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -178,7 +178,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -398,7 +398,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -618,7 +618,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -838,7 +838,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -178,7 +178,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -181,7 +181,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -170,7 +170,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -191,7 +191,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -195,7 +195,7 @@ spec:
         - 4190,9998,7777,8888
         - --outbound-ports-to-ignore
         - "9999"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -178,7 +178,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -398,7 +398,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -183,7 +183,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -178,7 +178,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -179,7 +179,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -179,7 +179,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -179,7 +179,7 @@ spec:
         - 4190,1234,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -180,7 +180,7 @@ spec:
         - 4190,4191,22,8100-8102
         - --outbound-ports-to-ignore
         - "5432"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -180,7 +180,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -180,7 +180,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.2.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -394,7 +394,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.2.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -180,7 +180,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.2.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -394,7 +394,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.2.1
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -162,7 +162,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.2.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -165,7 +165,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.2.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -164,7 +164,7 @@ spec:
     - 4190,4191,22,8100-8102
     - --outbound-ports-to-ignore
     - "5432"
-    image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.2.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -173,7 +173,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.2.1
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -179,7 +179,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -180,7 +180,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -402,7 +402,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -232,7 +232,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -119,7 +119,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.0.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.1.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -120,7 +120,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.0.0
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.1.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -120,7 +120,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.0.0
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.1.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -120,7 +120,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.0.0
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.1.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -120,7 +120,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.0.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.1.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -112,7 +112,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.0.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.1.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -113,7 +113,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.0.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.1.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -961,7 +961,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1422,7 +1422,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1755,7 +1755,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -960,7 +960,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1420,7 +1420,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1753,7 +1753,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: my.custom.registry/linkerd-io/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -960,7 +960,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.2.0
+        image: my.custom.registry/linkerd-io/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1420,7 +1420,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.2.0
+        image: my.custom.registry/linkerd-io/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1753,7 +1753,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.2.0
+        image: my.custom.registry/linkerd-io/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -960,7 +960,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1420,7 +1420,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1753,7 +1753,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -960,7 +960,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1420,7 +1420,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1753,7 +1753,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -958,7 +958,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1409,7 +1409,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1733,7 +1733,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -626,7 +626,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1042,7 +1042,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1548,7 +1548,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1917,7 +1917,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -626,7 +626,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1042,7 +1042,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1548,7 +1548,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1917,7 +1917,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -530,7 +530,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -891,7 +891,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1351,7 +1351,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1625,7 +1625,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -960,7 +960,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1420,7 +1420,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1753,7 +1753,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -599,7 +599,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.2.0
+        version: v2.2.1
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -960,7 +960,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1420,7 +1420,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1753,7 +1753,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.2.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.2.1
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cni-plugin/test/install-cni_test.go
+++ b/cni-plugin/test/install-cni_test.go
@@ -147,7 +147,7 @@ func populateK8sCreds(wd string, tempK8sSvcAcctDir string, t *testing.T) {
 
 // startDocker starts a test Docker container and runs the install-cni.sh script.
 func startDocker(testNum int, wd string, testWorkRootDir string, tempCNINetDir string, tempCNIBinDir string, tempK8sSvcAcctDir string, t *testing.T) string {
-	dockerImage := env("HUB", "cr.l5d.io/linkerd") + "/cni-plugin:" + env("CNI_PLUGIN_VERSION", "v1.0.0")
+	dockerImage := env("HUB", "cr.l5d.io/linkerd") + "/cni-plugin:" + env("CNI_PLUGIN_VERSION", "v1.1.0")
 	errFileName := testWorkRootDir + "/docker_run_stderr"
 
 	// Build arguments list by picking whatever is necessary from the environment.

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -58,7 +58,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.2.0",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.2.1",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -68,7 +68,7 @@
         "--outbound-ports-to-ignore",
         "34567"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.2.0",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.2.1",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -58,7 +58,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.2.0",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.2.1",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -1763,7 +1763,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
   proxy: |
-    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v2.2.0","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
+    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v2.2.1","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
   install: |
     {"cliVersion":"dev-undefined","flags":[]}
   values: |
@@ -1916,7 +1916,7 @@ data:
   global: |
     {"linkerdNamespace":"linkerd","cniEnabled":false,"version":"install-control-plane-version","identityContext":{"trustDomain":"cluster.local","trustAnchorsPem":"fake-trust-anchors-pem","issuanceLifetime":"86400s","clockSkewAllowance":"20s"}}
   proxy: |
-    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v2.2.0","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
+    {"proxyImage":{"imageName":"cr.l5d.io/linkerd/proxy","pullPolicy":"IfNotPresent"},"proxyInitImage":{"imageName":"cr.l5d.io/linkerd/proxy-init","pullPolicy":"IfNotPresent"},"controlPort":{"port":4190},"ignoreInboundPorts":[],"ignoreOutboundPorts":[],"inboundPort":{"port":4143},"adminPort":{"port":4191},"outboundPort":{"port":4140},"resource":{"requestCpu":"","requestMemory":"","limitCpu":"","limitMemory":""},"proxyUid":"2102","logLevel":{"level":"warn,linkerd=info"},"disableExternalProfiles":true,"proxyVersion":"install-proxy-version","proxy_init_image_version":"v2.2.1","debugImage":{"imageName":"cr.l5d.io/linkerd/debug","pullPolicy":"IfNotPresent"},"debugImageVersion":"install-debug-version"}
   install: |
     {"cliVersion":"dev-undefined","flags":[]}
   values: |
@@ -2422,7 +2422,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.0.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.1.0
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,8 +15,8 @@ var Version = undefinedVersion
 // ProxyInitVersion is the pinned version of the proxy-init, from
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
-var ProxyInitVersion = "v2.2.0"
-var LinkerdCNIVersion = "v1.0.0"
+var ProxyInitVersion = "v2.2.1"
+var LinkerdCNIVersion = "v1.1.0"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to

--- a/test/integration/multicluster/install_test.go
+++ b/test/integration/multicluster/install_test.go
@@ -110,7 +110,7 @@ func TestInstall(t *testing.T) {
 		"install",
 		"--controller-log-level", "debug",
 		"--set", "proxyInit.image.name=ghcr.io/linkerd/proxy-init",
-		"--set", "proxyInit.image.version=v2.2.0",
+		"--set", "proxyInit.image.version=v2.2.1",
 		"--set", fmt.Sprintf("proxy.image.version=%s", TestHelper.GetVersion()),
 		"--set", "heartbeatSchedule=1 2 3 4 5",
 		"--identity-trust-anchors-file", rootPath,

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -160,7 +160,7 @@ Kubernetes: `>=1.21.0-0`
 | tap.caBundle | string | `""` | Bundle of CA certificates for tap. If not provided nor injected with cert-manager, then Helm will use the certificate generated for `tap.crtPEM`. If `tap.externalSecret` is set to true, this value, injectCaFrom, or injectCaFromSecret must be set, as no certificate will be generated. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector) for more information. |
 | tap.crtPEM | string | `""` | Certificate for the Tap component. If not provided and not using an external secret then Helm will generate one. |
 | tap.externalSecret | bool | `false` | Do not create a secret resource for the Tap component. If this is set to `true`, the value `tap.caBundle` must be set or the ca bundle must injected with cert-manager ca injector using `tap.injectCaFrom` or `tap.injectCaFromSecret` (see below). |
-| tap.ignoreHeaders | list | `[]` |  |
+| tap.ignoreHeaders | list | `[]` | List of headers that will be ignored for Linkerd Tap |
 | tap.image.name | string | `"tap"` | Docker image name for the tap instance |
 | tap.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the tap component |
 | tap.image.registry | string | defaultRegistry | Docker registry for the tap instance |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -160,7 +160,7 @@ Kubernetes: `>=1.21.0-0`
 | tap.caBundle | string | `""` | Bundle of CA certificates for tap. If not provided nor injected with cert-manager, then Helm will use the certificate generated for `tap.crtPEM`. If `tap.externalSecret` is set to true, this value, injectCaFrom, or injectCaFromSecret must be set, as no certificate will be generated. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector) for more information. |
 | tap.crtPEM | string | `""` | Certificate for the Tap component. If not provided and not using an external secret then Helm will generate one. |
 | tap.externalSecret | bool | `false` | Do not create a secret resource for the Tap component. If this is set to `true`, the value `tap.caBundle` must be set or the ca bundle must injected with cert-manager ca injector using `tap.injectCaFrom` or `tap.injectCaFromSecret` (see below). |
-| tap.ignoreHeaders | list | `[]` | List of headers to be ignored by Linkerd Tap. Ignore auth tokens written in plain text or irrelevant cookies.
+| tap.ignoreHeaders | list | `[]` |  |
 | tap.image.name | string | `"tap"` | Docker image name for the tap instance |
 | tap.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the tap component |
 | tap.image.registry | string | defaultRegistry | Docker registry for the tap instance |

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -204,7 +204,7 @@ tap:
       # -- Amount of ephemeral storage that the tap container requests
       request: ""
 
-  # List of headers that will be ignored for Linkerd Tap
+  # -- List of headers that will be ignored for Linkerd Tap
   ignoreHeaders: []
 
   proxy:


### PR DESCRIPTION
proxy-init v2.2.1:
* Sanitize `subnets-to-ignore` flag
* Dep bumps

cni-plugin v1.1.0:
* Add support for the `config.linkerd.io/skip-subnets` annotation
* Dep bumps

validator v0.1.2:
* Dep bumps

Also, `linkerd-network-validator` is now released wrapped in a tar file, so this PR also amends `Dockerfile-proxy` to account for that.
