### PR TITLE
Explicitly use bash when using pipes in CI workflows

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
       - name: Yarn setup
+        shell: bash
         run: bin/scurl -o- https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
       - name: Unit tests
         run: |
@@ -54,7 +55,8 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
-      - run: mkdir -p target && cd target && bin/scurl -v https://github.com/xd009642/tarpaulin/releases/download/0.18.0/cargo-tarpaulin-0.18.0-travis.tar.gz | tar zxvf - && chmod 755 cargo-tarpaulin
+      - shell: bash
+        run: mkdir -p target && cd target && bin/scurl -v https://github.com/xd009642/tarpaulin/releases/download/0.18.0/cargo-tarpaulin-0.18.0-travis.tar.gz | tar zxvf - && chmod 755 cargo-tarpaulin
       - run: target/cargo-tarpaulin tarpaulin --workspace --out Xml
       - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -185,6 +185,7 @@ jobs:
       - run: find image-archives -ls
       - run: cp image-archives/linkerd "$HOME" && chmod 755 "$HOME/linkerd"
       - name: Setup deps
+        shell: bash
         run: |
           rm -rf "$HOME/.cargo"
           bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain "$(cat rust-toolchain)"
@@ -367,6 +368,7 @@ jobs:
       - run: cp image-archives/linkerd "$HOME" && chmod 755 "$HOME/linkerd"
       - run: ls -l image-archives/linkerd
       - name: Setup deps
+        shell: bash
         run: |
           echo "PATH=$PATH" >> "$GITHUB_ENV"
           bin/scurl -v "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | bash

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f
     - name: Yarn setup
+      shell: bash
       run: |
         bin/scurl --retry=2 https://yarnpkg.com/install.sh | bash -s -- --version 1.21.1 --network-concurrency 1
         echo PATH="$HOME/.yarn/bin:$PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8
       - name: Setup k3d
+        shell: bash
         run: |
           mkdir -p "$PWD/target/bin"
           PATH=$PATH:"$PWD/target/bin"
@@ -290,6 +291,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/edge')
       run: echo "INSTALL=install-edge" >> "$GITHUB_ENV"
     - name: Check published version
+      shell: bash
       run: |
         TAG='${{ needs.tag.outputs.tag }}'
         until RES=$(bin/scurl "https://run.linkerd.io/$INSTALL" | grep "LINKERD2_VERSION=\${LINKERD2_VERSION:-$TAG}") \


### PR DESCRIPTION
As detailed in the [docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell), not expliciting the `shell` field results in using `bash -e`, whereas expliciting it results in `bash --noprofile --norc -eo pipefail`. We'd like to have the pipefail option set whenever pipes are used. This avoids for example an issue we had recently in the release workflow where the k3d install script download was silently failing.
