### PR TITLE
edge-23.4.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,13 @@
 
 ## edge-23.4.1
 
-This edge release introduces request-level HTTP circuit-breaking using a
-consecutive failures failure accrual policy. Circuit breaking can be configured
-by adding failure accrual annotations to a Service.
+This is a release candidate for stable-2.13.0 &mdash; we encourage you to help
+try it out!
 
-In addition, this release adds new `outbound_route_backend_http_requests_total` and
+This edge release introduces request-level HTTP circuit-breaking
+using a consecutive failures failure accrual policy. Circuit breaking can be
+configured by adding failure accrual annotations to a Service. In addition, this
+release adds new `outbound_route_backend_http_requests_total` and
 `outbound_route_backend_grpc_requests_total` proxy metrics, which can be
 used to track how routing rules and backend distributions apply to
 requests. These metrics contain labels describing the route's parent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,8 +33,8 @@ resource being used by each request.
 * Viz
   * Added `tap.ignoredHeaders` Helm value to the linkerd-viz chart. This value
     allows users to specify a comma-separated list of header names which will be
-    ignored by Linkerd Tap
-  * Removed duplicate SecurityContext in Prometheus chart
+    ignored by Linkerd Tap (thanks @ryanhristovski!)
+  * Removed duplicate SecurityContext in Prometheus manifest
 
 * Multicluster
   * Removed duplicate AuthorizationPolicy for probes from the multicluster

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,43 @@
 # Changes
 
+## edge-23.4.1
+
+This edge release introduces request-level HTTP circuit-breaking using a
+consecutive failures failure accrual policy. Circuit breaking can be configured
+by adding failure accrual annotations to a Service.
+
+In addition, this release adds new `outbound_route_backend_http_requests_total` and
+`outbound_route_backend_grpc_requests_total` proxy metrics, which can be
+used to track how routing rules and backend distributions apply to
+requests. These metrics contain labels describing the route's parent
+(i.e. a Service), the route resource being used, and the backend
+resource being used by each request.
+
+* Proxy
+  * Added discovery of failure accrual policies from the OutboundPolicy API
+  * Implemented consecutive failures failure accrual policy
+  * Added INFO-level logging on failure accrual changes
+  * Added `outbound_route_backend_http_requests_total` and
+    `outbound_route_backend_grpc_requests_total` metrics
+
+* Policy Controller
+  * Added failure accrual configuration to the OutboundPolicy API
+  * Added Prometheus `/metrics` endpoint to the admin server, with process
+    metrics
+  * Changed the policy controller to only accept HTTPRoutes when the parentRef
+    is a ClusterIP Service
+  * Added ports to service references in the OutboundPolicy API
+
+* Viz
+  * Added `tap.ignoredHeaders` Helm value to the linkerd-viz chart. This value
+    allows users to specify a comma-separated list of header names which will be
+    ignored by Linkerd Tap
+  * Removed duplicate SecurityContext in Prometheus chart
+
+* Multicluster
+  * Removed duplicate AuthorizationPolicy for probes from the multicluster
+    gateway Helm chart
+
 ## edge-23.3.4
 
 This edge release further enhances the OutboundPolicies API used by the proxy to

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.11.9-edge
+version: 1.11.10-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.11.9-edge](https://img.shields.io/badge/Version-1.11.9--edge-informational?style=flat-square)
+![Version: 1.11.10-edge](https://img.shields.io/badge/Version-1.11.10--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.7.5-edge
+version: 30.7.6-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.7.5-edge](https://img.shields.io/badge/Version-30.7.5--edge-informational?style=flat-square)
+![Version: 30.7.6-edge](https://img.shields.io/badge/Version-30.7.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.7.8-edge
+version: 30.7.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.7.8-edge](https://img.shields.io/badge/Version-30.7.8--edge-informational?style=flat-square)
+![Version: 30.7.9-edge](https://img.shields.io/badge/Version-30.7.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.6.5-edge
+version: 30.6.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.6.5-edge](https://img.shields.io/badge/Version-30.6.5--edge-informational?style=flat-square)
+![Version: 30.6.6-edge](https://img.shields.io/badge/Version-30.6.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.7.2-edge
+version: 30.7.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.7.2-edge](https://img.shields.io/badge/Version-30.7.2--edge-informational?style=flat-square)
+![Version: 30.7.3-edge](https://img.shields.io/badge/Version-30.7.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
# edge-23.4.1

This edge release introduces request-level HTTP circuit-breaking using a
consecutive failures failure accrual policy. Circuit breaking can be
configured by adding failure accrual annotations to a Service.

In addition, this release adds new
`outbound_route_backend_http_requests_total` and
`outbound_route_backend_grpc_requests_total` proxy metrics, which can be
used to track how routing rules and backend distributions apply to
requests. These metrics contain labels describing the route's parent
(i.e. a Service), the route resource being used, and the backend
resource being used by each request.

* Proxy
  * Added discovery of failure accrual policies from the OutboundPolicy
    API
  * Implemented consecutive failures failure accrual policy
  * Added INFO-level logging on failure accrual changes
  * Added `outbound_route_backend_http_requests_total` and
    `outbound_route_backend_grpc_requests_total` metrics

* Policy Controller
  * Added failure accrual configuration to the OutboundPolicy API
  * Added Prometheus `/metrics` endpoint to the admin server, with
    process metrics
  * Changed the policy controller to only accept HTTPRoutes when the
    parentRef is a ClusterIP Service
  * Added ports to service references in the OutboundPolicy API

* Viz
  * Added `tap.ignoredHeaders` Helm value to the linkerd-viz chart. This
    value allows users to specify a comma-separated list of header names
    which will be ignored by Linkerd Tap
  * Removed duplicate SecurityContext in Prometheus chart

* Multicluster
  * Removed duplicate AuthorizationPolicy for probes from the
    multicluster gateway Helm chart