### PR TITLE
Fix bug where topology routing would not disable while service was under load.

### DIFF
--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -81,12 +81,6 @@ See https://github.com/docker/buildx/issues/59 for more details'
         exit 1
       fi
     fi
-    # Allow for specifying docker builder engine
-    # This is a great way to use k8s to build docker images on native hardware instead of emulated
-    # See https://docs.docker.com/build/drivers/kubernetes/ for an example
-    if [ "$DOCKER_BUILDER" ] then
-        output_params+=" --builder=$DOCKER_BUILDER"
-    fi
 
     log_debug "  :; docker buildx $rootdir $cache_params $output_params -t $repo:$tag -f $file $*"
     # shellcheck disable=SC2086

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -91,7 +91,6 @@ See https://github.com/docker/buildx/issues/59 for more details'
     log_debug "  :; docker buildx $rootdir $cache_params $output_params -t $repo:$tag -f $file $*"
     # shellcheck disable=SC2086
     docker buildx build "$rootdir" $cache_params \
-        --builder=kube \
         $output_params \
         -t "$repo:$tag" \
         -f "$file" \

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -81,10 +81,17 @@ See https://github.com/docker/buildx/issues/59 for more details'
         exit 1
       fi
     fi
+    # Allow for specifying docker builder engine
+    # This is a great way to use k8s to build docker images on native hardware instead of emulated
+    # See https://docs.docker.com/build/drivers/kubernetes/ for an example
+    if [ "$DOCKER_BUILDER" ] then
+        output_params+=" --builder=$DOCKER_BUILDER"
+    fi
 
     log_debug "  :; docker buildx $rootdir $cache_params $output_params -t $repo:$tag -f $file $*"
     # shellcheck disable=SC2086
     docker buildx build "$rootdir" $cache_params \
