### PR TITLE
helm: Configure policy controller resource requests/limits

### DIFF
--- a/charts/linkerd-control-plane/values-ha.yaml
+++ b/charts/linkerd-control-plane/values-ha.yaml
@@ -53,5 +53,8 @@ webhookFailurePolicy: Fail
 # service profile validator configuration
 spValidatorResources: *controller_resources
 
+# policy controller configuration
+policyControllerResources: *controller_resources
+
 # flag for linkerd check
 highAvailability: true

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -502,6 +502,9 @@ policyValidator:
   # for more information.
   injectCaFromSecret: ""
 
+# -|- CPU, Memory and Ephemeral Storage resources required by the policy controller 
+#policyControllerResources:
+
 # -- NodeSelector section, See the [K8S
 # documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
 # for more information


### PR DESCRIPTION
**Subject**

adding policy controller resource config option to control plane helm chart

**Problem**

When adding values-ha.yaml to a Helm deployment, all Control plane components obtain cpu requests and memory requests and limits, with the exception of the policy-controller. 

**Solution**

added policy controller resource config option in values.yaml and values-ha.yaml

Validation

Fixes #[[11301](https://github.com/linkerd/linkerd2/issues/11301)]

Alen Haric (deusxanima) aharic88@gmail.com
