### PR TITLE
Introduce support for modifying the network-validator and proxy securityContext

### DIFF
--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -159,6 +159,8 @@ proxy:
       request: ""
   # -- User id under which the proxy runs
   uid: 2102
+  securityContext:
+    enabled: true
   # -- If set the injected proxy sidecars in the data plane will stay alive for
   # at least the given period before receiving the SIGTERM signal from
   # Kubernetes but no longer than the pod's `terminationGracePeriodSeconds`.
@@ -266,6 +268,16 @@ networkValidator:
   listenAddr: "0.0.0.0:4140"
   # -- Timeout before network-validator fails to validate the pod's network connectivity
   timeout: "10s"
+  securityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
 # -- For Private docker registries, authentication is needed.
 #  Registry secrets are applied to the respective service accounts

--- a/charts/partials/templates/_network-validator.tpl
+++ b/charts/partials/templates/_network-validator.tpl
@@ -3,15 +3,9 @@ name: linkerd-network-validator
 image: {{.Values.proxy.image.name}}:{{.Values.proxy.image.version | default .Values.linkerdVersion }}
 imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPolicy}}
 {{ include "partials.resources" .Values.proxyInit.resources }}
-securityContext:
-  allowPrivilegeEscalation: false
-  capabilities:
-    drop:
-    - ALL
-  runAsNonRoot: true
-  runAsUser: 65534
-  seccompProfile:
-    type: RuntimeDefault
+{{- if .Values.networkValidator.securityContext.enabled }}
+securityContext: {{- omit .Values.networkValidator.securityContext "enabled" | toYaml | nindent 2 }}
+{{- end }}
 command:
   - /usr/lib/linkerd/linkerd2-network-validator
 args:

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -163,6 +163,7 @@ readinessProbe:
 {{- if .Values.proxy.resources }}
 {{ include "partials.resources" .Values.proxy.resources }}
 {{- end }}
+{{- if .Values.proxy.securityContext.enabled }}
 securityContext:
   allowPrivilegeEscalation: false
   {{- if .Values.proxy.capabilities -}}
@@ -173,6 +174,7 @@ securityContext:
   runAsUser: {{.Values.proxy.uid}}
   seccompProfile:
     type: RuntimeDefault
+{{- end }}
 terminationMessagePolicy: FallbackToLogsOnError
 {{- if or (.Values.proxy.await) (.Values.proxy.waitBeforeExitSeconds) }}
 lifecycle:

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -163,7 +163,7 @@ readinessProbe:
 {{- if .Values.proxy.resources }}
 {{ include "partials.resources" .Values.proxy.resources }}
 {{- end }}
-{{- if .Values.proxy.securityContext.enabled }}
+{{- if or (.Values.proxy.securityContext).enabled (not .Values.proxy.securityContext) }}
 securityContext:
   allowPrivilegeEscalation: false
   {{- if .Values.proxy.capabilities -}}

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"k8s.io/utils/pointer"
 	"os"
 	"path/filepath"
 	"testing"
@@ -97,6 +98,7 @@ func TestRender(t *testing.T) {
 				Outbound: 4140,
 			},
 			UID:                  2102,
+			SecurityContext: &charts.SecurityContext{Enabled: true},
 			OpaquePorts:          "25,443,587,3306,5432,11211",
 			Await:                true,
 			DefaultInboundPolicy: "default-allow-policy",
