### PR TITLE
Add imagePullSecrets support to linkerd-jaeger namespace-metadata ServiceAccount

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata-rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata-rbac.yaml
@@ -12,6 +12,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   name: namespace-metadata
   namespace: {{.Release.Namespace}}
+{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
This completes imagePullSecret support for _all_ ServiceAccounts in the linkerd control plane and core extensions.