### PR TITLE
dev: Move temporary docker-build metadata into target

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -58,7 +58,7 @@ runs:
       shell: bash
       id: image_digest
       run: |
-        image_digest=$(cat metadata-${{ inputs.component }}.json | jq -r '."containerimage.digest"')
+        image_digest=$(cat target/metadata-${{ inputs.component }}.json | jq -r '."containerimage.digest"')
         echo "${image_digest}"
         echo "DIGEST=${{ inputs.docker-registry }}/${{ inputs.component }}@${image_digest}" >> "$GITHUB_OUTPUT"
 

--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -97,7 +97,7 @@ See https://github.com/docker/buildx/issues/59 for more details'
         $output_params \
         -t "$repo:$tag" \
         -f "$file" \
-        --metadata-file metadata-"$name".json \
+        --metadata-file target/metadata-"$name".json \
         "$@"
 
     echo "$repo:$tag"


### PR DESCRIPTION
171985d updated the bin/docker-build script to output metadata files into to root directory of the repo. This dirties the git status and is generally inconcistent with the way our tooling works.

This change updates the location of the files to be under the `./target/` directory, along with all of our other build outputs.
