### PR TITLE
linkerd-cni v1.2.0

### DIFF
--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -31,7 +31,7 @@ Kubernetes: `>=1.21.0-0`
 | ignoreOutboundPorts | string | `""` | Default set of outbound ports to skip via iptables |
 | image.name | string | `"cr.l5d.io/linkerd/cni-plugin"` | Docker image for the CNI plugin |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the linkerd-cni container |
-| image.version | string | `"v1.1.3"` | Tag for the CNI container Docker image |
+| image.version | string | `"v1.2.0"` | Tag for the CNI container Docker image |
 | imagePullSecrets | list | `[]` |  |
 | inboundProxyPort | int | `4143` | Inbound port for the proxy container |
 | logLevel | string | `"info"` | Log level for the CNI plugin |

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -53,7 +53,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.1.3"
+  version: "v1.2.0"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -16,7 +16,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 
 	image := cniPluginImage{
 		name:       "my-docker-registry.io/awesome/cni-plugin-test-image",
-		version:    "v1.1.3",
+		version:    "v1.2.0",
 		pullPolicy: nil,
 	}
 	fullyConfiguredOptions := &cniPluginOptions{

--- a/cli/cmd/install_cni_helm_test.go
+++ b/cli/cmd/install_cni_helm_test.go
@@ -35,7 +35,7 @@ func TestRenderCniHelm(t *testing.T) {
   			"logLevel": "debug",
 			"image": {
 				"name": "cr.l5d.io/linkerd/cni-plugin",
-				"version": "v1.1.3"
+				"version": "v1.2.0"
 			},
   			"proxyUID": 1111,
   			"destCNINetDir": "/etc/cni/net.d-test",

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -119,8 +119,8 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.1.3
-        imagePullPolicy:
+        image: cr.l5d.io/linkerd/cni-plugin:v1.2.0
+        imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -120,8 +120,8 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.1.3
-        imagePullPolicy:
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.2.0
+        imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -120,8 +120,8 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.1.3
-        imagePullPolicy:
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.2.0
+        imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -120,8 +120,8 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.1.3
-        imagePullPolicy:
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.2.0
+        imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -120,8 +120,8 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.1.3
-        imagePullPolicy:
+        image: cr.l5d.io/linkerd/cni-plugin:v1.2.0
+        imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -112,7 +112,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.1.3
+        image: cr.l5d.io/linkerd/cni-plugin:v1.2.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -113,7 +113,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.1.3
+        image: cr.l5d.io/linkerd/cni-plugin:v1.2.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cni-plugin/test/install-cni_test.go
+++ b/cni-plugin/test/install-cni_test.go
@@ -147,7 +147,7 @@ func populateK8sCreds(wd string, tempK8sSvcAcctDir string, t *testing.T) {
 
 // startDocker starts a test Docker container and runs the install-cni.sh script.
 func startDocker(testNum int, wd string, testWorkRootDir string, tempCNINetDir string, tempCNIBinDir string, tempK8sSvcAcctDir string, t *testing.T) string {
-	dockerImage := env("HUB", "cr.l5d.io/linkerd") + "/cni-plugin:" + env("CNI_PLUGIN_VERSION", "v1.1.3")
+	dockerImage := env("HUB", "cr.l5d.io/linkerd") + "/cni-plugin:" + env("CNI_PLUGIN_VERSION", "v1.2.0")
 	errFileName := testWorkRootDir + "/docker_run_stderr"
 
 	// Build arguments list by picking whatever is necessary from the environment.

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2422,7 +2422,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.1.3
+        image: cr.l5d.io/linkerd/cni-plugin:v1.2.0
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var Version = undefinedVersion
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
 var ProxyInitVersion = "v2.2.1"
-var LinkerdCNIVersion = "v1.1.3"
+var LinkerdCNIVersion = "v1.2.0"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
This release stops using the "interface" mode, and instead wait till another CNI plugin drops a proper network config and then append the linkerd CNI config to it. This avoids having pods start before proper networking is established in the node.