### PR TITLE
Fix `linkerd check --output` flag description

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -79,7 +79,7 @@ following flags:
 
 * `--namespace`/`-n`: Namespace to use for –proxy checks (default: all
   namespaces)
-* `--output`/`-o`: Output format. One of: table, json
+* `--output`/`-o`: Output format. One of: table, json, short
 * `--pre`: Only run pre-installation checks, to determine if the extension can
   be installed
 * `--proxy`: Only run data-plane checks, to determine if the data plane is

--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -67,7 +67,7 @@ func (options *checkOptions) checkFlagSet() *pflag.FlagSet {
 
 	flags.StringVar(&options.versionOverride, "expected-version", options.versionOverride, "Overrides the version used when checking if Linkerd is running the latest version (mostly for testing)")
 	flags.StringVar(&options.cliVersionOverride, "cli-version-override", "", "Used to override the version of the cli (mostly for testing)")
-	flags.StringVarP(&options.output, "output", "o", options.output, "Output format. One of: basic, json, short")
+	flags.StringVarP(&options.output, "output", "o", options.output, "Output format. One of: table, json, short")
 	flags.DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 
 	return flags

--- a/jaeger/cmd/check.go
+++ b/jaeger/cmd/check.go
@@ -180,7 +180,7 @@ code.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "Output format. One of: basic, json")
+	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "Output format. One of: table, json, short")
 	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.Flags().BoolVar(&options.proxy, "proxy", options.proxy, "Also run data-plane checks, to determine if the data plane is healthy")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -105,7 +105,7 @@ non-zero exit code.`,
 			return configureAndRunChecks(stdout, stderr, options)
 		},
 	}
-	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "Output format. One of: basic, json")
+	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "Output format. One of: table, json, short")
 	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.Flags().Bool("proxy", false, "")
 	cmd.Flags().MarkHidden("proxy")

--- a/viz/cmd/check.go
+++ b/viz/cmd/check.go
@@ -54,7 +54,7 @@ code.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "Output format. One of: basic, json")
+	cmd.Flags().StringVarP(&options.output, "output", "o", options.output, "Output format. One of: table, json, short")
 	cmd.Flags().BoolVar(&options.proxy, "proxy", options.proxy, "Also run data-plane checks, to determine if the data plane is healthy")
 	cmd.Flags().DurationVar(&options.wait, "wait", options.wait, "Maximum allowed time for all tests to pass")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace to use for --proxy checks (default: all namespaces)")


### PR DESCRIPTION
The `linkerd check --output` flag supports 3 formats: `table`, `json`, and `short`. The default `linkerd check` command description incorrectly printed `basic, json, short`. Other extension check commands printed `basic, json`.

Modify all check output descriptions to print `table, json, short`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
