### PR TITLE
Improve route status reconcile integration tests

### DIFF
--- a/policy-test/tests/inbound_http_route_status.rs
+++ b/policy-test/tests/inbound_http_route_status.rs
@@ -192,6 +192,8 @@ async fn inbound_accepted_reconcile_no_parent() {
         };
         create(&client, server).await;
 
+        // HTTPRoute may not be patched instantly, await the condition where
+        // create_timestamp and observed_timestamp are different.
         let route_status = await_condition(
             &client,
             &ns,
@@ -276,6 +278,8 @@ async fn inbound_accepted_reconcile_parent_delete() {
         .await
         .expect("API delete request failed");
 
+        // HTTPRoute may not be patched instantly, await the condition where
+        // create_timestamp and observed_timestamp are different.
         let route_status = await_condition(
             &client,
             &ns,

--- a/policy-test/tests/inbound_http_route_status.rs
+++ b/policy-test/tests/inbound_http_route_status.rs
@@ -157,7 +157,7 @@ async fn inbound_accepted_reconcile_no_parent() {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("Server".to_string()),
             namespace: Some(ns.clone()),
-            name: "test-reconcile-inbound-server".to_string(),
+            name: server_name.to_string(),
             section_name: None,
             port: None,
         }];

--- a/policy-test/tests/inbound_http_route_status.rs
+++ b/policy-test/tests/inbound_http_route_status.rs
@@ -4,232 +4,225 @@ use linkerd_policy_test::{
     await_condition, await_route_status, create, find_route_condition, mk_route, with_temp_ns,
 };
 
-// #[tokio::test(flavor = "current_thread")]
-// async fn inbound_accepted_parent() {
-//     with_temp_ns(|client, ns| async move {
-//         // Create a test 'Server'
-//         let server = k8s::policy::Server {
-//             metadata: k8s::ObjectMeta {
-//                 namespace: Some(ns.to_string()),
-//                 name: Some("test-accepted-server".to_string()),
-//                 ..Default::default()
-//             },
-//             spec: k8s::policy::ServerSpec {
-//                 pod_selector: k8s::labels::Selector::from_iter(Some((
-//                     "app",
-//                     "test-accepted-server",
-//                 ))),
-//                 port: k8s::policy::server::Port::Name("http".to_string()),
-//                 proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
-//             },
-//         };
-//         let server = create(&client, server).await;
-//         let srv_ref = vec![k8s::policy::httproute::ParentReference {
-//             group: Some("policy.linkerd.io".to_string()),
-//             kind: Some("Server".to_string()),
-//             namespace: server.namespace(),
-//             name: server.name_unchecked(),
-//             section_name: None,
-//             port: None,
-//         }];
+#[tokio::test(flavor = "current_thread")]
+async fn inbound_accepted_parent() {
+    with_temp_ns(|client, ns| async move {
+        // Create a test 'Server'
+        let server_name = "test-accepted-server";
+        let server = k8s::policy::Server {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.to_string()),
+                name: Some(server_name.to_string()),
+                ..Default::default()
+            },
+            spec: k8s::policy::ServerSpec {
+                pod_selector: k8s::labels::Selector::from_iter(Some(("app", server_name))),
+                port: k8s::policy::server::Port::Name("http".to_string()),
+                proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+            },
+        };
+        let server = create(&client, server).await;
+        let srv_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("policy.linkerd.io".to_string()),
+            kind: Some("Server".to_string()),
+            namespace: server.namespace(),
+            name: server.name_unchecked(),
+            section_name: None,
+            port: None,
+        }];
 
-//         // Create a route that references the Server resource.
-//         let _route = create(&client, mk_route(&ns, "test-accepted-route", Some(srv_ref))).await;
-//         // Wait until route is updated with a status
-//         let statuses = await_route_status(&client, &ns, "test-accepted-route")
-//             .await
-//             .parents;
+        // Create a route that references the Server resource.
+        let _route = create(&client, mk_route(&ns, "test-accepted-route", Some(srv_ref))).await;
+        // Wait until route is updated with a status
+        let statuses = await_route_status(&client, &ns, "test-accepted-route")
+            .await
+            .parents;
 
-//         let route_status = statuses
-//             .clone()
-//             .into_iter()
-//             .find(|route_status| route_status.parent_ref.name == server.name_unchecked())
-//             .expect("must have at least one parent status");
+        let route_status = statuses
+            .clone()
+            .into_iter()
+            .find(|route_status| route_status.parent_ref.name == server_name)
+            .expect("must have at least one parent status");
 
-//         // Check status references to parent we have created
-//         assert_eq!(
-//             route_status.parent_ref.group.as_deref(),
-//             Some("policy.linkerd.io")
-//         );
-//         assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Server"));
+        // Check status references to parent we have created
+        assert_eq!(
+            route_status.parent_ref.group.as_deref(),
+            Some("policy.linkerd.io")
+        );
+        assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Server"));
 
-//         // Check status is accepted with a status of 'True'
-//         let cond = find_route_condition(&statuses, &server.name_unchecked())
-//             .expect("must have at least one 'Accepted' condition for accepted server");
-//         assert_eq!(cond.status, "True");
-//         assert_eq!(cond.reason, "Accepted")
-//     })
-//     .await;
-// }
+        // Check status is accepted with a status of 'True'
+        let cond = find_route_condition(&statuses, server_name)
+            .expect("must have at least one 'Accepted' condition for accepted server");
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason, "Accepted")
+    })
+    .await;
+}
 
