### PR TITLE
Add default jaeguer and tracing nodeAffinity labels

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -79,6 +79,7 @@ Kubernetes: `>=1.21.0-0`
 | collector.image.name | string | `"otel/opentelemetry-collector"` |  |
 | collector.image.pullPolicy | string | `"Always"` |  |
 | collector.image.version | string | `"0.59.0"` |  |
+| collector.nodeAffinity | string | `nil` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | collector.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | collector.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the collector container can use |
 | collector.resources.cpu.request | string | `nil` | Amount of CPU units that the collector container requests |
@@ -98,6 +99,7 @@ Kubernetes: `>=1.21.0-0`
 | jaeger.image.name | string | `"jaegertracing/all-in-one"` |  |
 | jaeger.image.pullPolicy | string | `"Always"` |  |
 | jaeger.image.version | float | `1.31` |  |
+| jaeger.nodeAffinity | string | `nil` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | jaeger.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | jaeger.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the jaeger container can use |
 | jaeger.resources.cpu.request | string | `nil` | Amount of CPU units that the jaeger container requests |
@@ -112,6 +114,7 @@ Kubernetes: `>=1.21.0-0`
 | namespaceMetadata.image.pullPolicy | string | imagePullPolicy | Pull policy for the namespace-metadata instance |
 | namespaceMetadata.image.registry | string | `"cr.l5d.io/linkerd"` | Docker registry for the namespace-metadata instance |
 | namespaceMetadata.image.tag | string | `"v0.1.0"` | Docker image tag for the namespace-metadata instance |
+| nodeAffinity | string | `nil` | Default nodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | podLabels | object | `{}` | Additional labels to add to all pods |
 | tolerations | string | `nil` | Default tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
@@ -130,6 +133,7 @@ Kubernetes: `>=1.21.0-0`
 | webhook.keyPEM | string | `""` | Certificate key for the webhook. If not provided and not using an external secret then Helm will generate one. |
 | webhook.logLevel | string | `"info"` |  |
 | webhook.namespaceSelector | string | `nil` |  |
+| webhook.nodeAffinity | string | `nil` | NodeAffinity section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information |
 | webhook.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | webhook.objectSelector | string | `nil` |  |
 | webhook.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the jaeger-injector container can use |

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -37,6 +37,7 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.webhook) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.webhook) | nindent 6 }}
+      {{- include "linkerd.affinity" (dict "Values" .Values.webhook) | nindent 6 }}
       containers:
       - args:
         - -collector-svc-addr={{.Values.webhook.collectorSvcAddr}}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -92,6 +92,7 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.collector) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.collector) | nindent 6 }}
+      {{- include "linkerd.affinity" (dict "Values" .Values.collector) | nindent 6 }}
       containers:
       - command:
         - /otelcol
@@ -211,6 +212,7 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.jaeger) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.jaeger) | nindent 6 }}
+      {{- include "linkerd.affinity" (dict "Values" .Values.jaeger) | nindent 6 }}
       containers:
       - args:
         {{-  range .Values.jaeger.args }}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -15,6 +15,10 @@ imagePullPolicy: IfNotPresent
 nodeSelector: &default_node_selector
   kubernetes.io/os: linux
 
+# -- Default nodeAffinity section, See the
+# [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+nodeAffinity: &default_node_affinity_selector
+
 # -- For Private docker registries, authentication is needed.
 #  Registry secrets are applied to the respective service accounts
 imagePullSecrets: []
@@ -64,6 +68,11 @@ collector:
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
   nodeSelector: *default_node_selector
+
+  # -- NodeAffinity section, See the
+  # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+  nodeAffinity: *default_node_affinity_selector
+
   # -- Tolerations section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
@@ -139,6 +148,11 @@ jaeger:
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
   nodeSelector: *default_node_selector
+
+  # -- NodeAffinity section, See the
+  # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+  nodeAffinity: *default_node_affinity_selector
+
   # -- Tolerations section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information
@@ -234,6 +248,11 @@ webhook:
   # -- NodeSelector section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information
   nodeSelector: *default_node_selector
+
+  # -- NodeAffinity section, See the
+  # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) for more information
+  nodeAffinity: *default_node_affinity_selector
+
   # -- Tolerations section, See the
   # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   # for more information


### PR DESCRIPTION
Add to Helm linkerd-jaeguer and tracing deployment resources nodeAffinity labels

NodeAffinity was not enabled for Jaeguer Deployments resources

Add to helm values and each of Jaeguer Deployment the labels to add the affinity labels from the shared partials and
allow to be more granular on the manifest setup

cd jaeger/charts/linkerd-jaeger/ 
helm template .

Fixes #10680 

Signed-off-by: Jayro Salgado [jayrosalgado@gmail.com](mailto:jayrosalgado@gmail.com)