### PR TITLE
policy: Add optional `boringssl` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,9 +151,12 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
+ "futures-core",
  "getrandom",
  "instant",
+ "pin-project-lite",
  "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -161,6 +170,25 @@ name = "base64"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
 
 [[package]]
 name = "bindgen"
@@ -195,6 +223,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "boring"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
+dependencies = [
+ "bitflags",
+ "boring-sys",
+ "foreign-types 0.5.0",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "boring-sys"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7663d3069437a5ccdb2b5f4f481c8b80446daea10fa8503844e89ac65fcdc363"
+dependencies = [
+ "bindgen 0.60.1",
+ "cmake",
 ]
 
 [[package]]
@@ -292,6 +343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -555,7 +615,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -563,6 +644,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -815,6 +902,23 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-boring"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7419ead5df56b00201fc95d01b2b5fed1329216f72306e3480c5dd6c2b8aa0a"
+dependencies = [
+ "antidote",
+ "boring",
+ "http",
+ "hyper",
+ "linked_hash_set",
+ "once_cell",
+ "tokio",
+ "tokio-boring",
+ "tower-layer",
 ]
 
 [[package]]
@@ -1151,11 +1255,12 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02666a25673a963105bf8a395aff94b8f56a2e709b99e8503ed9262c2a81a7b9"
+version = "0.16.1"
+source = "git+https://github.com/hawkw/kubert?branch=eliza/custom-client#3fcf657d16524ffe48e6a91e0c48262b0083c450"
 dependencies = [
  "ahash 0.8.3",
+ "backoff",
+ "bytes",
  "chrono",
  "clap",
  "deflate",
@@ -1177,7 +1282,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
- "tower-service",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1216,7 +1321,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
 dependencies = [
- "bindgen",
+ "bindgen 0.64.0",
  "errno",
  "libc",
 ]
@@ -1255,6 +1360,7 @@ dependencies = [
  "drain",
  "futures",
  "hyper",
+ "hyper-boring",
  "ipnet",
  "jemallocator",
  "k8s-gateway-api",
@@ -1644,7 +1750,7 @@ checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -2413,6 +2519,17 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tokio-boring"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb059337235a89f03252c6285da8f0a6747a85bbd42e9ece70178d578054cba7"
+dependencies = [
+ "boring",
+ "boring-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
 
 [profile.release]
 lto = "thin"
+
+[patch.crates-io]
+kubert = { git = "https://github.com/hawkw/kubert", branch = "eliza/custom-client" }

--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,10 @@ skip = [
     { name = "ahash", version = "0.7" },
     # syn v2 has been released and some libraries are slower to adopt it
     { name = "syn", version = "1.0" },
+    # `hyper-openssl` and `hyper-boring` depend on very different versions of
+    # this crate. this isn't a huge deal, as the features that enable
+    # `hyper-openssl` and `hyper-boring` are mutually exclusive.
+    { name = "foreign-types" },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -69,6 +69,7 @@ skip = [
     # this crate. this isn't a huge deal, as the features that enable
     # `hyper-openssl` and `hyper-boring` are mutually exclusive.
     { name = "foreign-types" },
+    { name = "foreign-types-shared" },
 ]
 
 [sources]

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -11,6 +11,7 @@ openssl-tls = ["kube/openssl-tls"]
 # Vendor openssl to statically link lib
 openssl-vendored = ["openssl/vendored"]
 rustls-tls = ["kube/rustls-tls"]
+boring-tls = ["hyper-boring"]
 
 [dependencies]
 anyhow = "1"
@@ -20,6 +21,7 @@ futures = { version = "0.3", default-features = false }
 k8s-gateway-api = "0.11"
 k8s-openapi = { version = "0.17", features = ["v1_20"] }
 hyper = { version = "0.14", features = ["http1", "http2", "runtime", "server"] }
+hyper-boring = { version = "2.1.2", optional = true, default-features = false, features = ["runtime"] }
 ipnet = { version = "2", default-features = false }
 linkerd-policy-controller-core = { path = "./core" }
 linkerd-policy-controller-grpc = { path = "./grpc" }


### PR DESCRIPTION
This branch adds a feature flag for building the policy controller with `boringssl` as the TLS client library.

Depends on olix0r/kubert#165