### PR TITLE
ci: increase release docker build timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,8 @@ jobs:
         - proxy
         - tap
         - web
-    timeout-minutes: 30
+    # policy-controller docker builds have occasionally hit a 30-minute timeout.
+    timeout-minutes: 45
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Set tag


### PR DESCRIPTION
The policy-controller docker build has been observed to occasionally hit
the 30-minute timeout while building a release image:
https://github.com/linkerd/linkerd2/actions/runs/5836908571/job/15831438183#step:4:1540

This branch increases the release docker build timeout by 15 minutes (to
45 minutes), so that we still have an upper bound in case something
hangs forever, but hopefully have to restart fewer builds.