### PR TITLE
add appVersion to linkerd-crds helm chart

### DIFF
--- a/bin/helm-build
+++ b/bin/helm-build
@@ -66,7 +66,7 @@ if [ "$1" = package ]; then
     # set version in Values files
     setValues 'linkerdVersionValue' "$fullVersion"
 
-    "$bindir"/helm -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd-crds
+    "$bindir"/helm --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd-crds
     "$bindir"/helm --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd-control-plane
     "$bindir"/helm --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/charts/linkerd2-cni
     "$bindir"/helm --app-version "$tag" -d "$rootdir"/target/helm package "$rootdir"/multicluster/charts/linkerd-multicluster

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: "v2"
+appVersion: edge-XX.X.X
 description: |
   Linkerd gives you observability, reliability, and security
   for your microservices — with no code change required.


### PR DESCRIPTION
the appVersion field is missing from the linkerd-crd helm chart. it appears on other linkerd helm charts.

add the appVersion field and update the build scripts to apply it.

Fixes https://github.com/linkerd/linkerd2/issues/10767

Signed-off-by: Calvin Bui <3604363+calvinbui@users.noreply.github.com>