### PR TITLE
Fixed destination metrics warning when re-linking

### DIFF
--- a/controller/api/destination/watcher/cluster_store.go
+++ b/controller/api/destination/watcher/cluster_store.go
@@ -173,6 +173,8 @@ func (cs *ClusterStore) removeCluster(clusterName string) {
 		return
 	}
 	r.watcher.removeHandlers()
+	r.watcher.k8sAPI.UnregisterGauges()
+	r.watcher.metadataAPI.UnregisterGauges()
 	close(r.stopCh)
 	delete(cs.store, clusterName)
 	cs.log.Infof("Removed cluster %s from ClusterStore", clusterName)

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -288,6 +288,11 @@ func (api *API) Sync(stopCh <-chan struct{}) {
 	waitForCacheSync(api.syncChecks)
 }
 
+// UnregisterGauges unregisters all the prometheus cache gauges associated to this API
+func (api *API) UnregisterGauges() {
+	api.promGauges.unregister()
+}
+
 // NS provides access to a shared informer and lister for Namespaces.
 func (api *API) NS() coreinformers.NamespaceInformer {
 	if api.ns == nil {

--- a/controller/k8s/metadata_api.go
+++ b/controller/k8s/metadata_api.go
@@ -100,6 +100,11 @@ func (api *MetadataAPI) Sync(stopCh <-chan struct{}) {
 	waitForCacheSync(api.syncChecks)
 }
 
+// UnregisterGauges unregisters all the prometheus cache gauges associated to this API
+func (api *MetadataAPI) UnregisterGauges() {
+	api.promGauges.unregister()
+}
+
 func (api *MetadataAPI) getLister(res APIResource) (cache.GenericLister, error) {
 	inf, ok := api.inf[res]
 	if !ok {

--- a/controller/k8s/prometheus.go
+++ b/controller/k8s/prometheus.go
@@ -20,3 +20,9 @@ func (p *promGauges) addInformerSize(kind string, labels prometheus.Labels, inf 
 		return float64(len(inf.GetStore().ListKeys()))
 	}))
 }
+
+func (p *promGauges) unregister() {
+	for _, gauge := range p.gauges {
+		prometheus.Unregister(gauge)
+	}
+}

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -965,6 +965,10 @@ func (rcsw *RemoteClusterServiceWatcher) Stop(cleanupState bool) {
 			rcsw.log.Warnf("error removing service informer handler: %s", err)
 		}
 	}
+
+	if rcsw.remoteAPIClient != nil {
+		rcsw.remoteAPIClient.UnregisterGauges()
+	}
 }
 
 func (rcsw *RemoteClusterServiceWatcher) resolveGatewayAddress() ([]corev1.EndpointAddress, error) {


### PR DESCRIPTION
Similar to #11246, the destination controller was complaning above trying to register dupe metrics for the api cache gauges, when a given target cluster got re-linked. This change unregisters the gauges for the target cluster when said cluster is removed.

Supersedes #11252