### PR TITLE
cli: inconsistent precedence for registry flag

### DIFF
--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -53,6 +53,13 @@ type (
 
 func newLinkCommand() *cobra.Command {
 	opts, err := newLinkOptionsWithDefault()
+
+	// Override the default value with env registry path.
+	// If cli cmd contains --registry flag, it will override env variable.
+	if registry := os.Getenv(flags.EnvOverrideDockerRegistry); registry != "" {
+		opts.dockerRegistry = registry
+	}
+
 	var valuesOptions valuespkg.Options
 
 	if err != nil {
@@ -421,10 +428,6 @@ func buildServiceMirrorValues(opts *linkOptions) (*multicluster.Values, error) {
 	defaults, err := multicluster.NewLinkValues()
 	if err != nil {
 		return nil, err
-	}
-
-	if reg := os.Getenv(flags.EnvOverrideDockerRegistry); reg != "" {
-		opts.dockerRegistry = reg
 	}
 
 	defaults.TargetClusterName = opts.clusterName


### PR DESCRIPTION
**Fixes:** #11115

**Problem:**
Commands `jaeger install`, `multicluster link` give precedence to `LINKERD_DOCKER_REGISTRY` env var, whereas commands `install`, `upgrade` and `inject` give preference to `--register` flag.

**Solution:**
Make the commands consitent by giving precedence to `--register` flag in all commands.

**Tasks:**
- [x] Make `jaeger install` give precedence to `--register`
- [x] Make `multicluster link` give precedence to `--register`

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
