### PR TITLE
Introduce trace logging in Control Plane

### DIFF
--- a/cli/cmd/install-cni-plugin.go
+++ b/cli/cmd/install-cni-plugin.go
@@ -60,7 +60,7 @@ func (options *cniPluginOptions) validate() error {
 	}
 
 	if _, err := log.ParseLevel(options.logLevel); err != nil {
-		return fmt.Errorf("--cni-log-level must be one of: panic, fatal, error, warn, info, debug")
+		return fmt.Errorf("--cni-log-level must be one of: panic, fatal, error, warn, info, debug, trace")
 	}
 
 	if err := validateRangeSlice(options.ignoreInboundPorts); err != nil {

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -438,7 +438,7 @@ func TestValidate(t *testing.T) {
 		}
 
 		values.ControllerLogLevel = "super"
-		expected := "--controller-log-level must be one of: panic, fatal, error, warn, info, debug"
+		expected := "--controller-log-level must be one of: panic, fatal, error, warn, info, debug, trace"
 
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -485,7 +485,7 @@ func validateValues(ctx context.Context, k *k8s.KubernetesAPI, values *l5dcharts
 	}
 
 	if _, err := log.ParseLevel(values.ControllerLogLevel); err != nil {
-		return fmt.Errorf("--controller-log-level must be one of: panic, fatal, error, warn, info, debug")
+		return fmt.Errorf("--controller-log-level must be one of: panic, fatal, error, warn, info, debug, trace")
 	}
 
 	if values.Proxy.LogLevel == "" {

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -411,7 +411,7 @@ func buildServiceMirrorValues(opts *linkOptions) (*multicluster.Values, error) {
 	}
 
 	if _, err := log.ParseLevel(opts.logLevel); err != nil {
-		return nil, fmt.Errorf("--log-level must be one of: panic, fatal, error, warn, info, debug")
+		return nil, fmt.Errorf("--log-level must be one of: panic, fatal, error, warn, info, debug, trace")
 	}
 
 	if opts.logFormat != "plain" && opts.logFormat != "json" {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -34,7 +34,7 @@ func ConfigureAndParse(cmd *flag.FlagSet, args []string) {
 	flag.Set("log_file", "/dev/null")
 	flag.Set("v", "0")
 	logLevel := cmd.String("log-level", log.InfoLevel.String(),
-		"log level, must be one of: panic, fatal, error, warn, info, debug")
+		"log level, must be one of: panic, fatal, error, warn, info, debug, trace")
 	logFormat := cmd.String("log-format", "plain",
 		"log format, must be one of: plain, json")
 	printVersion := cmd.Bool("version", false, "print version and exit")
@@ -66,12 +66,16 @@ func setLogLevel(logLevel string) {
 	}
 	log.SetLevel(level)
 
-	if level == log.DebugLevel {
+	if level >= log.DebugLevel {
 		flag.Set("stderrthreshold", "INFO")
 		flag.Set("logtostderr", "true")
-		flag.Set("v", "12") // At 7 and higher, authorization tokens get logged.
+		flag.Set("v", "6")
 		// pipe klog entries to logrus
 		klog.SetOutput(log.StandardLogger().Writer())
+	}
+
+	if level >= log.TraceLevel {
+		flag.Set("v", "12") // At 7 and higher, authorization tokens get logged.
 	}
 }
 


### PR DESCRIPTION
The `--log-level` flag did not support a `trace` level, despite the underlying `logrus` library supporting it. Also, at `debug` level, the Control Plane components were setting klog at v=12, which includes sensitive data.

Introduce a `trace` log level. Keep klog at `v=12` for `trace`, change it to `v=6` for `debug`.

Fixes linkerd/linkerd2#11132
