### PR TITLE
edge-23.5.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,12 @@
 
 This edge release includes fixes for several bugs related to HTTPRoute handling.
 
-- Fixed an issue where the `namespace` field on HTTPRoute `backendRef`s was
+* Fixed an issue where the `namespace` field on HTTPRoute `backendRef`s was
   ignored, and the backend Service would always be assumed to be in the
   namespace as the parent Service
-- Fixed an issue where default authorizations generated for readiness and
+* Fixed an issue where default authorizations generated for readiness and
   liveness probes would fail if the probe path included URI query parameters
-- Fixed the proxy not using gRPC response classification for gRPC requests to
+* Fixed the proxy not using gRPC response classification for gRPC requests to
   destinations without ServiceProfiles
 
 ## edge-23.5.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes
 
+## edge-23.5.3
+
+This edge release includes fixes for several bugs related to HTTPRoute handling.
+
+- Fixed an issue where the `namespace` field on HTTPRoute `backendRef`s was
+  ignored, and the backend Service would always be assumed to be in the
+  namespace as the parent Service
+- Fixed an issue where default authorizations generated for readiness and
+  liveness probes would fail if the probe path included URI query parameters
+- Fixed the proxy not using gRPC response classification for gRPC requests to
+  destinations without ServiceProfiles
+
 ## edge-23.5.2
 
 This edge release adds some minor improvements in the MeshTLSAuthentication CRD

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.13.3-edge
+version: 1.13.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.13.3-edge](https://img.shields.io/badge/Version-1.13.3--edge-informational?style=flat-square)
+![Version: 1.13.4-edge](https://img.shields.io/badge/Version-1.13.4--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.0-edge
+version: 30.10.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.10.0-edge](https://img.shields.io/badge/Version-30.10.0--edge-informational?style=flat-square)
+![Version: 30.10.1-edge](https://img.shields.io/badge/Version-30.10.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.9.0-edge
+version: 30.9.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.9.0-edge](https://img.shields.io/badge/Version-30.9.0--edge-informational?style=flat-square)
+![Version: 30.9.1-edge](https://img.shields.io/badge/Version-30.9.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.0-edge
+version: 30.10.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.10.0-edge](https://img.shields.io/badge/Version-30.10.0--edge-informational?style=flat-square)
+![Version: 30.10.1-edge](https://img.shields.io/badge/Version-30.10.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.5.3

This edge release includes fixes for several bugs related to HTTPRoute handling.

- Fixed an issue where the `namespace` field on HTTPRoute `backendRef`s was
  ignored, and the backend Service would always be assumed to be in the
  namespace as the parent Service
- Fixed an issue where default authorizations generated for readiness and
  liveness probes would fail if the probe path included URI query parameters
- Fixed the proxy not using gRPC response classification for gRPC requests to
  destinations without ServiceProfiles