-// #[tokio::test(flavor = "current_thread")]
-// async fn inbound_multiple_parents() {
-//     with_temp_ns(|client, ns| async move {
-//         // Exercise accepted test with a valid, and an invalid parent reference
-//         let srv_refs = vec![
-//             k8s::policy::httproute::ParentReference {
-//                 group: Some("policy.linkerd.io".to_string()),
-//                 kind: Some("Server".to_string()),
-//                 namespace: Some(ns.clone()),
-//                 name: "test-valid-server".to_string(),
-//                 section_name: None,
-//                 port: None,
-//             },
-//             k8s::policy::httproute::ParentReference {
-//                 group: Some("policy.linkerd.io".to_string()),
-//                 kind: Some("Server".to_string()),
-//                 namespace: Some(ns.clone()),
-//                 name: "test-invalid-server".to_string(),
-//                 section_name: None,
-//                 port: None,
-//             },
-//         ];
+#[tokio::test(flavor = "current_thread")]
+async fn inbound_multiple_parents() {
+    with_temp_ns(|client, ns| async move {
+        // Exercise accepted test with a valid, and an invalid parent reference
+        let srv_refs = vec![
+            k8s::policy::httproute::ParentReference {
+                group: Some("policy.linkerd.io".to_string()),
+                kind: Some("Server".to_string()),
+                namespace: Some(ns.clone()),
+                name: "test-valid-server".to_string(),
+                section_name: None,
+                port: None,
+            },
+            k8s::policy::httproute::ParentReference {
+                group: Some("policy.linkerd.io".to_string()),
+                kind: Some("Server".to_string()),
+                namespace: Some(ns.clone()),
+                name: "test-invalid-server".to_string(),
+                section_name: None,
+                port: None,
+            },
+        ];
 
-//         // Create only one of the parents
-//         let server = k8s::policy::Server {
-//             metadata: k8s::ObjectMeta {
-//                 namespace: Some(ns.to_string()),
-//                 name: Some("test-valid-server".to_string()),
-//                 ..Default::default()
-//             },
-//             spec: k8s::policy::ServerSpec {
-//                 pod_selector: k8s::labels::Selector::from_iter(Some(("app", "test-valid-server"))),
-//                 port: k8s::policy::server::Port::Name("http".to_string()),
-//                 proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
-//             },
-//         };
-//         let _server = create(&client, server).await;
+        // Create only one of the parents
+        let server = k8s::policy::Server {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.to_string()),
+                name: Some("test-valid-server".to_string()),
+                ..Default::default()
+            },
+            spec: k8s::policy::ServerSpec {
+                pod_selector: k8s::labels::Selector::from_iter(Some(("app", "test-valid-server"))),
+                port: k8s::policy::server::Port::Name("http".to_string()),
+                proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+            },
+        };
+        let _server = create(&client, server).await;
 
-//         // Create a route that references both parents.
-//         let _route = create(
-//             &client,
-//             mk_route(&ns, "test-multiple-parents-route", Some(srv_refs)),
-//         )
-//         .await;
-//         // Wait until route is updated with a status
-//         let parent_status = await_route_status(&client, &ns, "test-multiple-parents-route")
-//             .await
-//             .parents;
+        // Create a route that references both parents.
+        let _route = create(
+            &client,
+            mk_route(&ns, "test-multiple-parents-route", Some(srv_refs)),
+        )
+        .await;
+        // Wait until route is updated with a status
+        let parent_status = await_route_status(&client, &ns, "test-multiple-parents-route")
+            .await
+            .parents;
 
-//         // Find status for invalid parent and extract the condition
-//         let invalid_cond = find_route_condition(&parent_status, "test-invalid-server")
-//             .expect("must have at least one 'Accepted' condition set for invalid parent");
-//         // Route shouldn't be accepted
-//         assert_eq!(invalid_cond.status, "False");
-//         assert_eq!(invalid_cond.reason, "NoMatchingParent");
+        // Find status for invalid parent and extract the condition
+        let invalid_cond = find_route_condition(&parent_status, "test-invalid-server")
+            .expect("must have at least one 'Accepted' condition set for invalid parent");
+        // Route shouldn't be accepted
+        assert_eq!(invalid_cond.status, "False");
+        assert_eq!(invalid_cond.reason, "NoMatchingParent");
 
-//         // Find status for valid parent and extract the condition
-//         let valid_cond = find_route_condition(&parent_status, "test-valid-server")
-//             .expect("must have at least one 'Accepted' condition set for valid parent");
-//         assert_eq!(valid_cond.status, "True");
-//         assert_eq!(valid_cond.reason, "Accepted")
-//     })
-//     .await
-// }
+        // Find status for valid parent and extract the condition
+        let valid_cond = find_route_condition(&parent_status, "test-valid-server")
+            .expect("must have at least one 'Accepted' condition set for valid parent");
+        assert_eq!(valid_cond.status, "True");
+        assert_eq!(valid_cond.reason, "Accepted")
+    })
+    .await
+}
 
-// #[tokio::test(flavor = "current_thread")]
-// async fn inbound_no_parent_ref_patch() {
-//     with_temp_ns(|client, ns| async move {
-//         // A route may not include any parent references. When that's the case,
-//         // we expect the controller to simply ignore it.
-//         let _route = create(&client, mk_route(&ns, "test-no-parent-refs-route", None)).await;
+#[tokio::test(flavor = "current_thread")]
+async fn inbound_no_parent_ref_patch() {
+    with_temp_ns(|client, ns| async move {
+        // A route may not include any parent references. When that's the case,
+        // we expect the controller to simply ignore it.
+        let _route = create(&client, mk_route(&ns, "test-no-parent-refs-route", None)).await;
 
-//         // Status may not be set straight away. To account for that, wrap a
-//         // status condition watcher in a timeout.
-//         let status = await_route_status(&client, &ns, "test-no-parent-refs-route").await;
-//         // If timeout has elapsed, then route did not receive a status patch
-//         assert!(
-//             status.parents.is_empty(),
-//             "HTTPRoute Status shouldn't contain any parent statuses"
-//         );
-//     })
-//     .await
-// }
+        // Status may not be set straight away. To account for that, wrap a
+        // status condition watcher in a timeout.
+        let status = await_route_status(&client, &ns, "test-no-parent-refs-route").await;
+        // If timeout has elapsed, then route did not receive a status patch
+        assert!(
+            status.parents.is_empty(),
+            "HTTPRoute Status shouldn't contain any parent statuses"
+        );
+    })
+    .await
+}
 
-// #[tokio::test(flavor = "current_thread")]
-// // Tests that inbound routes (routes attached to a `Server`) are properly
-// // reconciled when the parentReference changes. Additionally, tests that routes
-// // whose parentRefs do not exist are patched with an appropriate status.
-// async fn inbound_accepted_reconcile_no_parent() {
-//     with_temp_ns(|client, ns| async move {
-//         // Given a route with a nonexistent parentReference, we expect to have an
-//         // 'Accepted' condition with 'False' as a status.
-//         let srv_ref = vec![k8s::policy::httproute::ParentReference {
-//             group: Some("policy.linkerd.io".to_string()),
-//             kind: Some("Server".to_string()),
-//             namespace: Some(ns.clone()),
-//             name: "test-reconcile-inbound-server".to_string(),
-//             section_name: None,
-//             port: None,
-//         }];
-//         let _route = create(
-//             &client,
-//             mk_route(&ns, "test-reconcile-inbound-route", Some(srv_ref)),
-//         )
-//         .await;
-//         let cond = find_route_condition(
-//             &await_route_status(&client, &ns, "test-reconcile-inbound-route")
-//                 .await
-//                 .parents,
-//             "test-reconcile-inbound-server",
-//         )
-//         .expect("must have at least one 'Accepted' condition set for parent");
-//         // Test when parent ref does not exist we get Accepted { False }.
-//         assert_eq!(cond.status, "False");
-//         assert_eq!(cond.reason, "NoMatchingParent");
+#[tokio::test(flavor = "current_thread")]
+// Tests that inbound routes (routes attached to a `Server`) are properly
+// reconciled when the parentReference changes. Additionally, tests that routes
+// whose parentRefs do not exist are patched with an appropriate status.
+async fn inbound_accepted_reconcile_no_parent() {
+    with_temp_ns(|client, ns| async move {
+        // Given a route with a nonexistent parentReference, we expect to have an
+        // 'Accepted' condition with 'False' as a status.
+        let server_name = "test-reconcile-inbound-server";
+        let srv_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("policy.linkerd.io".to_string()),
+            kind: Some("Server".to_string()),
+            namespace: Some(ns.clone()),
+            name: "test-reconcile-inbound-server".to_string(),
+            section_name: None,
+            port: None,
+        }];
+        let _route = create(
+            &client,
+            mk_route(&ns, "test-reconcile-inbound-route", Some(srv_ref)),
+        )
+        .await;
+        let route_status = await_route_status(&client, &ns, "test-reconcile-inbound-route").await;
+        let cond = find_route_condition(&route_status.parents, server_name)
+            .expect("must have at least one 'Accepted' condition set for parent");
+        // Test when parent ref does not exist we get Accepted { False }.
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "NoMatchingParent");
 
-//         // Save create_timestamp to assert status has been updated.
-//         let create_timestamp = &cond.last_transition_time;
+        // Save create_timestamp to assert status has been updated.
+        let create_timestamp = &cond.last_transition_time;
 
