### PR TITLE
Add mutex lock to updateServer

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -593,6 +593,9 @@ func (sp *servicePublisher) metricsLabels(port Port, hostname string) prometheus
 }
 
 func (sp *servicePublisher) updateServer(server *v1beta1.Server, isAdd bool) {
+	sp.Lock()
+	defer sp.Unlock()
+
 	selector, err := metav1.LabelSelectorAsSelector(server.Spec.PodSelector)
 	if err != nil {
 		sp.log.Errorf("failed to create Selector: %s", err)


### PR DESCRIPTION
Fixes #11163

The `servicePublisher.updateServer` function will iterate through all registered listeners and update them.  However, a nil listener may temporarily be in the list of listeners if an unsubscribe is in progress.  This results in a nil pointer dereference.

All functions which result in updating the listeners must therefore be protected by the mutex so that we don't try to act on the list of listeners while it is being modified.