### PR TITLE
charts: set defaultRegistry for namespace metadata

### DIFF
--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: namespace-metadata
       containers:
       - name: namespace-metadata
-        image: {{.Values.namespaceMetadata.image.registry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
+        image: {{.Values.namespaceMetadata.image.registry | default .Values.defaultRegistry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
         imagePullPolicy: {{.Values.namespaceMetadata.image.pullPolicy | default .Values.defaultImagePullPolicy}}
         securityContext:
           allowPrivilegeEscalation: false

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -378,7 +378,8 @@ dashboard:
 namespaceMetadata:
   image:
     # -- Docker registry for the namespace-metadata instance
-    registry: cr.l5d.io/linkerd
+    # @default -- defaultRegistry
+    registry: ""
     # -- Docker image name for the namespace-metadata instance
     name: extension-init
     # -- Docker image tag for the namespace-metadata instance


### PR DESCRIPTION
The namespace metadata service was not using the default registry, which was causing inconsistency with the rest of the services in the project.

Updated the namespace metadata service to use the default registry, making it consistent with the other services. 

Tested the namespace metadata service locally and verified that it is now using the default registry. Confirmed that the changes did not introduce any regressions or conflicts with other charts.

Signed-off-by: Ryan Hristovski <ryan.hristovski@docker.com>