-//         // Create the 'Server' that route references and expect it to be picked up
-//         // by the index. Consequently, route will have its status reconciled.
-//         let server = {
-//             let server = k8s::policy::Server {
-//                 metadata: k8s::ObjectMeta {
-//                     namespace: Some(ns.to_string()),
-//                     name: Some("test-reconcile-inbound-server".to_string()),
-//                     ..Default::default()
-//                 },
-//                 spec: k8s::policy::ServerSpec {
-//                     pod_selector: k8s::labels::Selector::from_iter(Some((
-//                         "app",
-//                         "test-reconcile-inbound-server",
-//                     ))),
-//                     port: k8s::policy::server::Port::Name("http".to_string()),
-//                     proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
-//                 },
-//             };
-//             create(&client, server).await
-//         };
+        // Create the 'Server' that route references and expect it to be picked up
+        // by the index. Consequently, route will have its status reconciled.
+        let server = k8s::policy::Server {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.to_string()),
+                name: Some(server_name.to_string()),
+                ..Default::default()
+            },
+            spec: k8s::policy::ServerSpec {
+                pod_selector: k8s::labels::Selector::from_iter(Some(("app", server_name))),
+                port: k8s::policy::server::Port::Name("http".to_string()),
+                proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+            },
+        };
+        create(&client, server).await;
 
-//         // HTTPRoute may not be patched instantly, wrap with a timeout and loop
-//         // until create_timestamp and observed_timestamp are different.
-//         let cond = tokio::time::timeout(tokio::time::Duration::from_secs(60), async move {
-//             loop {
-//                 let cond = find_route_condition(
-//                     &await_route_status(&client, &ns, "test-reconcile-inbound-route")
-//                         .await
-//                         .parents,
-//                     &server.name_unchecked(),
-//                 )
-//                 .expect("must have least one 'Accepted' condition");
+        let route_status = await_condition(
+            &client,
+            &ns,
+            "test-reconcile-inbound-route",
+            |obj: Option<&k8s::policy::httproute::HttpRoute>| -> bool {
+                tracing::trace!(?obj, "got route status");
+                let status = match obj.and_then(|route| route.status.as_ref()) {
+                    Some(status) => status,
+                    None => return false,
+                };
+                let cond = match find_route_condition(&status.inner.parents, server_name) {
+                    Some(cond) => cond,
+                    None => return false,
+                };
+                &cond.last_transition_time > create_timestamp
+            },
+        )
+        .await
+        .expect("must fetch route")
+        .status
+        .expect("route must contain a status representation");
 
