### PR TITLE
Helm linkerd-controler-plane Allow Custom labels on Pod Monitor

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -192,6 +192,7 @@ Kubernetes: `>=1.21.0-0`
 | podMonitor.controller.enabled | bool | `true` | Enables the creation of PodMonitor for the control-plane |
 | podMonitor.controller.namespaceSelector | string | `"matchNames:\n  - {{ .Release.Namespace }}\n  - linkerd-viz\n  - linkerd-jaeger\n"` | Selector to select which namespaces the Endpoints objects are discovered from |
 | podMonitor.enabled | bool | `false` | Enables the creation of Prometheus Operator [PodMonitor](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor) |
+| podMonitor.labels | object | `{}` | Labels to apply to all pod Monitors |
 | podMonitor.proxy.enabled | bool | `true` | Enables the creation of PodMonitor for the data-plane |
 | podMonitor.scrapeInterval | string | `"10s"` | Interval at which metrics should be scraped |
 | podMonitor.scrapeTimeout | string | `"10s"` | Iimeout after which the scrape is ended |

--- a/charts/linkerd-control-plane/templates/podmonitor.yaml
+++ b/charts/linkerd-control-plane/templates/podmonitor.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     linkerd.io/control-plane-ns: {{ .Release.Namespace }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+    {{- with .Values.podMonitor.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -44,6 +45,7 @@ metadata:
   labels:
     linkerd.io/control-plane-ns: {{ .Release.Namespace }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+    {{- with .Values.podMonitor.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -78,6 +80,7 @@ metadata:
   labels:
     linkerd.io/control-plane-ns: {{ .Release.Namespace }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+    {{- with .Values.podMonitor.labels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -530,6 +530,8 @@ podMonitor:
   scrapeInterval: 10s
   # -- Iimeout after which the scrape is ended
   scrapeTimeout: 10s
+  # -- Labels to apply to all pod Monitors
+  labels: {}
   controller:
     # -- Enables the creation of PodMonitor for the control-plane
     enabled: true


### PR DESCRIPTION
Need to be able to set labels on Pod Monitors

add a labels section to podMonitor

Helm Lint/Helm Template

Fixes #11175

Signed-off-by: Justin S <justinseiser@gmail.com>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
