### PR TITLE
fix broken link to circuit-breaking docs in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,7 +196,7 @@ thank-you to everyone who helped make this release possible:
 * ziollek [@ziollek](https://github.com/ziollek)
 
 [dynamic request routing]: https://linkerd.io/2.13/tasks/configuring-dynamic-request-routing
-[circuit breaking]: https://linkerd.io/2.13/tasks/circuit-breaking
+[circuit breaking]: https://linkerd.io/2.13/tasks/circuit-breakers
 [new proxy metrics]: https://linkerd.io/2.13/reference/proxy-metrics/#outbound-xroute-metrics
 [upgrade-2130]: https://linkerd.io/2/tasks/upgrade/#upgrade-notice-stable-2130
 


### PR DESCRIPTION
This link points to the wrong URL and currently 404s. This commit points it at the correct URL.

Fixes #10734