-//                 // Observe condition's current timestamp. If it differs from the
-//                 // previously recorded timestamp, then it means the underlying
-//                 // condition has been updated so we can check the message and
-//                 // status.
-//                 if &cond.last_transition_time > create_timestamp {
-//                     return cond;
-//                 }
-//             }
-//         })
-//         .await
-//         .expect("Timed-out waiting for HTTPRoute status update");
-//         assert_eq!(cond.status, "True");
-//         assert_eq!(cond.reason, "Accepted");
-//     })
-//     .await;
-// }
+        // HTTPRoute may not be patched instantly, wrap with a timeout and loop
+        // until create_timestamp and observed_timestamp are different.
+        let cond = find_route_condition(&route_status.inner.parents, server_name)
+            .expect("route must have a route condition");
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason, "Accepted");
+    })
+    .await;
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn inbound_accepted_reconcile_parent_delete() {

--- a/policy-test/tests/inbound_http_route_status.rs
+++ b/policy-test/tests/inbound_http_route_status.rs
@@ -1,265 +1,262 @@
 use kube::ResourceExt;
 use linkerd_policy_controller_k8s_api as k8s;
 use linkerd_policy_test::{
-    await_route_status, create, find_route_condition, mk_route, with_temp_ns,
+    await_condition, await_route_status, create, find_route_condition, mk_route, with_temp_ns,
 };
 
-#[tokio::test(flavor = "current_thread")]
-async fn inbound_accepted_parent() {
-    with_temp_ns(|client, ns| async move {
-        // Create a test 'Server'
-        let server = k8s::policy::Server {
-            metadata: k8s::ObjectMeta {
-                namespace: Some(ns.to_string()),
-                name: Some("test-accepted-server".to_string()),
-                ..Default::default()
-            },
-            spec: k8s::policy::ServerSpec {
-                pod_selector: k8s::labels::Selector::from_iter(Some((
-                    "app",
-                    "test-accepted-server",
-                ))),
-                port: k8s::policy::server::Port::Name("http".to_string()),
-                proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
-            },
-        };
-        let server = create(&client, server).await;
-        let srv_ref = vec![k8s::policy::httproute::ParentReference {
-            group: Some("policy.linkerd.io".to_string()),
-            kind: Some("Server".to_string()),
-            namespace: server.namespace(),
-            name: server.name_unchecked(),
-            section_name: None,
-            port: None,
-        }];
+// #[tokio::test(flavor = "current_thread")]
+// async fn inbound_accepted_parent() {
+//     with_temp_ns(|client, ns| async move {
+//         // Create a test 'Server'
+//         let server = k8s::policy::Server {
+//             metadata: k8s::ObjectMeta {
+//                 namespace: Some(ns.to_string()),
+//                 name: Some("test-accepted-server".to_string()),
+//                 ..Default::default()
+//             },
+//             spec: k8s::policy::ServerSpec {
+//                 pod_selector: k8s::labels::Selector::from_iter(Some((
+//                     "app",
+//                     "test-accepted-server",
+//                 ))),
+//                 port: k8s::policy::server::Port::Name("http".to_string()),
+//                 proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+//             },
+//         };
+//         let server = create(&client, server).await;
+//         let srv_ref = vec![k8s::policy::httproute::ParentReference {
+//             group: Some("policy.linkerd.io".to_string()),
+//             kind: Some("Server".to_string()),
+//             namespace: server.namespace(),
+//             name: server.name_unchecked(),
+//             section_name: None,
+//             port: None,
+//         }];
 
-        // Create a route that references the Server resource.
-        let _route = create(&client, mk_route(&ns, "test-accepted-route", Some(srv_ref))).await;
-        // Wait until route is updated with a status
-        let statuses = await_route_status(&client, &ns, "test-accepted-route")
-            .await
-            .parents;
+//         // Create a route that references the Server resource.
+//         let _route = create(&client, mk_route(&ns, "test-accepted-route", Some(srv_ref))).await;
+//         // Wait until route is updated with a status
+//         let statuses = await_route_status(&client, &ns, "test-accepted-route")
+//             .await
+//             .parents;
 
-        let route_status = statuses
-            .clone()
-            .into_iter()
-            .find(|route_status| route_status.parent_ref.name == server.name_unchecked())
-            .expect("must have at least one parent status");
+//         let route_status = statuses
+//             .clone()
+//             .into_iter()
+//             .find(|route_status| route_status.parent_ref.name == server.name_unchecked())
+//             .expect("must have at least one parent status");
 
-        // Check status references to parent we have created
-        assert_eq!(
-            route_status.parent_ref.group.as_deref(),
-            Some("policy.linkerd.io")
-        );
-        assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Server"));
+//         // Check status references to parent we have created
+//         assert_eq!(
+//             route_status.parent_ref.group.as_deref(),
+//             Some("policy.linkerd.io")
+//         );
+//         assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Server"));
 
-        // Check status is accepted with a status of 'True'
-        let cond = find_route_condition(statuses, &server.name_unchecked())
-            .expect("must have at least one 'Accepted' condition for accepted server");
-        assert_eq!(cond.status, "True");
-        assert_eq!(cond.reason, "Accepted")
-    })
-    .await;
-}
+//         // Check status is accepted with a status of 'True'
+//         let cond = find_route_condition(&statuses, &server.name_unchecked())
+//             .expect("must have at least one 'Accepted' condition for accepted server");
+//         assert_eq!(cond.status, "True");
+//         assert_eq!(cond.reason, "Accepted")
+//     })
+//     .await;
+// }
 
-#[tokio::test(flavor = "current_thread")]
-async fn inbound_multiple_parents() {
-    with_temp_ns(|client, ns| async move {
-        // Exercise accepted test with a valid, and an invalid parent reference
-        let srv_refs = vec![
-            k8s::policy::httproute::ParentReference {
-                group: Some("policy.linkerd.io".to_string()),
-                kind: Some("Server".to_string()),
-                namespace: Some(ns.clone()),
-                name: "test-valid-server".to_string(),
-                section_name: None,
-                port: None,
-            },
-            k8s::policy::httproute::ParentReference {
-                group: Some("policy.linkerd.io".to_string()),
-                kind: Some("Server".to_string()),
-                namespace: Some(ns.clone()),
-                name: "test-invalid-server".to_string(),
-                section_name: None,
-                port: None,
-            },
-        ];
+// #[tokio::test(flavor = "current_thread")]
+// async fn inbound_multiple_parents() {
+//     with_temp_ns(|client, ns| async move {
+//         // Exercise accepted test with a valid, and an invalid parent reference
+//         let srv_refs = vec![
+//             k8s::policy::httproute::ParentReference {
+//                 group: Some("policy.linkerd.io".to_string()),
+//                 kind: Some("Server".to_string()),
+//                 namespace: Some(ns.clone()),
+//                 name: "test-valid-server".to_string(),
+//                 section_name: None,
+//                 port: None,
+//             },
+//             k8s::policy::httproute::ParentReference {
+//                 group: Some("policy.linkerd.io".to_string()),
+//                 kind: Some("Server".to_string()),
+//                 namespace: Some(ns.clone()),
+//                 name: "test-invalid-server".to_string(),
+//                 section_name: None,
+//                 port: None,
+//             },
+//         ];
 
-        // Create only one of the parents
-        let server = k8s::policy::Server {
-            metadata: k8s::ObjectMeta {
-                namespace: Some(ns.to_string()),
-                name: Some("test-valid-server".to_string()),
-                ..Default::default()
-            },
-            spec: k8s::policy::ServerSpec {
-                pod_selector: k8s::labels::Selector::from_iter(Some(("app", "test-valid-server"))),
-                port: k8s::policy::server::Port::Name("http".to_string()),
-                proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
-            },
-        };
-        let _server = create(&client, server).await;
+//         // Create only one of the parents
+//         let server = k8s::policy::Server {
+//             metadata: k8s::ObjectMeta {
+//                 namespace: Some(ns.to_string()),
+//                 name: Some("test-valid-server".to_string()),
+//                 ..Default::default()
+//             },
+//             spec: k8s::policy::ServerSpec {
+//                 pod_selector: k8s::labels::Selector::from_iter(Some(("app", "test-valid-server"))),
+//                 port: k8s::policy::server::Port::Name("http".to_string()),
+//                 proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+//             },
+//         };
+//         let _server = create(&client, server).await;
 
-        // Create a route that references both parents.
-        let _route = create(
-            &client,
-            mk_route(&ns, "test-multiple-parents-route", Some(srv_refs)),
-        )
-        .await;
-        // Wait until route is updated with a status
-        let parent_status = await_route_status(&client, &ns, "test-multiple-parents-route")
-            .await
-            .parents;
+//         // Create a route that references both parents.
+//         let _route = create(
+//             &client,
+//             mk_route(&ns, "test-multiple-parents-route", Some(srv_refs)),
+//         )
+//         .await;
+//         // Wait until route is updated with a status
+//         let parent_status = await_route_status(&client, &ns, "test-multiple-parents-route")
+//             .await
+//             .parents;
 
-        // Find status for invalid parent and extract the condition
-        let invalid_cond = find_route_condition(parent_status.clone(), "test-invalid-server")
-            .expect("must have at least one 'Accepted' condition set for invalid parent");
-        // Route shouldn't be accepted
-        assert_eq!(invalid_cond.status, "False");
-        assert_eq!(invalid_cond.reason, "NoMatchingParent");
+//         // Find status for invalid parent and extract the condition
+//         let invalid_cond = find_route_condition(&parent_status, "test-invalid-server")
+//             .expect("must have at least one 'Accepted' condition set for invalid parent");
+//         // Route shouldn't be accepted
+//         assert_eq!(invalid_cond.status, "False");
+//         assert_eq!(invalid_cond.reason, "NoMatchingParent");
 
-        // Find status for valid parent and extract the condition
-        let valid_cond = find_route_condition(parent_status, "test-valid-server")
-            .expect("must have at least one 'Accepted' condition set for valid parent");
-        assert_eq!(valid_cond.status, "True");
-        assert_eq!(valid_cond.reason, "Accepted")
-    })
-    .await
-}
+//         // Find status for valid parent and extract the condition
+//         let valid_cond = find_route_condition(&parent_status, "test-valid-server")
+//             .expect("must have at least one 'Accepted' condition set for valid parent");
+//         assert_eq!(valid_cond.status, "True");
+//         assert_eq!(valid_cond.reason, "Accepted")
+//     })
+//     .await
+// }
 
-#[tokio::test(flavor = "current_thread")]
-async fn inbound_no_parent_ref_patch() {
-    with_temp_ns(|client, ns| async move {
-        // A route may not include any parent references. When that's the case,
-        // we expect the controller to simply ignore it.
-        let _route = create(&client, mk_route(&ns, "test-no-parent-refs-route", None)).await;
+// #[tokio::test(flavor = "current_thread")]
+// async fn inbound_no_parent_ref_patch() {
+//     with_temp_ns(|client, ns| async move {
+//         // A route may not include any parent references. When that's the case,
+//         // we expect the controller to simply ignore it.
+//         let _route = create(&client, mk_route(&ns, "test-no-parent-refs-route", None)).await;
 
-        // Status may not be set straight away. To account for that, wrap a
-        // status condition watcher in a timeout.
-        let status = await_route_status(&client, &ns, "test-no-parent-refs-route").await;
-        // If timeout has elapsed, then route did not receive a status patch
-        assert!(
-            status.parents.is_empty(),
-            "HTTPRoute Status shouldn't contain any parent statuses"
-        );
-    })
-    .await
-}
+//         // Status may not be set straight away. To account for that, wrap a
+//         // status condition watcher in a timeout.
+//         let status = await_route_status(&client, &ns, "test-no-parent-refs-route").await;
+//         // If timeout has elapsed, then route did not receive a status patch
+//         assert!(
+//             status.parents.is_empty(),
+//             "HTTPRoute Status shouldn't contain any parent statuses"
+//         );
+//     })
+//     .await
+// }
 
-#[tokio::test(flavor = "current_thread")]
-// Tests that inbound routes (routes attached to a `Server`) are properly
-// reconciled when the parentReference changes. Additionally, tests that routes
-// whose parentRefs do not exist are patched with an appropriate status.
-async fn inbound_accepted_reconcile_no_parent() {
-    with_temp_ns(|client, ns| async move {
-        // Given a route with a nonexistent parentReference, we expect to have an
-        // 'Accepted' condition with 'False' as a status.
-        let srv_ref = vec![k8s::policy::httproute::ParentReference {
-            group: Some("policy.linkerd.io".to_string()),
-            kind: Some("Server".to_string()),
-            namespace: Some(ns.clone()),
-            name: "test-reconcile-inbound-server".to_string(),
-            section_name: None,
-            port: None,
-        }];
-        let _route = create(
-            &client,
-            mk_route(&ns, "test-reconcile-inbound-route", Some(srv_ref)),
-        )
-        .await;
-        let cond = find_route_condition(
-            await_route_status(&client, &ns, "test-reconcile-inbound-route")
-                .await
-                .parents,
-            "test-reconcile-inbound-server",
-        )
-        .expect("must have at least one 'Accepted' condition set for parent");
-        // Test when parent ref does not exist we get Accepted { False }.
-        assert_eq!(cond.status, "False");
-        assert_eq!(cond.reason, "NoMatchingParent");
+// #[tokio::test(flavor = "current_thread")]
+// // Tests that inbound routes (routes attached to a `Server`) are properly
+// // reconciled when the parentReference changes. Additionally, tests that routes
+// // whose parentRefs do not exist are patched with an appropriate status.
+// async fn inbound_accepted_reconcile_no_parent() {
+//     with_temp_ns(|client, ns| async move {
+//         // Given a route with a nonexistent parentReference, we expect to have an
+//         // 'Accepted' condition with 'False' as a status.
+//         let srv_ref = vec![k8s::policy::httproute::ParentReference {
+//             group: Some("policy.linkerd.io".to_string()),
+//             kind: Some("Server".to_string()),
+//             namespace: Some(ns.clone()),
+//             name: "test-reconcile-inbound-server".to_string(),
+//             section_name: None,
+//             port: None,
+//         }];
+//         let _route = create(
+//             &client,
+//             mk_route(&ns, "test-reconcile-inbound-route", Some(srv_ref)),
+//         )
+//         .await;
+//         let cond = find_route_condition(
+//             &await_route_status(&client, &ns, "test-reconcile-inbound-route")
+//                 .await
+//                 .parents,
+//             "test-reconcile-inbound-server",
+//         )
+//         .expect("must have at least one 'Accepted' condition set for parent");
+//         // Test when parent ref does not exist we get Accepted { False }.
+//         assert_eq!(cond.status, "False");
+//         assert_eq!(cond.reason, "NoMatchingParent");
 
-        // Save create_timestamp to assert status has been updated.
-        let create_timestamp = &cond.last_transition_time;
+//         // Save create_timestamp to assert status has been updated.
+//         let create_timestamp = &cond.last_transition_time;
 
-        // Create the 'Server' that route references and expect it to be picked up
-        // by the index. Consequently, route will have its status reconciled.
-        let server = {
-            let server = k8s::policy::Server {
-                metadata: k8s::ObjectMeta {
-                    namespace: Some(ns.to_string()),
-                    name: Some("test-reconcile-inbound-server".to_string()),
-                    ..Default::default()
-                },
-                spec: k8s::policy::ServerSpec {
-                    pod_selector: k8s::labels::Selector::from_iter(Some((
-                        "app",
-                        "test-reconcile-inbound-server",
-                    ))),
-                    port: k8s::policy::server::Port::Name("http".to_string()),
-                    proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
-                },
-            };
-            create(&client, server).await
-        };
+//         // Create the 'Server' that route references and expect it to be picked up
+//         // by the index. Consequently, route will have its status reconciled.
+//         let server = {
+//             let server = k8s::policy::Server {
+//                 metadata: k8s::ObjectMeta {
+//                     namespace: Some(ns.to_string()),
+//                     name: Some("test-reconcile-inbound-server".to_string()),
+//                     ..Default::default()
+//                 },
+//                 spec: k8s::policy::ServerSpec {
+//                     pod_selector: k8s::labels::Selector::from_iter(Some((
+//                         "app",
+//                         "test-reconcile-inbound-server",
+//                     ))),
+//                     port: k8s::policy::server::Port::Name("http".to_string()),
+//                     proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+//                 },
+//             };
+//             create(&client, server).await
+//         };
 
-        // HTTPRoute may not be patched instantly, wrap with a timeout and loop
-        // until create_timestamp and observed_timestamp are different.
-        let cond = tokio::time::timeout(tokio::time::Duration::from_secs(60), async move {
-            loop {
-                let cond = find_route_condition(
-                    await_route_status(&client, &ns, "test-reconcile-inbound-route")
-                        .await
-                        .parents,
-                    &server.name_unchecked(),
-                )
-                .expect("must have least one 'Accepted' condition");
+//         // HTTPRoute may not be patched instantly, wrap with a timeout and loop
+//         // until create_timestamp and observed_timestamp are different.
+//         let cond = tokio::time::timeout(tokio::time::Duration::from_secs(60), async move {
+//             loop {
+//                 let cond = find_route_condition(
+//                     &await_route_status(&client, &ns, "test-reconcile-inbound-route")
+//                         .await
+//                         .parents,
+//                     &server.name_unchecked(),
+//                 )
+//                 .expect("must have least one 'Accepted' condition");
 
-                // Observe condition's current timestamp. If it differs from the
-                // previously recorded timestamp, then it means the underlying
-                // condition has been updated so we can check the message and
-                // status.
-                if &cond.last_transition_time > create_timestamp {
-                    return cond;
-                }
-            }
-        })
-        .await
-        .expect("Timed-out waiting for HTTPRoute status update");
-        assert_eq!(cond.status, "True");
-        assert_eq!(cond.reason, "Accepted");
-    })
-    .await;
-}
+//                 // Observe condition's current timestamp. If it differs from the
+//                 // previously recorded timestamp, then it means the underlying
+//                 // condition has been updated so we can check the message and
+//                 // status.
+//                 if &cond.last_transition_time > create_timestamp {
+//                     return cond;
+//                 }
+//             }
+//         })
+//         .await
+//         .expect("Timed-out waiting for HTTPRoute status update");
+//         assert_eq!(cond.status, "True");
+//         assert_eq!(cond.reason, "Accepted");
+//     })
+//     .await;
+// }
 
 #[tokio::test(flavor = "current_thread")]
 async fn inbound_accepted_reconcile_parent_delete() {
     with_temp_ns(|client, ns| async move {
         // Attach a route to a Server and expect the route to be patched with an
         // Accepted status.
-        let server = {
-            let server = k8s::policy::Server {
-                metadata: k8s::ObjectMeta {
-                    namespace: Some(ns.to_string()),
-                    name: Some("test-reconcile-delete-server".to_string()),
-                    ..Default::default()
-                },
-                spec: k8s::policy::ServerSpec {
-                    pod_selector: k8s::labels::Selector::from_iter(Some((
-                        "app",
-                        "test-reconcile-delete-server",
-                    ))),
-                    port: k8s::policy::server::Port::Name("http".to_string()),
-                    proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
-                },
-            };
-            create(&client, server).await
+        let server_name = "test-reconcile-delete-server";
+        let server = k8s::policy::Server {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.to_string()),
+                name: Some(server_name.to_string()),
+                ..Default::default()
+            },
+            spec: k8s::policy::ServerSpec {
+                pod_selector: k8s::labels::Selector::from_iter(Some(("app", server_name))),
+                port: k8s::policy::server::Port::Name("http".to_string()),
+                proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+            },
         };
+        create(&client, server).await;
+
         // Create parentReference and route
         let srv_ref = vec![k8s::policy::httproute::ParentReference {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("Server".to_string()),
             namespace: Some(ns.clone()),
-            name: "test-reconcile-delete-server".to_string(),
+            name: server_name.to_string(),
             section_name: None,
             port: None,
         }];
@@ -268,13 +265,9 @@ async fn inbound_accepted_reconcile_parent_delete() {
             mk_route(&ns, "test-reconcile-delete-route", Some(srv_ref)),
         )
         .await;
-        let cond = find_route_condition(
-            await_route_status(&client, &ns, "test-reconcile-delete-route")
-                .await
-                .parents,
-            &server.name_unchecked(),
-        )
-        .expect("must have at least one 'Accepted' condition");
+        let route_status = await_route_status(&client, &ns, "test-reconcile-delete-route").await;
+        let cond = find_route_condition(&route_status.parents, server_name)
+            .expect("must have at least one 'Accepted' condition");
         assert_eq!(cond.status, "True");
         assert_eq!(cond.reason, "Accepted");
 
@@ -290,29 +283,30 @@ async fn inbound_accepted_reconcile_parent_delete() {
         .await
         .expect("API delete request failed");
 
-        // HTTPRoute may not be patched instantly, wrap with a timeout and loop
-        // until create_timestamp and observed_timestamp are different.
-        let cond = tokio::time::timeout(tokio::time::Duration::from_secs(60), async move {
-            loop {
-                let cond = find_route_condition(
-                    await_route_status(&client, &ns, "test-reconcile-delete-route")
-                        .await
-                        .parents,
-                    &server.name_unchecked(),
-                )
-                .expect("must have at least one 'Accepted' condition");
-
-                // Observe condition's current timestamp. If it differs from the
-                // previously recorded timestamp, then it means the underlying
-                // condition has been updated so we can check the message and
-                // status.
-                if &cond.last_transition_time > create_timestamp {
-                    return cond;
-                }
-            }
-        })
+        let route_status = await_condition(
+            &client,
+            &ns,
+            "test-reconcile-delete-route",
+            |obj: Option<&k8s::policy::httproute::HttpRoute>| -> bool {
+                tracing::trace!(?obj, "got route status");
+                let status = match obj.and_then(|route| route.status.as_ref()) {
+                    Some(status) => status,
+                    None => return false,
+                };
+                let cond = match find_route_condition(&status.inner.parents, server_name) {
+                    Some(cond) => cond,
+                    None => return false,
+                };
+                &cond.last_transition_time > create_timestamp
+            },
+        )
         .await
-        .expect("Timed-out waiting for HTTPRoute status update");
+        .expect("must fetch route")
+        .status
+        .expect("route must contain a status representation");
+
+        let cond = find_route_condition(&route_status.inner.parents, server_name)
+            .expect("route must have a route condition");
         assert_eq!(cond.status, "False");
         assert_eq!(cond.reason, "NoMatchingParent");
     })

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -1,151 +1,151 @@
-use kube::ResourceExt;
-use linkerd_policy_controller_k8s_api as k8s;
-use linkerd_policy_test::{
-    await_route_status, create, find_route_condition, mk_route, with_temp_ns,
-};
+// use kube::ResourceExt;
+// use linkerd_policy_controller_k8s_api as k8s;
+// use linkerd_policy_test::{
+//     await_route_status, create, find_route_condition, mk_route, with_temp_ns,
+// };
 
-#[tokio::test(flavor = "current_thread")]
-async fn accepted_parent() {
-    with_temp_ns(|client, ns| async move {
-        // Create a parent Service
-        let svc = k8s::Service {
-            metadata: k8s::ObjectMeta {
-                namespace: Some(ns.clone()),
-                name: Some("test-service".to_string()),
-                ..Default::default()
-            },
-            spec: Some(k8s::ServiceSpec {
-                type_: Some("ClusterIP".to_string()),
-                ports: Some(vec![k8s::ServicePort {
-                    port: 80,
-                    ..Default::default()
-                }]),
-                ..Default::default()
-            }),
-            ..k8s::Service::default()
-        };
-        let svc = create(&client, svc).await;
-        let svc_ref = vec![k8s::policy::httproute::ParentReference {
-            group: Some("core".to_string()),
-            kind: Some("Service".to_string()),
-            namespace: svc.namespace(),
-            name: svc.name_unchecked(),
-            section_name: None,
-            port: Some(80),
-        }];
+// #[tokio::test(flavor = "current_thread")]
+// async fn accepted_parent() {
+//     with_temp_ns(|client, ns| async move {
+//         // Create a parent Service
+//         let svc = k8s::Service {
+//             metadata: k8s::ObjectMeta {
+//                 namespace: Some(ns.clone()),
+//                 name: Some("test-service".to_string()),
+//                 ..Default::default()
+//             },
+//             spec: Some(k8s::ServiceSpec {
+//                 type_: Some("ClusterIP".to_string()),
+//                 ports: Some(vec![k8s::ServicePort {
+//                     port: 80,
+//                     ..Default::default()
+//                 }]),
+//                 ..Default::default()
+//             }),
+//             ..k8s::Service::default()
+//         };
+//         let svc = create(&client, svc).await;
+//         let svc_ref = vec![k8s::policy::httproute::ParentReference {
+//             group: Some("core".to_string()),
+//             kind: Some("Service".to_string()),
+//             namespace: svc.namespace(),
+//             name: svc.name_unchecked(),
+//             section_name: None,
+//             port: Some(80),
+//         }];
 
-        // Create a route that references the Service resource.
-        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
-        // Wait until route is updated with a status
-        let statuses = await_route_status(&client, &ns, "test-route").await.parents;
+//         // Create a route that references the Service resource.
+//         let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+//         // Wait until route is updated with a status
+//         let statuses = await_route_status(&client, &ns, "test-route").await.parents;
 
-        let route_status = statuses
-            .clone()
-            .into_iter()
-            .find(|route_status| route_status.parent_ref.name == svc.name_unchecked())
-            .expect("must have at least one parent status");
+//         let route_status = statuses
+//             .clone()
+//             .into_iter()
+//             .find(|route_status| route_status.parent_ref.name == svc.name_unchecked())
+//             .expect("must have at least one parent status");
 
-        // Check status references to parent we have created
-        assert_eq!(route_status.parent_ref.group.as_deref(), Some("core"));
-        assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Service"));
+//         // Check status references to parent we have created
+//         assert_eq!(route_status.parent_ref.group.as_deref(), Some("core"));
+//         assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Service"));
 
-        // Check status is accepted with a status of 'True'
-        let cond = find_route_condition(statuses, &svc.name_unchecked())
-            .expect("must have at least one 'Accepted' condition for accepted servuce");
-        assert_eq!(cond.status, "True");
-        assert_eq!(cond.reason, "Accepted")
-    })
-    .await;
-}
+//         // Check status is accepted with a status of 'True'
+//         let cond = find_route_condition(statuses, &svc.name_unchecked())
+//             .expect("must have at least one 'Accepted' condition for accepted servuce");
+//         assert_eq!(cond.status, "True");
+//         assert_eq!(cond.reason, "Accepted")
+//     })
+//     .await;
+// }
 
-#[tokio::test(flavor = "current_thread")]
-async fn no_cluster_ip() {
-    with_temp_ns(|client, ns| async move {
-        // Create a parent Service
-        let svc = k8s::Service {
-            metadata: k8s::ObjectMeta {
-                namespace: Some(ns.clone()),
-                name: Some("test-service".to_string()),
-                ..Default::default()
-            },
-            spec: Some(k8s::ServiceSpec {
-                cluster_ip: Some("None".to_string()),
-                type_: Some("ClusterIP".to_string()),
-                ports: Some(vec![k8s::ServicePort {
-                    port: 80,
-                    ..Default::default()
-                }]),
-                ..Default::default()
-            }),
-            ..k8s::Service::default()
-        };
-        let svc = create(&client, svc).await;
-        let svc_ref = vec![k8s::policy::httproute::ParentReference {
-            group: Some("core".to_string()),
-            kind: Some("Service".to_string()),
-            namespace: svc.namespace(),
-            name: svc.name_unchecked(),
-            section_name: None,
-            port: Some(80),
-        }];
+// #[tokio::test(flavor = "current_thread")]
+// async fn no_cluster_ip() {
+//     with_temp_ns(|client, ns| async move {
+//         // Create a parent Service
+//         let svc = k8s::Service {
+//             metadata: k8s::ObjectMeta {
+//                 namespace: Some(ns.clone()),
+//                 name: Some("test-service".to_string()),
+//                 ..Default::default()
+//             },
+//             spec: Some(k8s::ServiceSpec {
+//                 cluster_ip: Some("None".to_string()),
+//                 type_: Some("ClusterIP".to_string()),
+//                 ports: Some(vec![k8s::ServicePort {
+//                     port: 80,
+//                     ..Default::default()
+//                 }]),
+//                 ..Default::default()
+//             }),
+//             ..k8s::Service::default()
+//         };
+//         let svc = create(&client, svc).await;
+//         let svc_ref = vec![k8s::policy::httproute::ParentReference {
+//             group: Some("core".to_string()),
+//             kind: Some("Service".to_string()),
+//             namespace: svc.namespace(),
+//             name: svc.name_unchecked(),
+//             section_name: None,
+//             port: Some(80),
+//         }];
 
-        // Create a route that references the Service resource.
-        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
-        // Wait until route is updated with a status
-        let cond = find_route_condition(
-            await_route_status(&client, &ns, "test-route").await.parents,
-            "test-service",
-        )
-        .expect("must have at least one 'Accepted' condition set for parent");
-        // Parent with no ClusterIP should not match.
-        assert_eq!(cond.status, "False");
-        assert_eq!(cond.reason, "NoMatchingParent");
-    })
-    .await;
-}
+//         // Create a route that references the Service resource.
+//         let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+//         // Wait until route is updated with a status
+//         let cond = find_route_condition(
+//             await_route_status(&client, &ns, "test-route").await.parents,
+//             "test-service",
+//         )
+//         .expect("must have at least one 'Accepted' condition set for parent");
+//         // Parent with no ClusterIP should not match.
+//         assert_eq!(cond.status, "False");
+//         assert_eq!(cond.reason, "NoMatchingParent");
+//     })
+//     .await;
+// }
 
-#[tokio::test(flavor = "current_thread")]
-async fn external_name() {
-    with_temp_ns(|client, ns| async move {
-        // Create a parent Service
-        let svc = k8s::Service {
-            metadata: k8s::ObjectMeta {
-                namespace: Some(ns.clone()),
-                name: Some("test-service".to_string()),
-                ..Default::default()
-            },
-            spec: Some(k8s::ServiceSpec {
-                type_: Some("ExternalName".to_string()),
-                external_name: Some("linkerd.io".to_string()),
-                ports: Some(vec![k8s::ServicePort {
-                    port: 80,
-                    ..Default::default()
-                }]),
-                ..Default::default()
-            }),
-            ..k8s::Service::default()
-        };
-        let svc = create(&client, svc).await;
-        let svc_ref = vec![k8s::policy::httproute::ParentReference {
-            group: Some("core".to_string()),
-            kind: Some("Service".to_string()),
-            namespace: svc.namespace(),
-            name: svc.name_unchecked(),
-            section_name: None,
-            port: Some(80),
-        }];
+// #[tokio::test(flavor = "current_thread")]
+// async fn external_name() {
+//     with_temp_ns(|client, ns| async move {
+//         // Create a parent Service
+//         let svc = k8s::Service {
+//             metadata: k8s::ObjectMeta {
+//                 namespace: Some(ns.clone()),
+//                 name: Some("test-service".to_string()),
+//                 ..Default::default()
+//             },
+//             spec: Some(k8s::ServiceSpec {
+//                 type_: Some("ExternalName".to_string()),
+//                 external_name: Some("linkerd.io".to_string()),
+//                 ports: Some(vec![k8s::ServicePort {
+//                     port: 80,
+//                     ..Default::default()
+//                 }]),
+//                 ..Default::default()
+//             }),
+//             ..k8s::Service::default()
+//         };
+//         let svc = create(&client, svc).await;
+//         let svc_ref = vec![k8s::policy::httproute::ParentReference {
+//             group: Some("core".to_string()),
+//             kind: Some("Service".to_string()),
+//             namespace: svc.namespace(),
+//             name: svc.name_unchecked(),
+//             section_name: None,
+//             port: Some(80),
+//         }];
 
-        // Create a route that references the Service resource.
-        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
-        // Wait until route is updated with a status
-        let cond = find_route_condition(
-            await_route_status(&client, &ns, "test-route").await.parents,
-            "test-service",
-        )
-        .expect("must have at least one 'Accepted' condition set for parent");
-        // Parent with ExternalName should not match.
-        assert_eq!(cond.status, "False");
-        assert_eq!(cond.reason, "NoMatchingParent");
-    })
-    .await;
-}
+//         // Create a route that references the Service resource.
+//         let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+//         // Wait until route is updated with a status
+//         let cond = find_route_condition(
+//             await_route_status(&client, &ns, "test-route").await.parents,
+//             "test-service",
+//         )
+//         .expect("must have at least one 'Accepted' condition set for parent");
+//         // Parent with ExternalName should not match.
+//         assert_eq!(cond.status, "False");
+//         assert_eq!(cond.reason, "NoMatchingParent");
+//     })
+//     .await;
+// }

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -1,151 +1,148 @@
-// use kube::ResourceExt;
-// use linkerd_policy_controller_k8s_api as k8s;
-// use linkerd_policy_test::{
-//     await_route_status, create, find_route_condition, mk_route, with_temp_ns,
-// };
+use kube::ResourceExt;
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_test::{
+    await_route_status, create, find_route_condition, mk_route, with_temp_ns,
+};
 
-// #[tokio::test(flavor = "current_thread")]
-// async fn accepted_parent() {
-//     with_temp_ns(|client, ns| async move {
-//         // Create a parent Service
-//         let svc = k8s::Service {
-//             metadata: k8s::ObjectMeta {
-//                 namespace: Some(ns.clone()),
-//                 name: Some("test-service".to_string()),
-//                 ..Default::default()
-//             },
-//             spec: Some(k8s::ServiceSpec {
-//                 type_: Some("ClusterIP".to_string()),
-//                 ports: Some(vec![k8s::ServicePort {
-//                     port: 80,
-//                     ..Default::default()
-//                 }]),
-//                 ..Default::default()
-//             }),
-//             ..k8s::Service::default()
-//         };
-//         let svc = create(&client, svc).await;
-//         let svc_ref = vec![k8s::policy::httproute::ParentReference {
-//             group: Some("core".to_string()),
-//             kind: Some("Service".to_string()),
-//             namespace: svc.namespace(),
-//             name: svc.name_unchecked(),
-//             section_name: None,
-//             port: Some(80),
-//         }];
+#[tokio::test(flavor = "current_thread")]
+async fn accepted_parent() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent Service
+        let svc_name = "test-service";
+        let svc = k8s::Service {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some(svc_name.to_string()),
+                ..Default::default()
+            },
+            spec: Some(k8s::ServiceSpec {
+                type_: Some("ClusterIP".to_string()),
+                ports: Some(vec![k8s::ServicePort {
+                    port: 80,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..k8s::Service::default()
+        };
+        let svc = create(&client, svc).await;
+        let svc_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("core".to_string()),
+            kind: Some("Service".to_string()),
+            namespace: svc.namespace(),
+            name: svc.name_unchecked(),
+            section_name: None,
+            port: Some(80),
+        }];
 
-//         // Create a route that references the Service resource.
-//         let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
-//         // Wait until route is updated with a status
-//         let statuses = await_route_status(&client, &ns, "test-route").await.parents;
+        // Create a route that references the Service resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+        // Wait until route is updated with a status
+        let statuses = await_route_status(&client, &ns, "test-route").await.parents;
 
-//         let route_status = statuses
-//             .clone()
-//             .into_iter()
-//             .find(|route_status| route_status.parent_ref.name == svc.name_unchecked())
-//             .expect("must have at least one parent status");
+        let route_status = statuses
+            .clone()
+            .into_iter()
+            .find(|route_status| route_status.parent_ref.name == svc_name)
+            .expect("must have at least one parent status");
 
-//         // Check status references to parent we have created
-//         assert_eq!(route_status.parent_ref.group.as_deref(), Some("core"));
-//         assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Service"));
+        // Check status references to parent we have created
+        assert_eq!(route_status.parent_ref.group.as_deref(), Some("core"));
+        assert_eq!(route_status.parent_ref.kind.as_deref(), Some("Service"));
 
-//         // Check status is accepted with a status of 'True'
-//         let cond = find_route_condition(statuses, &svc.name_unchecked())
-//             .expect("must have at least one 'Accepted' condition for accepted servuce");
-//         assert_eq!(cond.status, "True");
-//         assert_eq!(cond.reason, "Accepted")
-//     })
-//     .await;
-// }
+        // Check status is accepted with a status of 'True'
+        let cond = find_route_condition(&statuses, svc_name)
+            .expect("must have at least one 'Accepted' condition for accepted servuce");
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason, "Accepted")
+    })
+    .await;
+}
 