@@ -132,6 +134,20 @@ func TestRender(t *testing.T) {
 			ConnectAddr: "1.1.1.1:20001",
 			ListenAddr:  "0.0.0.0:4140",
 			Timeout:     "10s",
+			SecurityContext: &charts.SecurityContext{
+				Enabled: true,
+				SecurityContext: corev1.SecurityContext{
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+					RunAsNonRoot: pointer.Bool(true),
+					RunAsUser:    pointer.Int64(65534),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+			},
 		},
 		Configs: charts.ConfigJSONs{
 			Global:  "GlobalConfig",

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -521,6 +521,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -623,6 +633,8 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -521,6 +521,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -623,6 +633,8 @@ data:
           limit: 250Mi
           request: 300Mi
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -425,6 +425,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -527,6 +537,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -471,6 +471,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -573,6 +583,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -498,6 +498,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -600,6 +610,8 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -498,6 +498,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -604,6 +614,8 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -493,6 +493,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -595,6 +605,8 @@ data:
           limit: 250Mi
           request: 20Mi
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -487,6 +487,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -576,6 +586,8 @@ data:
           limit: memory-limit
           request: memory-request
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -494,6 +494,16 @@ data:
       listenAddr: 0.0.0.0:4140
       logFormat: plain
       logLevel: debug
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       timeout: 10s
     nodeAffinity: null
     nodeSelector:
@@ -596,6 +606,8 @@ data:
           limit: ""
           request: ""
       saMountPath: null
+      securityContext:
+        enabled: true
       shutdownGracePeriod: ""
       uid: 2102
       waitBeforeExitSeconds: 0

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -117,6 +117,7 @@ type (
 		DefaultInboundPolicy                string           `json:"defaultInboundPolicy"`
 		AccessLog                           string           `json:"accessLog"`
 		ShutdownGracePeriod                 string           `json:"shutdownGracePeriod"`
+		SecurityContext                     *SecurityContext `json:"securityContext"`
 	}
 
 	// ProxyInit contains the fields to set the proxy-init container
@@ -140,11 +141,12 @@ type (
 	}
 
 	NetworkValidator struct {
-		LogLevel    string `json:"logLevel"`
-		LogFormat   string `json:"logFormat"`
-		ConnectAddr string `json:"connectAddr"`
-		ListenAddr  string `json:"listenAddr"`
-		Timeout     string `json:"timeout"`
+		LogLevel        string           `json:"logLevel"`
+		LogFormat       string           `json:"logFormat"`
+		ConnectAddr     string           `json:"connectAddr"`
+		ListenAddr      string           `json:"listenAddr"`
+		Timeout         string           `json:"timeout"`
+		SecurityContext *SecurityContext `json:"securityContext"`
 	}
 
 	// DebugContainer contains the fields to set the debugging sidecar
@@ -207,6 +209,11 @@ type (
 	Capabilities struct {
 		Add  []string `json:"add"`
 		Drop []string `json:"drop"`
+	}
+
+	SecurityContext struct {
+		corev1.SecurityContext
+		Enabled bool `json:"enabled"`
 	}
 
 	// VolumeMountPath contains the details for volume mounts

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -1,6 +1,8 @@
 package linkerd2
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -123,7 +125,10 @@ func TestNewValues(t *testing.T) {
 					Request: "",
 				},
 			},
-			UID:                                 2102,
+			UID: 2102,
+			SecurityContext: &SecurityContext{
+				Enabled: true,
+			},
 			WaitBeforeExitSeconds:               0,
 			OutboundConnectTimeout:              "1000ms",
 			InboundConnectTimeout:               "100ms",
@@ -167,6 +172,20 @@ func TestNewValues(t *testing.T) {
 			ConnectAddr: "1.1.1.1:20001",
 			ListenAddr:  "0.0.0.0:4140",
 			Timeout:     "10s",
+			SecurityContext: &SecurityContext{
+				Enabled: true,
+				SecurityContext: corev1.SecurityContext{
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{"ALL"},
+					},
+					RunAsNonRoot: pointer.Bool(true),
+					RunAsUser:    pointer.Int64(65534),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+			},
 		},
 		Identity: &Identity{
 			ServiceAccountTokenProjection: true,


### PR DESCRIPTION
This MR enables configuration of the security context of the `network-validator` and `proxy` components of Linkerd.

To ensure that this change is not breaking, only the `network-validator` allows full configuration of the security context while the `proxy` adds an on/off switch.

This is needed as while the current security context is a secure and sane default, it blocks Linkerd from being used on distributions such as OpenShift which enforce their own security context standards.

The introduced configuration was based on the pattern used by the Bitnami charts which I assumed would be good to follow. If you believe the method should be different, please let me know as I am happy to accommodate.

Ideally somewhere down the line, all security context configuration (e.g., `proxy.uid`, `proxy.capabilities`) should be merged under a single `securityContext` field like I am doing with the `networkValidator`, however that is a much larger change.

Fixes #10879 
