### PR TITLE
jaeger/charts/linkerd-jaeger: remove "/bin/sh" command for namespace metadata container

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -35,7 +35,6 @@ spec:
       - name: namespace-metadata
         image: {{.Values.namespaceMetadata.image.registry}}/{{.Values.namespaceMetadata.image.name}}:{{.Values.namespaceMetadata.image.tag}}
         imagePullPolicy: {{.Values.namespaceMetadata.image.pullPolicy | default .Values.imagePullPolicy}}
-        command: ["/bin/sh"]
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
This is required as a follow-up for https://github.com/linkerd/linkerd2/pull/10376/commits/1b5ca5b4ef2720e8d5c67b4d62853b9c67116dc2 
Switching image for namespace-metadata resulted in different container without "/bin/sh" available.

Changes in https://github.com/linkerd/linkerd2/commit/1b5ca5b4ef2720e8d5c67b4d62853b9c67116dc2 removed `/bin/sh` usage for most charts, but no jaeger one. This is resulting in container getting into `StartError` state since `/bin/sh` is not present in new image.

This PR removes invalid reference to `/bin/sh`.

Validated in local k3d cluster, pod is not getting into `StartError` state anymore.

Signed-off-by: Zakhar Bessarab <zekker6@gmail.com>
