### PR TITLE
Add informative error messages when there is no internet connection.

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1439,10 +1439,10 @@ func CheckProxyVersionsUpToDate(pods []corev1.Pod, versions version.Channels) er
 			}
 		}
 	}
+	if versions.Empty() {
+		return fmt.Errorf("unable to determine version channel")
+	}
 	if len(outdatedPods) > 0 {
-		if len(versions.Array) == 0 {
-			return fmt.Errorf("unable to determine version channel")
-		}
 		podList := strings.Join(outdatedPods, "\n")
 		return fmt.Errorf("some proxies are not running the current version:\n%s", podList)
 	}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1440,6 +1440,9 @@ func CheckProxyVersionsUpToDate(pods []corev1.Pod, versions version.Channels) er
 		}
 	}
 	if len(outdatedPods) > 0 {
+		if len(versions.Array) == 0 {
+			return fmt.Errorf("unable to determine version channel")
+		}
 		podList := strings.Join(outdatedPods, "\n")
 		return fmt.Errorf("some proxies are not running the current version:\n%s", podList)
 	}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1440,7 +1440,7 @@ func CheckProxyVersionsUpToDate(pods []corev1.Pod, versions version.Channels) er
 		}
 	}
 	if versions.Empty() {
-		return fmt.Errorf("unable to determine version channel")
+		return errors.New("unable to determine version channel")
 	}
 	if len(outdatedPods) > 0 {
 		podList := strings.Join(outdatedPods, "\n")

--- a/pkg/version/channels.go
+++ b/pkg/version/channels.go
@@ -45,7 +45,7 @@ func (c Channels) Match(actualVersion string) error {
 		return errors.New("actual version is empty")
 	}
 
-	if len(c.array) == 0 {
+	if c.Empty() {
 		return errors.New("unable to determine version channel")
 	}
 
@@ -83,8 +83,8 @@ func getLatestVersions(ctx context.Context, client *http.Client, url string) (Ch
 
 	rsp, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		var DnsError *net.DNSError
-		if errors.As(err, &DnsError) {
+		var dnsError *net.DNSError
+		if errors.As(err, &dnsError) {
 			return Channels{}, fmt.Errorf("failed to resolve version check server: %s", url)
 		}
 		return Channels{}, err

--- a/pkg/version/channels_test.go
+++ b/pkg/version/channels_test.go
@@ -88,13 +88,13 @@ func TestGetLatestVersions(t *testing.T) {
 }
 
 func channelsEqual(c1, c2 Channels) bool {
-	if len(c1.array) != len(c2.array) {
+	if len(c1.Array) != len(c2.Array) {
 		return false
 	}
 
-	for _, cv1 := range c1.array {
+	for _, cv1 := range c1.Array {
 		found := false
-		for _, cv2 := range c2.array {
+		for _, cv2 := range c2.Array {
 			if cv1 == cv2 {
 				found = true
 				break

--- a/pkg/version/channels_test.go
+++ b/pkg/version/channels_test.go
@@ -88,13 +88,13 @@ func TestGetLatestVersions(t *testing.T) {
 }
 
 func channelsEqual(c1, c2 Channels) bool {
-	if len(c1.Array) != len(c2.Array) {
+	if len(c1.array) != len(c2.array) {
 		return false
 	}
 
-	for _, cv1 := range c1.Array {
+	for _, cv1 := range c1.array {
 		found := false
-		for _, cv2 := range c2.Array {
+		for _, cv2 := range c2.array {
 			if cv1 == cv2 {
 				found = true
 				break


### PR DESCRIPTION
Added a way to narrow down the errors to a lack of internet connection for the proxy version check and also an additional check when matching the channels and last but not least identifying a DNS error when getting the latest versions.

If this happens to be merged then I'd happily update the [docs](https://linkerd.io/2.14/tasks/troubleshooting/) in the errors' respective places to let the users know that they should check their connections as it is not currently listed as a possible solution to the issues.

Sample output with the submitted solution: 
[pr-validation-output.txt](https://github.com/linkerd/linkerd2/files/12641016/pr-validation-output.txt)

Fixes #11349 
