### PR TITLE
ci: allow `nextest` to retry policy test failures

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -210,6 +210,11 @@ jobs:
           done
           exit 1
       - run: just policy-test-run --jobs=1
+        env:
+          # End-to-end integration tests involve a large number of moving parts
+          # and sometimes exhibit flaky failures. Allow nextest to retry these
+          # tests a few times before failing.
+          NEXTEST_RETRIES: 5
 
   ##
   ## Ext: Run tests that require non-core components.


### PR DESCRIPTION
End-to-end integration tests like these involve a large number of moving parts (running an entire Kubernetes cluster with multiple pods), and sometimes exhibit flaky failures. While a failing test job can be manually restarted on GitHub Actions, it's more convenient to not have to do this.

`cargo nextest` supports [automatic retries] for flaky tests. This commit enables `nextest` retries when running the policy integration tests, so that we hopefully end up needing to restart fewer CI runs.

[automatic retries]: https://nexte.st/book/retries.html