### PR TITLE
Templating prometheus url into cronjob heartbeat

### DIFF
--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -64,7 +64,11 @@ spec:
             - "-controller-namespace={{.Release.Namespace}}"
             - "-log-level={{.Values.controllerLogLevel}}"
             - "-log-format={{.Values.controllerLogFormat}}"
+            {{- if .Values.prometheusUrl }}
+            - "-prometheus-url={{.Values.prometheusUrl}}"
+            {{- else }}
             - "-prometheus-url=http://prometheus.linkerd-viz.svc.{{.Values.clusterDomain}}:9090"
+            {{- end }}
             {{- if .Values.heartbeatResources -}}
             {{- include "partials.resources" .Values.heartbeatResources | nindent 12 }}
             {{- end }}

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -502,7 +502,7 @@ policyValidator:
   # for more information.
   injectCaFromSecret: ""
 
-# -|- CPU, Memory and Ephemeral Storage resources required by the policy controller 
+# -|- CPU, Memory and Ephemeral Storage resources required by the policy controller
 #policyControllerResources:
 
 # -- NodeSelector section, See the [K8S
@@ -524,6 +524,9 @@ nodeSelector:
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information
 #nodeAffinity:
+
+# -- url of external prometheus instance (used for the heartbeat)
+prometheusUrl: ""
 
 # Prometheus Operator PodMonitor configuration
 podMonitor:


### PR DESCRIPTION
Can not use external prometheus with hearbeat

Added new variable `.prometheusUrl` in value and use it into heartbeat from linkerd-control-plane chart

Run `helm template` check the cronjob manifest

Fixes #11342