### PR TITLE
edge-23.8.3 Change notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,32 @@
 # Changes
 
+## edge-23.8.3
+
+This is a release candidate for stable-2.14.0; we encourage you to help trying
+it out!
+
+This edge release contains a number of improvements over the multi-cluster
+features introduced in the last edge release supporting flat networks. It also
+hardens the containers security stance by removing write access to the root
+filesystem.
+
+* Enhanced `linkerd multicluster link` to allow clusters to be linked without a
+  gateway ([#11226])
+* Added cluster store size gauge metric ([#11256])
+* Disabled local traffic policy for remote discovery ([#11257])
+* Fixed various innocuous multi-cluster warnings ([#11251], [#11246], [#11253])
+* Set `readOnlyRootFilesystem: true` in all the containers, as they don't
+  require write permissions ([#11221]; fixes [#11142]) (thanks @mikutas!)
+
+[#11226]: https://github.com/linkerd/linkerd2/pull/11226
+[#11256]: https://github.com/linkerd/linkerd2/pull/11256
+[#11257]: https://github.com/linkerd/linkerd2/pull/11257
+[#11251]: https://github.com/linkerd/linkerd2/pull/11251
+[#11246]: https://github.com/linkerd/linkerd2/pull/11246
+[#11253]: https://github.com/linkerd/linkerd2/pull/11253
+[#11221]: https://github.com/linkerd/linkerd2/pull/11221
+[#11142]: https://github.com/linkerd/linkerd2/issues/11142
+
 ## edge-23.8.2
 
 This edge release adds improvements to Linkerd's multi-cluster features as part

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.14.2-edge
+version: 1.14.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.14.2-edge](https://img.shields.io/badge/Version-1.14.2--edge-informational?style=flat-square)
+![Version: 1.14.3-edge](https://img.shields.io/badge/Version-1.14.3--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.9-edge
+version: 30.10.10-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.10.9-edge](https://img.shields.io/badge/Version-30.10.9--edge-informational?style=flat-square)
+![Version: 30.10.10-edge](https://img.shields.io/badge/Version-30.10.10--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.9.9-edge
+version: 30.9.10-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.9.9-edge](https://img.shields.io/badge/Version-30.9.9--edge-informational?style=flat-square)
+![Version: 30.9.10-edge](https://img.shields.io/badge/Version-30.9.10--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.8-edge
+version: 30.10.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.10.8-edge](https://img.shields.io/badge/Version-30.10.8--edge-informational?style=flat-square)
+![Version: 30.10.9-edge](https://img.shields.io/badge/Version-30.10.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This is a release candidate for stable-2.14.0; we encourage you to help trying it out!

This edge release contains a number of improvements over the multi-cluster features introduced in the last edge release supporting flat networks. It also hardens the containers security stance by removing write access to the root filesystem.

* Enhanced `linkerd multicluster link` to allow clusters to be linked without a gateway ([#11226])
* Added cluster store size gauge metric ([#11256])
* Disabled local traffic policy for remote discovery ([#11257])
* Fixed various innocuous multi-cluster warnings ([#11251], [#11246], [#11253])
* Set `readOnlyRootFilesystem: true` in all the containers, as they don't require write permissions ([#11221]; fixes [#11142]) (thanks @mikutas!)
