### PR TITLE
Fix missing resource-cni label on linkerd-cni

### DIFF
--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -196,10 +196,10 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
       annotations:
         {{ include "partials.annotations.created-by" . }}
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       {{- if .Values.tolerations }}

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -99,9 +99,9 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       tolerations:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -99,9 +99,9 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       tolerations:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -99,9 +99,9 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       tolerations:

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -99,9 +99,9 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       tolerations:

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -100,9 +100,9 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       tolerations:

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -92,9 +92,9 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
       annotations:
         linkerd.io/created-by: linkerd/cli dev-undefined
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       tolerations:

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -92,9 +92,9 @@ spec:
     metadata:
       labels:
         k8s-app: linkerd-cni
+        linkerd.io/cni-resource: "true"
       annotations:
         linkerd.io/created-by: test-version
-        linkerd.io/cni-resource: "true"
         linkerd.io/inject: disabled
     spec:
       tolerations:


### PR DESCRIPTION
Move  `linkerd.io/cni-resource: "true"` from an annotation to a label in linkerd-cni.

This will improve the decoupling of the linkerd cni and the linkerd control plane (proxy injector).

With this change, even if the proxy injector is broken (for whatever reason), the linkerd-cni can still come up. Currently, since the label is not present (and if you configure the MutatingWebhook with a policy `fail`) the cni pods will completely fail to come up and this might cause and outage.

See default `objectSelector` for the `MutatingWebhook`: https://github.com/linkerd/linkerd2/blob/main/charts/linkerd-control-plane/values.yaml#L370

Closes #11058