### PR TITLE
Add functionality to helm chart to allow image digest for controllerImage

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -156,6 +156,7 @@ Kubernetes: `>=1.21.0-0`
 | controllerLogLevel | string | `"info"` | Log level for the control plane components |
 | controllerReplicas | int | `1` | Number of replicas for each control plane pod |
 | controllerUID | int | `2103` | User ID for the control plane components |
+| controllerImageVersion | string | `"tag@digest"` | Image tag and digest for the destination and identity components |
 | debugContainer.image.name | string | `"cr.l5d.io/linkerd/debug"` | Docker image for the debug container |
 | debugContainer.image.pullPolicy | string | imagePullPolicy | Pull policy for the debug container Docker image |
 | debugContainer.image.version | string | linkerdVersion | Tag for the debug container Docker image |

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -152,11 +152,11 @@ Kubernetes: `>=1.21.0-0`
 | controlPlaneTracing | bool | `false` | enables control plane tracing |
 | controlPlaneTracingNamespace | string | `"linkerd-jaeger"` | namespace to send control plane traces to |
 | controllerImage | string | `"cr.l5d.io/linkerd/controller"` | Docker image for the destination and identity components |
+| controllerImageVersion | string | `""` | Optionally allow a specific container image Tag (or SHA) to be specified for the controllerImage. |
 | controllerLogFormat | string | `"plain"` | Log format for the control plane components |
 | controllerLogLevel | string | `"info"` | Log level for the control plane components |
 | controllerReplicas | int | `1` | Number of replicas for each control plane pod |
 | controllerUID | int | `2103` | User ID for the control plane components |
-| controllerImageVersion | string | `"tag@digest"` | Image tag and digest for the destination and identity components |
 | debugContainer.image.name | string | `"cr.l5d.io/linkerd/debug"` | Docker image for the debug container |
 | debugContainer.image.pullPolicy | string | imagePullPolicy | Pull policy for the debug container Docker image |
 | debugContainer.image.version | string | linkerdVersion | Tag for the debug container Docker image |

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -203,7 +203,7 @@ spec:
         - -default-opaque-ports={{.Values.proxy.opaquePorts}}
         - -enable-pprof={{.Values.enablePprof | default false}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
-        image: {{.Values.controllerImage}}:{{.Values.linkerdVersion}}
+        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:
@@ -239,7 +239,7 @@ spec:
         - -log-level={{.Values.controllerLogLevel}}
         - -log-format={{.Values.controllerLogFormat}}
         - -enable-pprof={{.Values.enablePprof | default false}}
-        image: {{.Values.controllerImage}}:{{.Values.linkerdVersion}}
+        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -54,7 +54,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: heartbeat
-            image: {{.Values.controllerImage}}:{{.Values.linkerdVersion}}
+            image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
             imagePullPolicy: {{.Values.imagePullPolicy}}
             env:
             - name: LINKERD_DISABLED

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -163,7 +163,7 @@ spec:
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"
-        image: {{.Values.controllerImage}}:{{.Values.linkerdVersion}}
+        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -76,7 +76,7 @@ spec:
         - -log-format={{.Values.controllerLogFormat}}
         - -linkerd-namespace={{.Release.Namespace}}
         - -enable-pprof={{.Values.enablePprof | default false}}
-        image: {{.Values.controllerImage}}:{{.Values.linkerdVersion}}
+        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -290,8 +290,8 @@ controllerImage: cr.l5d.io/linkerd/controller
 controllerReplicas: 1
 # -- User ID for the control plane components
 controllerUID: 2103
-# -- Tag for the controllerImage if SHA is required
-#controllerImageVersion: tag@sha:123
+# -- Optionally allow a specific container image Tag (or SHA) to be specified for the controllerImage.
+controllerImageVersion: ""
 
 # destination configuration
 # set resources for the sp-validator and its linkerd proxy respectively

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -290,6 +290,8 @@ controllerImage: cr.l5d.io/linkerd/controller
 controllerReplicas: 1
 # -- User ID for the control plane components
 controllerUID: 2103
+# -- Tag for the controllerImage if SHA is required
+#controllerImageVersion: tag@sha:123
 
 # destination configuration
 # set resources for the sp-validator and its linkerd proxy respectively

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -286,12 +286,13 @@ webhookFailurePolicy: Ignore
 
 # controllerImage -- Docker image for the destination and identity components
 controllerImage: cr.l5d.io/linkerd/controller
+# -- Optionally allow a specific container image Tag (or SHA) to be specified for the controllerImage.
+controllerImageVersion: ""
+
 # -- Number of replicas for each control plane pod
 controllerReplicas: 1
 # -- User ID for the control plane components
 controllerUID: 2103
-# -- Optionally allow a specific container image Tag (or SHA) to be specified for the controllerImage.
-controllerImageVersion: ""
 
 # destination configuration
 # set resources for the sp-validator and its linkerd proxy respectively


### PR DESCRIPTION
Subject
Introduce helm functionality for controllerImage  digest/tag

Problem
I need to reference each image via a digest or its not allowed to run in our cluster. 
The current helm chart behaviour appends .Values.linkerdVersion but there is currently no way to add a digest.

This is not an issue for other images because they already allow tags

Solution
Add helm functionality to allow setting the controllerImage  tag

Validation
1. update values.yaml with 
controllerImageVersion: tag@sha

2. Run helm template using the above values and view the output. The controllerImage  now has   the   value `cr.l5d.io/linkerd/controller:tag@sha:123` allowing you to reference a digest

Fixes #11312 

DCO Sign off
Signed-off-by: Dan Levin dan@badpacket.in
