### PR TITLE
Bump Prometheus to v2.47.0

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -224,6 +224,7 @@ Kubernetes: `>=1.21.0-0`
 | profileValidator.injectCaFromSecret | string | `""` | Inject the CA bundle from a Secret. If set, the `cert-manager.io/inject-ca-from-secret` annotation will be added to the webhook. The Secret must have the CA Bundle stored in the `ca.crt` key and have the `cert-manager.io/allow-direct-injection` annotation set to `true`. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector/#injecting-ca-data-from-a-secret-resource) for more information. |
 | profileValidator.keyPEM | string | `""` | Certificate key for the service profile validator. If not provided and not using an external secret then Helm will generate one. |
 | profileValidator.namespaceSelector | object | `{"matchExpressions":[{"key":"config.linkerd.io/admission-webhooks","operator":"NotIn","values":["disabled"]}]}` | Namespace selector used by admission webhook |
+| prometheusUrl | string | `""` | url of external prometheus instance (used for the heartbeat) |
 | proxy.await | bool | `true` | If set, the application container will not start until the proxy is ready |
 | proxy.cores | int | `0` | The `cpu.limit` and `cores` should be kept in sync. The value of `cores` must be an integer and should typically be set by rounding up from the limit. E.g. if cpu.limit is '1500m', cores should be 2. |
 | proxy.defaultInboundPolicy | string | "all-unauthenticated" | The default allow policy to use when no `Server` selects a pod.  One of: "all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny" |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -141,7 +141,7 @@ Kubernetes: `>=1.21.0-0`
 | prometheus.image.name | string | `"prometheus"` | Docker image name for the prometheus instance |
 | prometheus.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the prometheus instance |
 | prometheus.image.registry | string | `"prom"` | Docker registry for the prometheus instance |
-| prometheus.image.tag | string | `"v2.43.0"` | Docker image tag for the prometheus instance |
+| prometheus.image.tag | string | `"v2.47.0"` | Docker image tag for the prometheus instance |
 | prometheus.logFormat | string | defaultLogLevel | log format (plain, json) of the prometheus instance |
 | prometheus.logLevel | string | defaultLogLevel | log level of the prometheus instance |
 | prometheus.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -418,7 +418,7 @@ prometheus:
     # -- Docker image name for the prometheus instance
     name: prometheus
     # -- Docker image tag for the prometheus instance
-    tag: v2.43.0
+    tag: v2.47.0
     # -- Pull policy for the prometheus instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.43.0
+        image: prom/prometheus:v2.47.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.43.0
+        image: prom/prometheus:v2.47.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -732,7 +732,7 @@ spec:
         - --log.level=debug
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.43.0
+        image: prom/prometheus:v2.47.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -736,7 +736,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.43.0
+        image: prom/prometheus:v2.47.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
```
$ grype --add-cpes-if-none prom/prometheus:v2.43.0
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                                                       prom/prometheus:v2.43.0
 ✔ Parsed image                                                                                                                                                       sha256:a07b618ecd1dce142bce4c52f0e80982eaf1f14265a2415c2d35978ccaa0a464
 ✔ Cataloged packages              [305 packages]
 ✔ Scanned for vulnerabilities     [14 vulnerabilities]
   ├── 0 critical, 6 high, 8 medium, 0 low, 0 negligible
   └── 12 fixed
NAME                                INSTALLED             FIXED-IN      TYPE       VULNERABILITY        SEVERITY
github.com/docker/distribution      v2.8.1+incompatible   2.8.2-beta.1  go-module  GHSA-hqxw-f8mx-cpmw  High
github.com/docker/docker            v23.0.1+incompatible  23.0.3        go-module  GHSA-232p-vwff-86mp  High
github.com/docker/docker            v23.0.1+incompatible  23.0.3        go-module  GHSA-6wrf-mxfj-pf5p  Medium
github.com/docker/docker            v23.0.1+incompatible  23.0.3        go-module  GHSA-33pg-m6jh-5237  Medium
github.com/prometheus/alertmanager  v0.25.0               0.25.1        go-module  GHSA-v86x-5fm3-5p7j  Medium
github.com/prometheus/alertmanager  v0.25.0                             go-module  CVE-2023-40577       Medium
google.golang.org/protobuf          v1.29.0               1.29.1        go-module  GHSA-hw7c-3rfg-p46j  High

$ grype --add-cpes-if-none prom/prometheus:v2.47.0
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                                                       prom/prometheus:v2.47.0
 ✔ Parsed image                                                                                                                                                       sha256:9c703d373f61ca33f879dbc6cb65bb1f2a78c676c75abaa56c7b98795a7b1737
 ✔ Cataloged packages              [334 packages]
 ✔ Scanned for vulnerabilities     [4 vulnerabilities]
   ├── 0 critical, 0 high, 4 medium, 0 low, 0 negligible
   └── 2 fixed
NAME                                INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/prometheus/alertmanager  v0.25.0    0.25.1    go-module  GHSA-v86x-5fm3-5p7j  Medium
github.com/prometheus/alertmanager  v0.25.0              go-module  CVE-2023-40577       Medium
```