### PR TITLE
service-mirror: support gateway resolving to multiple addresses

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -984,22 +984,25 @@ func (rcsw *RemoteClusterServiceWatcher) resolveGatewayAddress() ([]corev1.Endpo
 	var gatewayEndpoints []corev1.EndpointAddress
 	var errors []error
 	for _, addr := range strings.Split(rcsw.link.GatewayAddress, ",") {
-		ipAddr, err := net.ResolveIPAddr("ip", addr)
-		if err == nil {
-			gatewayEndpoints = append(gatewayEndpoints, corev1.EndpointAddress{
-				IP: ipAddr.String(),
-			})
-		} else {
+		ipAddrs, err := net.LookupIP(addr)
+		if err != nil {
 			err = fmt.Errorf("Error resolving '%s': %w", addr, err)
 			rcsw.log.Warn(err)
 			errors = append(errors, err)
+			continue
+		}
+
+		for _, ipAddr := range ipAddrs {
+			gatewayEndpoints = append(gatewayEndpoints, corev1.EndpointAddress{
+				IP: ipAddr.String(),
+			})
 		}
 	}
-	// one resolved address is enough
-	if len(gatewayEndpoints) > 0 {
-		return gatewayEndpoints, nil
+
+	if len(gatewayEndpoints) == 0 {
+		return nil, RetryableError{errors}
 	}
-	return nil, RetryableError{errors}
+	return gatewayEndpoints, nil
 }
 
 func (rcsw *RemoteClusterServiceWatcher) repairEndpoints(ctx context.Context) error {

--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"time"
 
@@ -1002,6 +1003,10 @@ func (rcsw *RemoteClusterServiceWatcher) resolveGatewayAddress() ([]corev1.Endpo
 	if len(gatewayEndpoints) == 0 {
 		return nil, RetryableError{errors}
 	}
+
+	sort.SliceStable(gatewayEndpoints, func(i, j int) bool {
+		return gatewayEndpoints[i].IP < gatewayEndpoints[j].IP
+	})
 	return gatewayEndpoints, nil
 }
 


### PR DESCRIPTION
If the gateway address was a name resolving to multiple addresses, previously service-mirror took only one of those address. This behavior could led to downtime in case the gateway behind the IP picked by service-mirror is down. This commit fix this behavior by considering all the IPs resolved.