### PR TITLE
added .Release.Name to webhook configuration `inject-ca-from` annotation in the Helm templates 

### DIFF
--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -85,10 +85,10 @@ metadata:
   {{- if or (.Values.profileValidator.injectCaFrom) (.Values.profileValidator.injectCaFromSecret) }}
   annotations:
   {{- if .Values.profileValidator.injectCaFrom }}
-    cert-manager.io/inject-ca-from: {{ .Values.profileValidator.injectCaFrom }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.profileValidator.injectCaFrom }}
   {{- end }}
   {{- if .Values.profileValidator.injectCaFromSecret }}
-    cert-manager.io/inject-ca-from-secret: {{ .Values.profileValidator.injectCaFromSecret }}
+    cert-manager.io/inject-ca-from-secret: {{ .Release.Namespace }}/{{ .Values.profileValidator.injectCaFromSecret }}
   {{- end }}
   {{- end }}
   labels:
@@ -144,10 +144,10 @@ metadata:
   {{- if or (.Values.policyValidator.injectCaFrom) (.Values.policyValidator.injectCaFromSecret) }}
   annotations:
   {{- if .Values.policyValidator.injectCaFrom }}
-    cert-manager.io/inject-ca-from: {{ .Values.policyValidator.injectCaFrom }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.policyValidator.injectCaFrom }}
   {{- end }}
   {{- if .Values.policyValidator.injectCaFromSecret }}
-    cert-manager.io/inject-ca-from-secret: {{ .Values.policyValidator.injectCaFromSecret }}
+    cert-manager.io/inject-ca-from-secret: {{ .Release.Namespace }}/{{ .Values.policyValidator.injectCaFromSecret }}
   {{- end }}
   {{- end }}
   labels:

--- a/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
@@ -84,10 +84,10 @@ metadata:
   {{- if or (.Values.proxyInjector.injectCaFrom) (.Values.proxyInjector.injectCaFromSecret) }}
   annotations:
   {{- if .Values.proxyInjector.injectCaFrom }}
-    cert-manager.io/inject-ca-from: {{ .Values.proxyInjector.injectCaFrom }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.proxyInjector.injectCaFrom }}
   {{- end }}
   {{- if .Values.proxyInjector.injectCaFromSecret }}
-    cert-manager.io/inject-ca-from-secret: {{ .Values.proxyInjector.injectCaFromSecret }}
+    cert-manager.io/inject-ca-from-secret: {{ .Release.Namespace }}/{{ .Values.proxyInjector.injectCaFromSecret }}
   {{- end }}
   {{- end }}
   labels:


### PR DESCRIPTION
Subject: added .Release.Name to webhook configuration `inject-ca-from` annotation in the Helm templates 

Problem: unable to configure webhook certificate auto rotation due to improper webhook annotation format

Solution: modified existing annotation points to add .Release.Namespace variable in Secret reference path

Validation

Fixes #[10922]

Signed-off-by: Jane Smith <jane.smith@example.com>
