### PR TITLE
Bump node version to v20

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     container:
-      image: node:14-stretch
+      image: node:20-stretch
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Yarn setup

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     container:
-      image: node:20-stretch
+      image: node:20-bullseye
     env:
       NODE_ENV: test
     steps:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     container:
-      image: node:20-bullseye
+      image: node:20-bookworm
     env:
       NODE_ENV: test
     steps:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     container:
-      image: node:14-stretch
+      image: node:20-stretch
     env:
       NODE_ENV: test
     steps:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## bundle web assets
-FROM --platform=$BUILDPLATFORM node:19-bullseye as webpack-bundle
+FROM --platform=$BUILDPLATFORM node:20-bullseye as webpack-bundle
 RUN bin/scurl --retry=2 https://yarnpkg.com/install.sh | bash -s -- --version 1.22.10 --network-concurrency 1
 
 ENV PATH /root/.yarn/bin:$PATH

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## bundle web assets
-FROM --platform=$BUILDPLATFORM node:20-bullseye as webpack-bundle
+FROM --platform=$BUILDPLATFORM node:20-bookworm as webpack-bundle
 RUN bin/scurl --retry=2 https://yarnpkg.com/install.sh | bash -s -- --version 1.22.10 --network-concurrency 1
 
 ENV PATH /root/.yarn/bin:$PATH


### PR DESCRIPTION
lingui/cli manages locales, extracts messages from source files and compiles message catalogs for production use. Dependabot's bump seems to fail since lingui/cli requires at least node v16, and the current Dockerfile uses node v14.

This change updates the web dockerfile to use node v20 and also configures the JS web test runner to use node v20.

Lingui/cli's migration docs are covered in
https://lingui.dev/releases/migration-4#backward-incompatible-changes for migrating from v3.x.x to v4.x.x.


<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
