### PR TITLE
Add missing label "linkerd.io/extension"

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata-rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata-rbac.yaml
@@ -2,9 +2,9 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -16,9 +16,9 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -35,9 +35,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -58,9 +58,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Values.linkerdNamespace }}
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install

--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -8,6 +8,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    linkerd.io/extension: jaeger
     app.kubernetes.io/name: namespace-metadata
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
@@ -21,6 +22,7 @@ spec:
         {{ include "partials.annotations.created-by" . }}
         linkerd.io/inject: disabled
       labels:
+        linkerd.io/extension: jaeger
         app.kubernetes.io/name: namespace-metadata
         app.kubernetes.io/part-of: Linkerd
         app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}

--- a/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
@@ -8,9 +8,9 @@ apiVersion: v1
 metadata:
   name: collector
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{ end -}}
 ---
@@ -51,10 +51,9 @@ apiVersion: v1
 metadata:
   name: jaeger-injector
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.commonLabels }}
   labels:
-    {{ toYaml . | trim | indent 4 }}
-  {{- end }}
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 {{- $host := printf "jaeger-injector.%s.svc" .Release.Namespace }}
@@ -65,9 +64,9 @@ apiVersion: v1
 metadata:
   name: jaeger-injector-k8s-tls
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.webhook.crtPEM)) (empty .Values.webhook.crtPEM) }}
@@ -128,8 +127,8 @@ apiVersion: v1
 metadata:
   name: jaeger
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: jaeger
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{ end -}}

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c7e6fd0e7aad8fbcdf4f47b4d05c8e6b7e0e489cf9afc2026d4b6accd590ea71
+        checksum/config: c5d4d160a7fd2febef85a7a02d2df5b5575dec35abc84d696e9afa8d3f8423e6
         linkerd.io/inject: enabled
         config.linkerd.io/proxy-await: "enabled"
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
@@ -197,6 +197,8 @@ apiVersion: v1
 metadata:
   name: jaeger-injector
   namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -230,6 +232,8 @@ apiVersion: v1
 metadata:
   name: jaeger
   namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
 ---
 ###
 ### Tracing Jaeger Service

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0d7be729559727e479e66942fc892c724870bdfda2beaeb2a93c5070f349f4a2
+        checksum/config: 3fdd1946a20d2c03424324fdfd88d7fa77dcef0c5bedf314570ff74d0b49e981
         linkerd.io/inject: enabled
         config.linkerd.io/proxy-await: "enabled"
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
@@ -170,6 +170,8 @@ apiVersion: v1
 metadata:
   name: collector
   namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
 ---
 ###
 ### Jaeger Injector RBAC
@@ -206,6 +208,8 @@ apiVersion: v1
 metadata:
   name: jaeger-injector
   namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -239,6 +243,8 @@ apiVersion: v1
 metadata:
   name: jaeger
   namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
 ---
 ###
 ### Tracing Collector Service

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d10abe745e0df2e543fb40fcfecf1df813afc2259991761174790f0735959752
+        checksum/config: b8ce5fb085b648e293a23ee74978b9bf316e40dacddd262c6877b2a7691be716
         linkerd.io/inject: enabled
         config.linkerd.io/proxy-await: "enabled"
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
@@ -170,6 +170,8 @@ apiVersion: v1
 metadata:
   name: collector
   namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
 ---
 ###
 ### Jaeger Injector RBAC
@@ -206,6 +208,8 @@ apiVersion: v1
 metadata:
   name: jaeger-injector
   namespace: linkerd-jaeger
+  labels:
+    linkerd.io/extension: jaeger
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/multicluster/charts/linkerd-multicluster-link/templates/gateway-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/gateway-mirror.yaml
@@ -5,6 +5,7 @@ metadata:
   name: probe-gateway-{{.Values.targetClusterName}}
   namespace: {{ .Release.Namespace }}
   labels:
+    linkerd.io/extension: multicluster
     mirror.linkerd.io/mirrored-gateway: "true"
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -107,6 +107,7 @@ spec:
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
         {{- with .Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
+        linkerd.io/extension: multicluster
         component: linkerd-service-mirror
         mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -38,6 +38,7 @@ spec:
         {{- with .Values.gateway.deploymentAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       labels:
         app: {{.Values.gateway.name}}
+        linkerd.io/extension: multicluster
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
       {{- $_ := set $tree "component" .Values.gateway.name -}}
@@ -77,6 +78,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{.Values.gateway.name}}
+    linkerd.io/extension: multicluster
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata-rbac.yaml
@@ -1,9 +1,9 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: multicluster
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -15,9 +15,9 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: multicluster
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -34,9 +34,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: multicluster
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -57,9 +57,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Values.linkerdNamespace }}
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: multicluster
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -7,6 +7,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    linkerd.io/extension: multicluster
     app.kubernetes.io/name: namespace-metadata
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
@@ -20,6 +21,7 @@ spec:
         {{ include "partials.annotations.created-by" . }}
         linkerd.io/inject: disabled
       labels:
+        linkerd.io/extension: multicluster
         app.kubernetes.io/name: namespace-metadata
         app.kubernetes.io/part-of: Linkerd
         app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}

--- a/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:
@@ -20,6 +21,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -36,6 +36,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: linkerd-gateway
+        linkerd.io/extension: multicluster
     spec:
       
       containers:
@@ -319,6 +320,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
 spec:
   podSelector:
@@ -333,6 +335,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
 spec:
   targetRef:

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -39,6 +39,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: linkerd-gateway
+        linkerd.io/extension: multicluster
     spec:
       affinity:
         podAntiAffinity:
@@ -84,6 +85,7 @@ metadata:
   namespace: linkerd-multicluster
   labels:
     app: linkerd-gateway
+    linkerd.io/extension: multicluster
   annotations:
     linkerd.io/created-by: linkerd/helm linkerdVersionValue
 spec:
@@ -390,6 +392,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
 spec:
   podSelector:
@@ -404,6 +407,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
 spec:
   targetRef:

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -36,6 +36,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: linkerd-gateway
+        linkerd.io/extension: multicluster
     spec:
       
       containers:
@@ -353,6 +354,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
 spec:
   podSelector:
@@ -367,6 +369,7 @@ metadata:
   namespace: linkerd-multicluster
   name: service-mirror
   labels:
+    linkerd.io/extension: multicluster
     component: linkerd-service-mirror
 spec:
   targetRef:

--- a/multicluster/cmd/testdata/serivce_mirror_default.golden
+++ b/multicluster/cmd/testdata/serivce_mirror_default.golden
@@ -100,6 +100,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
       labels:
+        linkerd.io/extension: multicluster
         component: linkerd-service-mirror
         mirror.linkerd.io/cluster-name: test-cluster
     spec:
@@ -136,6 +137,7 @@ metadata:
   name: probe-gateway-test-cluster
   namespace: test
   labels:
+    linkerd.io/extension: multicluster
     mirror.linkerd.io/mirrored-gateway: "true"
     mirror.linkerd.io/cluster-name: test-cluster
 spec:

--- a/viz/charts/linkerd-viz/templates/namespace-metadata-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata-rbac.yaml
@@ -1,9 +1,9 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: viz
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -16,9 +16,9 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: viz
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -35,9 +35,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: viz
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install
@@ -58,9 +58,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: {{ .Values.linkerdNamespace }}
-  {{- with .Values.commonLabels }}
-  labels: {{ toYaml . | trim | nindent 4 }}
-  {{- end }}
+  labels:
+    linkerd.io/extension: viz
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     "helm.sh/hook": post-install

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -7,6 +7,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
+    linkerd.io/extension: viz
     app.kubernetes.io/name: namespace-metadata
     app.kubernetes.io/part-of: Linkerd
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}
@@ -20,6 +21,7 @@ spec:
         {{ include "partials.annotations.created-by" . }}
         linkerd.io/inject: disabled
       labels:
+        linkerd.io/extension: viz
         app.kubernetes.io/name: namespace-metadata
         app.kubernetes.io/part-of: Linkerd
         app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.cliVersion}}


### PR DESCRIPTION
* Add missing label "linkerd.io/extension" to these extensions: viz, multicluster and jaeger

Fixes #10705