### PR TITLE
Fix kind in policy status index delete

### DIFF
--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -406,8 +406,8 @@ impl kubert::index::IndexNamespacedResource<k8s_gateway_api::HttpRoute> for Inde
         let id = NamespaceGroupKindName {
             namespace,
             gkn: GroupKindName {
-                group: k8s::policy::HttpRoute::group(&()),
-                kind: k8s::policy::HttpRoute::kind(&()),
+                group: k8s_gateway_api::HttpRoute::group(&()),
+                kind: k8s_gateway_api::HttpRoute::kind(&()),
                 name: name.into(),
             },
         };


### PR DESCRIPTION
When the policy controller's status index detects the deletion of a gateway API HTTPRoute, it attempts to delete that resource out of its own index.  However, we use the wrong kind in the key when deleting.  This results in the resource persisting in the index after it has been deleted from the cluster, which causes an error to be logged every 10 seconds when the policy controller attempts to do reconciliation and ensure that the statuses of all HTTPRoutes in its index are correct:

```
2023-10-09T20:53:17.059098Z ERROR status::Controller: linkerd_policy_controller_k8s_status::index: Failed to patch HTTPRoute namespace=linkerd-policy-test-sev0n7 route=GroupKindName { group: "gateway.networking.k8s.io", kind: "HTTPRoute", name: "test" } error=ApiError: httproutes.gateway.networking.k8s.io "test" not found: NotFound (ErrorResponse { status: "Failure", message: "httproutes.gateway.networking.k8s.io \"test\" not found", reason: "NotFound", code: 404 })
```

To fix this, we use the correct kind when deleting from the index.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
