### PR TITLE
Fix typo in resource name for prune

### DIFF
--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -43,7 +43,7 @@ var prunableNamespaceResources []schema.GroupVersionResource = []schema.GroupVer
 	apps.SchemeGroupVersion.WithResource("deployments"),
 	batch.SchemeGroupVersion.WithResource("jobs"),
 	policy.SchemeGroupVersion.WithResource("meshtlsauthentications"),
-	policy.SchemeGroupVersion.WithResource("networkauthentication"),
+	policy.SchemeGroupVersion.WithResource("networkauthentications"),
 	core.SchemeGroupVersion.WithResource("replicationcontrollers"),
 	core.SchemeGroupVersion.WithResource("secrets"),
 	core.SchemeGroupVersion.WithResource("services"),


### PR DESCRIPTION
A typo in the resource name `networkauthentication` (should have been `networkauthentications`) was causing `linkerd prune` (and similar extension prune commands) to not prune NetworkAuthentications.

Fix the typo.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
