### PR TITLE
Remove namespace field from cluster scoped resources

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
@@ -9,7 +9,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{.}}
-  namespace: {{$.Release.Namespace}}
   labels:
     linkerd.io/extension: multicluster
     {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -55,7 +54,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{.}}
-  namespace: {{$.Release.Namespace}}
   labels:
     linkerd.io/extension: multicluster
     {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -166,7 +166,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: linkerd-service-mirror-remote-access-default
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:
@@ -209,7 +208,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: linkerd-service-mirror-remote-access-default
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -237,7 +237,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: linkerd-service-mirror-remote-access-default
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:
@@ -280,7 +279,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: linkerd-service-mirror-remote-access-default
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -200,7 +200,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: linkerd-service-mirror-remote-access-default
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:
@@ -243,7 +242,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: linkerd-service-mirror-remote-access-default
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/pull/9351 added a namespace field onto some ClusterRole and ClusterRoleBinding resources in the linkerd-multicluster extension.  This was causing the resources in the templates to not match the resources installed in the cluster when compared by name/namespace and causing `linkerd mc prune` to flag those resources for deletion even though they exist in the template.

We remove the namespace field from cluster scoped resources.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
