### PR TITLE
Validate failure accrual annotations in policy controller

### DIFF
--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -488,6 +488,15 @@ fn parse_accrual_config(
                         "min_penalty ({min_penalty:?}) cannot exceed max_penalty ({max_penalty:?})",
                     );
                 }
+                if max_penalty == time::Duration::from_millis(0) {
+                    bail!("max_penalty cannot be zero");
+                }
+                if jitter < 0.0 {
+                    bail!("jitter cannot be negative");
+                }
+                if jitter > 100.0 {
+                    bail!("jitter cannot be greater than 100");
+                }
 
                 Ok(FailureAccrual::Consecutive {
                     max_failures,


### PR DESCRIPTION
Followup to #10655

As per this [comment](https://github.com/linkerd/linkerd2/pull/10655#discussion_r1156599685).