### PR TITLE
Replaced deprecated label failure-domain

### DIFF
--- a/charts/partials/templates/_affinity.tpl
+++ b/charts/partials/templates/_affinity.tpl
@@ -8,7 +8,7 @@ podAntiAffinity:
           operator: In
           values:
           - {{ .component }}
-      topologyKey: toplogy.kubernetes.io/zone
+      topologyKey: topology.kubernetes.io/zone
     weight: 100
   requiredDuringSchedulingIgnoredDuringExecution:
   - labelSelector:

--- a/charts/partials/templates/_affinity.tpl
+++ b/charts/partials/templates/_affinity.tpl
@@ -8,7 +8,7 @@ podAntiAffinity:
           operator: In
           values:
           - {{ .component }}
-      topologyKey: toplogy.beta.kubernetes.io/zone
+      topologyKey: toplogy.kubernetes.io/zone
     weight: 100
   requiredDuringSchedulingIgnoredDuringExecution:
   - labelSelector:

--- a/charts/partials/templates/_affinity.tpl
+++ b/charts/partials/templates/_affinity.tpl
@@ -8,7 +8,7 @@ podAntiAffinity:
           operator: In
           values:
           - {{ .component }}
-      topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologyKey: toplogy.beta.kubernetes.io/zone
     weight: 100
   requiredDuringSchedulingIgnoredDuringExecution:
   - labelSelector:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -865,7 +865,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1284,7 +1284,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1741,7 +1741,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -865,7 +865,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1284,7 +1284,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1741,7 +1741,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -865,7 +865,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1284,7 +1284,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1741,7 +1741,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -865,7 +865,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1284,7 +1284,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1741,7 +1741,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -865,7 +865,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1284,7 +1284,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1741,7 +1741,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -865,7 +865,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1284,7 +1284,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1741,7 +1741,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -838,7 +838,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1260,7 +1260,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1722,7 +1722,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -838,7 +838,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1260,7 +1260,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1722,7 +1722,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -838,7 +838,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1260,7 +1260,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1722,7 +1722,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -846,7 +846,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1272,7 +1272,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1742,7 +1742,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -846,7 +846,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1272,7 +1272,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1742,7 +1742,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -846,7 +846,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1272,7 +1272,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1742,7 +1742,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -828,7 +828,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1250,7 +1250,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1712,7 +1712,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -828,7 +828,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1250,7 +1250,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1712,7 +1712,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -828,7 +828,7 @@ spec:
                   operator: In
                   values:
                   - identity
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1250,7 +1250,7 @@ spec:
                   operator: In
                   values:
                   - destination
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -1712,7 +1712,7 @@ spec:
                   operator: In
                   values:
                   - proxy-injector
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -51,7 +51,7 @@ spec:
                   operator: In
                   values:
                   - linkerd-gateway
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: toplogy.beta.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -51,7 +51,7 @@ spec:
                   operator: In
                   values:
                   - linkerd-gateway
-              topologyKey: toplogy.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -51,7 +51,7 @@ spec:
                   operator: In
                   values:
                   - linkerd-gateway
-              topologyKey: toplogy.beta.kubernetes.io/zone
+              topologyKey: toplogy.kubernetes.io/zone
             weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:


### PR DESCRIPTION
This PR fixes #11114 as mentioned in the issue,  templates are using a deprecated label `failure-domain`which has been replaced with `topology` from K8S version 1.17

[k8s docs about update for deprecated label](https://kubernetes.io/docs/reference/labels-annotations-taints/#failure-domainbetakubernetesiozone) (mentioned in the respective issue also)