### PR TITLE
Add validatorEnabled field to the linkerd-control-plane values.yaml

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -330,7 +330,7 @@ spec:
           name: policy-tls
           readOnly: true
       initContainers:
-      {{ if .Values.cniEnabled -}}
+      {{ if and (.Values.cniEnabled) (.Values.validatorEnabled) -}}
       - {{- include "partials.network-validator" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ else -}}
       {{- /*

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -216,7 +216,7 @@ spec:
       {{- $_ := set $tree.Values.proxy "inboundDiscoveryCacheUnusedTimeout" "90s" }}
       - {{- include "partials.proxy" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       initContainers:
-      {{ if .Values.cniEnabled -}}
+      {{ if and (.Values.cniEnabled) (.Values.validatorEnabled) -}}
       - {{- include "partials.network-validator" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ else -}}
       {{- /*

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -118,7 +118,7 @@ spec:
           name: tls
           readOnly: true
       initContainers:
-      {{ if .Values.cniEnabled -}}
+      {{ if and (.Values.cniEnabled) (.Values.validatorEnabled) -}}
       - {{- include "partials.network-validator" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ else -}}
       {{- /*

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -43,6 +43,10 @@ enablePodDisruptionBudget: false
 # and the proxy-init container when injecting the proxy;
 # requires the linkerd-cni plugin to already be installed
 cniEnabled: false
+# -- setting validatorEnabled to false will eliminate the network validator when
+# using the linkerd-cni plugin. This will only take effect if you are using the
+# linkerd-cni plugin.
+validatorEnabled: true
 # -- Trust root certificate (ECDSA). It must be provided during install.
 identityTrustAnchorsPEM: |
 # -- Trust domain used for identity

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -140,11 +140,12 @@ type (
 	}
 
 	NetworkValidator struct {
-		LogLevel    string `json:"logLevel"`
-		LogFormat   string `json:"logFormat"`
-		ConnectAddr string `json:"connectAddr"`
-		ListenAddr  string `json:"listenAddr"`
-		Timeout     string `json:"timeout"`
+		LogLevel         string `json:"logLevel"`
+		LogFormat        string `json:"logFormat"`
+		ConnectAddr      string `json:"connectAddr"`
+		ListenAddr       string `json:"listenAddr"`
+		Timeout          string `json:"timeout"`
+		ValidatorEnabled bool   `json:"validatorEnabled"`
 	}
 
 	// DebugContainer contains the fields to set the debugging sidecar

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -162,11 +162,12 @@ func TestNewValues(t *testing.T) {
 			RunAsUser: 65534,
 		},
 		NetworkValidator: &NetworkValidator{
-			LogLevel:    "debug",
-			LogFormat:   "plain",
-			ConnectAddr: "1.1.1.1:20001",
-			ListenAddr:  "0.0.0.0:4140",
-			Timeout:     "10s",
+			LogLevel:         "debug",
+			LogFormat:        "plain",
+			ConnectAddr:      "1.1.1.1:20001",
+			ListenAddr:       "0.0.0.0:4140",
+			Timeout:          "10s",
+			ValidatorEnabled: true,
 		},
 		Identity: &Identity{
 			ServiceAccountTokenProjection: true,


### PR DESCRIPTION

In order to address the issue #10879 Linkerd 2.13 needs to be modified to allow openshift users to disable the network validator init container. This change introduces an option that allows users to do so.

This adds the field `validatorEnabled` with a default value of `true` to the values.yaml for the linkerd-control-plane chart. It also adds a condition to the linkerd-control-plane chart so that we only add the network-validator partials if `validatorEnabled` is set to true. This gives a linkerd operator the option to disable the validator if they need to.