### PR TITLE
Fix response class schema

### DIFF
--- a/charts/linkerd-crds/templates/serviceprofile.yaml
+++ b/charts/linkerd-crds/templates/serviceprofile.yaml
@@ -126,10 +126,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).
@@ -252,10 +250,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -5980,10 +5980,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).
@@ -6106,10 +6104,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -5994,10 +5994,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).
@@ -6120,10 +6118,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -5994,10 +5994,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).
@@ -6120,10 +6118,8 @@ spec:
                                   type: object
                                   x-kubernetes-preserve-unknown-fields: true
                               not:
-                                type: array
-                                items:
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               status:
                                 type: object
                                 description: Range describes a range of integers (e.g. status codes).


### PR DESCRIPTION
Fixes #11483

Service profile's response class schema indicates that a `not` response match should be an array.  This is incorrect and parsing of the response class will fail if an array is provided.  

Update the schema to properly indicate that `not`'s value should be an object.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
