### PR TITLE
policy: add end-to-end test for failure accrual

### DIFF
--- a/policy-test/src/bb.rs
+++ b/policy-test/src/bb.rs
@@ -15,6 +15,8 @@ impl Terminus {
     const APP: &str = "bb-terminus";
     pub const SERVICE_NAME: &str = Self::APP;
 
+    /// Builds a `bb-terminus` pod that can be configured to fail some (or all)
+    /// requests.
     pub fn new(ns: impl ToString) -> Self {
         Self {
             name: "bb-terminus".to_string(),
@@ -32,6 +34,7 @@ impl Terminus {
         }
     }
 
+    /// Sets the `bb-terminus` pod's name. By default, the name is "bb-terminus".
     pub fn named(self, name: impl ToString) -> Self {
         Self {
             name: name.to_string(),
@@ -39,6 +42,7 @@ impl Terminus {
         }
     }
 
+    /// Returns the constructed [`k8s::Pod`].
     pub fn to_pod(self) -> k8s::Pod {
         let args = [
             "terminus",
@@ -83,6 +87,8 @@ impl Terminus {
         }
     }
 
+    /// Returns a ClusterIP [`k8s::api::core::v1::Service`] that selects pods
+    /// with the label `app: bb-terminus`.
     pub fn service(ns: &str) -> k8s::api::core::v1::Service {
         k8s::api::core::v1::Service {
             metadata: k8s::ObjectMeta {

--- a/policy-test/src/bb.rs
+++ b/policy-test/src/bb.rs
@@ -1,0 +1,108 @@
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use linkerd_policy_controller_k8s_api::{self as k8s};
+use maplit::{btreemap, convert_args};
+
+#[derive(Debug, Clone)]
+pub struct Terminus {
+    name: String,
+    ns: String,
+    percent_failure: usize,
+}
+
+impl Terminus {
+    const PORT: i32 = 80;
+    const PORT_NAME: &str = "http";
+    const APP: &str = "bb-terminus";
+    pub const SERVICE_NAME: &str = Self::APP;
+
+    pub fn new(ns: impl ToString) -> Self {
+        Self {
+            name: "bb-terminus".to_string(),
+            ns: ns.to_string(),
+            percent_failure: 0,
+        }
+    }
+
+    #[track_caller]
+    pub fn percent_failure(self, percent_failure: usize) -> Self {
+        assert!(percent_failure <= 100);
+        Self {
+            percent_failure,
+            ..self
+        }
+    }
+
+    pub fn named(self, name: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            ..self
+        }
+    }
+
+    pub fn to_pod(self) -> k8s::Pod {
+        let args = [
+            "terminus",
+            "--h1-server-port",
+            "80",
+            "--response-text",
+            &self.name,
+            "--percent-failure",
+            &self.percent_failure.to_string(),
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        k8s::Pod {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(self.ns),
+                name: Some(self.name),
+                annotations: Some(convert_args!(btreemap!(
+                    "linkerd.io/inject" => "enabled",
+                    "config.linkerd.io/proxy-log-level" => "linkerd=trace,info",
+                ))),
+                labels: Some(convert_args!(btreemap!(
+                    "app" => Self::APP,
+                ))),
+                ..Default::default()
+            },
+            spec: Some(k8s::PodSpec {
+                containers: vec![k8s::api::core::v1::Container {
+                    name: "bb-terminus".to_string(),
+                    image: Some("buoyantio/bb:latest".to_string()),
+                    ports: Some(vec![k8s::api::core::v1::ContainerPort {
+                        name: Some(Self::PORT_NAME.to_string()),
+                        container_port: Self::PORT,
+                        ..Default::default()
+                    }]),
+                    args: Some(args),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..k8s::Pod::default()
+        }
+    }
+
+    pub fn service(ns: &str) -> k8s::api::core::v1::Service {
+        k8s::api::core::v1::Service {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.to_string()),
+                name: Some(Self::SERVICE_NAME.to_string()),
+                ..Default::default()
+            },
+            spec: Some(k8s::api::core::v1::ServiceSpec {
+                type_: Some("ClusterIP".to_string()),
+                selector: Some(convert_args!(btreemap!(
+                    "app" => Self::APP,
+                ))),
+                ports: Some(vec![k8s::api::core::v1::ServicePort {
+                    port: Self::PORT,
+                    target_port: Some(IntOrString::String(Self::PORT_NAME.to_string())),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+}

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -111,8 +111,7 @@ impl Runner {
                 containers: vec![k8s::api::core::v1::Container {
                     name: "curl".to_string(),
                     image: Some(Self::CURL_IMAGE.to_string()),
-                    command: Some(vec!["sh".to_string(), "-c".to_string()]),
-                    args: Some(vec!["while true; do sleep 60; done".to_string()]),
+                    command: Some(vec!["sleep".to_string(), "infinite".to_string()]),
                     ..Default::default()
                 }],
                 restart_policy: Some("Never".to_string()),

--- a/policy-test/src/web.rs
+++ b/policy-test/src/web.rs
@@ -17,23 +17,19 @@ pub fn pod(ns: &str) -> k8s::Pod {
             ..Default::default()
         },
         spec: Some(k8s::PodSpec {
-            containers: vec![hokay_container()],
+            containers: vec![k8s::api::core::v1::Container {
+                name: "hokay".to_string(),
+                image: Some("ghcr.io/olix0r/hokay:latest".to_string()),
+                ports: Some(vec![k8s::api::core::v1::ContainerPort {
+                    name: Some("http".to_string()),
+                    container_port: 8080,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }],
             ..Default::default()
         }),
         ..k8s::Pod::default()
-    }
-}
-
-pub fn hokay_container() -> k8s::api::core::v1::Container {
-    k8s::api::core::v1::Container {
-        name: "hokay".to_string(),
-        image: Some("ghcr.io/olix0r/hokay:latest".to_string()),
-        ports: Some(vec![k8s::api::core::v1::ContainerPort {
-            name: Some("http".to_string()),
-            container_port: 8080,
-            ..Default::default()
-        }]),
-        ..Default::default()
     }
 }
 

--- a/policy-test/src/web.rs
+++ b/policy-test/src/web.rs
@@ -17,19 +17,23 @@ pub fn pod(ns: &str) -> k8s::Pod {
             ..Default::default()
         },
         spec: Some(k8s::PodSpec {
-            containers: vec![k8s::api::core::v1::Container {
-                name: "hokay".to_string(),
-                image: Some("ghcr.io/olix0r/hokay:latest".to_string()),
-                ports: Some(vec![k8s::api::core::v1::ContainerPort {
-                    name: Some("http".to_string()),
-                    container_port: 8080,
-                    ..Default::default()
-                }]),
-                ..Default::default()
-            }],
+            containers: vec![hokay_container()],
             ..Default::default()
         }),
         ..k8s::Pod::default()
+    }
+}
+
+pub fn hokay_container() -> k8s::api::core::v1::Container {
+    k8s::api::core::v1::Container {
+        name: "hokay".to_string(),
+        image: Some("ghcr.io/olix0r/hokay:latest".to_string()),
+        ports: Some(vec![k8s::api::core::v1::ContainerPort {
+            name: Some("http".to_string()),
+            container_port: 8080,
+            ..Default::default()
+        }]),
+        ..Default::default()
     }
 }
 

--- a/policy-test/tests/e2e_failure_accrual.rs
+++ b/policy-test/tests/e2e_failure_accrual.rs
@@ -48,8 +48,12 @@ async fn consecutive_failures() {
                 .await
                 .expect("curl command should succeed");
             tracing::info!(request, ?status, failures);
-            if status.is_server_error() {
-                failures += 1;
+
+            match status {
+                // An error was returned by the failing endpoint.
+                hyper::StatusCode::INTERNAL_SERVER_ERROR => failures += 1,
+                hyper::StatusCode::OK => {},
+                other => panic!("unexpected status code {other}"),
             }
         }
 

--- a/policy-test/tests/e2e_failure_accrual.rs
+++ b/policy-test/tests/e2e_failure_accrual.rs
@@ -22,6 +22,7 @@ async fn consecutive_failures() {
             annotate_service(svc, maplit::btreemap!{
                 "balancer.linkerd.io/failure-accrual" => "consecutive".to_string(),
                 "balancer.linkerd.io/failure-accrual-consecutive-max-failures" => MAX_FAILS.to_string(),
+                // don't allow the failing pod to enter probation during the test.
                 "balancer.linkerd.io/failure-accrual-consecutive-min-penalty" => "5m".to_string(),
                 "balancer.linkerd.io/failure-accrual-consecutive-max-penalty" => "10m".to_string(),
             })
@@ -52,7 +53,7 @@ async fn consecutive_failures() {
             }
         }
 
-        assert!(failures <= MAX_FAILS);
+        assert!(failures <= MAX_FAILS, "no more than {MAX_FAILS} requests may fail");
     })
     .await;
 }

--- a/policy-test/tests/e2e_failure_accrual.rs
+++ b/policy-test/tests/e2e_failure_accrual.rs
@@ -1,0 +1,50 @@
+use kube::ResourceExt;
+use linkerd_policy_controller_k8s_api::{
+    self as k8s,
+    policy::{LocalTargetRef, NamespacedTargetRef},
+};
+use linkerd_policy_test::{create, create_ready_pod, curl, web, with_temp_ns, LinkerdInject};
+
+#[tokio::test(flavor = "current_thread")]
+async fn consecutive_failures() {
+    with_temp_ns(|client, ns| async move {
+        // Create a web service with two pods, one of which always returns 204
+        // No Content, and the other of which always returns 500 Internal Server
+        // Error;
+        let good_pod = {
+            let mut pod = web::pod(&ns);
+            pod.metadata.name = Some("web-good".to_string());
+            pod
+        };
+        let bad_pod = {
+            let mut pod = web::pod(&ns);
+            pod.metadata.name = Some("web-bad".to_string());
+            pod.spec = Some(k8s::PodSpec {
+                containers: vec![k8s::api::core::v1::Container {
+                    // Always return 500s.
+                    args: Some(vec!["--status".to_string(), "500".to_string()]),
+                    ..web::hokay_container()
+                }],
+                ..Default::default()
+            });
+            pod
+        };
+        tokio::join!(
+            create(&client, web::service(&ns)),
+            create_ready_pod(&client, good_pod),
+            // create_ready_pod(&client, bad_pod),
+        );
+
+        let curl = curl::Runner::init(&client, &ns)
+            .await
+            .run_execable("curl", LinkerdInject::Enabled)
+            .await;
+        let status = curl
+            .curl("http://web")
+            .await
+            .expect("curl command should succeed");
+        tracing::info!(?status);
+        assert_eq!(status, "204")
+    })
+    .await;
+}

--- a/policy-test/tests/e2e_failure_accrual.rs
+++ b/policy-test/tests/e2e_failure_accrual.rs
@@ -7,6 +7,7 @@ use linkerd_policy_test::{create, create_ready_pod, curl, web, with_temp_ns, Lin
 
 #[tokio::test(flavor = "current_thread")]
 async fn consecutive_failures() {
+    const MAX_FAILS: usize = 5;
     with_temp_ns(|client, ns| async move {
         // Create a web service with two pods, one of which always returns 204
         // No Content, and the other of which always returns 500 Internal Server


### PR DESCRIPTION
This branch adds an end-to-end test for failure accrual. This test
exercises the entire flow for circuit breaking, including discovering
failure accrual configuration from Service annotations and the actual
behavior of the proxy. This test does *not* exercise probation and
recovery. Instead, it asserts that once an endpoint's circuit breaker
trips, no subsequent requests are sent to that endpoint.

This test is implemented using `bb` to create a `Service` backed by an
endpoints, which always returns`500 Internal Server Error`. New test
support code is added for constructing `bb-terminus` Pods and Services.
The client is an injected `curl` pod. The existing test support code for
running `curl` doesn't quite work for this test, as the current
`curl::Runner::run` function creates a `curl` pod that executes a
_single_ `curl` command and exits. Since we need to test the client's
failure accrual behavior (which requires the _same_ client to issue
multiple requests), we add a new `curl::Runner::run_execable` method,
which creates a single `curl` pod that doesn't actually make any HTTP
requests and instead just sleeps forever. A handle to that pod is then
used to `kubectl exec` multiple `curl` commands inside the `curl`
container. We inject the `curl` pod with the proxy, annotate the
`bb-terminus` Service with failure accrual annotations (with a limit of
5 consecutive failures), and then execute 10 requests to `bb-terminus`
in the `curl` container. We assert that only the first 5 of the 10
requests fail with 500s from the `bb-terminus` backend, and that the
remainder fail with 503/504s due to the proxy's load balancer having no
ready endpoints. This ensures that the circuit breaker prevents
subsequent requests from being sent to the failing endpoint.