-// #[tokio::test(flavor = "current_thread")]
-// async fn no_cluster_ip() {
-//     with_temp_ns(|client, ns| async move {
-//         // Create a parent Service
-//         let svc = k8s::Service {
-//             metadata: k8s::ObjectMeta {
-//                 namespace: Some(ns.clone()),
-//                 name: Some("test-service".to_string()),
-//                 ..Default::default()
-//             },
-//             spec: Some(k8s::ServiceSpec {
-//                 cluster_ip: Some("None".to_string()),
-//                 type_: Some("ClusterIP".to_string()),
-//                 ports: Some(vec![k8s::ServicePort {
-//                     port: 80,
-//                     ..Default::default()
-//                 }]),
-//                 ..Default::default()
-//             }),
-//             ..k8s::Service::default()
-//         };
-//         let svc = create(&client, svc).await;
-//         let svc_ref = vec![k8s::policy::httproute::ParentReference {
-//             group: Some("core".to_string()),
-//             kind: Some("Service".to_string()),
-//             namespace: svc.namespace(),
-//             name: svc.name_unchecked(),
-//             section_name: None,
-//             port: Some(80),
-//         }];
+#[tokio::test(flavor = "current_thread")]
+async fn no_cluster_ip() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent Service
+        let svc = k8s::Service {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some("test-service".to_string()),
+                ..Default::default()
+            },
+            spec: Some(k8s::ServiceSpec {
+                cluster_ip: Some("None".to_string()),
+                type_: Some("ClusterIP".to_string()),
+                ports: Some(vec![k8s::ServicePort {
+                    port: 80,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..k8s::Service::default()
+        };
+        let svc = create(&client, svc).await;
+        let svc_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("core".to_string()),
+            kind: Some("Service".to_string()),
+            namespace: svc.namespace(),
+            name: svc.name_unchecked(),
+            section_name: None,
+            port: Some(80),
+        }];
 
-//         // Create a route that references the Service resource.
-//         let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
-//         // Wait until route is updated with a status
-//         let cond = find_route_condition(
-//             await_route_status(&client, &ns, "test-route").await.parents,
-//             "test-service",
-//         )
-//         .expect("must have at least one 'Accepted' condition set for parent");
-//         // Parent with no ClusterIP should not match.
-//         assert_eq!(cond.status, "False");
-//         assert_eq!(cond.reason, "NoMatchingParent");
-//     })
-//     .await;
-// }
+        // Create a route that references the Service resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+        // Wait until route is updated with a status
+        let status = await_route_status(&client, &ns, "test-route").await;
+        let cond = find_route_condition(&status.parents, "test-service")
+            .expect("must have at least one 'Accepted' condition set for parent");
+        // Parent with no ClusterIP should not match.
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "NoMatchingParent");
+    })
+    .await;
+}
 
