### PR TITLE
edge-23.9.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,41 @@
 # Changes
 
+## edge-23.9.1
+
+This edge release introduces a fix for service discovery on endpoints that use
+hostPorts. Previously, the destination service would return the pod IP for the
+discovery request which could break connectivity on pod restart. To fix this,
+direct pod communication for a pod bound on a hostPort will always return the
+hostIP. In addition, this change fixes a security vulnerability (CVE-2023-2603)
+detected in the CNI plugin and proxy-init images and includes a number of other
+fixes and small improvements.
+
+* Addressed security vulnerability CVE-2023-2603 in proxy-init and CNI plugin
+  ([11296])
+* Introduced resource requests/limits for the policy controller resource in the
+  control plane helm chart ([11301])
+* Fixed an issue where an empty `remoteDiscoverySelector` field in a
+  multicluster link would cause all services to be mirrored ([11309])
+* Removed time out from `linkerd multicluster gateways` command; when no
+  metrics exist the command will return instantly ([11265])
+* Improved help messaging for `linkerd multicluster link` ([11265])
+* Changed hostPort lookup behaviour in the destination service; previously,
+  endpoint lookups for pods bound on a hostPort would return the Pod IP which
+  would result in loss of connectivity on pod restart, hostIPs are now always
+  returned when a pod uses a hostPort ([11328])
+* Updated HTTPRoute webhook rule to validate all apiVersions of the resource
+  (thanks @mikutas!) ([11149])
+* Fixed erroneous `skipped` messages when injecting namespaces with `linkerd
+  inject` (thanks @mikutas!) ([10231])
+
+[11309]: https://github.com/linkerd/linkerd2/issues/11309
+[11296]: https://github.com/linkerd/linkerd2/discussions/11296
+[11328]: https://github.com/linkerd/linkerd2/pull/11328
+[11301]: https://github.com/linkerd/linkerd2/issues/11301
+[11265]: https://github.com/linkerd/linkerd2/pull/11265
+[11149]: https://github.com/linkerd/linkerd2/pull/11149
+[10231]: https://github.com/linkerd/linkerd2/issues/10231
+
 ## stable-2.14.0
 
 This release introduces direct pod-to-pod multicluster service mirroring. When

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,10 +19,12 @@ fixes and small improvements.
 * Removed time out from `linkerd multicluster gateways` command; when no
   metrics exist the command will return instantly ([#11265])
 * Improved help messaging for `linkerd multicluster link` ([#11265])
-* Changed hostPort lookup behaviour in the destination service; previously,
-  endpoint lookups for pods bound on a hostPort would return the Pod IP which
-  would result in loss of connectivity on pod restart, hostIPs are now always
-  returned when a pod uses a hostPort ([#11328])
+* Changed how hostPort lookups are handled in the destination service.
+  Previously, when doing service discovery for an endpoint bound on a hostPort,
+  the destination service would return the corresponding pod IP. On pod
+  restart, this could lead to loss of connectivity on the client's side. The
+  destination service now always returns host IPs for service discovery on an
+  endpoint that uses hostPorts ([#11328])
 * Updated HTTPRoute webhook rule to validate all apiVersions of the resource
   (thanks @mikutas!) ([#11149])
 * Fixed erroneous `skipped` messages when injecting namespaces with `linkerd

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,35 +6,35 @@ This edge release introduces a fix for service discovery on endpoints that use
 hostPorts. Previously, the destination service would return the pod IP for the
 discovery request which could break connectivity on pod restart. To fix this,
 direct pod communication for a pod bound on a hostPort will always return the
-hostIP. In addition, this change fixes a security vulnerability (CVE-2023-2603)
-detected in the CNI plugin and proxy-init images and includes a number of other
+hostIP. In addition, this release fixes a security vulnerability (CVE-2023-2603)
+detected in the CNI plugin and proxy-init images, and includes a number of other
 fixes and small improvements.
 
 * Addressed security vulnerability CVE-2023-2603 in proxy-init and CNI plugin
-  ([11296])
+  ([#11296])
 * Introduced resource requests/limits for the policy controller resource in the
-  control plane helm chart ([11301])
+  control plane helm chart ([#11301])
 * Fixed an issue where an empty `remoteDiscoverySelector` field in a
-  multicluster link would cause all services to be mirrored ([11309])
+  multicluster link would cause all services to be mirrored ([#11309])
 * Removed time out from `linkerd multicluster gateways` command; when no
-  metrics exist the command will return instantly ([11265])
-* Improved help messaging for `linkerd multicluster link` ([11265])
+  metrics exist the command will return instantly ([#11265])
+* Improved help messaging for `linkerd multicluster link` ([#11265])
 * Changed hostPort lookup behaviour in the destination service; previously,
   endpoint lookups for pods bound on a hostPort would return the Pod IP which
   would result in loss of connectivity on pod restart, hostIPs are now always
-  returned when a pod uses a hostPort ([11328])
+  returned when a pod uses a hostPort ([#11328])
 * Updated HTTPRoute webhook rule to validate all apiVersions of the resource
-  (thanks @mikutas!) ([11149])
+  (thanks @mikutas!) ([#11149])
 * Fixed erroneous `skipped` messages when injecting namespaces with `linkerd
-  inject` (thanks @mikutas!) ([10231])
+  inject` (thanks @mikutas!) ([#10231])
 
-[11309]: https://github.com/linkerd/linkerd2/issues/11309
-[11296]: https://github.com/linkerd/linkerd2/discussions/11296
-[11328]: https://github.com/linkerd/linkerd2/pull/11328
-[11301]: https://github.com/linkerd/linkerd2/issues/11301
-[11265]: https://github.com/linkerd/linkerd2/pull/11265
-[11149]: https://github.com/linkerd/linkerd2/pull/11149
-[10231]: https://github.com/linkerd/linkerd2/issues/10231
+[#11309]: https://github.com/linkerd/linkerd2/issues/11309
+[#11296]: https://github.com/linkerd/linkerd2/discussions/11296
+[#11328]: https://github.com/linkerd/linkerd2/pull/11328
+[#11301]: https://github.com/linkerd/linkerd2/issues/11301
+[#11265]: https://github.com/linkerd/linkerd2/pull/11265
+[#11149]: https://github.com/linkerd/linkerd2/pull/11149
+[#10231]: https://github.com/linkerd/linkerd2/issues/10231
 
 ## stable-2.14.0
 

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.15.0
+version: 1.16.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square)
+![Version: 1.16.0-edge](https://img.shields.io/badge/Version-1.16.0--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.12.0-edge
+version: 30.11.1-edge

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.11.0
+version: 30.12.0-edge

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.11.1-edge
+version: 30.12.0-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.11.1-edge](https://img.shields.io/badge/Version-30.11.1--edge-informational?style=flat-square)
+![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
+![Version: 30.11.1-edge](https://img.shields.io/badge/Version-30.11.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.11.0](https://img.shields.io/badge/Version-30.11.0-informational?style=flat-square)
+![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.0-edge
+version: 30.11.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.1-edge
+version: 30.12.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.0-edge
+version: 30.11.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.0
+version: 30.12.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.11.0-edge](https://img.shields.io/badge/Version-30.11.0--edge-informational?style=flat-square)
+![Version: 30.11.1-edge](https://img.shields.io/badge/Version-30.11.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
+![Version: 30.11.0-edge](https://img.shields.io/badge/Version-30.11.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.11.1-edge](https://img.shields.io/badge/Version-30.11.1--edge-informational?style=flat-square)
+![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.11.0](https://img.shields.io/badge/Version-30.11.0-informational?style=flat-square)
+![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.0-edge
+version: 30.10.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.0
+version: 30.11.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.10.1-edge
+version: 30.11.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.0-edge
+version: 30.10.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.10.0-edge](https://img.shields.io/badge/Version-30.10.0--edge-informational?style=flat-square)
+![Version: 30.10.1-edge](https://img.shields.io/badge/Version-30.10.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.10.0](https://img.shields.io/badge/Version-30.10.0-informational?style=flat-square)
+![Version: 30.11.0-edge](https://img.shields.io/badge/Version-30.11.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.11.0-edge](https://img.shields.io/badge/Version-30.11.0--edge-informational?style=flat-square)
+![Version: 30.10.0-edge](https://img.shields.io/badge/Version-30.10.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.10.1-edge](https://img.shields.io/badge/Version-30.10.1--edge-informational?style=flat-square)
+![Version: 30.11.0-edge](https://img.shields.io/badge/Version-30.11.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.0-edge
+version: 30.11.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.0-edge
+version: 30.11.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.1-edge
+version: 30.12.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.0
+version: 30.12.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.11.0-edge](https://img.shields.io/badge/Version-30.11.0--edge-informational?style=flat-square)
+![Version: 30.11.1-edge](https://img.shields.io/badge/Version-30.11.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
+![Version: 30.11.0-edge](https://img.shields.io/badge/Version-30.11.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.11.1-edge](https://img.shields.io/badge/Version-30.11.1--edge-informational?style=flat-square)
+![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.11.0](https://img.shields.io/badge/Version-30.11.0-informational?style=flat-square)
+![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release introduces a fix for service discovery on endpoints that use hostPorts. Previously, the destination service would return the pod IP for the discovery request which could break connectivity on pod restart. To fix this, direct pod communication for a pod bound on a hostPort will always return the hostIP. In addition, this change fixes a security vulnerability (CVE-2023-2603) detected in the CNI plugin and proxy-init images and includes a number of other fixes and small improvements.

* Addressed security vulnerability CVE-2023-2603 in proxy-init and CNI plugin ([11296])
* Introduced resource requests/limits for the policy controller resource in the control plane helm chart ([11301])
* Fixed an issue where an empty `remoteDiscoverySelector` field in a multicluster link would cause all services to be mirrored ([11309])
* Removed time out from `linkerd multicluster gateways` command; when no metrics exist the command will return instantly ([11265])
* Improved help messaging for `linkerd multicluster link` ([11265])
* Changed hostPort lookup behaviour in the destination service; previously, endpoint lookups for pods bound on a hostPort would return the Pod IP which would result in loss of connectivity on pod restart, hostIPs are now always returned when a pod uses a hostPort ([11328])
* Updated HTTPRoute webhook rule to validate all apiVersions of the resource (thanks @mikutas!) ([11149])
* Fixed erroneous `skipped` messages when injecting namespaces with `linkerd inject` (thanks @mikutas!) ([10231])

[11309]: https://github.com/linkerd/linkerd2/issues/11309
[11296]: https://github.com/linkerd/linkerd2/discussions/11296
[11328]: https://github.com/linkerd/linkerd2/pull/11328
[11301]: https://github.com/linkerd/linkerd2/issues/11301
[11265]: https://github.com/linkerd/linkerd2/pull/11265
[11149]: https://github.com/linkerd/linkerd2/pull/11149
[10231]: https://github.com/linkerd/linkerd2/issues/10231

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
