### PR TITLE
Make `CheckURL` and `DefaultDockerRegistry` vars

### DIFF
--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -84,7 +84,7 @@ func (options *cniPluginOptions) pluginImage() cnicharts.Image {
 		image.Name = cmd.RegistryOverride(options.image.name, override)
 		return image
 	}
-	if options.dockerRegistry != defaultDockerRegistry {
+	if options.dockerRegistry != cmd.DefaultDockerRegistry {
 		image.Name = cmd.RegistryOverride(options.image.name, options.dockerRegistry)
 		return image
 	}
@@ -108,7 +108,7 @@ This command installs a DaemonSet into the Linkerd control plane. The DaemonSet
 copies the necessary linkerd-cni plugin binaries and configs onto the host. It
 assumes that the 'linkerd install' command will be executed with the
 '--linkerd-cni-enabled' flag. This command needs to be executed before the
-'linkerd install --linkerd-cni-enabled' command. 
+'linkerd install --linkerd-cni-enabled' command.
 
 The installation can be configured by using the --set, --values, --set-string and --set-file flags. A full list of configurable values can be found at https://artifacthub.io/packages/helm/linkerd2/linkerd2-cni#values`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -151,13 +151,13 @@ func newCNIInstallOptionsWithDefaults() (*cniPluginOptions, error) {
 	}
 
 	cniPluginImage := cniPluginImage{
-		name:    defaultDockerRegistry + "/cni-plugin",
+		name:    cmd.DefaultDockerRegistry + "/cni-plugin",
 		version: version.LinkerdCNIVersion,
 	}
 
 	cniOptions := cniPluginOptions{
 		linkerdVersion:      version.Version,
-		dockerRegistry:      defaultDockerRegistry,
+		dockerRegistry:      cmd.DefaultDockerRegistry,
 		proxyControlPort:    4190,
 		proxyAdminPort:      4191,
 		inboundPort:         defaults.InboundProxyPort,

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -397,7 +397,7 @@ func makeProxyFlags(defaults *l5dcharts.Values) ([]flag.Flag, *pflag.FlagSet) {
 			}),
 	}
 
-	registryFlag := flag.NewStringFlag(proxyFlags, "registry", defaultDockerRegistry,
+	registryFlag := flag.NewStringFlag(proxyFlags, "registry", cmd.DefaultDockerRegistry,
 		fmt.Sprintf("Docker registry to pull images from ($%s)", flagspkg.EnvOverrideDockerRegistry),
 		func(values *l5dcharts.Values, value string) error {
 			values.ControllerImage = cmd.RegistryOverride(values.ControllerImage, value)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -22,7 +22,6 @@ const (
 	defaultLinkerdNamespace = "linkerd"
 	defaultCNINamespace     = "linkerd-cni"
 	defaultClusterDomain    = "cluster.local"
-	defaultDockerRegistry   = "cr.l5d.io/linkerd"
 
 	jsonOutput  = healthcheck.JSONOutput
 	tableOutput = healthcheck.TableOutput

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -11,7 +11,7 @@ import (
 	"github.com/linkerd/linkerd2/jaeger/static"
 	"github.com/linkerd/linkerd2/pkg/charts"
 	partials "github.com/linkerd/linkerd2/pkg/charts/static"
-	"github.com/linkerd/linkerd2/pkg/cmd"
+	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/spf13/cobra"
@@ -75,7 +75,7 @@ A full list of configurable values can be found at https://www.github.com/linker
 		},
 	}
 
-	cmd.Flags().StringVar(&registry, "registry", "cr.l5d.io/linkerd",
+	cmd.Flags().StringVar(&registry, "registry", pkgcmd.DefaultDockerRegistry,
 		fmt.Sprintf("Docker registry to pull jaeger-webhook image from ($%s)", flags.EnvOverrideDockerRegistry))
 	cmd.Flags().BoolVar(&skipChecks, "skip-checks", false, `Skip checks for linkerd core control-plane existence`)
 	cmd.Flags().BoolVar(&ignoreCluster, "ignore-cluster", false,
@@ -152,11 +152,11 @@ func render(w io.Writer, valuesOverrides map[string]interface{}, registry string
 
 	regOrig := vals["webhook"].(map[string]interface{})["image"].(map[string]interface{})["name"].(string)
 	if registry != "" {
-		vals["webhook"].(map[string]interface{})["image"].(map[string]interface{})["name"] = cmd.RegistryOverride(regOrig, registry)
+		vals["webhook"].(map[string]interface{})["image"].(map[string]interface{})["name"] = pkgcmd.RegistryOverride(regOrig, registry)
 	}
 	// env var overrides CLI flag
 	if override := os.Getenv(flags.EnvOverrideDockerRegistry); override != "" {
-		vals["webhook"].(map[string]interface{})["image"].(map[string]interface{})["name"] = cmd.RegistryOverride(regOrig, override)
+		vals["webhook"].(map[string]interface{})["image"].(map[string]interface{})["name"] = pkgcmd.RegistryOverride(regOrig, override)
 	}
 
 	fullValues := map[string]interface{}{

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -389,7 +389,7 @@ func newLinkOptionsWithDefault() (*linkOptions, error) {
 	return &linkOptions{
 		controlPlaneVersion:     version.Version,
 		namespace:               defaultMulticlusterNamespace,
-		dockerRegistry:          defaultDockerRegistry,
+		dockerRegistry:          pkgcmd.DefaultDockerRegistry,
 		serviceMirrorRetryLimit: defaults.ServiceMirrorRetryLimit,
 		logLevel:                defaults.LogLevel,
 		logFormat:               defaults.LogFormat,

--- a/multicluster/cmd/root.go
+++ b/multicluster/cmd/root.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	defaultDockerRegistry                = "cr.l5d.io/linkerd"
 	defaultLinkerdNamespace              = "linkerd"
 	defaultMulticlusterNamespace         = "linkerd-multicluster"
 	defaultGatewayName                   = "linkerd-gateway"

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -22,6 +22,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+var (
+	// DefaultDockerRegistry specifies the default location for Linkerd's images.
+	DefaultDockerRegistry = "cr.l5d.io/linkerd"
+)
+
 // GetDefaultNamespace fetches the default namespace
 // used in the current KubeConfig context
 func GetDefaultNamespace(kubeconfigPath, kubeContext string) string {

--- a/pkg/version/channels.go
+++ b/pkg/version/channels.go
@@ -17,7 +17,7 @@ type Channels struct {
 	array []channelVersion
 }
 
-const (
+var (
 	// CheckURL provides an online endpoint for Linkerd's version checks
 	CheckURL = "https://versioncheck.linkerd.io/version.json"
 )


### PR DESCRIPTION
It's useful to modify values for `CheckURL` and `DefaultDockerRegistry`, to test different configurations of Linkerd. To modify these at build time, they must be public vars.

Make `CheckURL` and `DefaultDockerRegistry` public vars, to allow for build-time modification using Go's `-ldflags`.

Also, DRY up `DefaultDockerRegistry`.
