### PR TITLE
Lower log level for dupe metrics registration in Destination

### DIFF
--- a/controller/k8s/metadata_api.go
+++ b/controller/k8s/metadata_api.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -55,7 +56,14 @@ func InitializeMetadataAPIForConfig(kubeConfig *rest.Config, cluster string, res
 
 	for _, gauge := range api.gauges {
 		if err := prometheus.Register(gauge); err != nil {
-			log.Warnf("failed to register Prometheus gauge %s: %s", gauge.Desc().String(), err)
+			msg := fmt.Sprintf("failed to register Prometheus gauge %s: %s", gauge.Desc().String(), err)
+			var dupe prometheus.AlreadyRegisteredError
+			if errors.As(err, &dupe) {
+				// This can happen when connecting to more than one target cluster and is innocuous
+				log.Debug(msg)
+			} else {
+				log.Warn(msg)
+			}
 		}
 	}
 	return api, nil


### PR DESCRIPTION
Similar to #11246, we were getting warnings in the Destination controller whenever a new remote cluster was linked, complaining about the attempt to register dupe api cache metrics. So we lower here to debug level such messages.