### PR TITLE
Add cache configuration annotation support

### DIFF
--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -110,7 +110,7 @@ type (
 		OutboundConnectTimeout              string           `json:"outboundConnectTimeout"`
 		InboundConnectTimeout               string           `json:"inboundConnectTimeout"`
 		OutboundDiscoveryCacheUnusedTimeout string           `json:"outboundDiscoveryCacheUnusedTimeout"`
-		InboundDiscoveryCacheUusedTimeout   string           `json:"inboundDiscoveryCacheUnusedTimeout"`
+		InboundDiscoveryCacheUnusedTimeout  string           `json:"inboundDiscoveryCacheUnusedTimeout"`
 		PodInboundPorts                     string           `json:"podInboundPorts"`
 		OpaquePorts                         string           `json:"opaquePorts"`
 		Await                               bool             `json:"await"`

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -131,7 +131,7 @@ func TestNewValues(t *testing.T) {
 			Await:                               true,
 			DefaultInboundPolicy:                "all-unauthenticated",
 			OutboundDiscoveryCacheUnusedTimeout: "5s",
-			InboundDiscoveryCacheUusedTimeout:   "90s",
+			InboundDiscoveryCacheUnusedTimeout:  "90s",
 		},
 		ProxyInit: &ProxyInit{
 			IptablesMode:        "legacy",

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -73,6 +73,8 @@ var (
 		k8s.ProxySkipSubnetsAnnotation,
 		k8s.ProxyAccessLogAnnotation,
 		k8s.ProxyShutdownGracePeriodAnnotation,
+		k8s.ProxyOutboundDiscoveryCacheTimeout,
+		k8s.ProxyInboundDiscoveryCacheTimeout,
 	}
 	// ProxyAlphaConfigAnnotations is the list of all alpha configuration
 	// (config.alpha prefix) that can be applied to a pod or namespace.
@@ -931,6 +933,24 @@ func (conf *ResourceConfig) applyAnnotationOverrides(values *l5dcharts.Values) {
 			log.Warnf("unrecognized proxy-inbound-connect-timeout duration value found on pod annotation: %s", err.Error())
 		} else {
 			values.Proxy.InboundConnectTimeout = fmt.Sprintf("%dms", int(duration.Seconds()*1000))
+		}
+	}
+
+	if override, ok := annotations[k8s.ProxyOutboundDiscoveryCacheTimeout]; ok {
+		duration, err := time.ParseDuration(override)
+		if err != nil {
+			log.Warnf("unrecognized proxy-outbound-discovery-unused-timeout duration value found on pod annotation: %s", err.Error())
+		} else {
+			values.Proxy.OutboundDiscoveryCacheUnusedTimeout = fmt.Sprintf("%ds", int(duration.Seconds()))
+		}
+	}
+
+	if override, ok := annotations[k8s.ProxyInboundDiscoveryCacheTimeout]; ok {
+		duration, err := time.ParseDuration(override)
+		if err != nil {
+			log.Warnf("unrecognized proxy-inbound-discovery-unused-timeout duration value found on pod annotation: %s", err.Error())
+		} else {
+			values.Proxy.InboundDiscoveryCacheUnusedTimeout = fmt.Sprintf("%ds", int(duration.Seconds()))
 		}
 	}
 

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -70,6 +70,8 @@ func TestGetOverriddenValues(t *testing.T) {
 							k8s.ProxySkipSubnetsAnnotation:                   "172.17.0.0/16",
 							k8s.ProxyAccessLogAnnotation:                     "apache",
 							k8s.ProxyShutdownGracePeriodAnnotation:           "30s",
+							k8s.ProxyOutboundDiscoveryCacheTimeout:           "50000ms",
+							k8s.ProxyInboundDiscoveryCacheTimeout:            "900s",
 						},
 					},
 					Spec: corev1.PodSpec{},
@@ -118,6 +120,8 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.Proxy.Await = true
 				values.Proxy.AccessLog = "apache"
 				values.Proxy.ShutdownGracePeriod = "30000ms"
+				values.Proxy.OutboundDiscoveryCacheUnusedTimeout = "50s"
+				values.Proxy.InboundDiscoveryCacheUnusedTimeout = "900s"
 				return values
 			},
 		},
