### PR TITLE
inject: don't expand opaque port ranges

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -257,10 +257,7 @@ func (et *endpointTranslator) sendClientAdd(set watcher.AddressSet) {
 			err         error
 		)
 		if address.Pod != nil {
-			opaquePorts, err = getAnnotatedOpaquePorts(address.Pod, et.defaultOpaquePorts)
-			if err != nil {
-				et.log.Errorf("failed to get opaque ports for pod %s/%s: %s", address.Pod.Namespace, address.Pod.Name, err)
-			}
+			opaquePorts = getAnnotatedOpaquePorts(address.Pod, et.defaultOpaquePorts)
 			wa, err = createWeightedAddr(address, opaquePorts, et.enableH2Upgrade, et.identityTrustDomain, et.controllerNS, et.log)
 		} else {
 			var authOverride *pb.AuthorityOverride

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -1051,8 +1051,15 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 	}
 
 	if override, ok := annotations[k8s.ProxyOpaquePortsAnnotation]; ok {
-		opaquePortsStrs := util.ParseContainerOpaquePorts(override, conf.pod.spec.Containers)
-		values.Proxy.OpaquePorts = strings.Join(opaquePortsStrs, ",")
+		var opaquePorts strings.Builder
+		for _, pr := range util.ParseContainerOpaquePorts(override, conf.pod.spec.Containers) {
+			if opaquePorts.Len() > 0 {
+				opaquePorts.WriteRune(',')
+			}
+			opaquePorts.WriteString(pr.ToString())
+		}
+
+		values.Proxy.OpaquePorts = opaquePorts.String()
 	}
 
 	if override, ok := annotations[k8s.DebugImageAnnotation]; ok {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -114,7 +114,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.Proxy.RequireIdentityOnInboundPorts = "8888,9999"
 				values.Proxy.OutboundConnectTimeout = "6000ms"
 				values.Proxy.InboundConnectTimeout = "600ms"
-				values.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
+				values.Proxy.OpaquePorts = "4320-4325,3306"
 				values.Proxy.Await = true
 				values.Proxy.AccessLog = "apache"
 				values.Proxy.ShutdownGracePeriod = "30000ms"
@@ -201,7 +201,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.ProxyInit.IgnoreOutboundPorts = "8079,8080"
 				values.Proxy.OutboundConnectTimeout = "6000ms"
 				values.Proxy.InboundConnectTimeout = "600ms"
-				values.Proxy.OpaquePorts = "4320,4321,4322,4323,4324,4325,3306"
+				values.Proxy.OpaquePorts = "4320-4325,3306"
 				values.Proxy.Await = true
 				values.Proxy.AccessLog = "apache"
 				values.Proxy.IsIngress = true

--- a/pkg/util/portrange.go
+++ b/pkg/util/portrange.go
@@ -51,3 +51,20 @@ func ParsePortRange(portRange string) (PortRange, error) {
 func isPort(port int) bool {
 	return 0 <= port && port <= 65535
 }
+
+// Ports returns an array of all the ports contained by this range.
+func (pr PortRange) Ports() []uint16 {
+	var ports []uint16
+	for i := pr.LowerBound; i <= pr.UpperBound; i++ {
+		ports = append(ports, uint16(i))
+	}
+	return ports
+}
+
+func (pr PortRange) ToString() string {
+	if pr.LowerBound == pr.UpperBound {
+		return strconv.Itoa(pr.LowerBound)
+	}
+
+	return fmt.Sprintf("%d-%d", pr.LowerBound, pr.UpperBound)
+}


### PR DESCRIPTION
Currently, the proxy injector will expand lists of opaque port ranges
into lists of individual port numbers. This is because the proxy has
historically not accepted port ranges in the
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
variable. However, when very large ranges are used, the size of the
injected manifest can be quite large, since each individual port number
in a range must be listed separately.

Proxy PR linkerd/linkerd2-proxy#2395 changed the proxy to accept ranges
as well as individual port numbers in the opaque ports environment
variable, and this change was included in the latest proxy release
(v2.200.0). This means that the proxy-injector no longer needs to expand
large port ranges into individual port numbers, and can now simply
forward the list of ranges to the proxy. This branch changes the proxy
injector to do this, resolving issues with manifest size due to large
port ranges.

Closes #9803