### PR TITLE
Add docker builder option to improve build tooling

### DIFF
--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -82,6 +82,13 @@ See https://github.com/docker/buildx/issues/59 for more details'
       fi
     fi
 
+    # Allow for specifying docker builder engine
+    # This is a great way to use k8s to build docker images on native hardware instead of emulated
+    # See https://docs.docker.com/build/drivers/kubernetes/ for an example
+    if [ "$DOCKER_BUILDER" ] then
+        output_params+=" --builder=$DOCKER_BUILDER"
+    fi
+
     log_debug "  :; docker buildx $rootdir $cache_params $output_params -t $repo:$tag -f $file $*"
     # shellcheck disable=SC2086
     docker buildx build "$rootdir" $cache_params \


### PR DESCRIPTION
This adds the ability to pass in a docker builder option to docker. This makes building multi-arch images super simple by using our k8s infrastructure.

It also makes building multi-arch images very fast since they can be built in parallel and on native hardware.

DCO Sign off

I agree to the DCO for all the commits in this PR.
