### PR TITLE
Fix mirroring all services when remote selector is empty

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -739,7 +739,7 @@ func (rcsw *RemoteClusterServiceWatcher) getMirrorServices() (*corev1.ServiceLis
 }
 
 func (rcsw *RemoteClusterServiceWatcher) handleOnDelete(service *corev1.Service) {
-	if rcsw.isExported(service.Labels) {
+	if rcsw.isExported(service.Labels) || rcsw.isRemoteDiscovery(service.Labels) {
 		rcsw.eventsQueue.Add(&RemoteServiceDeleted{
 			Name:      service.Name,
 			Namespace: service.Namespace,
@@ -1242,12 +1242,7 @@ func (rcsw *RemoteClusterServiceWatcher) isExported(l map[string]string) bool {
 		rcsw.log.Errorf("Invalid selector: %s", err)
 		return false
 	}
-	remoteDiscoverySelector, err := metav1.LabelSelectorAsSelector(&rcsw.link.RemoteDiscoverySelector)
-	if err != nil {
-		rcsw.log.Errorf("Invalid selector: %s", err)
-		return false
-	}
-	return selector.Matches(labels.Set(l)) || remoteDiscoverySelector.Matches(labels.Set(l))
+	return selector.Matches(labels.Set(l))
 }
 
 func (rcsw *RemoteClusterServiceWatcher) isRemoteDiscovery(l map[string]string) bool {


### PR DESCRIPTION
The multicluster link supports two selectors: one for normal (endpoint-based) mirrors, and one for remote-discovery where only service imports are created. When the remote-discovery selector is empty (i.e. an empty object '{}'), then all services in a cluster will be mirrored. The created imports also have an underlying Endpoints object created.

There are two distinct checks that decide whether a service import should be created: `isExported` and `isRemote`. When a selector is empty, the checks are shortcircuted and return early. The former check (`isExported`) additionally also checks if a service is remote, without checking if the corresponding selector is empty. This allows services to slip through since an empty selector encompasses everything.

The change fixes the issue by removing any remote discovery checks from `isExported`. Where necessary, we add another call to `isRemote`.

Fixes #11309

---

### Reproducing the issue

* Set-up two clusters and install the latest version of linkerd.
* Create at least one service in the target cluster.
* Link the two clusters and use an empty remote discovery selector.

The source cluster will now contain imports for all services in the target, including the `kubernetes` service.


```
NAME     SERVERS   AGENTS   LOADBALANCER
source   1/1       0/0      true
target   1/1       0/0      true

# Target cluster services
NAME         TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   10.43.0.1     <none>        443/TCP   22m
podinfo      ClusterIP   10.43.74.37   <none>        80/TCP    18m
nginx-svc    ClusterIP   10.43.72.33   <none>        80/TCP    8m39s

# Link spec, notice empty selector
spec:
  clusterCredentialsSecret: cluster-credentials-target
  gatewayAddress: 192.168.224.4
  gatewayIdentity: linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.cluster.local
  gatewayPort: "4143"
  probeSpec:
    path: /ready
    period: 3s
    port: "4191"
  remoteDiscoverySelector: {}
  selector:
    matchLabels:
      mirror.linkerd.io/exported: "true"
  targetClusterDomain: cluster.local
  targetClusterLinkerdNamespace: linkerd
  targetClusterName: target

# One service is exported
:; k get svc podinfo -o yaml | rg 'labels' -A 5
      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{"service.kubernetes.io/topology-aware-hints":"auto"},"labels":{"mirror.linkerd.io/exported":"true"},"name":"podinfo","namespace":"default"},"spec":{"ports":[{"port":80,"targetPort":9898}],"selector":{"app":"podinfo"},"type":"ClusterIP"}}
    service.kubernetes.io/topology-aware-hints: auto
  creationTimestamp: "2023-09-06T14:58:29Z"
  labels:
    mirror.linkerd.io/exported: "true"

# The other isn't
:; k get svc nginx-svc -o yaml | rg 'labels' -A 3
<empty>

# All are replicated in the source cluster
NAME                TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
kubernetes          ClusterIP   10.43.0.1       <none>        443/TCP   6m52s
nginx-svc-target    ClusterIP   10.43.115.177   <none>        80/TCP    21s
podinfo-target      ClusterIP   10.43.120.163   <none>        80/TCP    20s
kubernetes-target   ClusterIP   10.43.81.214    <none>        443/TCP   16s
```

### Testing

With the change in place, tested:
* An empty selector does not trigger service creation
* A specified remote-discovery selector can still be used and services are imported.
* On deletion of the exported (actual) service, imported services are cleaned-up


```
# Apply change
NAME                                             READY   STATUS        RESTARTS   AGE
linkerd-gateway-59c55f65b6-ggxmh                 2/2     Running       0          8m4s
linkerd-service-mirror-target-7db69c6df5-4r9m6   2/2     Running       0          3s
linkerd-service-mirror-target-777b9fdb95-f7fvt   2/2     Terminating   0          3m43s

# Wait for new deployment to roll out
# Old state
NAME                TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
kubernetes          ClusterIP   10.43.0.1       <none>        443/TCP   10m
nginx-svc-target    ClusterIP   10.43.115.177   <none>        80/TCP    3m43s
podinfo-target      ClusterIP   10.43.120.163   <none>        80/TCP    3m42s
kubernetes-target   ClusterIP   10.43.81.214    <none>        443/TCP   3m38s

# New state a few seconds later
:; k get svc
NAME             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
kubernetes       ClusterIP   10.43.0.1       <none>        443/TCP   10m
podinfo-target   ClusterIP   10.43.120.163   <none>        80/TCP    3m51s

# Re-create link
spec:
  clusterCredentialsSecret: cluster-credentials-target
  gatewayAddress: 192.168.224.4
  gatewayIdentity: linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.cluster.local
  gatewayPort: "4143"
  probeSpec:
    path: /ready
    period: 3s
    port: "4191"
  remoteDiscoverySelector:
    matchLabels:
      mirror.linkerd.io/exported: remote-discovery
  selector:
    matchLabels:
      mirror.linkerd.io/exported: "true"

# Label nginx-svc with remote-discovery
NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
kubernetes         ClusterIP   10.43.0.1       <none>        443/TCP   14m
podinfo-target     ClusterIP   10.43.120.163   <none>        80/TCP    8m5s
nginx-svc-target   ClusterIP   10.43.160.156   <none>        80/TCP    2s

# No endpoints created
NAME             ENDPOINTS            AGE
kubernetes       192.168.224.2:6443   14m
podinfo-target   192.168.224.4:4143   8m7s

# Delete nginx-svc in target cluster
NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
kubernetes         ClusterIP   10.43.0.1       <none>        443/TCP   27m
podinfo-target     ClusterIP   10.43.120.163   <none>        80/TCP    20m
nginx-svc-target   ClusterIP   10.43.160.156   <none>        80/TCP    12m

# Service mirror cleans it up
NAME             TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
kubernetes       ClusterIP   10.43.0.1       <none>        443/TCP   27m
podinfo-target   ClusterIP   10.43.120.163   <none>        80/TCP    21m
```
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
