### PR TITLE
Added jsonpath filter flag for tap cmd

### DIFF
--- a/viz/cmd/root.go
+++ b/viz/cmd/root.go
@@ -27,6 +27,7 @@ const (
 	jsonOutput  = healthcheck.JSONOutput
 	tableOutput = healthcheck.TableOutput
 	wideOutput  = healthcheck.WideOutput
+	jsonPathOutput = "jsonpath"
 )
 
 var (

--- a/viz/cmd/tap_test.go
+++ b/viz/cmd/tap_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/duration"
@@ -140,11 +141,13 @@ func busyTest(t *testing.T, output string) {
 	}
 
 	var goldenFilePath string
-	switch options.output {
-	case wideOutput:
+	switch {
+	case options.output == wideOutput:
 		goldenFilePath = "testdata/tap_busy_output_wide.golden"
-	case jsonOutput:
+	case options.output == jsonOutput:
 		goldenFilePath = "testdata/tap_busy_output_json.golden"
+	case strings.HasPrefix(options.output, jsonPathOutput):
+		goldenFilePath = "testdata/tap_busy_output_jsonpath.golden"
 	default:
 		goldenFilePath = "testdata/tap_busy_output.golden"
 	}
@@ -173,6 +176,10 @@ func TestRequestTapByResourceFromAPI(t *testing.T) {
 
 	t.Run("Should render JSON busy response if everything went well", func(t *testing.T) {
 		busyTest(t, "json")
+	})
+
+	t.Run("Should render jsonpath busy response if everything went well", func(t *testing.T) {
+		busyTest(t, "jsonpath={.source}")
 	})
 
 	t.Run("Should render empty response if no events returned", func(t *testing.T) {

--- a/viz/cmd/testdata/tap_busy_output_jsonpath.golden
+++ b/viz/cmd/testdata/tap_busy_output_jsonpath.golden
@@ -1,0 +1,10 @@
+{
+  "ip": "0.0.0.1",
+  "port": 0,
+  "metadata": null
+}
+{
+  "ip": "0.0.0.1",
+  "port": 0,
+  "metadata": null
+}

--- a/viz/pkg/jsonpath/jsonpath.go
+++ b/viz/pkg/jsonpath/jsonpath.go
@@ -1,0 +1,86 @@
+package jsonpath
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
+
+func GetJsonPathFlagVal(flagVal string) (string, error) {
+	val := strings.Split(flagVal, "=")
+	if len(val) != 2 || len(val) == 2 && val[1] == "" {
+		return "", errors.New("{\"error jsonpath\": \"jsonpath filter not found\"}")
+	}
+
+	return val[1], nil
+
+}
+
+// GetJSONPathExpression get jsonpath filter from flag and attempts to be flexible with JSONPath expressions, it accepts:
+//   - metadata.name (no leading '.' or curly braces '{...}'
+//   - {metadata.name} (no leading '.')
+//   - .metadata.name (no curly braces '{...}')
+//   - {.metadata.name} (complete expression)
+//
+// And transforms them all into a valid jsonpath expression:
+//
+//	{.metadata.name}
+func GetFormatedJSONPathExpression(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", errors.New("{\"error jsonpath\": \"unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'\"}")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("{\"error jsonpath\":\"unexpected submatch list: %v\"", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}
+
+func GetJsonFilteredByJPath(event interface{}, jsonPath string) ([]string, error) {
+	fields, err := GetFormatedJSONPathExpression(jsonPath)
+	if err != nil {
+		return []string{}, err
+	}
+
+	j := jsonpath.New("EventParser")
+	if err := j.Parse(fields); err != nil {
+		return []string{}, fmt.Errorf("{\"error parsing jsonpath\":\" %s\" }", err.Error())
+	}
+
+	results, err := j.FindResults(event)
+	if err != nil {
+		return []string{}, fmt.Errorf("{\"error jsonpath\":\" %s\" }", err.Error())
+	}
+
+	filteredEvent := []string{}
+	if len(results) == 0 || len(results[0]) == 0 {
+		return filteredEvent, errors.New("{\"error filtering JSON\": \"couldn't find any results matching with jsonpath filter\"}")
+	}
+
+	for _, result := range results {
+		for _, match := range result {
+			e, err := json.MarshalIndent(match.Interface(), "", "  ")
+			if err != nil {
+				return []string{}, fmt.Errorf("{\"error marshalling JSON\": \"%s\"}", err.Error())
+			}
+			filteredEvent = append(filteredEvent, string(e))
+		}
+	}
+
+	return filteredEvent, nil
+}


### PR DESCRIPTION
Problem: Tap events doesn't supports filtering of json output fields

Solution: Using jsonpath to filter the json tap events events

This PR includes changes to support filtering of json events according to jsonpath provided in the -o flag

Fixes: #3035

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
Attaching screenshot of local testing

![Screenshot from 2023-06-08 13-10-45](https://github.com/linkerd/linkerd2/assets/46951138/f2042c8c-28fc-422e-9913-a7b6be3ab993)

