### PR TITLE
Fix `linkerd mc allow` integration test

### DIFF
--- a/test/integration/multicluster/testdata/allow.golden
+++ b/test/integration/multicluster/testdata/allow.golden
@@ -10,7 +10,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .AccountName }}
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:
@@ -53,7 +52,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .AccountName }}
-  namespace: linkerd-multicluster
   labels:
     linkerd.io/extension: multicluster
   annotations:


### PR DESCRIPTION
#10713 removed the namespace from the cluster-level resources that `linkerd mc allow` also uses, and whose integration test was introduced by #10632 at the same time, and didn't get a chance to pick those namespace removals.