### PR TITLE
Force MeshTLSAuthentication CRs to provide at least one identity/identityRef

### DIFF
--- a/charts/linkerd-crds/templates/policy/meshtls-authentication.yaml
+++ b/charts/linkerd-crds/templates/policy/meshtls-authentication.yaml
@@ -46,11 +46,13 @@ spec:
                     a domain. An identity string of `*` indicates that
                     all authentication clients are authorized.
                   type: array
+                  minItems: 1
                   items:
                     type: string
                     pattern: '^(\*|[a-z0-9]([-a-z0-9]*[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 identityRefs:
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     required:

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -2589,11 +2589,13 @@ spec:
                     a domain. An identity string of `*` indicates that
                     all authentication clients are authorized.
                   type: array
+                  minItems: 1
                   items:
                     type: string
                     pattern: '^(\*|[a-z0-9]([-a-z0-9]*[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 identityRefs:
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     required:

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -2595,11 +2595,13 @@ spec:
                     a domain. An identity string of `*` indicates that
                     all authentication clients are authorized.
                   type: array
+                  minItems: 1
                   items:
                     type: string
                     pattern: '^(\*|[a-z0-9]([-a-z0-9]*[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 identityRefs:
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     required:

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -2595,11 +2595,13 @@ spec:
                     a domain. An identity string of `*` indicates that
                     all authentication clients are authorized.
                   type: array
+                  minItems: 1
                   items:
                     type: string
                     pattern: '^(\*|[a-z0-9]([-a-z0-9]*[a-z0-9])?)(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
                 identityRefs:
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     required:


### PR DESCRIPTION
Fixes #10782

Added the `minItems: 1` field to `spec.identities` and `spec.identitiRefs`. This is a BC change so it's not required to bump the CRD version, plus current CRs not abiding to this constraint would be broken anyway.

```bash
$ cat << EOF | k apply -f -
> apiVersion: policy.linkerd.io/v1alpha1
kind: MeshTLSAuthentication
metadata:
  name: "test"
spec:
  identities: []
> EOF
The MeshTLSAuthentication "test" is invalid: spec.identities: Invalid value: 0: spec.identities in body should have at least 1 items
```