@@ -162,6 +166,8 @@ func TestGetOverriddenValues(t *testing.T) {
 				k8s.ProxyAwait:                            "enabled",
 				k8s.ProxyAccessLogAnnotation:              "apache",
 				k8s.ProxyInjectAnnotation:                 "ingress",
+				k8s.ProxyOutboundDiscoveryCacheTimeout:    "50s",
+				k8s.ProxyInboundDiscoveryCacheTimeout:     "6000ms",
 			},
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
@@ -205,13 +211,17 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.Proxy.Await = true
 				values.Proxy.AccessLog = "apache"
 				values.Proxy.IsIngress = true
+				values.Proxy.OutboundDiscoveryCacheUnusedTimeout = "50s"
+				values.Proxy.InboundDiscoveryCacheUnusedTimeout = "6s"
 				return values
 			},
 		},
-		{id: "use invalid duration for TCP connect timeouts",
+		{id: "use invalid duration for proxy timeouts",
 			nsAnnotations: map[string]string{
-				k8s.ProxyOutboundConnectTimeout: "6000",
-				k8s.ProxyInboundConnectTimeout:  "600",
+				k8s.ProxyOutboundConnectTimeout:        "6000",
+				k8s.ProxyInboundConnectTimeout:         "600",
+				k8s.ProxyOutboundDiscoveryCacheTimeout: "50",
+				k8s.ProxyInboundDiscoveryCacheTimeout:  "5000",
 			},
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
@@ -224,11 +234,13 @@ func TestGetOverriddenValues(t *testing.T) {
 				return values
 			},
 		},
-		{id: "use valid duration for TCP connect timeouts",
+		{id: "use valid duration for proxy timeouts",
 			nsAnnotations: map[string]string{
 				// Validate we're converting time values into ms for the proxy to parse correctly.
-				k8s.ProxyOutboundConnectTimeout: "6s5ms",
-				k8s.ProxyInboundConnectTimeout:  "2s5ms",
+				k8s.ProxyOutboundConnectTimeout:        "6s5ms",
+				k8s.ProxyInboundConnectTimeout:         "2s5ms",
+				k8s.ProxyOutboundDiscoveryCacheTimeout: "6s5000ms",
+				k8s.ProxyInboundDiscoveryCacheTimeout:  "6s5000ms",
 			},
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{
@@ -240,6 +252,8 @@ func TestGetOverriddenValues(t *testing.T) {
 				values, _ := l5dcharts.NewValues()
 				values.Proxy.OutboundConnectTimeout = "6005ms"
 				values.Proxy.InboundConnectTimeout = "2005ms"
+				values.Proxy.OutboundDiscoveryCacheUnusedTimeout = "11s"
+				values.Proxy.InboundDiscoveryCacheUnusedTimeout = "11s"
 				return values
 			},
 		},

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -230,6 +230,14 @@ const (
 	// timeout in the proxy
 	ProxyInboundConnectTimeout = ProxyConfigAnnotationsPrefix + "/proxy-inbound-connect-timeout"
 
+	// ProxyOutboundDiscoveryCacheTimeout can be used to configure the timeout
+	// that will evict unused outbound discovery result
+	ProxyOutboundDiscoveryCacheTimeout = ProxyConfigAnnotationsPrefix + "/proxy-outbound-discovery-cache-unused-timeout"
+
+	// ProxyInboundDiscoveryCacheTimeout can be used to configure the timeout
+	// that will evict unused inbound discovery result
+	ProxyInboundDiscoveryCacheTimeout = ProxyConfigAnnotationsPrefix + "/proxy-inbound-discovery-cache-unused-timeout"
+
 	// ProxyEnableGatewayAnnotation can be used to configure the proxy
 	// to operate as a gateway, routing requests that target the inbound router.
 	ProxyEnableGatewayAnnotation = ProxyConfigAnnotationsPrefix + "/enable-gateway"


### PR DESCRIPTION
The proxy caches discovery results in-memory. Linkerd supports overriding the default eviction timeout for cached discovery results through install (i.e. helm) values. However, it is currently not possible to configure timeouts on a workload-per-workload basis, or to configure the values after Linkerd has been installed (or upgraded).

This change adds support for annotation based configuration. Workloads and namespaces now support two new configuration annotations that will override the install values when specified.

Additionally, a typo has been fixed on the internal type representation. This is not a breaking change since the type itself is not exposed to users and is parsed correctly in the values.yaml file (or CLI)

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
