### PR TITLE
Introduce small improvements to ClusterStore

### DIFF
--- a/controller/api/destination/watcher/cluster_store.go
+++ b/controller/api/destination/watcher/cluster_store.go
@@ -221,10 +221,8 @@ func (cs *ClusterStore) addCluster(clusterName string, secret *v1.Secret) error 
 		stopCh,
 	}
 
-	go func() {
-		remoteAPI.Sync(stopCh)
-		metadataAPI.Sync(stopCh)
-	}()
+	go remoteAPI.Sync(stopCh)
+	go metadataAPI.Sync(stopCh)
 
 	cs.log.Tracef("Added cluster %s to ClusterStore", clusterName)
 

--- a/controller/api/destination/watcher/cluster_store_test.go
+++ b/controller/api/destination/watcher/cluster_store_test.go
@@ -139,32 +139,30 @@ func TestClusterStoreHandlers(t *testing.T) {
 			}
 
 			// Handle delete events
-			if len(tt.deleteClusters) != 0 {
-				for k := range tt.deleteClusters {
-					watcher, _, found := cs.Get(k)
-					if !found {
-						t.Fatalf("Unexpected error: watcher %s should exist in the cache", k)
-					}
-					// Unfortunately, mock k8s client does not propagate
-					// deletes, so we have to call remove directly.
-					cs.removeCluster(k)
-					// Leave it to do its thing and gracefully shutdown
-					time.Sleep(50 * time.Millisecond)
-					var hasStopped bool
-					if tt.enableEndpointSlices {
-						hasStopped = watcher.k8sAPI.ES().Informer().IsStopped()
-					} else {
-						hasStopped = watcher.k8sAPI.Endpoint().Informer().IsStopped()
-					}
-					if !hasStopped {
-						t.Fatalf("Unexpected error: informers for watcher %s should be stopped", k)
-					}
-
-					if _, _, found := cs.Get(k); found {
-						t.Fatalf("Unexpected error: watcher %s should have been removed from the cache", k)
-					}
-
+			for k := range tt.deleteClusters {
+				watcher, _, found := cs.Get(k)
+				if !found {
+					t.Fatalf("Unexpected error: watcher %s should exist in the cache", k)
 				}
+				// Unfortunately, mock k8s client does not propagate
+				// deletes, so we have to call remove directly.
+				cs.removeCluster(k)
+				// Leave it to do its thing and gracefully shutdown
+				time.Sleep(50 * time.Millisecond)
+				var hasStopped bool
+				if tt.enableEndpointSlices {
+					hasStopped = watcher.k8sAPI.ES().Informer().IsStopped()
+				} else {
+					hasStopped = watcher.k8sAPI.Endpoint().Informer().IsStopped()
+				}
+				if !hasStopped {
+					t.Fatalf("Unexpected error: informers for watcher %s should be stopped", k)
+				}
+
+				if _, _, found := cs.Get(k); found {
+					t.Fatalf("Unexpected error: watcher %s should have been removed from the cache", k)
+				}
+
 			}
 		})
 	}

--- a/controller/k8s/metadata_api.go
+++ b/controller/k8s/metadata_api.go
@@ -39,23 +39,7 @@ func InitializeMetadataAPI(kubeConfig string, resources ...APIResource) (*Metada
 	if err != nil {
 		return nil, fmt.Errorf("error configuring Kubernetes API client: %w", err)
 	}
-
-	client, err := metadata.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	api, err := newClusterScopedMetadataAPI(client, resources...)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, gauge := range api.gauges {
-		if err := prometheus.Register(gauge); err != nil {
-			log.Warnf("failed to register Prometheus gauge %s: %s", gauge.Desc().String(), err)
-		}
-	}
-	return api, nil
+	return InitializeMetadataAPIForConfig(config, resources...)
 }
 
 func InitializeMetadataAPIForConfig(kubeConfig *rest.Config, resources ...APIResource) (*MetadataAPI, error) {

--- a/controller/k8s/test_helper.go
+++ b/controller/k8s/test_helper.go
@@ -43,7 +43,7 @@ func NewFakeAPI(configs ...string) (*API, error) {
 
 // NewFakeMetadataAPI provides a mock Kubernetes API for testing.
 func NewFakeMetadataAPI(configs []string) (*MetadataAPI, error) {
-	sch := clientsetscheme.Scheme
+	sch := runtime.NewScheme()
 	metav1.AddMetaToScheme(sch)
 
 	var objs []runtime.Object


### PR DESCRIPTION
There were a few improvements we could have made to a recent change that added a ClusterStore concept to the destination service. This PR introduces the small improvements:

* Sync dynamically created clients in separate go routines
* Refactor metadata API creation
* Remove redundant check in cluster_store_test
* Create a new runtime schema every time a fake metadata API client is created to avoid racey behaviour.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
