### PR TITLE
prepare to release edge-23.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,8 @@
 ## edge-23.7.1
 
 This edge release adds support for the upstream `gateway.networking.k8s.io`
-HTTPRoute resource (rather than the `policy.linkerd.io` CRD installed by
-Linkerd). In addition, it fixes a bug where the ingress-mode proxy would fail to
+HTTPRoute resource (in addition to the `policy.linkerd.io` CRD installed by
+Linkerd). Furthermore, it fixes a bug where the ingress-mode proxy would fail to
 fall back to ServiceProfiles for destinations without HTTPRoutes.
 
 * Added support for `gateway.networking.k8s.io` HTTPRoutes in the policy

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes
 
+## edge-23.7.1
+
+This edge release adds support for the upstream `gateway.networking.k8s.io`
+HTTPRoute resource (rather than the `policy.linkerd.io` CRD installed by
+Linkerd). In addition, it fixes a bug where the ingress-mode proxy would fail to
+fall back to ServiceProfiles for destinations without HTTPRoutes.
+
+* Added support for `gateway.networking.k8s.io` HTTPRoutes in the policy
+  controller
+* Added distinguishable version information to proxy logs and metrics
+* Fixed incorrect handling of `NotFound` client policies in ingress-mode proxies
+
 ## edge-23.6.3
 
 This edge release adds leader-election capabilities to the service-mirror

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.13.7-edge
+version: 1.13.8-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.13.7-edge](https://img.shields.io/badge/Version-1.13.7--edge-informational?style=flat-square)
+![Version: 1.13.8-edge](https://img.shields.io/badge/Version-1.13.8--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.7.3-edge
+version: 1.7.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.7.3-edge](https://img.shields.io/badge/Version-1.7.3--edge-informational?style=flat-square)
+![Version: 1.7.4-edge](https://img.shields.io/badge/Version-1.7.4--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.9.3-edge
+version: 30.9.4-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.9.3-edge](https://img.shields.io/badge/Version-30.9.3--edge-informational?style=flat-square)
+![Version: 30.9.4-edge](https://img.shields.io/badge/Version-30.9.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -105,7 +105,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -3437,7 +3437,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -3525,7 +3525,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -3578,7 +3578,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -3844,7 +3844,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -3979,7 +3979,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
@@ -4257,7 +4257,7 @@ metadata:
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.7.3-edge
+    helm.sh/chart: linkerd-crds-1.7.4-edge
     linkerd.io/control-plane-ns: linkerd
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.4-edge
+version: 30.10.5-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.10.4-edge](https://img.shields.io/badge/Version-30.10.4--edge-informational?style=flat-square)
+![Version: 30.10.5-edge](https://img.shields.io/badge/Version-30.10.5--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.9.4-edge
+version: 30.9.5-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.9.4-edge](https://img.shields.io/badge/Version-30.9.4--edge-informational?style=flat-square)
+![Version: 30.9.5-edge](https://img.shields.io/badge/Version-30.9.5--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.3-edge
+version: 30.10.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.10.3-edge](https://img.shields.io/badge/Version-30.10.3--edge-informational?style=flat-square)
+![Version: 30.10.4-edge](https://img.shields.io/badge/Version-30.10.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release adds support for the upstream `gateway.networking.k8s.io`
HTTPRoute resource (rather than the `policy.linkerd.io` CRD installed by
Linkerd). In addition, it fixes a bug where the ingress-mode proxy would fail to
fall back to ServiceProfiles for destinations without HTTPRoutes.

* Added support for `gateway.networking.k8s.io` HTTPRoutes in the policy
  controller
* Added distinguishable version information to proxy logs and metrics
* Fixed incorrect handling of `NotFound` client policies in ingress-mode proxies