### PR TITLE
edge-23.9.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,12 +16,15 @@ This edge release makes Linkerd even better.
   HostPort endpoints) ([#11334]).
 * Added a validating webhook config for httproutes.gateway.networking.k8s.io
   resources (thanks @mikutas!) ([#11150])
+* Introduced a new `multicluster check --timeout` flag to limit the time
+  allowed for Kubernetes API calls (thanks @moki1202) ([#11420])
 
 [#11150]: https://github.com/linkerd/linkerd2/pull/11150
 [#11334]: https://github.com/linkerd/linkerd2/pull/11334
 [#11376]: https://github.com/linkerd/linkerd2/pull/11376
 [#11377]: https://github.com/linkerd/linkerd2/pull/11377
 [#11406]: https://github.com/linkerd/linkerd2/pull/11406
+[#11420]: https://github.com/linkerd/linkerd2/pull/11420
 
 ## edge-29.9.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## edge-29.9.4
+## edge-23.9.4
 
 This edge release makes Linkerd even better.
 
@@ -26,7 +26,7 @@ This edge release makes Linkerd even better.
 [#11406]: https://github.com/linkerd/linkerd2/pull/11406
 [#11420]: https://github.com/linkerd/linkerd2/pull/11420
 
-## edge-29.9.3
+## edge-23.9.3
 
 This edge release updates the proxy's dependency on the `rustls` library to
 patch security vulnerability [RUSTSEC-2023-0052][RUSTSEC-2023-0052-0]
@@ -52,7 +52,7 @@ control plane and jaeger extension Helm charts.
 [#11342]: https://github.com/linkerd/linkerd2/issues/11342
 [RUSTSEC-2023-0052-0]: https://rustsec.org/advisories/RUSTSEC-2023-0052.html
 
-## edge-29.9.2
+## edge-23.9.2
 
 This edge release updates the proxy's dependency on the `webpki` library to
 patch security vulnerability [RUSTSEC-2023-0052] (GHSA-8qv2-5vq6-g2g7), a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Changes
 
+## edge-29.9.4
+
+This edge release makes Linkerd even better.
+
+* Added a controlPlaneVersion override to the `linkerd-control-plane` Helm chart
+  to support including SHA256 image digests in Linkerd manifests (thanks
+  @cromulentbanana!) ([#11406])
+* Improved `linkerd viz check` to attempt to validate that the Prometheus scrape
+  interval will work well with the CLI and Web query parameters ([#11376])
+* Fixed an issue where the destination controller would not update pod metadata
+  for profile resolutions for a pod accessed via the host network (e.g.
+  HostPort endpoints) ([#11334]).
+* Added a validating webhook config for httproutes.gateway.networking.k8s.io
+  resources (thanks @mikutas!) ([#11150])
+
+[#11150]: https://github.com/linkerd/linkerd2/pull/11150
+[#11334]: https://github.com/linkerd/linkerd2/pull/11334
+[#11376]: https://github.com/linkerd/linkerd2/pull/11376
+[#11406]: https://github.com/linkerd/linkerd2/pull/11406
+
 ## edge-29.9.3
 
 This edge release updates the proxy's dependency on the `rustls` library to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ This edge release makes Linkerd even better.
 [#11150]: https://github.com/linkerd/linkerd2/pull/11150
 [#11334]: https://github.com/linkerd/linkerd2/pull/11334
 [#11376]: https://github.com/linkerd/linkerd2/pull/11376
+[#11377]: https://github.com/linkerd/linkerd2/pull/11377
 [#11406]: https://github.com/linkerd/linkerd2/pull/11406
 
 ## edge-29.9.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ This edge release makes Linkerd even better.
   @cromulentbanana!) ([#11406])
 * Improved `linkerd viz check` to attempt to validate that the Prometheus scrape
   interval will work well with the CLI and Web query parameters ([#11376])
+* Improved CLI error handling to print differentiated error information when
+  versioncheck.linkerd.io cannot be resolved (thanks @dtaskai) ([#11377])
 * Fixed an issue where the destination controller would not update pod metadata
   for profile resolutions for a pod accessed via the host network (e.g.
   HostPort endpoints) ([#11334]).

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.17.0-edge
+version: 1.17.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.17.0-edge](https://img.shields.io/badge/Version-1.17.0--edge-informational?style=flat-square)
+![Version: 1.17.1-edge](https://img.shields.io/badge/Version-1.17.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.12.1-edge
+version: 30.13.0-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.12.1-edge](https://img.shields.io/badge/Version-30.12.1--edge-informational?style=flat-square)
+![Version: 30.13.0-edge](https://img.shields.io/badge/Version-30.13.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.0-edge
+version: 30.13.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.13.0-edge](https://img.shields.io/badge/Version-30.13.0--edge-informational?style=flat-square)
+![Version: 30.13.1-edge](https://img.shields.io/badge/Version-30.13.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.2-edge
+version: 30.11.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.3-edge
+version: 30.12.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.11.3-edge](https://img.shields.io/badge/Version-30.11.3--edge-informational?style=flat-square)
+![Version: 30.12.0-edge](https://img.shields.io/badge/Version-30.12.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.11.2-edge](https://img.shields.io/badge/Version-30.11.2--edge-informational?style=flat-square)
+![Version: 30.11.3-edge](https://img.shields.io/badge/Version-30.11.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.2-edge
+version: 30.12.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.3-edge
+version: 30.13.0-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.12.2-edge](https://img.shields.io/badge/Version-30.12.2--edge-informational?style=flat-square)
+![Version: 30.12.3-edge](https://img.shields.io/badge/Version-30.12.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.12.3-edge](https://img.shields.io/badge/Version-30.12.3--edge-informational?style=flat-square)
+![Version: 30.13.0-edge](https://img.shields.io/badge/Version-30.13.0--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release makes Linkerd even better.

* Added a controlPlaneVersion override to the `linkerd-control-plane` Helm chart
  to support including SHA256 image digests in Linkerd manifests (thanks
  @cromulentbanana!) ([#11406])
* Improved `linkerd viz check` to attempt to validate that the Prometheus scrape
  interval will work well with the CLI and Web query parameters ([#11376])
* Improved CLI error handling to print differentiated error information when
  versioncheck.linkerd.io cannot be resolved (thanks @dtaskai) ([#11377])
* Fixed an issue where the destination controller would not update pod metadata
  for profile resolutions for a pod accessed via the host network (e.g.
  HostPort endpoints) ([#11334]).
* Added a validating webhook config for httproutes.gateway.networking.k8s.io
  resources (thanks @mikutas!) ([#11150])

[#11150]: https://github.com/linkerd/linkerd2/pull/11150
[#11334]: https://github.com/linkerd/linkerd2/pull/11334
[#11376]: https://github.com/linkerd/linkerd2/pull/11376
[#11377]: https://github.com/linkerd/linkerd2/pull/11377
[#11406]: https://github.com/linkerd/linkerd2/pull/11406