### PR TITLE
Add affinity settings in viz and jaeger chart

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -82,6 +82,7 @@ Kubernetes: `>=1.21.0-0`
 | collector.image.pullPolicy | string | `""` |  |
 | collector.image.version | string | `"0.83.0"` |  |
 | collector.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
+| collector.replicas | int | `1` | Number of collector component replicas |
 | collector.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the collector container can use |
 | collector.resources.cpu.request | string | `nil` | Amount of CPU units that the collector container requests |
 | collector.resources.ephemeral-storage.limit | string | `""` | Maximum amount of ephemeral storage that the collector container can use |
@@ -92,6 +93,7 @@ Kubernetes: `>=1.21.0-0`
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | defaultUID | int | `2103` | Default UID for all the jaeger components |
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
+| enablePodAntiAffinity | bool | `false` | enables pod anti affinity creation on deployments for high availability |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
 | jaeger.UID | string | `nil` | UID for the jaeger resource |
 | jaeger.args | list | `["--query.base-path=/jaeger"]` | CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory) |
@@ -107,6 +109,7 @@ Kubernetes: `>=1.21.0-0`
 | jaeger.resources.memory.limit | string | `nil` | Maximum amount of memory that jaeger container can use |
 | jaeger.resources.memory.request | string | `nil` | Amount of memory that the jaeger container requests |
 | jaeger.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
+| jaegerInjector.replicas | int | `1` | Number of jaeger-injector component replicas |
 | linkerdNamespace | string | `"linkerd"` | Namespace of the Linkerd core control-plane install |
 | linkerdVersion | string | `"linkerdVersionValue"` |  |
 | namespaceMetadata.image.name | string | `"extension-init"` | Docker image name for the namespace-metadata instance |

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -82,7 +82,7 @@ Kubernetes: `>=1.21.0-0`
 | collector.image.pullPolicy | string | `""` |  |
 | collector.image.version | string | `"0.83.0"` |  |
 | collector.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
-| collector.replicas | int | `1` | Number of collector component replicas |
+| collector.replicas | int | `1` | Number of replicas of the collector component |
 | collector.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the collector container can use |
 | collector.resources.cpu.request | string | `nil` | Amount of CPU units that the collector container requests |
 | collector.resources.ephemeral-storage.limit | string | `""` | Maximum amount of ephemeral storage that the collector container can use |
