### PR TITLE
Add link credentials secret to linkerd namespace

### DIFF
--- a/multicluster/cmd/unlink.go
+++ b/multicluster/cmd/unlink.go
@@ -89,6 +89,17 @@ func newUnlinkCommand() *cobra.Command {
 				)
 			}
 
+			selector = fmt.Sprintf("%s=%s", clusterNameLabel, opts.clusterName)
+			destinationCredentials, err := k.CoreV1().Secrets(controlPlaneNamespace).List(cmd.Context(), metav1.ListOptions{LabelSelector: selector})
+			if err != nil {
+				return err
+			}
+			for _, secret := range destinationCredentials.Items {
+				resources = append(resources,
+					resource.NewNamespaced(corev1.SchemeGroupVersion.String(), "Secret", secret.Name, secret.Namespace),
+				)
+			}
+
 			for _, r := range resources {
 				if err := r.RenderResource(stdout); err != nil {
 					log.Errorf("failed to render resource %s: %s", r.Name, err)


### PR DESCRIPTION
We update the `multicluster link` command to write a credentials secret into the `linkerd` core control plane namespace in addition to writing one into the `linkerd-multicluster` namespace.  This is a prerequisite for the destination controller to be able to connect to linked clusters to do remote service discovery.

We also update the `multicluster unlink` command so that these credentials secrets are properly deleted when the cluster is unlinked.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
