### PR TITLE
Add PDB for tap and tap-injector

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -98,6 +98,7 @@ Kubernetes: `>=1.21.0-0`
 | defaultUID | int | `2103` | UID for all the viz components |
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
+| enablePodDisruptionBudget | bool | `false` | enables the creation of pod disruption budgets for tap and tap-injector components |
 | grafana.externalUrl | string | `nil` | url of a Grafana instance hosted off-cluster. Cannot be set if grafana.url is set. The reverse proxy will not be used for this URL. |
 | grafana.uidPrefix | string | `nil` | prefix for Grafana dashboard UID's, used when grafana.externalUrl is set. |
 | grafana.url | string | `nil` | url of an in-cluster Grafana instance with reverse proxy configured, used by the Linkerd viz web dashboard to provide direct links to specific Grafana dashboards. Cannot be set if grafana.externalUrl is set. See the [Linkerd documentation](https://linkerd.io/2/tasks/grafana) for more information |

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -127,3 +127,24 @@ spec:
       - name: tls
         secret:
           secretName: tap-injector-k8s-tls
+{{- if .Values.enablePodDisruptionBudget }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: tap-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+    namespace: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: viz
+      component: tap-injector
+{{- end }}

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -142,3 +142,24 @@ spec:
       - name: tls
         secret:
           secretName: tap-k8s-tls
+{{- if .Values.enablePodDisruptionBudget }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: tap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+    namespace: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: viz
+      component: tap
+{{- end }}

--- a/viz/charts/linkerd-viz/values-ha.yaml
+++ b/viz/charts/linkerd-viz/values-ha.yaml
@@ -3,6 +3,7 @@
 #   helm install -f values.yaml -f values-ha.yaml
 
 enablePodAntiAffinity: true
+enablePodDisruptionBudget: true
 
 # nodeAffinity:
 

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -50,6 +50,9 @@ tolerations: &default_tolerations
 # Enable this only when you have multiple replicas of components.
 enablePodAntiAffinity: false
 
+# -- enables the creation of pod disruption budgets for tap and tap-injector components
+enablePodDisruptionBudget: false
+
 # -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information


### PR DESCRIPTION
To avoid disruption during cluster nodes rolling or scaling, it's desired to complement the maxUnavailable from the rolling strategy with a PodDisruptionBudget.

This commit adds the respective PDB objects following the core components implementation to the `tap` and `tap-injector` deployments. It can be enabled with the enablePodDisruptionBudget helm chart value.

Fixes #11248

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
