### PR TITLE
edge-23.10.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@ security advisories [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 and GHSA-c827-hfw6-qwvm
 [#11449]: https://github.com/linkerd/linkerd2/issues/11449
 [#11480]: https://github.com/linkerd/linkerd2/issues/11480
 [#11504]: https://github.com/linkerd/linkerd2/issues/11504
-[#11504]: https://github.com/linkerd/linkerd2/issues/11512
+[#11512]: https://github.com/linkerd/linkerd2/issues/11512
 [linkerd2-proxy#2480]: https://github.com/linkerd/linkerd2-proxy/pull/2480
 [linkerd2-proxy#2484]: https://github.com/linkerd/linkerd2-proxy/pull/2484
 [linkerd2-proxy#2486]: https://github.com/linkerd/linkerd2-proxy/pull/2486

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## edge-23.10.3
 
-This edge release fixes issues in the proxy and destination controller which can
+This edge release fixes issues in the proxy and Destination controller which can
 result in Linkerd proxies sending traffic to stale endpoints. In addition, it
 contains other bugfixes and updates dependencies to include patches for the
 security advisories [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 and GHSA-c827-hfw6-qwvm.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,49 @@
 # Changes
 
+## edge-23.10.3
+
+This edge release fixes issues in the proxy and destination controller which can
+result in Linkerd proxies sending traffic to stale endpoints. In addition, it
+contains other bugfixes and updates dependencies to include patches for the
+security advisories [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 and GHSA-c827-hfw6-qwvm.
+
+* Fixed an issue where the Destination controller could stop processing
+  changes in the endpoints of a destination, if a proxy subscribed to that
+  destination stops reading service discovery updates. This issue results in
+  proxies attempting to send traffic for that destination to stale endpoints
+  ([#11483], fixes [#11480], [#11279], and [#10590])
+* Fixed a regression introduced in stable-2.13.0 where proxies would not
+  terminate unused service discovery watches, exerting backpressure on the
+  Destination controller which could cause it to become stuck
+  ([linkerd2-proxy#2484] and [linkerd2-proxy#2486])
+* Added `INFO`-level logging to the proxy when endpoints are added or removed
+  from a load balancer. These logs are enabled by default, and can be disabled
+  by [setting the proxy log level][proxy-log-level] to
+  `warn,linkerd=info,linkerd_proxy_balance=warn` or similar
+  ([linkerd2-proxy#2486])
+* Fixed a regression where the proxy rendered `grpc_status` metric labels as a
+  string rather than as the numeric status code ([linkerd2-proxy#2480]; fixes
+  [#11449])
+* Added missing `imagePullSecrets` to `linkerd-jaeger` ServiceAccount ([#11504])
+* Updated the control plane's dependency on the `golang.google.org/grpc` Go
+  package to include patches for [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 ([#11496])
+* Updated dependencies on `rustix` to include patches for GHSA-c827-hfw6-qwvm
+  ([linkerd2-proxy#2488] and [#11512]).
+
+[#10590]: https://github.com/linkerd/linkerd2/issues/10590
+[#11279]: https://github.com/linkerd/linkerd2/issues/11279
+[#11483]: https://github.com/linkerd/linkerd2/issues/11483
+[#11449]: https://github.com/linkerd/linkerd2/issues/11449
+[#11480]: https://github.com/linkerd/linkerd2/issues/11480
+[#11504]: https://github.com/linkerd/linkerd2/issues/11504
+[#11504]: https://github.com/linkerd/linkerd2/issues/11512
+[linkerd2-proxy#2480]: https://github.com/linkerd/linkerd2-proxy/pull/2480
+[linkerd2-proxy#2484]: https://github.com/linkerd/linkerd2-proxy/pull/2484
+[linkerd2-proxy#2486]: https://github.com/linkerd/linkerd2-proxy/pull/2486
+[linkerd2-proxy#2488]: https://github.com/linkerd/linkerd2-proxy/pull/2488
+[proxy-log-level]: https://linkerd.io/2.14/tasks/modifying-proxy-log-level/
+[CVE-2023-44487]: https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+
 ## edge-23.10.2
 
 This edge release includes a fix addressing an issue during upgrades for

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,8 @@ security advisories [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 and GHSA-c827-hfw6-qwvm
 * Fixed a regression where the proxy rendered `grpc_status` metric labels as a
   string rather than as the numeric status code ([linkerd2-proxy#2480]; fixes
   [#11449])
-* Added missing `imagePullSecrets` to `linkerd-jaeger` ServiceAccount ([#11504])
+* Extended `linkerd-jaeger`'s `imagePullSecrets` Helm value to also apply to
+the `namespace-metadata` ServiceAccount ([#11504])
 * Updated the control plane's dependency on the `golang.google.org/grpc` Go
   package to include patches for [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 ([#11496])
 * Updated dependencies on `rustix` to include patches for GHSA-c827-hfw6-qwvm

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.17.3-edge
+version: 1.17.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.17.3-edge](https://img.shields.io/badge/Version-1.17.3--edge-informational?style=flat-square)
+![Version: 1.17.4-edge](https://img.shields.io/badge/Version-1.17.4--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.21.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.13.0-edge
+version: 30.13.1-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.13.0-edge](https://img.shields.io/badge/Version-30.13.0--edge-informational?style=flat-square)
+![Version: 30.13.1-edge](https://img.shields.io/badge/Version-30.13.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.3-edge
+version: 30.13.4-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.13.3-edge](https://img.shields.io/badge/Version-30.13.3--edge-informational?style=flat-square)
+![Version: 30.13.4-edge](https://img.shields.io/badge/Version-30.13.4--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.2-edge
+version: 30.12.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.12.2-edge](https://img.shields.io/badge/Version-30.12.2--edge-informational?style=flat-square)
+![Version: 30.12.3-edge](https://img.shields.io/badge/Version-30.12.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.2-edge
+version: 30.13.3-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.13.2-edge](https://img.shields.io/badge/Version-30.13.2--edge-informational?style=flat-square)
+![Version: 30.13.3-edge](https://img.shields.io/badge/Version-30.13.3--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.10.3

This edge release fixes issues in the proxy and destination controller which can
result in Linkerd proxies sending traffic to stale endpoints. In addition, it
contains other bugfixes and updates dependencies to include patches for the
security advisories [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 and GHSA-c827-hfw6-qwvm.

* Fixed an issue where the Destination controller could stop processing
  changes in the endpoints of a destination, if a proxy subscribed to that
  destination stops reading service discovery updates. This issue results in
  proxies attempting to send traffic for that destination to stale endpoints
  ([#11483], fixes [#11480], [#11279], and [#10590])
* Fixed a regression introduced in stable-2.13.0 where proxies would not
  terminate unused service discovery watches, exerting backpressure on the
  Destination controller which could cause it to become stuck
  ([linkerd2-proxy#2484] and [linkerd2-proxy#2486])
* Added `INFO`-level logging to the proxy when endpoints are added or removed
  from a load balancer. These logs are enabled by default, and can be disabled
  by [setting the proxy log level][proxy-log-level] to
  `warn,linkerd=info,linkerd_proxy_balance=warn` or similar
  ([linkerd2-proxy#2486])
* Fixed a regression where the proxy rendered `grpc_status` metric labels as a
  string rather than as the numeric status code ([linkerd2-proxy#2480]; fixes
  [#11449])
* Added missing `imagePullSecrets` to `linkerd-jaeger` ServiceAccount ([#11504])
* Updated the control plane's dependency on the `golang.google.org/grpc` Go
  package to include patches for [CVE-2023-44487]/GHSA-qppj-fm5r-hxr3 ([#11496])
* Updated dependencies on `rustix` to include patches for GHSA-c827-hfw6-qwvm
  ([linkerd2-proxy#2488] and [#11512]).

[#10590]: https://github.com/linkerd/linkerd2/issues/10590
[#11279]: https://github.com/linkerd/linkerd2/issues/11279
[#11483]: https://github.com/linkerd/linkerd2/issues/11483
[#11449]: https://github.com/linkerd/linkerd2/issues/11449
[#11480]: https://github.com/linkerd/linkerd2/issues/11480
[#11504]: https://github.com/linkerd/linkerd2/issues/11504
[#11504]: https://github.com/linkerd/linkerd2/issues/11512
[linkerd2-proxy#2480]: https://github.com/linkerd/linkerd2-proxy/pull/2480
[linkerd2-proxy#2484]: https://github.com/linkerd/linkerd2-proxy/pull/2484
[linkerd2-proxy#2486]: https://github.com/linkerd/linkerd2-proxy/pull/2486
[linkerd2-proxy#2488]: https://github.com/linkerd/linkerd2-proxy/pull/2488
[proxy-log-level]: https://linkerd.io/2.14/tasks/modifying-proxy-log-level/
[CVE-2023-44487]: https://github.com/advisories/GHSA-qppj-fm5r-hxr3