### PR TITLE
edge-23.8.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changes
 
+## edge-23.8.1
+
+This edge release restores a proxy setting for it to shed load less aggressively
+while under high load, which should result in lower error rates. It also removes
+the usage of host networking in the linkerd-cni extension.
+
+* Changed the default HTTP request queue capacities for the inbound and outbound
+  proxies back to 10,000 requests (#11198)
+* Lifted need of using host networking in the linkerd-cni Daemonset (#11141)
+  (thanks @abhijeetgauravm!)
+
 ## edge-23.7.3
 
 This edge release improves Linkerd's support for HttpRoute by allowing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,11 @@
 ## edge-23.8.1
 
 This edge release restores a proxy setting for it to shed load less aggressively
-while under high load, which should result in lower error rates. It also removes
-the usage of host networking in the linkerd-cni extension.
+while under high load, which should result in lower error rates (see #11055). It
+also removes the usage of host networking in the linkerd-cni extension.
 
 * Changed the default HTTP request queue capacities for the inbound and outbound
-  proxies back to 10,000 requests (#11198)
+  proxies back to 10,000 requests (see #11055 and #11198)
 * Lifted need of using host networking in the linkerd-cni Daemonset (#11141)
   (thanks @abhijeetgauravm!)
 

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.14.0-edge
+version: 1.14.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.14.0-edge](https://img.shields.io/badge/Version-1.14.0--edge-informational?style=flat-square)
+![Version: 1.14.1-edge](https://img.shields.io/badge/Version-1.14.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.9.5-edge
+version: 30.10.0-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.9.5-edge](https://img.shields.io/badge/Version-30.9.5--edge-informational?style=flat-square)
+![Version: 30.10.0-edge](https://img.shields.io/badge/Version-30.10.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.7-edge
+version: 30.10.8-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.10.7-edge](https://img.shields.io/badge/Version-30.10.7--edge-informational?style=flat-square)
+![Version: 30.10.8-edge](https://img.shields.io/badge/Version-30.10.8--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.9.7-edge
+version: 30.9.8-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.9.7-edge](https://img.shields.io/badge/Version-30.9.7--edge-informational?style=flat-square)
+![Version: 30.9.8-edge](https://img.shields.io/badge/Version-30.9.8--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.6-edge
+version: 30.10.7-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.10.6-edge](https://img.shields.io/badge/Version-30.10.6--edge-informational?style=flat-square)
+![Version: 30.10.7-edge](https://img.shields.io/badge/Version-30.10.7--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release restores a proxy setting for it to shed load less aggressively
while under high load, which should result in lower error rates (addressing
#11055). It also removes the usage of host networking in the linkerd-cni
extension.

* Changed the default HTTP request queue capacities for the inbound and outbound
  proxies back to 10,000 requests (see #11055 and #11198)
* Lifted need of using host networking in the linkerd-cni Daemonset (#11141)
  (thanks @abhijeetgauravm!)
