### PR TITLE
Update tungstenite for CVE-2023-43669

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,9 +2727,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
  "bytes",


### PR DESCRIPTION
Note that tungstenite is only a dependency of our integration test suite and is not enabled in production-facing code.