### PR TITLE
Add default jaeguer and tracing nodeAffinity labels

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -37,6 +37,7 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.webhook) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.webhook) | nindent 6 }}
+      {{- include "linkerd.affinity" (dict "Values" .Values.webhook) | nindent 6 }}
       containers:
       - args:
         - -collector-svc-addr={{.Values.webhook.collectorSvcAddr}}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -92,6 +92,7 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.collector) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.collector) | nindent 6 }}
+      {{- include "linkerd.affinity" (dict "Values" .Values.collector) | nindent 6 }}
       containers:
       - command:
         - /otelcol
@@ -211,6 +212,7 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.jaeger) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.jaeger) | nindent 6 }}
+      {{- include "linkerd.affinity" (dict "Values" .Values.jaeger) | nindent 6 }}
       containers:
       - args:
         {{-  range .Values.jaeger.args }}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -15,6 +15,10 @@ imagePullPolicy: IfNotPresent
 nodeSelector: &default_node_selector
   kubernetes.io/os: linux
 
+# -- Default nodeAffinity section, See the
+# [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+nodeAffinity: &default_node_affinity_selector
+
 # -- For Private docker registries, authentication is needed.
 #  Registry secrets are applied to the respective service accounts
 imagePullSecrets: []
@@ -64,6 +68,9 @@ collector:
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
   nodeSelector: *default_node_selector
+  # -- NodeAffinity section, See the
+  # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+  nodeAffinity: *default_node_affinity_selector
   # -- Tolerations section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
@@ -139,6 +146,9 @@ jaeger:
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
   nodeSelector: *default_node_selector
+  # -- NodeAffinity section, See the
+  # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+  nodeAffinity: *default_node_affinity_selector
   # -- Tolerations section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
@@ -234,6 +244,9 @@ webhook:
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
   nodeSelector: *default_node_selector
+  # -- NodeAffinity section, See the
+  # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+  nodeAffinity: *default_node_affinity_selector
   # -- Tolerations section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information


### PR DESCRIPTION
Add to Helm linkerd-jaeguer and tracing deployment resources nodeAffinity labels

NodeAffinity was not enabled for Jaeguer Deployments resources

Add to helm values and each of Jaeguer Deployment the labels to add the affinity labels from the shared partials and
allow to be more granular on the manifest setup

```
cd jaeger/charts/linkerd-jaeger/ 
helm template .
```
Fixes #[10680]

Signed-off-by: John Doe <jayrosalgado@gmail.com.com>
