### PR TITLE
add menuItemServices to message locales es

### DIFF
--- a/web/app/js/locales/es/messages.json
+++ b/web/app/js/locales/es/messages.json
@@ -124,6 +124,7 @@
   "menuItemReplicaSets": "Replica Sets",
   "menuItemReplicationControllers": "Replication Controllers",
   "menuItemRoutes": "Rutas",
+  "menuItemServices": "Services",
   "menuItemSlack": "Slack",
   "menuItemStatefulSets": "Stateful Sets",
   "menuItemTap": "Tap",


### PR DESCRIPTION
Viz dashboard with `locales es` doesn't have  `menuItemService` item

![image](https://github.com/linkerd/linkerd2/assets/453675/722809a2-6338-459e-affa-493d7fb5a9dc)