### PR TITLE
Parse probe paths as URI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "futures",
+ "http",
  "k8s-gateway-api",
  "kubert",
  "linkerd-policy-controller-core",

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 ahash = "0.8"
 anyhow = "1"
 futures = { version = "0.3", default-features = false }
+http = "0.2"
 k8s-gateway-api = "0.11"
 kubert = { version = "0.16", default-features = false, features = ["index"] }
 linkerd-policy-controller-core = { path = "../../core" }

--- a/policy-controller/k8s/index/src/inbound/pod.rs
+++ b/policy-controller/k8s/index/src/inbound/pod.rs
@@ -74,8 +74,13 @@ fn container_http_probe_paths(
         .filter_map(|p| {
             let probe = p.http_get.as_ref()?;
             let port = get_port(&probe.port, container)?;
-            let path = probe.path.clone().unwrap_or_else(|| "/".to_string());
-            Some((port, path))
+            match http::Uri::try_from(probe.path.as_deref().unwrap_or("/")) {
+                Ok(uri) => Some((port, uri.path().to_string())),
+                Err(error) => {
+                    tracing::warn!(%error, "invalid probe path");
+                    None
+                }
+            }
         })
 }
 
@@ -312,5 +317,28 @@ mod tests {
         let paths = probes.get(&8080.try_into().unwrap()).unwrap();
         assert_eq!(paths.len(), 1);
         assert_eq!(paths.iter().next().unwrap(), "/");
+    }
+
+    #[test]
+    fn probe_with_params() {
+        let probes = pod_http_probes(&k8s::PodSpec {
+            containers: vec![k8s::Container {
+                liveness_probe: Some(k8s::Probe {
+                    http_get: Some(k8s::HTTPGetAction {
+                        path: Some("/liveness-container-1?foo=bar".to_string()),
+                        port: k8s::IntOrString::Int(5432),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+
+        assert_eq!(probes.len(), 1);
+        let paths = probes.get(&5432.try_into().unwrap()).unwrap();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths.iter().next().unwrap(), "/liveness-container-1");
     }
 }


### PR DESCRIPTION
Fixes #10877

Linkerd reads the list of container readiness and liveness probes for a pod in order to generate authorizations which allow probes by default.  However, when reading the `path` field of a probe, we interpret this field literally rather than parsing it as a URI.  This means that any non-path parts of the URI (such as URI params) will attempt to match against the path of a probe request, causing these authorizations to fail.

Instead, we parse this field as a URI and only use the path part for path matching. 

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
