### PR TITLE
edge-23.10.2 change notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Changes
 
+## edge-23.10.2
+
+This edge release includes a fix addressing an issue during upgrades for
+instances not relying on automated webhook certificate management (like
+cert-manager provides).
+
+* Added a `checksum/config` annotation to the destination and proxy injector
+  deployment manifests to force restarting those workloads whenever their
+  webhook secrets change during upgrade (thanks @iAnomaly!) ([#11440])
+* Fixed policy controller error when deleting a gateway API HTTPRoute resource
+  ([#11471])
+
+[#11440]: https://github.com/linkerd/linkerd2/pull/11440
+[#11471]: https://github.com/linkerd/linkerd2/pull/11471
+
 ## edge-23.10.1
 
 This edge release adds additional configurability to Linkerd's viz and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,9 @@ instances not relying on automated webhook certificate management (like
 cert-manager provides).
 
 * Added a `checksum/config` annotation to the destination and proxy injector
-  deployment manifests to force restarting those workloads whenever their
+  deployment manifests, to force restarting those workloads whenever their
   webhook secrets change during upgrade (thanks @iAnomaly!) ([#11440])
-* Fixed policy controller error when deleting a gateway API HTTPRoute resource
+* Fixed policy controller error when deleting a Gateway API HTTPRoute resource
   ([#11471])
 
 [#11440]: https://github.com/linkerd/linkerd2/pull/11440

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.17.2-edge
+version: 1.17.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.17.2-edge](https://img.shields.io/badge/Version-1.17.2--edge-informational?style=flat-square)
+![Version: 1.17.3-edge](https://img.shields.io/badge/Version-1.17.3--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.2-edge
+version: 30.13.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.13.2-edge](https://img.shields.io/badge/Version-30.13.2--edge-informational?style=flat-square)
+![Version: 30.13.3-edge](https://img.shields.io/badge/Version-30.13.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.1-edge
+version: 30.12.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.12.1-edge](https://img.shields.io/badge/Version-30.12.1--edge-informational?style=flat-square)
+![Version: 30.12.2-edge](https://img.shields.io/badge/Version-30.12.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.1-edge
+version: 30.13.2-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.13.1-edge](https://img.shields.io/badge/Version-30.13.1--edge-informational?style=flat-square)
+![Version: 30.13.2-edge](https://img.shields.io/badge/Version-30.13.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
This edge release includes a fix addressing an issue during upgrades for instances not relying on automated webhook certificate management (like cert-manager provides).

* Added a `checksum/config` annotation to the destination and proxy injector deployment manifests to force restarting those workloads whenever their webhook secrets change during upgrade (thanks @iAnomaly!) ([#11440])
* Fixed policy controller error when deleting a gateway API HTTPRoute resource ([#11471])