### PR TITLE
optimize error info

### DIFF
--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -170,7 +170,7 @@ func makeInstallUpgradeFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.Fl
 	// Hide developer focused flags in release builds.
 	release, err := version.IsReleaseChannel(version.Version)
 	if err != nil {
-		log.Errorf("Unable to parse version: %s", version.Version)
+		log.Errorf("Unable to parse version: %v", err)
 	}
 	if release {
 		installUpgradeFlags.MarkHidden("control-plane-version")
@@ -419,7 +419,7 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 	// Hide developer focused flags in release builds.
 	release, err := version.IsReleaseChannel(version.Version)
 	if err != nil {
-		log.Errorf("Unable to parse version: %s", version.Version)
+		log.Errorf("Unable to parse version: %v", err)
 	}
 	if release {
 		proxyFlags.MarkHidden("proxy-image")

--- a/multicluster/cmd/install.go
+++ b/multicluster/cmd/install.go
@@ -91,7 +91,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 	// Hide developer focused flags in release builds.
 	release, err := version.IsReleaseChannel(version.Version)
 	if err != nil {
-		log.Errorf("Unable to parse version: %s", version.Version)
+		log.Errorf("Unable to parse version: %v", err)
 	}
 	if release {
 		cmd.Flags().MarkHidden("control-plane-version")


### PR DESCRIPTION
Error log:
```
target/cli/linux-amd64/linkerd install --crds | kubectl apply -f - &&  target/cli/linux-amd64/linkerd install --set proxyInit.runAsRoot=true    --set "proxyInit.iptablesMode=nft"  --set "proxyInit.logLevel=debug,linkerd=info"   | kubectl apply -f -
ERRO[0000] Unable to parse version:
ERRO[0000] Unable to parse version:
ERRO[0000] Unable to parse version:
ERRO[0000] Unable to parse version:
ERRO[0000] Unable to parse version:
ERRO[0000] Unable to parse version:
Rendering Linkerd CRDs...
Next, run `linkerd install | kubectl apply -f -` to install the control plane.
```

Whatever the version string, the log error can be better.

If not, the `err` is not used actually.