### PR TITLE
Disable helm-update integration test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         - default-policy-deny
         - external
         - rsa-ca
-        - helm-upgrade
+      # - helm-upgrade
         - uninstall
       # - upgrade-edge
         - upgrade-stable


### PR DESCRIPTION
In this particular case that attempts to downgrade from 2.14.1 to 2.13.7, which is not possible for `linkerd-crds` because the version
  `v1beta3` of `httproutes.policy.linkerd.io` got introduced in 2.14.1:
```
Error: UPGRADE FAILED: an error occurred while rolling back the release. original upgrade error: cannot patch "httproutes.policy.linkerd.io" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "httproutes.policy.linkerd.io" is invalid: status.storedVersions[0]: Invalid value: "v1beta3": must appear in spec.versions: no CustomResourceDefinition with the name "httproutes.gateway.networking.k8s.io" found
```
