### PR TITLE
edge-23.8.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ fixes an issue ([#10764]) where warnings about an invalid metric were logged
 frequently by the Destination controller.
 
 * Added a new `remoteDiscoverySelector` field to the multicluster `Link` CRD,
-  which enables a service mirroring mod where the control plane
+  which enables a service mirroring mode where the control plane
   performs discovery for the mirrored service from the remote cluster, rather
   than creating Endpoints for the mirrored service in the source cluster
   ([#11190], [#11201], [#11220], and [#11224])

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,6 @@ frequently by the Destination controller.
 [#11229]: https://github.com/linkerd/linkerd2/issues/11229
 [flat network support]: https://linkerd.io/2023/07/20/enterprise-multi-cluster-at-scale-supporting-flat-networks-in-linkerd/
 
-
 ## edge-23.8.1
 
 This edge release restores a proxy setting for it to shed load less aggressively

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,9 @@ frequently by the Destination controller.
 * Replaced `server_port_subscribers` Destination controller gauge metric with
   `server_port_subscribes` and `server_port_unsubscribes` counter metrics
   ([#11206]; fixes [#10764])
-* Replaced deprecated `failure-domain.beta.kubernetes.io` labels in Helm charts
-  with `topology.kubernetes.io` labels ([#11148]; fixes [#11114]) (thanks @piyushsingariya!)
+* Replaced deprecated `failure-domain.beta.kubernetes.io/zone` labels in Helm
+  charts  with `topology.kubernetes.io/zone` labels ([#11148]; fixes [#11114])
+  (thanks @piyushsingariya!)
 
 [#10764]: https://github.com/linkerd/linkerd2/issues/10764
 [#11114]: https://github.com/linkerd/linkerd2/issues/11114

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,37 @@
 # Changes
 
+## edge-23.8.2
+
+This edge release adds improvements to Linkerd's multi-cluster features as part
+of the [flat network support] planned for Linkerd stable-2.14.0. In addition, it
+fixes an issue ([#10764]) where warnings about an invalid metric were logged
+frequently by the Destination controller.
+
+* Added a new `remoteDiscoverySelector` field to the multicluster `Link` CRD,
+  which enables a service mirroring mod where the control plane
+  performs discovery for the mirrored service from the remote cluster, rather
+  than creating Endpoints for the mirrored service in the source cluster
+  ([#11190], [#11201], [#11220], and [#11224])
+* Fixed missing "Services" menu item in the Spanish localization for the
+  `linkerd-viz` web dashboard ([#11229]) (thanks @mclavel!)
+* Replaced `server_port_subscribers` Destination controller gauge metric with
+  `server_port_subscribes` and `server_port_unsubscribes` counter metrics
+  ([#11206]; fixes [#10764])
+* Replaced deprecated `failure-domain.beta.kubernetes.io` labels in Helm charts
+  with `topology.kubernetes.io` labels ([#11148]; fixes [#11114]) (thanks @piyushsingariya!)
+
+[#10764]: https://github.com/linkerd/linkerd2/issues/10764
+[#11114]: https://github.com/linkerd/linkerd2/issues/11114
+[#11148]: https://github.com/linkerd/linkerd2/issues/11148
+[#11190]: https://github.com/linkerd/linkerd2/issues/11190
+[#11201]: https://github.com/linkerd/linkerd2/issues/11201
+[#11206]: https://github.com/linkerd/linkerd2/issues/11206
+[#11220]: https://github.com/linkerd/linkerd2/issues/11220
+[#11224]: https://github.com/linkerd/linkerd2/issues/11224
+[#11229]: https://github.com/linkerd/linkerd2/issues/11229
+[flat network support]: https://linkerd.io/2023/07/20/enterprise-multi-cluster-at-scale-supporting-flat-networks-in-linkerd/
+
+
 ## edge-23.8.1
 
 This edge release restores a proxy setting for it to shed load less aggressively

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.14.3-edge
+version: 1.14.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.14.1-edge
+version: 1.14.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.14.3-edge](https://img.shields.io/badge/Version-1.14.3--edge-informational?style=flat-square)
+![Version: 1.14.2-edge](https://img.shields.io/badge/Version-1.14.2--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.14.1-edge](https://img.shields.io/badge/Version-1.14.1--edge-informational?style=flat-square)
+![Version: 1.14.3-edge](https://img.shields.io/badge/Version-1.14.3--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.8-edge
+version: 30.10.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.10.8-edge](https://img.shields.io/badge/Version-30.10.8--edge-informational?style=flat-square)
+![Version: 30.10.9-edge](https://img.shields.io/badge/Version-30.10.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.9.8-edge
+version: 30.9.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.9.8-edge](https://img.shields.io/badge/Version-30.9.8--edge-informational?style=flat-square)
+![Version: 30.9.9-edge](https://img.shields.io/badge/Version-30.9.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.7-edge
+version: 30.10.8-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.10.7-edge](https://img.shields.io/badge/Version-30.10.7--edge-informational?style=flat-square)
+![Version: 30.10.8-edge](https://img.shields.io/badge/Version-30.10.8--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.8.2

This edge release adds improvements to Linkerd's multi-cluster features as part
of the [flat network support] planned for Linkerd stable-2.14.0. In addition, it
fixes an issue ([#10764]) where warnings about an invalid metric were logged
frequently by the Destination controller.

* Added a new `remoteDiscoverySelector` field to the multicluster `Link` CRD,
  which enables a service mirroring mod where the control plane
  performs discovery for the mirrored service from the remote cluster, rather
  than creating Endpoints for the mirrored service in the source cluster
  ([#11190], [#11201], [#11220], and [#11224])
* Fixed missing "Services" menu item in the Spanish localization for the
  `linkerd-viz` web dashboard ([#11229]) (thanks @mclavel!)
* Replaced `server_port_subscribers` Destination controller gauge metric with
  `server_port_subscribes` and `server_port_unsubscribes` counter metrics
  ([#11206]; fixes [#10764])
* Replaced deprecated `failure-domain.beta.kubernetes.io` labels in Helm charts
  with `topology.kubernetes.io` labels ([#11148]; fixes [#11114]) (thanks @piyushsingariya!)

[#10764]: https://github.com/linkerd/linkerd2/issues/10764
[#11114]: https://github.com/linkerd/linkerd2/issues/11114
[#11148]: https://github.com/linkerd/linkerd2/issues/11148
[#11190]: https://github.com/linkerd/linkerd2/issues/11190
[#11201]: https://github.com/linkerd/linkerd2/issues/11201
[#11206]: https://github.com/linkerd/linkerd2/issues/11206
[#11220]: https://github.com/linkerd/linkerd2/issues/11220
[#11224]: https://github.com/linkerd/linkerd2/issues/11224
[#11229]: https://github.com/linkerd/linkerd2/issues/11229
[flat network support]: https://linkerd.io/2023/07/20/enterprise-multi-cluster-at-scale-supporting-flat-networks-in-linkerd/