### PR TITLE
Bump composite actions deps

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -33,14 +33,14 @@ runs:
     - name: Configure cache
       shell: bash
       run: echo "DOCKER_BUILDKIT_CACHE=${{ runner.temp }}/.buildx-cache" >> $GITHUB_ENV
-    - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d
+    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
       with:
         path: ${{ env.DOCKER_BUILDKIT_CACHE }}
         key: ${{ runner.os }}-buildx-${{ inputs.component }}-${{ inputs.tag }}
         restore-keys: ${{ runner.os }}-buildx-${{ inputs.component }}-
 
-    - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
-    - uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
+    - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
+    - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
     - name: Run bin/docker-build-${{ inputs.component }}
       env:
         DOCKER_REGISTRY: ${{ inputs.docker-registry }}

--- a/.github/actions/helm-publish/action.yml
+++ b/.github/actions/helm-publish/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
   - name: Set up Cloud SDK
-    uses: 'google-github-actions/setup-gcloud@a45a0825993ace67ae6e11cf3011b3e7d6795f82'
+    uses: 'google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b'
   - shell: bash
     run: |
       mkdir -p target/helm

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/integration.yml
+      - .github/actions/**
       - .proxy-version
       - '**/*.go'
       - '**/Dockerfile*'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/integration.yml
-      - .github/actions/**
       - .proxy-version
       - '**/*.go'
       - '**/Dockerfile*'


### PR DESCRIPTION
GH actions dependencies used in our composite actions (under `.github/actions`) aren't updated by dependabot, so I'm manually updating all of them to their latest.