### PR TITLE
Don't strip trailing slashes when generating service profiles

### DIFF
--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path"
 	"sort"
+	"strings"
 
 	"github.com/go-openapi/spec"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
@@ -67,9 +67,10 @@ func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomai
 		sort.Strings(paths)
 	}
 
+	base := strings.TrimRight(swagger.BasePath, "/")
 	for _, relPath := range paths {
 		item := swagger.Paths.Paths[relPath]
-		path := path.Join(swagger.BasePath, relPath)
+		path := base + "/" + strings.TrimLeft(relPath, "/")
 		pathRegex := PathToRegex(path)
 		if item.Delete != nil {
 			spec := MkRouteSpec(path, pathRegex, http.MethodDelete, item.Delete)

--- a/pkg/profiles/openapi_test.go
+++ b/pkg/profiles/openapi_test.go
@@ -35,6 +35,11 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 							},
 						},
 					},
+					"/path/with/trailing/slash/": {
+						PathItemProps: spec.PathItemProps{
+							Get: &spec.Operation{},
+						},
+					},
 				},
 			},
 		},
@@ -67,6 +72,13 @@ func TestSwaggerToServiceProfile(t *testing.T) {
 					},
 					IsRetryable: true,
 					Timeout:     "60s",
+				},
+				{
+					Name: "GET /path/with/trailing/slash/",
+					Condition: &sp.RequestMatch{
+						PathRegex: "/path/with/trailing/slash/",
+						Method:    "GET",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
When using the `linkerd profile` command with the `--open-api` flag to generate a service profile from a swagger file, we combine each route's base path with it's relative path to get the full path used in the service profile.  However, we use `path.Join` to do so, which strips trailing slashes, leaving the final path different from the intended one.

We avoid using `path.Join`, instead joining the paths manually to avoid stripping trailing slashes.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
