### PR TITLE
Block `linkerd viz check` on pods readiness

### DIFF
--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -115,6 +115,7 @@ func (hc *HealthChecker) VizCategory(fullCheck bool) *healthcheck.Category {
 		*healthcheck.NewChecker("can initialize the client").
 			WithHintAnchor("l5d-viz-existence-client").
 			Fatal().
+			WithRetryDeadline(hc.RetryDeadline).
 			WithCheck(func(ctx context.Context) (err error) {
 				if hc.APIAddr != "" {
 					hc.vizAPIClient, err = client.NewInternalClient(hc.APIAddr)


### PR DESCRIPTION
Fixes #10829

Added `WithRetryDeadline(hc.RetryDeadline)` call to the "can initialize the client" check to wait for pods to become ready.

```console
$ bin/go-run cli viz check
linkerd-viz
-----------
√ linkerd-viz Namespace exists
\ waiting for check to complete
```