@@ -93,7 +93,7 @@ Kubernetes: `>=1.21.0-0`
 | commonLabels | object | `{}` | Labels to apply to all resources |
 | defaultUID | int | `2103` | Default UID for all the jaeger components |
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
-| enablePodAntiAffinity | bool | `false` | enables pod anti affinity creation on deployments for high availability |
+| enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
 | jaeger.UID | string | `nil` | UID for the jaeger resource |
 | jaeger.args | list | `["--query.base-path=/jaeger"]` | CLI arguments for Jaeger, See [Jaeger AIO Memory CLI reference](https://www.jaegertracing.io/docs/1.24/cli/#jaeger-all-in-one-memory) |
@@ -109,7 +109,6 @@ Kubernetes: `>=1.21.0-0`
 | jaeger.resources.memory.limit | string | `nil` | Maximum amount of memory that jaeger container can use |
 | jaeger.resources.memory.request | string | `nil` | Amount of memory that the jaeger container requests |
 | jaeger.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
-| jaegerInjector.replicas | int | `1` | Number of jaeger-injector component replicas |
 | linkerdNamespace | string | `"linkerd"` | Namespace of the Linkerd core control-plane install |
 | linkerdVersion | string | `"linkerdVersionValue"` |  |
 | namespaceMetadata.image.name | string | `"extension-init"` | Docker image name for the namespace-metadata instance |
@@ -138,6 +137,7 @@ Kubernetes: `>=1.21.0-0`
 | webhook.namespaceSelector | string | `nil` |  |
 | webhook.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | webhook.objectSelector | string | `nil` |  |
+| webhook.replicas | int | `1` | Number of replicas of the jaeger-injector component |
 | webhook.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the jaeger-injector container can use |
 | webhook.resources.cpu.request | string | `nil` | Amount of CPU units that the jaeger-injector container requests |
 | webhook.resources.memory.limit | string | `nil` | Maximum amount of memory that jaeger-injector container can use |

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -16,7 +16,7 @@ metadata:
   name: jaeger-injector
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: {{ .Values.jaegerInjector.replicas }}
+  replicas: {{ .Values.webhook.replicas }}
   selector:
     matchLabels:
       linkerd.io/extension: jaeger
@@ -45,7 +45,7 @@ spec:
       {{- include "linkerd.node-selector" (dict "Values" .Values.webhook) | nindent 6 }}
       {{- $_ := set $tree "component" "jaeger-injector" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" . | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - -collector-svc-addr={{.Values.webhook.collectorSvcAddr}}

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -16,11 +16,16 @@ metadata:
   name: jaeger-injector
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.jaegerInjector.replicas }}
   selector:
     matchLabels:
       linkerd.io/extension: jaeger
       component: jaeger-injector
+  {{- if .Values.enablePodAntiAffinity }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -2,6 +2,7 @@
 ###
 ### Jaeger Injector
 ###
+{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,6 +38,9 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.webhook) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.webhook) | nindent 6 }}
+      {{- $_ := set $tree "component" "jaeger-injector" -}}
+      {{- $_ := set $tree "label" "component" -}}
+      {{- include "linkerd.affinity" . | nindent 6 }}
       containers:
       - args:
         - -collector-svc-addr={{.Values.webhook.collectorSvcAddr}}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -101,7 +101,7 @@ spec:
       {{- include "linkerd.node-selector" (dict "Values" .Values.collector) | nindent 6 }}
       {{- $_ := set $tree "component" "collector" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" . | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - command:
         - {{ .Values.collector.command }}
@@ -239,7 +239,7 @@ spec:
       {{- include "linkerd.node-selector" (dict "Values" .Values.jaeger) | nindent 6 }}
       {{- $_ := set $tree "component" "jaeger" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" . | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         {{-  range .Values.jaeger.args }}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -68,10 +68,15 @@ metadata:
   name: collector
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.collector.replicas }}
   selector:
     matchLabels:
       component: collector
+  {{- if .Values.enablePodAntiAffinity }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+  {{- end }}
   minReadySeconds: 5
   progressDeadlineSeconds: 120
   template:
@@ -209,6 +214,11 @@ spec:
   selector:
     matchLabels:
       component: jaeger
+  {{- if .Values.enablePodAntiAffinity }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -55,6 +55,7 @@ spec:
   selector:
     component: collector
 ---
+{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -93,6 +94,9 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.collector) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.collector) | nindent 6 }}
+      {{- $_ := set $tree "component" "collector" -}}
+      {{- $_ := set $tree "label" "component" -}}
+      {{- include "linkerd.affinity" . | nindent 6 }}
       containers:
       - command:
         - {{ .Values.collector.command }}
@@ -188,6 +192,7 @@ spec:
     - name: ui
       port: 16686
 ---
+{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -222,6 +227,9 @@ spec:
       {{- include "linkerd.tolerations" (dict "Values" .Values.jaeger) | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" (dict "Values" .Values.jaeger) | nindent 6 }}
+      {{- $_ := set $tree "component" "jaeger" -}}
+      {{- $_ := set $tree "label" "component" -}}
+      {{- include "linkerd.affinity" . | nindent 6 }}
       containers:
       - args:
         {{-  range .Values.jaeger.args }}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -22,6 +22,11 @@ imagePullSecrets: []
 # for more information
 tolerations: &default_tolerations
 
+# -- NodeAffinity section, See the
+# [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
+# for more information
+#nodeAffinity:
+
 # -- Create Roles and RoleBindings to associate this extension's
 # ServiceAccounts to the control plane PSP resource. This requires that
 # `enabledPSP` is set to true on the control plane install. Note PSP has been

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -22,6 +22,11 @@ imagePullSecrets: []
 # for more information
 tolerations: &default_tolerations
 
+# -- Enables Pod Anti Affinity logic to balance the placement of replicas
+# across hosts and zones for High Availability.
+# Enable this only when you have multiple replicas of components.
+enablePodAntiAffinity: false
+
 # -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information
@@ -41,6 +46,8 @@ clusterDomain: cluster.local
 collector:
   # -- Set to false to exclude collector installation
   enabled: true
+  # -- number of replicas of the collector component
+  replicas: 1
   image:
     name: otel/opentelemetry-collector-contrib
     version: 0.83.0
@@ -203,6 +210,10 @@ jaeger:
 
   # -- UID for the jaeger resource
   UID:
+
+jaegerInjector:
+  # -- number of replicas of the jaeger-injector component
+  replicas: 1
 
 linkerdVersion: &linkerd_version linkerdVersionValue
 

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -46,7 +46,7 @@ clusterDomain: cluster.local
 collector:
   # -- Set to false to exclude collector installation
   enabled: true
-  # -- number of replicas of the collector component
+  # -- Number of replicas of the collector component
   replicas: 1
   image:
     name: otel/opentelemetry-collector-contrib
@@ -211,10 +211,6 @@ jaeger:
   # -- UID for the jaeger resource
   UID:
 
-jaegerInjector:
-  # -- number of replicas of the jaeger-injector component
-  replicas: 1
-
 linkerdVersion: &linkerd_version linkerdVersionValue
 
 namespaceMetadata:
@@ -238,6 +234,8 @@ namespaceMetadata:
   tolerations: *default_tolerations
 
 webhook:
+  # -- Number of replicas of the jaeger-injector component
+  replicas: 1
   # -- Do not create a secret resource for the webhook.
   # If this is set to `true`, the value `webhook.caBundle` must be set
   # or the ca bundle must injected with cert-manager ca injector using

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -115,7 +115,7 @@ Kubernetes: `>=1.21.0-0`
 | metricsAPI.logLevel | string | defaultLogLevel | log level of the metrics-api component |
 | metricsAPI.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | metricsAPI.proxy | string | `nil` |  |
-| metricsAPI.replicas | int | `1` | number of replicas of the metrics-api component |
+| metricsAPI.replicas | int | `1` | Number of replicas of the metrics-api component |
 | metricsAPI.resources.cpu.limit | string | `nil` | Maximum amount of CPU units that the metrics-api container can use |
 | metricsAPI.resources.cpu.request | string | `nil` | Amount of CPU units that the metrics-api container requests |
 | metricsAPI.resources.ephemeral-storage.limit | string | `""` | Maximum amount of ephemeral storage that the metrics-api container can use |

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -77,7 +77,7 @@ spec:
       {{- include "linkerd.node-selector" . | nindent 6 }}
       {{- $_ := set $tree "component" "web" -}}
       {{- $_ := set $tree "label" "component" -}}
-      {{- include "linkerd.affinity" . | nindent 6 }}
+      {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - -linkerd-metrics-api-addr=metrics-api.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}:8085

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -29,6 +29,7 @@ spec:
     port: 9994
     targetPort: 9994
 ---
+{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -74,6 +75,9 @@ spec:
       {{- include "linkerd.tolerations" . | nindent 6 }}
       {{- end -}}
       {{- include "linkerd.node-selector" . | nindent 6 }}
+      {{- $_ := set $tree "component" "web" -}}
+      {{- $_ := set $tree "label" "component" -}}
+      {{- include "linkerd.affinity" . | nindent 6 }}
       containers:
       - args:
         - -linkerd-metrics-api-addr=metrics-api.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}:8085

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -70,7 +70,7 @@ jaegerUrl: ""
 
 # metrics API configuration
 metricsAPI:
-  # -- number of replicas of the metrics-api component
+  # -- Number of replicas of the metrics-api component
   replicas: 1
   # -- log level of the metrics-api component
   # @default -- defaultLogLevel
@@ -131,7 +131,7 @@ metricsAPI:
 
 # tap configuration
 tap:
-    # -- Number of tap component replicas
+  # -- Number of tap component replicas
   replicas: 1
   # -- log level of the tap component
   # @default -- defaultLogLevel


### PR DESCRIPTION
Add `nodeAffinity` for `deployment` template to `linkerd-viz` and `linkerd-jaeger` charts

Fixes #10680