### PR TITLE
charts: fix uninstall issue

### DIFF
--- a/charts/linkerd-crds/templates/policy/httproute.yaml
+++ b/charts/linkerd-crds/templates/policy/httproute.yaml
@@ -2,9 +2,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-
-  creationTimestamp: null
   name: httproutes.policy.linkerd.io
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    linkerd.io/control-plane-ns: {{.Release.Namespace}}
 spec:
   group: policy.linkerd.io
   names:


### PR DESCRIPTION
Now we use label to filter all resources to uninstall, but `httproutes.policy.linkerd.io` does not have label, so every uninstall would not remove it.