+        --builder=kube \
         $output_params \
         -t "$repo:$tag" \
         -f "$file" \

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -155,6 +155,7 @@ func (et *endpointTranslator) filterAddresses() watcher.AddressSet {
 			for k, v := range et.availableEndpoints.Addresses {
 				filtered[k] = v
 			}
+			et.log.Debugf("Hints not available on endpointslice. Zone Filtering disabled. Falling back to routing to all pods")
 			return watcher.AddressSet{
 				Addresses:          filtered,
 				Labels:             et.availableEndpoints.Labels,

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -677,16 +677,6 @@ func (pp *portPublisher) updateEndpointSlice(oldSlice *discovery.EndpointSlice, 
 	}
 
 	add, remove := diffAddresses(pp.addresses, updatedAddressSet)
-	pp.log.Debugf("Editing endpoint-slice %v", oldSlice.Name)
-	pp.log.Debugf("Editing endpoint-slice %v - add %v - remove %v", oldSlice.Name, len(add.Addresses), len(remove.Addresses))
-	for _, address := range add.Addresses {
-		pp.log.Debugf("Add address %#v with zones %v", address.Pod.Name, address.ForZones)
-	}
-	for _, address := range remove.Addresses {
-		pp.log.Debugf("Remove address %#v with zones %v", address.Pod.Name, address.ForZones)
-	}
-	pp.log.Debugf("Done Editing endpoint-slice %v", oldSlice.Name)
-
 	for _, listener := range pp.listeners {
 		if len(remove.Addresses) > 0 {
 			listener.Remove(remove)

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -677,6 +677,16 @@ func (pp *portPublisher) updateEndpointSlice(oldSlice *discovery.EndpointSlice, 
 	}
 
 	add, remove := diffAddresses(pp.addresses, updatedAddressSet)
+	pp.log.Debugf("Editing endpoint-slice %v", oldSlice.Name)
+	pp.log.Debugf("Editing endpoint-slice %v - add %v - remove %v", oldSlice.Name, len(add.Addresses), len(remove.Addresses))
+	for _, address := range add.Addresses {
+		pp.log.Debugf("Add address %#v with zones %v", address.Pod.Name, address.ForZones)
+	}
+	for _, address := range remove.Addresses {
+		pp.log.Debugf("Remove address %#v with zones %v", address.Pod.Name, address.ForZones)
+	}
+	pp.log.Debugf("Done Editing endpoint-slice %v", oldSlice.Name)
+
 	for _, listener := range pp.listeners {
 		if len(remove.Addresses) > 0 {
 			listener.Remove(remove)

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -1171,6 +1171,7 @@ func addressChanged(oldAddress Address, newAddress Address) bool {
 	}
 
 	// Sort the zone information so that we can compare them accurately
+	// We can't use `sort.StringSlice` because these are arrays of structs and not just strings
 	sort.Slice(oldAddress.ForZones, func(i, j int) bool {
 		return oldAddress.ForZones[i].Name < (oldAddress.ForZones[j].Name)
 	})

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -2351,7 +2351,7 @@ endpoints:
     name: name1-1
     namespace: ns
   topology:
-  kubernetes.io/hostname: node-1
+    kubernetes.io/hostname: node-1
 kind: EndpointSlice
 metadata:
   labels:
@@ -2411,7 +2411,122 @@ status:
 		ForZones: []dv1.ForZone{{Name: "zone1"}},
 	}
 
-	es, err = k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Update(context.Background(), es, metav1.UpdateOptions{})
+	_, err = k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Update(context.Background(), es, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k8sAPI.Sync(nil)
+
+	listener.ExpectAdded([]string{"172.17.0.12:8989"}, t)
+}
+
+// Test that when an endpointslice loses a hint, then mark it as a change
+func TestEndpointSliceRemoveHints(t *testing.T) {
+	k8sConfigsWithES := []string{`
+kind: APIResourceList
+apiVersion: v1
+groupVersion: discovery.k8s.io/v1
+resources:
+- name: endpointslices
+  singularName: endpointslice
+  namespaced: true
+  kind: EndpointSlice
+  verbs:
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - create
+    - update
+    - watch
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: name1
+  namespace: ns
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8989`, `
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 172.17.0.12
+  conditions:
+  ready: true
+  targetRef:
+    kind: Pod
+    name: name1-1
+    namespace: ns
+  topology:
+    kubernetes.io/hostname: node-1
+kind: EndpointSlice
+hints:
+  forZones:
+  - name: zone1
+metadata:
+  labels:
+    kubernetes.io/service-name: name1
+  name: name1-es
+  namespace: ns
+ports:
+- name: ""
+  port: 8989`, `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: name1-1
+  namespace: ns
+status:
+  phase: Running
+  podIP: 172.17.0.12`}
+
+	// Create an EndpointSlice with one endpoint, backed by a pod.
+
+	k8sAPI, err := k8s.NewFakeAPI(k8sConfigsWithES...)
+	if err != nil {
+		t.Fatalf("NewFakeAPI returned an error: %s", err)
+	}
+
+	metadataAPI, err := k8s.NewFakeMetadataAPI(nil)
+	if err != nil {
+		t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
+	}
+
+	watcher, err := NewEndpointsWatcher(k8sAPI, metadataAPI, logging.WithField("test", t.Name()), true)
+	if err != nil {
+		t.Fatalf("can't create Endpoints watcher: %s", err)
+	}
+
+	k8sAPI.Sync(nil)
+	metadataAPI.Sync(nil)
+
+	listener := newBufferingEndpointListener()
+
+	err = watcher.Subscribe(ServiceID{Name: "name1", Namespace: "ns"}, 8989, "", listener)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k8sAPI.Sync(nil)
+
+	listener.ExpectAdded([]string{"172.17.0.12:8989"}, t)
+
+	// Remove a hint from the EndpointSlice
+	es, err := k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Get(context.Background(), "name1-es", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	es.Endpoints[0].Hints = &dv1.EndpointHints{
+		//ForZones: []dv1.ForZone{{Name: "zone1"}},
+	}
+
+	_, err = k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Update(context.Background(), es, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add support for enabling and disabling topology aware routing when hints are added/removed.

The testing setup is very involved because it involves so many moving parts

1) Setup a service which is layered over several availability zones.
1a) The best way to do this is one service object, with 3 replicasets explicitly forced to use a specific AZ each.
2) Add `service.kubernetes.io/topology-aware-hints: Auto` annotation to the Service object
3) Use a load tester like k6 to send meaningful traffic to your service but only in one AZ
3) Scale up your replica sets until k8s adds Hints to your endpointslices
4) Observe that traffic shifts to only hit pods in one AZ

5) Turn down the replicasets count until such time that K8s removes the hints from your endpointslices
6) Observe traffic shifts back to all pods across all AZ.

![image](https://github.com/linkerd/linkerd2/assets/2237823/88097567-b120-4144-ba4e-a5cfb3efbede)
 In this image, you can see traffic shifting from all pods, to only some pods and back to all pods. The orange line is the average traffic which remains constant.
