### PR TITLE
edge-23.4.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ in the Helm chart. It also addresses a CVE by upgrading an underlying
 dependency.
 
 * Upgraded `h2` dependency to address CVE-2023-26964
-* Fixed an issue where `server_port_subscribers` metric in the Destination 
+* Fixed an issue where `server_port_subscribers` metric in the Destination
   controller was sometimes absent
 * Removed the policy-controller-write Lease from the control plane Helm chart in
   favor of creating it runtime

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ dependency.
 * Updated the proxy-injector to pass opaque port lists to the proxy as ranges
   rather than individually, greatly reducing the size of proxy manifests when
   large opaque port ranges are set
+* Fixed an issue where the proxy was performing protocol detection on ports
+  marked as opaque
+* Improved backwards compatibility between 2.13 proxies and 2.12 control planes
 
 ## edge-23.4.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ dependency.
 * Fixed an issue where `server_port_subscribers` metric in the Destination
   controller was sometimes absent
 * Removed the policy-controller-write Lease from the control plane Helm chart in
-  favor of creating it runtime
+  favor of creating it at runtime
 * Updated the proxy-injector to pass opaque port lists to the proxy as ranges
   rather than individually, greatly reducing the size of proxy manifests when
   large opaque port ranges are set

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,21 @@
 # Changes
 
+## edge-23.4.3
+
+This edge release improves compatibility with ArgoCD by changing the Linkerd
+control plane to create Lease resources at runtime rather than including them
+in the Helm chart. It also addresses a CVE by upgrading an underlying
+dependency.
+
+* Upgraded `h2` dependency to address CVE-2023-26964
+* Fixed an issue where `server_port_subscribers` metric in the Destination 
+  controller was sometimes absent
+* Removed the policy-controller-write Lease from the control plane Helm chart in
+  favor of creating it runtime
+* Updated the proxy-injector to pass opaque port lists to the proxy as ranges
+  rather than individually, greatly reducing the size of proxy manifests when
+  large opaque port ranges are set
+
 ## edge-23.4.2
 
 This edge release contains a number of bug fixes.

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.13.0-edge
+version: 1.13.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.13.0-edge](https://img.shields.io/badge/Version-1.13.0--edge-informational?style=flat-square)
+![Version: 1.13.1-edge](https://img.shields.io/badge/Version-1.13.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.8.1
+version: 30.9.0-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.8.1](https://img.shields.io/badge/Version-30.8.1-informational?style=flat-square)
+![Version: 30.9.0-edge](https://img.shields.io/badge/Version-30.9.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.9.0-edge
+version: 30.9.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.9.0-edge](https://img.shields.io/badge/Version-30.9.0--edge-informational?style=flat-square)
+![Version: 30.9.1-edge](https://img.shields.io/badge/Version-30.9.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.8.0-edge
+version: 30.8.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.8.0-edge](https://img.shields.io/badge/Version-30.8.0--edge-informational?style=flat-square)
+![Version: 30.8.1-edge](https://img.shields.io/badge/Version-30.8.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.9.0-edge
+version: 30.9.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.9.0-edge](https://img.shields.io/badge/Version-30.9.0--edge-informational?style=flat-square)
+![Version: 30.9.1-edge](https://img.shields.io/badge/Version-30.9.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release improves compatibility with ArgoCD by changing the Linkerd
control plane to create Lease resources at runtime rather than including them
in the Helm chart. It also addresses a CVE by upgrading an underlying
dependency.

* Upgraded `h2` dependency to address CVE-2023-26964
* Fixed an issue where `server_port_subscribers` metric in the Destination
  controller was sometimes absent
* Removed the policy-controller-write Lease from the control plane Helm chart in
  favor of creating it at runtime
* Updated the proxy-injector to pass opaque port lists to the proxy as ranges
  rather than individually, greatly reducing the size of proxy manifests when
  large opaque port ranges are set
* Fixed an issue where the proxy was performing protocol detection on ports
  marked as opaque
* Improved backwards compatibility between 2.13 proxies and 2.12 control planes