-// #[tokio::test(flavor = "current_thread")]
-// async fn external_name() {
-//     with_temp_ns(|client, ns| async move {
-//         // Create a parent Service
-//         let svc = k8s::Service {
-//             metadata: k8s::ObjectMeta {
-//                 namespace: Some(ns.clone()),
-//                 name: Some("test-service".to_string()),
-//                 ..Default::default()
-//             },
-//             spec: Some(k8s::ServiceSpec {
-//                 type_: Some("ExternalName".to_string()),
-//                 external_name: Some("linkerd.io".to_string()),
-//                 ports: Some(vec![k8s::ServicePort {
-//                     port: 80,
-//                     ..Default::default()
-//                 }]),
-//                 ..Default::default()
-//             }),
-//             ..k8s::Service::default()
-//         };
-//         let svc = create(&client, svc).await;
-//         let svc_ref = vec![k8s::policy::httproute::ParentReference {
-//             group: Some("core".to_string()),
-//             kind: Some("Service".to_string()),
-//             namespace: svc.namespace(),
-//             name: svc.name_unchecked(),
-//             section_name: None,
-//             port: Some(80),
-//         }];
+#[tokio::test(flavor = "current_thread")]
+async fn external_name() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent Service
+        let svc = k8s::Service {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some("test-service".to_string()),
+                ..Default::default()
+            },
+            spec: Some(k8s::ServiceSpec {
+                type_: Some("ExternalName".to_string()),
+                external_name: Some("linkerd.io".to_string()),
+                ports: Some(vec![k8s::ServicePort {
+                    port: 80,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..k8s::Service::default()
+        };
+        let svc = create(&client, svc).await;
+        let svc_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("core".to_string()),
+            kind: Some("Service".to_string()),
+            namespace: svc.namespace(),
+            name: svc.name_unchecked(),
+            section_name: None,
+            port: Some(80),
+        }];
 
-//         // Create a route that references the Service resource.
-//         let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
-//         // Wait until route is updated with a status
-//         let cond = find_route_condition(
-//             await_route_status(&client, &ns, "test-route").await.parents,
-//             "test-service",
-//         )
-//         .expect("must have at least one 'Accepted' condition set for parent");
-//         // Parent with ExternalName should not match.
-//         assert_eq!(cond.status, "False");
-//         assert_eq!(cond.reason, "NoMatchingParent");
-//     })
-//     .await;
-// }
+        // Create a route that references the Service resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+        // Wait until route is updated with a status
+        let status = await_route_status(&client, &ns, "test-route").await;
+        let cond = find_route_condition(&status.parents, "test-service")
+            .expect("must have at least one 'Accepted' condition set for parent");
+        // Parent with ExternalName should not match.
+        assert_eq!(cond.status, "False");
+        assert_eq!(cond.reason, "NoMatchingParent");
+    })
+    .await;
+}


### PR DESCRIPTION
The route status reconcile integration tests are flaky and often spuriously fail in CI.  The assertion which fails is that the `Accepted` status should be true after reconciliation but it is observed to be false.

I have not been able to reproduce this failure locally so it is hard to determine what causes these failures.  However, I noticed that these tests utilize a loop without any backoff and repeatedly request a route from the kubernetes API until the status modified timestamp is updated.  This hot loop results in a very large number of kubernetes API requests very quickly.  It's not clear if these excessive requests could cause the kubernetes API to become overloaded and result in the flaky failures, but it seems like something that's worth fixing regardless.

We replace the hot loop with a usage of `await_condition` so that we take advantage of a watch on the route instead of repeatedly polling it.  This results is far fewer API calls.

We also add some logging of the status each time we retrieve it.  This will be helpful in understanding why these tests fail, if they fail again in the future.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
