### PR TITLE
Disable stable upgrade tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
       # - helm-upgrade
         - uninstall
       # - upgrade-edge
-        - upgrade-stable
+      # - upgrade-stable
     timeout-minutes: 60
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Latest stable patched release (`stable-2.13.7`) cannot be released since the integration upgrade tests fail due to a skew in the HTTPRoute CRD version we use.

Upgrade tests can be a bit difficult to run for backported fixes in previous stable versions. Our stable integration tests [will run the latest stable version](https://github.com/linkerd/linkerd2/blob/main/test/integration/upgrade-stable/upgrade_stable_test.go#L45-L70) and then upgrade to the build being tested. This is the expected flow under normal circumstances:

```
Building `stable-2.14.2`:
* Install & test expected output for current stable: 2.14.1
* Upgrade to current build and test output: 2.14.2
```

However, for patch releases in previous stables, we are essentially downgrading, not upgrading. When there's a CRD version drift, this makes the downgrade throw errors. For 2.13.7, we get the error snippet pasted below:


```
Error: TestUpgradeCli - 'kubectl apply' command failed
--- FAIL: TestUpgradeCli (0.65s)
    upgrade_stable_test.go:205: 'kubectl apply' command failed
        customresourcedefinition.apiextensions.k8s.io/authorizationpolicies.policy.linkerd.io configured
        customresourcedefinition.apiextensions.k8s.io/meshtlsauthentications.policy.linkerd.io configured
        customresourcedefinition.apiextensions.k8s.io/networkauthentications.policy.linkerd.io configured
        customresourcedefinition.apiextensions.k8s.io/serverauthorizations.policy.linkerd.io configured
        customresourcedefinition.apiextensions.k8s.io/servers.policy.linkerd.io configured
        customresourcedefinition.apiextensions.k8s.io/serviceprofiles.linkerd.io configured
        The CustomResourceDefinition "httproutes.policy.linkerd.io" is invalid: status.storedVersions[0]: Invalid value: "v1beta3": must appear in spec.versions
FAIL
FAIL	github.com/linkerd/linkerd2/test/integration/upgrade-stable	111.339s
FAIL
Error: Process completed with exit code 1.
```

This can easily be reproduced by installing 2.14.0 CRDs in a k3d cluster and attempting to upgrade the CRDs only with a 2.13.x client. The short term solution is to disable these tests. The long term solution is to re-think how downgrades, or upgrades for backported versions should be done.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
