### PR TITLE
update `kubert` to v0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,8 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.15.0"
-source = "git+https://github.com/olix0r/kubert?branch=main#8c582e42b6ae4aec76ac3af54e6742945d452207"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02666a25673a963105bf8a395aff94b8f56a2e709b99e8503ed9262c2a81a7b9"
 dependencies = [
  "ahash 0.8.3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ members = [
 lto = "thin"
 
 [patch.crates-io]
-kubert = { git = "https://github.com/olix0r/kubert", branch = "main" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -73,7 +73,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/linkerd/linkerd2-proxy-api",
-    "https://github.com/olix0r/kubert",
 ]
 
 [sources.allow-org]

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -45,7 +45,7 @@ default-features = false
 features = ["admission", "derive"]
 
 [dependencies.kubert]
-version = "0.15"
+version = "0.16"
 default-features = false
 features = ["clap", "index", "lease", "metrics", "runtime", "server"]
 

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -10,7 +10,7 @@ ahash = "0.8"
 anyhow = "1"
 futures = { version = "0.3", default-features = false }
 k8s-gateway-api = "0.11"
-kubert = { version = "0.15", default-features = false, features = ["index"] }
+kubert = { version = "0.16", default-features = false, features = ["index"] }
 linkerd-policy-controller-core = { path = "../../core" }
 linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -10,7 +10,7 @@ ahash = "0.8"
 anyhow = "1"
 # Fix for https://github.com/chronotope/chrono/issues/602
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
-kubert = { version = "0.15", default-features = false, features = [
+kubert = { version = "0.16", default-features = false, features = [
     "index",
     "lease",
 ] }


### PR DESCRIPTION
Now that v0.16 of `kubert` has been published to crates.io, this PR updates the dependency to use the published version.
