### PR TITLE
Add wait conditions to combat flakiness

### DIFF
--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -12,8 +12,8 @@ pub use k8s_openapi::{
         self,
         coordination::v1::Lease,
         core::v1::{
-            Container, ContainerPort, HTTPGetAction, Namespace, Node, NodeSpec, Pod, PodSpec,
-            PodStatus, Probe, Service, ServiceAccount, ServicePort, ServiceSpec,
+            Container, ContainerPort, Endpoints, HTTPGetAction, Namespace, Node, NodeSpec, Pod,
+            PodSpec, PodStatus, Probe, Service, ServiceAccount, ServicePort, ServiceSpec,
         },
     },
     apimachinery::{

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -168,6 +168,14 @@ pub async fn await_route_status(
     .inner
 }
 
+// Wait for the endpoints controller to populate the Endpoints resource.
+pub fn endpoints_ready(obj: Option<&k8s::Endpoints>) -> bool {
+    if let Some(ep) = obj {
+        return ep.subsets.iter().flatten().count() > 0;
+    }
+    false
+}
+
 #[tracing::instrument(skip_all, fields(%pod, %container))]
 pub async fn logs(client: &kube::Client, ns: &str, pod: &str, container: &str) {
     let params = kube::api::LogParams {

--- a/policy-test/tests/e2e_authorization_policy.rs
+++ b/policy-test/tests/e2e_authorization_policy.rs
@@ -4,7 +4,8 @@ use linkerd_policy_controller_k8s_api::{
     policy::{LocalTargetRef, NamespacedTargetRef},
 };
 use linkerd_policy_test::{
-    await_condition, create, create_ready_pod, curl, web, with_temp_ns, LinkerdInject,
+    await_condition, create, create_ready_pod, curl, endpoints_ready, web, with_temp_ns,
+    LinkerdInject,
 };
 
 #[tokio::test(flavor = "current_thread")]
@@ -296,13 +297,6 @@ async fn network() {
             create_ready_pod(&client, web::pod(&ns))
         );
 
-        // Wait for the endpoints controller to populate the Endpoints resource.
-        let endpoints_ready = |obj: Option<&k8s::Endpoints>| -> bool {
-            if let Some(ep) = obj {
-                return ep.subsets.iter().flatten().count() > 0;
-            }
-            false
-        };
         await_condition(&client, &ns, "web", endpoints_ready).await;
 
         // Once the web pod is ready, delete the `curl-lock` configmap to
@@ -384,13 +378,6 @@ async fn both() {
             create_ready_pod(&client, web::pod(&ns))
         );
 
-        // Wait for the endpoints controller to populate the Endpoints resource.
-        let endpoints_ready = |obj: Option<&k8s::Endpoints>| -> bool {
-            if let Some(ep) = obj {
-                return ep.subsets.iter().flatten().count() > 0;
-            }
-            false
-        };
         await_condition(&client, &ns, "web", endpoints_ready).await;
 
         // Once the web pod is ready, delete the `curl-lock` configmap to
@@ -495,13 +482,6 @@ async fn either() {
             create_ready_pod(&client, web::pod(&ns)),
         );
 
-        // Wait for the endpoints controller to populate the Endpoints resource.
-        let endpoints_ready = |obj: Option<&k8s::Endpoints>| -> bool {
-            if let Some(ep) = obj {
-                return ep.subsets.iter().flatten().count() > 0;
-            }
-            false
-        };
         await_condition(&client, &ns, "web", endpoints_ready).await;
 
         // Once the web pod is ready, delete the `curl-lock` configmap to

--- a/policy-test/tests/e2e_server_authorization.rs
+++ b/policy-test/tests/e2e_server_authorization.rs
@@ -2,7 +2,8 @@ use linkerd_policy_controller_k8s_api::{
     self as k8s, policy::server_authorization::Client as ClientAuthz, ResourceExt,
 };
 use linkerd_policy_test::{
-    await_condition, create, create_ready_pod, curl, web, with_temp_ns, LinkerdInject,
+    await_condition, create, create_ready_pod, curl, endpoints_ready, web, with_temp_ns,
+    LinkerdInject,
 };
 
 #[tokio::test(flavor = "current_thread")]
@@ -90,13 +91,6 @@ async fn network() {
             create_ready_pod(&client, web::pod(&ns))
         );
 
-        // Wait for the endpoints controller to populate the Endpoints resource.
-        let endpoints_ready = |obj: Option<&k8s::Endpoints>| -> bool {
-            if let Some(ep) = obj {
-                return ep.subsets.iter().flatten().count() > 0;
-            }
-            false
-        };
         await_condition(&client, &ns, "web", endpoints_ready).await;
 
         // Once the web pod is ready, delete the `curl-lock` configmap to
@@ -183,13 +177,6 @@ async fn both() {
             create_ready_pod(&client, web::pod(&ns))
         );
 
-        // Wait for the endpoints controller to populate the Endpoints resource.
-        let endpoints_ready = |obj: Option<&k8s::Endpoints>| -> bool {
-            if let Some(ep) = obj {
-                return ep.subsets.iter().flatten().count() > 0;
-            }
-            false
-        };
         await_condition(&client, &ns, "web", endpoints_ready).await;
 
         // Once the web pod is ready, delete the `curl-lock` configmap to
@@ -303,13 +290,6 @@ async fn either() {
             create_ready_pod(&client, web::pod(&ns)),
         );
 
-        // Wait for the endpoints controller to populate the Endpoints resource.
-        let endpoints_ready = |obj: Option<&k8s::Endpoints>| -> bool {
-            if let Some(ep) = obj {
-                return ep.subsets.iter().flatten().count() > 0;
-            }
-            false
-        };
         await_condition(&client, &ns, "web", endpoints_ready).await;
 
         // Once the web pod is ready, delete the `curl-lock` configmap to


### PR DESCRIPTION
We intermittently see flaky policy integration test failures like:

```
 failures:
    either

thread 'either' panicked at 'assertion failed: `(left == right)`
  left: `7`,
 right: `0`: blessed uninjected curl must succeed', policy-test/tests/e2e_server_authorization.rs:293:9
```

This test failure is saying that the curl process is returning an exit code of 7 instead of the expected exit code of 0.  This exit code indicates that curl failed to establish a connection.  https://everything.curl.dev/usingcurl/returns

It's unclear why this connection occasionally fails in CI and I have not been able to reproduce this failure locally.

However, by looking at the logic of the integration test, we can see that the integration test creates the `web` Service and the `web` Pod and waits for that pod to become ready before unblocking the curl from executing.  This means that, theoretically, there could be a race condition between the test and the kubernetes endpoints controller.  As soon as the web pod becomes ready, the endpoints controller will update the endpoints resource for the `web` Service and at the same time, our test will unblock the curl command.  If the test wins this race, it is possible that curl will run before the endpoints resource has been updated.

We add an additional wait condition to the test to wait until the endpoints resource has an endpoint before unblocking curl.

Since I could not reproduce the test failure locally, it is impossible to say if this is actually the cause of the flakiness or if this change fixes it.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
