### PR TITLE
Skip `multicluster-gateways-endpoints` for links with no gateways

### DIFF
--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -555,6 +555,13 @@ func (hc *healthChecker) checkIfGatewayMirrorsHaveEndpoints(ctx context.Context,
 	links := []string{}
 	errors := []error{}
 	for _, link := range hc.links {
+		// When linked against a cluster without a gateway, there will be no
+		// gateway address and no probe spec initialised. In such cases, skip
+		// the check
+		if link.GatewayAddress == "" || link.ProbeSpec.Path == "" {
+			continue
+		}
+
 		// Check that each gateway probe service has endpoints.
 		selector := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s,%s=%s", k8s.MirroredGatewayLabel, k8s.RemoteClusterNameLabel, link.TargetClusterName)}
 		gatewayMirrors, err := hc.KubeAPIClient().CoreV1().Services(metav1.NamespaceAll).List(ctx, selector)


### PR DESCRIPTION
The multicluster extension has always allowed the extension to be installed without a gateway; the idea being that users would provide their own. With p2p, we extended this to allow links that do not specify a gateway at all, but in the process we missed changing a key check -- `multicluster-gateways-endpoints` -- that asserts all links have a probe service.

Without a gateway on the other end, a link will not have a probe spec (or a gateway address) so it makes no sense to run this check, there will never be a probe service created in the source cluster. To fix this issue, we skip the check when the link misses either a gateway address or a probe spec.

Fixes #11428

---

Before:

```
linkerd-multicluster
--------------------
√ Link CRD exists
√ Link resources are valid
        * target
√ remote cluster access credentials are valid
        * target
√ clusters share trust anchors
        * target
√ service mirror controller has required permissions
        * target
√ service mirror controllers are running
        * target
× probe services able to communicate with all gateway mirrors
        wrong number (0) of probe gateways for target cluster target
    see https://linkerd.io/2.14/checks/#l5d-multicluster-gateways-endpoints for hints
√ multicluster extension proxies are healthy
‼ multicluster extension proxies are up-to-date
    some proxies are not running the current version:
        * linkerd-gateway-59c55f65b6-vcxnx (stable-2.14.0)
        * linkerd-service-mirror-target-777b9fdb95-tdvhr (stable-2.14.0)
    see https://linkerd.io/2.14/checks/#l5d-multicluster-proxy-cp-version for hints
√ multicluster extension proxies and cli versions match

Status check results are ×

```

After:

```
:; bin/linkerd mc check
linkerd-multicluster
--------------------
√ Link CRD exists
√ Link resources are valid
        * target
√ remote cluster access credentials are valid
        * target
√ clusters share trust anchors
        * target
√ service mirror controller has required permissions
        * target
√ service mirror controllers are running
        * target
√ multicluster extension proxies are healthy
‼ multicluster extension proxies are up-to-date
    some proxies are not running the current version:
        * linkerd-gateway-59c55f65b6-vcxnx (stable-2.14.0)
        * linkerd-service-mirror-target-777b9fdb95-tdvhr (stable-2.14.0)
    see https://linkerd.io/2/checks/#l5d-multicluster-proxy-cp-version for hints
‼ multicluster extension proxies and cli versions match
    linkerd-gateway-59c55f65b6-vcxnx running stable-2.14.0 but cli running dev-1934bee1-matei
    see https://linkerd.io/2/checks/#l5d-multicluster-proxy-cli-version for hints

Status check results are √
```

Diff: the check is no longer run when a link isn't associated with a gateway. In this case, we only had one link, so the check does not appear at all.


### Alternative

As an alternative, we could opt to output the cluster and mention it has been skipped since its link is not supposed to forward traffic to a gateway. Since the check's name is `multicluster-**gateway**-endpoints` I thought it makes more sense to completely skip it.

<details>

<summary> Running the build locally </summary>

```
k3d cluster create source \
              --network=my-mc-bridge \
              --k3s-arg --disable='local-storage,metrics-server@server:*' \
              --k3s-arg '--cluster-cidr=10.23.0.0/24@server:*'

k3d cluster create target \
       --network=my-mc-bridge \
       --k3s-arg --disable='local-storage,metrics-server@server:*' \
       --k3s-arg '--cluster-cidr=10.20.0.0/24@server:*'
```

```
for ctx in source target
       linkerd install --context=k3d-$ctx --crds | k --context=k3d-$ctx apply -f -
       linkerd install --context=k3d-$ctx --identity-trust-anchors-file ca.crt --identity-issuer-certificate-file issuer.crt --identity-issuer
-key-file issuer.key| k --context=k3d-$ctx apply -f -
       sleep 1m
   end

 linkerd mc install --context=k3d-source | k --context=k3d-source apply -f -
 linkerd mc install --context=k3d-target | k --context=k3d-target apply -f -
```

</details>

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
