### PR TITLE
Add podAnnotations option to linkerd-multicluster-link chart

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -33,6 +33,7 @@ Kubernetes: `>=1.21.0-0`
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
 | nodeSelector | object | `{}` | Node selectors for the Service mirror pod |
+| podAnnotations | object | `{}` | Additional annotations to add to all pods |
 | podLabels | object | `{}` | Additional labels to add to all pods |
 | resources | object | `{}` | Resources for the Service mirror container |
 | serviceMirrorRetryLimit | int | `3` | Number of times update from the remote cluster is allowed to be requeued (retried) |

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -105,6 +105,7 @@ spec:
         linkerd.io/inject: enabled
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
+        {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
         component: linkerd-service-mirror
         mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -3,6 +3,8 @@
 controllerImage: cr.l5d.io/linkerd/controller
 # -- Tag for the Service Mirror container Docker image
 controllerImageVersion: linkerdVersionValue
+# -- Additional annotations to add to all pods
+podAnnotations: {}
 # -- Additional labels to add to all pods
 podLabels: {}
 # -- Labels to apply to all resources


### PR DESCRIPTION
The linkerd-multicluster-link chart provides no option to add additional user defined pod annotations.

This change brings the linkerd-multicluster-link chart in line with other charts that expose the podAnnotation option in the helm values.yaml.

This change was tested by rendering the chart locally:

```sh
helm template link multicluster/charts/linkerd-multicluster-link \
  --set 'podAnnotations.config\.linkerd\.io\/test1=banana'  \
  --set 'podAnnotations.config\.linkerd\.io\/test2=apple'
```

Which produces this kubernetes manifest snippet:

```yaml
apiVersion: apps/v1
kind: Deployment
spec:
  template:
    metadata:
      annotations:
        linkerd.io/inject: enabled
        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
        config.linkerd.io/test1: banana
        config.linkerd.io/test2: apple
```

Fixes #10674 