### PR TITLE
Add log-format value to the multicluster-link helm chart

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -31,6 +31,7 @@ Kubernetes: `>=1.21.0-0`
 | enableHeadlessServices | bool | `false` | Toggle support for mirroring headless services |
 | enablePSP | bool | `false` | Create RoleBindings to associate ServiceAccount of target cluster Service Mirror to the control plane PSP resource. This requires that `enabledPSP` is set to true on the extension and control plane install. Note PSP has been deprecated since k8s v1.21 |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
+| logFormat | string | `"plain"` | Log format (`plain` or `json`) |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
 | nodeSelector | object | `{}` | Node selectors for the Service mirror pod |
 | podLabels | object | `{}` | Additional labels to add to all pods |

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -114,6 +114,7 @@ spec:
       - args:
         - service-mirror
         - -log-level={{.Values.logLevel}}
+        - -log-format={{.Values.logFormat}}
         - -event-requeue-limit={{.Values.serviceMirrorRetryLimit}}
         - -namespace={{.Release.Namespace}}
         {{- if .Values.enableHeadlessServices }}

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -15,6 +15,8 @@ gateway:
     port: 4191
 # -- Log level for the Multicluster components
 logLevel: info
+# -- Log format (`plain` or `json`)
+logFormat: plain
 # -- Node selectors for the Service mirror pod
 nodeSelector: {}
 # -- Resources for the Service mirror container

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -41,6 +41,7 @@ type (
 		gatewayNamespace        string
 		serviceMirrorRetryLimit uint32
 		logLevel                string
+		logFormat               string
 		controlPlaneVersion     string
 		dockerRegistry          string
 		selector                string
@@ -280,6 +281,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 	cmd.Flags().StringVar(&opts.gatewayNamespace, "gateway-namespace", defaultMulticlusterNamespace, "The namespace of the gateway service")
 	cmd.Flags().Uint32Var(&opts.serviceMirrorRetryLimit, "service-mirror-retry-limit", opts.serviceMirrorRetryLimit, "The number of times a failed update from the target cluster is allowed to be retried")
 	cmd.Flags().StringVar(&opts.logLevel, "log-level", opts.logLevel, "Log level for the Multicluster components")
+	cmd.Flags().StringVar(&opts.logFormat, "log-format", opts.logFormat, "Log format for the Multicluster components")
 	cmd.Flags().StringVar(&opts.dockerRegistry, "registry", opts.dockerRegistry,
 		fmt.Sprintf("Docker registry to pull service mirror controller image from ($%s)", flags.EnvOverrideDockerRegistry))
 	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter which services in the target cluster to mirror")
@@ -378,6 +380,7 @@ func newLinkOptionsWithDefault() (*linkOptions, error) {
 		dockerRegistry:          defaultDockerRegistry,
 		serviceMirrorRetryLimit: defaults.ServiceMirrorRetryLimit,
 		logLevel:                defaults.LogLevel,
+		logFormat:               defaults.LogFormat,
 		selector:                fmt.Sprintf("%s=%s", k8s.DefaultExportedServiceSelector, "true"),
 		gatewayAddresses:        "",
 		gatewayPort:             0,
@@ -398,6 +401,10 @@ func buildServiceMirrorValues(opts *linkOptions) (*multicluster.Values, error) {
 		return nil, fmt.Errorf("--log-level must be one of: panic, fatal, error, warn, info, debug")
 	}
 
+	if opts.logFormat != "plain" && opts.logFormat != "json" {
+		return nil, fmt.Errorf("--log-format must be one of: plain, json")
+	}
+
 	defaults, err := multicluster.NewLinkValues()
 	if err != nil {
 		return nil, err
@@ -410,6 +417,7 @@ func buildServiceMirrorValues(opts *linkOptions) (*multicluster.Values, error) {
 	defaults.TargetClusterName = opts.clusterName
 	defaults.ServiceMirrorRetryLimit = opts.serviceMirrorRetryLimit
 	defaults.LogLevel = opts.logLevel
+	defaults.LogFormat = opts.logFormat
 	defaults.ControllerImageVersion = opts.controlPlaneVersion
 	defaults.ControllerImage = fmt.Sprintf("%s/controller", opts.dockerRegistry)
 

--- a/multicluster/cmd/testdata/serivce_mirror_default.golden
+++ b/multicluster/cmd/testdata/serivce_mirror_default.golden
@@ -107,6 +107,7 @@ spec:
       - args:
         - service-mirror
         - -log-level=info
+        - -log-format=plain
         - -event-requeue-limit=3
         - -namespace=test
         - -enable-pprof=false

--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -28,6 +28,7 @@ type Values struct {
 	ProxyOutboundPort              uint32   `json:"proxyOutboundPort"`
 	ServiceMirror                  bool     `json:"serviceMirror"`
 	LogLevel                       string   `json:"logLevel"`
+	LogFormat                      string   `json:"logFormat"`
 	ServiceMirrorRetryLimit        uint32   `json:"serviceMirrorRetryLimit"`
 	ServiceMirrorUID               int64    `json:"serviceMirrorUID"`
 	RemoteMirrorServiceAccount     bool     `json:"remoteMirrorServiceAccount"`

--- a/test/integration/multicluster/install_test.go
+++ b/test/integration/multicluster/install_test.go
@@ -184,6 +184,7 @@ func TestLinkClusters(t *testing.T) {
 	linkCmd := []string{
 		"--context=" + contexts[testutil.TargetContextKey],
 		"multicluster", "link",
+		"--log-format", "json",
 		"--log-level", "debug",
 		"--api-server-address", fmt.Sprintf("https://%s:6443", lbIP),
 		"--cluster-name", linkName, "--set", "enableHeadlessServices=true",


### PR DESCRIPTION
Make log-format configurable on the multicluster-link helm chart

Signed-off-by: Arnaud Beun [arnaud.beun@sorare.com](mailto:arnaud.beun@sorare.com)