### PR TITLE
viz: Fix jaeger check test

### DIFF
--- a/test/integration/viz/tracing/tracing_test.go
+++ b/test/integration/viz/tracing/tracing_test.go
@@ -80,7 +80,11 @@ func TestTracing(t *testing.T) {
 		}
 
 		tpl := template.Must(template.ParseFiles("testdata" + "/" + golden))
-		versionErr := healthcheck.CheckProxyVersionsUpToDate(pods, version.Channels{})
+		chs, err := version.NewChannels("test-99.88.77")
+		if err != nil {
+			panic(err.Error())
+		}
+		versionErr := healthcheck.CheckProxyVersionsUpToDate(pods, chs)
 		versionErrMsg := ""
 		if versionErr != nil {
 			versionErrMsg = versionErr.Error()


### PR DESCRIPTION
64b66f921 changed the behavior of healthcheck.CheckProxyVersionsUpToDate so that it errors when there are no channels provided. The viz tracing test uses this utility to generate the expected error message, and it did so without providing any channels.

This regression is fixed by instantiating the Channels struct with data.
