### PR TITLE
Add informer lag histograms

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -301,7 +301,7 @@ func (ew *EndpointsWatcher) updateService(oldObj interface{}, newObj interface{}
 	updated := latestUpdated(newService.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		serviceInformerLag.Observe(float64(delta.Milliseconds()))
+		serviceInformerLag.Observe(delta.Seconds())
 	}
 
 	ew.addService(newObj)
@@ -361,7 +361,7 @@ func (ew *EndpointsWatcher) updateEndpoints(oldObj interface{}, newObj interface
 	updated := latestUpdated(newEndpoints.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		endpointsInformerLag.Observe(float64(delta.Milliseconds()))
+		endpointsInformerLag.Observe(delta.Seconds())
 	}
 
 	id := ServiceID{newEndpoints.Namespace, newEndpoints.Name}
@@ -427,7 +427,7 @@ func (ew *EndpointsWatcher) updateEndpointSlice(oldObj interface{}, newObj inter
 	updated := latestUpdated(newSlice.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		endpointsliceInformerLag.Observe(float64(delta.Milliseconds()))
+		endpointsliceInformerLag.Observe(delta.Seconds())
 	}
 
 	id, err := getEndpointSliceServiceID(newSlice)
@@ -518,7 +518,7 @@ func (ew *EndpointsWatcher) updateServer(oldObj interface{}, newObj interface{})
 	updated := latestUpdated(newServer.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		serverInformerLag.Observe(float64(delta.Milliseconds()))
+		serverInformerLag.Observe(delta.Seconds())
 	}
 
 	ew.addServer(newObj)

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/linkerd/linkerd2/controller/gen/apis/server/v1beta1"
 	"github.com/linkerd/linkerd2/controller/k8s"
@@ -168,7 +169,7 @@ func NewEndpointsWatcher(k8sAPI *k8s.API, metadataAPI *k8s.MetadataAPI, log *log
 	ew.svcHandle, err = k8sAPI.Svc().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ew.addService,
 		DeleteFunc: ew.deleteService,
-		UpdateFunc: func(_, obj interface{}) { ew.addService(obj) },
+		UpdateFunc: ew.updateService,
 	})
 	if err != nil {
 		return nil, err
@@ -177,7 +178,7 @@ func NewEndpointsWatcher(k8sAPI *k8s.API, metadataAPI *k8s.MetadataAPI, log *log
 	ew.srvHandle, err = k8sAPI.Srv().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ew.addServer,
 		DeleteFunc: ew.deleteServer,
-		UpdateFunc: func(_, obj interface{}) { ew.addServer(obj) },
+		UpdateFunc: ew.updateServer,
 	})
 	if err != nil {
 		return nil, err
@@ -199,7 +200,7 @@ func NewEndpointsWatcher(k8sAPI *k8s.API, metadataAPI *k8s.MetadataAPI, log *log
 		ew.epHandle, err = k8sAPI.Endpoint().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    ew.addEndpoints,
 			DeleteFunc: ew.deleteEndpoints,
-			UpdateFunc: func(_, obj interface{}) { ew.addEndpoints(obj) },
+			UpdateFunc: ew.updateEndpoints,
 		})
 		if err != nil {
 			return nil, err
@@ -292,6 +293,20 @@ func (ew *EndpointsWatcher) addService(obj interface{}) {
 	sp.updateService(service)
 }
 
+func (ew *EndpointsWatcher) updateService(oldObj interface{}, newObj interface{}) {
+	oldService := oldObj.(*corev1.Service)
+	newService := newObj.(*corev1.Service)
+
+	oldUpdated := latestUpdated(oldService.ManagedFields)
+	updated := latestUpdated(newService.ManagedFields)
+	if !updated.IsZero() && updated != oldUpdated {
+		delta := time.Since(updated)
+		serviceInformerLag.Observe(float64(delta.Milliseconds()))
+	}
+
+	ew.addService(newObj)
+}
+
 func (ew *EndpointsWatcher) deleteService(obj interface{}) {
 	service, ok := obj.(*corev1.Service)
 	if !ok {
@@ -328,6 +343,30 @@ func (ew *EndpointsWatcher) addEndpoints(obj interface{}) {
 	id := ServiceID{endpoints.Namespace, endpoints.Name}
 	sp := ew.getOrNewServicePublisher(id)
 	sp.updateEndpoints(endpoints)
+}
+
+func (ew *EndpointsWatcher) updateEndpoints(oldObj interface{}, newObj interface{}) {
+	oldEndpoints, ok := oldObj.(*corev1.Endpoints)
+	if !ok {
+		ew.log.Errorf("error processing endpoints resource, got %#v expected *corev1.Endpoints", oldObj)
+		return
+	}
+	newEndpoints, ok := newObj.(*corev1.Endpoints)
+	if !ok {
+		ew.log.Errorf("error processing endpoints resource, got %#v expected *corev1.Endpoints", newObj)
+		return
+	}
+
+	oldUpdated := latestUpdated(oldEndpoints.ManagedFields)
+	updated := latestUpdated(newEndpoints.ManagedFields)
+	if !updated.IsZero() && updated != oldUpdated {
+		delta := time.Since(updated)
+		endpointsInformerLag.Observe(float64(delta.Milliseconds()))
+	}
+
+	id := ServiceID{newEndpoints.Namespace, newEndpoints.Name}
+	sp := ew.getOrNewServicePublisher(id)
+	sp.updateEndpoints(newEndpoints)
 }
 
 func (ew *EndpointsWatcher) deleteEndpoints(obj interface{}) {
@@ -383,6 +422,12 @@ func (ew *EndpointsWatcher) updateEndpointSlice(oldObj interface{}, newObj inter
 	if !ok {
 		ew.log.Errorf("error processing EndpointSlice resource, got %#v expected *discovery.EndpointSlice", newObj)
 		return
+	}
+	oldUpdated := latestUpdated(oldSlice.ManagedFields)
+	updated := latestUpdated(newSlice.ManagedFields)
+	if !updated.IsZero() && updated != oldUpdated {
+		delta := time.Since(updated)
+		endpointsliceInformerLag.Observe(float64(delta.Milliseconds()))
 	}
 
 	id, err := getEndpointSliceServiceID(newSlice)
@@ -464,6 +509,19 @@ func (ew *EndpointsWatcher) addServer(obj interface{}) {
 	for _, sp := range ew.publishers {
 		sp.updateServer(server, true)
 	}
+}
+
+func (ew *EndpointsWatcher) updateServer(oldObj interface{}, newObj interface{}) {
+	oldServer := oldObj.(*v1beta1.Server)
+	newServer := newObj.(*v1beta1.Server)
+	oldUpdated := latestUpdated(oldServer.ManagedFields)
+	updated := latestUpdated(newServer.ManagedFields)
+	if !updated.IsZero() && updated != oldUpdated {
+		delta := time.Since(updated)
+		serverInformerLag.Observe(float64(delta.Milliseconds()))
+	}
+
+	ew.addServer(newObj)
 }
 
 func (ew *EndpointsWatcher) deleteServer(obj interface{}) {
@@ -1337,4 +1395,16 @@ func SetToServerProtocol(k8sAPI *k8s.API, address *Address, port Port) error {
 		}
 	}
 	return nil
+}
+
+func latestUpdated(managedFields []metav1.ManagedFieldsEntry) time.Time {
+	var latest time.Time
+	for _, field := range managedFields {
+		if field.Operation == metav1.ManagedFieldsOperationUpdate {
+			if latest.IsZero() || field.Time.After(latest) {
+				latest = field.Time.Time
+			}
+		}
+	}
+	return latest
 }

--- a/controller/api/destination/watcher/opaque_ports_watcher.go
+++ b/controller/api/destination/watcher/opaque_ports_watcher.go
@@ -142,7 +142,7 @@ func (opw *OpaquePortsWatcher) updateService(oldObj interface{}, newObj interfac
 	updated := latestUpdated(newSvc.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		serviceInformerLag.Observe(float64(delta.Milliseconds()))
+		serviceInformerLag.Observe(delta.Seconds())
 	}
 	opw.addService(newObj)
 }

--- a/controller/api/destination/watcher/pod_watcher.go
+++ b/controller/api/destination/watcher/pod_watcher.go
@@ -184,7 +184,7 @@ func (pw *PodWatcher) updatePod(oldObj any, newObj any) {
 	updated := latestUpdated(newPod.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		podInformerLag.Observe(float64(delta.Milliseconds()))
+		podInformerLag.Observe(delta.Seconds())
 	}
 
 	pw.log.Tracef("Updated pod %s.%s", newPod.Name, newPod.Namespace)
@@ -239,7 +239,7 @@ func (pw *PodWatcher) updateServer(oldObj interface{}, newObj interface{}) {
 	updated := latestUpdated(newServer.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		serverInformerLag.Observe(float64(delta.Milliseconds()))
+		serverInformerLag.Observe(delta.Seconds())
 	}
 
 	pw.updateServers(newObj)

--- a/controller/api/destination/watcher/pod_watcher.go
+++ b/controller/api/destination/watcher/pod_watcher.go
@@ -7,7 +7,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/linkerd/linkerd2/controller/gen/apis/server/v1beta1"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	consts "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/util"
@@ -78,9 +80,9 @@ func NewPodWatcher(k8sAPI *k8s.API, metadataAPI *k8s.MetadataAPI, log *logging.E
 	}
 
 	_, err = k8sAPI.Srv().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    pw.updateServer,
-		DeleteFunc: pw.updateServer,
-		UpdateFunc: func(_, obj interface{}) { pw.updateServer(obj) },
+		AddFunc:    pw.updateServers,
+		DeleteFunc: pw.updateServers,
+		UpdateFunc: pw.updateServer,
 	})
 	if err != nil {
 		return nil, err
@@ -177,6 +179,14 @@ func (pw *PodWatcher) updatePod(oldObj any, newObj any) {
 		// this is just a mark, wait for actual deletion event
 		return
 	}
+
+	oldUpdated := latestUpdated(oldPod.ManagedFields)
+	updated := latestUpdated(newPod.ManagedFields)
+	if !updated.IsZero() && updated != oldUpdated {
+		delta := time.Since(updated)
+		podInformerLag.Observe(float64(delta.Milliseconds()))
+	}
+
 	pw.log.Tracef("Updated pod %s.%s", newPod.Name, newPod.Namespace)
 	go pw.submitPodUpdate(newPod, false)
 }
@@ -221,10 +231,24 @@ func (pw *PodWatcher) submitPodUpdate(pod *corev1.Pod, remove bool) {
 	}
 }
 
+func (pw *PodWatcher) updateServer(oldObj interface{}, newObj interface{}) {
+	oldServer := oldObj.(*v1beta1.Server)
+	newServer := newObj.(*v1beta1.Server)
+
+	oldUpdated := latestUpdated(oldServer.ManagedFields)
+	updated := latestUpdated(newServer.ManagedFields)
+	if !updated.IsZero() && updated != oldUpdated {
+		delta := time.Since(updated)
+		serverInformerLag.Observe(float64(delta.Milliseconds()))
+	}
+
+	pw.updateServers(newObj)
+}
+
 // updateServer triggers an Update() call to the listeners of the podPublishers
 // whose pod matches the Server's selector. This function is an event handler
 // so it cannot block.
-func (pw *PodWatcher) updateServer(_ any) {
+func (pw *PodWatcher) updateServers(_ any) {
 	pw.mu.RLock()
 	defer pw.mu.RUnlock()
 

--- a/controller/api/destination/watcher/profile_watcher.go
+++ b/controller/api/destination/watcher/profile_watcher.go
@@ -113,7 +113,7 @@ func (pw *ProfileWatcher) updateProfile(old interface{}, new interface{}) {
 	updated := latestUpdated(newProfile.ManagedFields)
 	if !updated.IsZero() && updated != oldUpdated {
 		delta := time.Since(updated)
-		serviceProfileInformerLag.Observe(float64(delta.Milliseconds()))
+		serviceProfileInformerLag.Observe(delta.Seconds())
 	}
 
 	pw.addProfile(new)

--- a/controller/api/destination/watcher/profile_watcher.go
+++ b/controller/api/destination/watcher/profile_watcher.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"sync"
+	"time"
 
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
 	splisters "github.com/linkerd/linkerd2/controller/gen/client/listers/serviceprofile/v1alpha2"
@@ -105,6 +106,16 @@ func (pw *ProfileWatcher) addProfile(obj interface{}) {
 }
 
 func (pw *ProfileWatcher) updateProfile(old interface{}, new interface{}) {
+	oldProfile := old.(*sp.ServiceProfile)
+	newProfile := new.(*sp.ServiceProfile)
+
+	oldUpdated := latestUpdated(oldProfile.ManagedFields)
+	updated := latestUpdated(newProfile.ManagedFields)
+	if !updated.IsZero() && updated != oldUpdated {
+		delta := time.Since(updated)
+		serviceProfileInformerLag.Observe(float64(delta.Milliseconds()))
+	}
+
 	pw.addProfile(new)
 }
 

--- a/controller/api/destination/watcher/prometheus.go
+++ b/controller/api/destination/watcher/prometheus.go
@@ -35,7 +35,7 @@ type (
 )
 
 var (
-	informer_lag_secs_buckets = []float64{
+	informer_lag_seconds_buckets = []float64{
 		0.5,  // 500ms
 		1,    // 1s
 		2.5,  // 2.5s
@@ -49,49 +49,49 @@ var (
 	}
 	endpointsInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "endpoints_informer_lag_secs",
+			Name:    "endpoints_informer_lag_seconds",
 			Help:    "The amount of time between when an Endpoints resource is updated and when an informer observes it",
-			Buckets: informer_lag_secs_buckets,
+			Buckets: informer_lag_seconds_buckets,
 		},
 	)
 
 	endpointsliceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "endpointslices_informer_lag_secs",
+			Name:    "endpointslices_informer_lag_seconds",
 			Help:    "The amount of time between when an EndpointSlice resource is updated and when an informer observes it",
-			Buckets: informer_lag_secs_buckets,
+			Buckets: informer_lag_seconds_buckets,
 		},
 	)
 
 	serviceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "services_informer_lag_secs",
+			Name:    "services_informer_lag_seconds",
 			Help:    "The amount of time between when a Service resource is updated and when an informer observes it",
-			Buckets: informer_lag_secs_buckets,
+			Buckets: informer_lag_seconds_buckets,
 		},
 	)
 
 	serverInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "servers_informer_lag_secs",
+			Name:    "servers_informer_lag_seconds",
 			Help:    "The amount of time between when a Server resource is updated and when an informer observes it",
-			Buckets: informer_lag_secs_buckets,
+			Buckets: informer_lag_seconds_buckets,
 		},
 	)
 
 	podInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "pods_informer_lag_secs",
+			Name:    "pods_informer_lag_seconds",
 			Help:    "The amount of time between when a Pod resource is updated and when an informer observes it",
-			Buckets: informer_lag_secs_buckets,
+			Buckets: informer_lag_seconds_buckets,
 		},
 	)
 
 	serviceProfileInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "serviceprofiles_informer_lag_secs",
+			Name:    "serviceprofiles_informer_lag_seconds",
 			Help:    "The amount of time between when a ServiceProfile resource is updated and when an informer observes it",
-			Buckets: informer_lag_secs_buckets,
+			Buckets: informer_lag_seconds_buckets,
 		},
 	)
 )

--- a/controller/api/destination/watcher/prometheus.go
+++ b/controller/api/destination/watcher/prometheus.go
@@ -34,6 +34,68 @@ type (
 	}
 )
 
+var (
+	informer_lag_ms_buckets = []float64{
+		500,     // 500ms
+		1000,    // 1s
+		2500,    // 2.5s
+		5000,    // 5s
+		10000,   // 10s
+		25000,   // 25s
+		50000,   // 50s
+		100000,  // 1m 40s
+		250000,  // 4m 10s
+		1000000, // 16m 40s
+	}
+	endpointsInformerLag = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "endpoints_informer_lag_ms",
+			Help:    "The amount of time between when an Endpoints resources is updated and when an informer observes it",
+			Buckets: informer_lag_ms_buckets,
+		},
+	)
+
+	endpointsliceInformerLag = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "endpointslice_informer_lag_ms",
+			Help:    "The amount of time between when an EndpointSlice resources is updated and when an informer observes it",
+			Buckets: informer_lag_ms_buckets,
+		},
+	)
+
+	serviceInformerLag = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "service_informer_lag_ms",
+			Help:    "The amount of time between when a Serivce resources is updated and when an informer observes it",
+			Buckets: informer_lag_ms_buckets,
+		},
+	)
+
+	serverInformerLag = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "server_informer_lag_ms",
+			Help:    "The amount of time between when a Server resources is updated and when an informer observes it",
+			Buckets: informer_lag_ms_buckets,
+		},
+	)
+
+	podInformerLag = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "pod_informer_lag_ms",
+			Help:    "The amount of time between when a Pod resources is updated and when an informer observes it",
+			Buckets: informer_lag_ms_buckets,
+		},
+	)
+
+	serviceProfileInformerLag = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "serviceprofile_informer_lag_ms",
+			Help:    "The amount of time between when a ServiceProfile resources is updated and when an informer observes it",
+			Buckets: informer_lag_ms_buckets,
+		},
+	)
+)
+
 func newMetricsVecs(name string, labels []string) metricsVecs {
 	subscribers := promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/controller/api/destination/watcher/prometheus.go
+++ b/controller/api/destination/watcher/prometheus.go
@@ -57,7 +57,7 @@ var (
 
 	endpointsliceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "endpointslice_informer_lag_secs",
+			Name:    "endpointslices_informer_lag_secs",
 			Help:    "The amount of time between when an EndpointSlice resource is updated and when an informer observes it",
 			Buckets: informer_lag_secs_buckets,
 		},
@@ -65,7 +65,7 @@ var (
 
 	serviceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "service_informer_lag_secs",
+			Name:    "services_informer_lag_secs",
 			Help:    "The amount of time between when a Service resource is updated and when an informer observes it",
 			Buckets: informer_lag_secs_buckets,
 		},
@@ -73,7 +73,7 @@ var (
 
 	serverInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "server_informer_lag_secs",
+			Name:    "servers_informer_lag_secs",
 			Help:    "The amount of time between when a Server resource is updated and when an informer observes it",
 			Buckets: informer_lag_secs_buckets,
 		},
@@ -81,7 +81,7 @@ var (
 
 	podInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "pod_informer_lag_secs",
+			Name:    "pods_informer_lag_secs",
 			Help:    "The amount of time between when a Pod resource is updated and when an informer observes it",
 			Buckets: informer_lag_secs_buckets,
 		},
@@ -89,7 +89,7 @@ var (
 
 	serviceProfileInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "serviceprofile_informer_lag_secs",
+			Name:    "serviceprofiles_informer_lag_secs",
 			Help:    "The amount of time between when a ServiceProfile resource is updated and when an informer observes it",
 			Buckets: informer_lag_secs_buckets,
 		},

--- a/controller/api/destination/watcher/prometheus.go
+++ b/controller/api/destination/watcher/prometheus.go
@@ -35,63 +35,63 @@ type (
 )
 
 var (
-	informer_lag_ms_buckets = []float64{
-		500,     // 500ms
-		1000,    // 1s
-		2500,    // 2.5s
-		5000,    // 5s
-		10000,   // 10s
-		25000,   // 25s
-		50000,   // 50s
-		100000,  // 1m 40s
-		250000,  // 4m 10s
-		1000000, // 16m 40s
+	informer_lag_secs_buckets = []float64{
+		0.5,  // 500ms
+		1,    // 1s
+		2.5,  // 2.5s
+		5,    // 5s
+		10,   // 10s
+		25,   // 25s
+		50,   // 50s
+		100,  // 1m 40s
+		250,  // 4m 10s
+		1000, // 16m 40s
 	}
 	endpointsInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "endpoints_informer_lag_ms",
+			Name:    "endpoints_informer_lag_secs",
 			Help:    "The amount of time between when an Endpoints resource is updated and when an informer observes it",
-			Buckets: informer_lag_ms_buckets,
+			Buckets: informer_lag_secs_buckets,
 		},
 	)
 
 	endpointsliceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "endpointslice_informer_lag_ms",
+			Name:    "endpointslice_informer_lag_secs",
 			Help:    "The amount of time between when an EndpointSlice resource is updated and when an informer observes it",
-			Buckets: informer_lag_ms_buckets,
+			Buckets: informer_lag_secs_buckets,
 		},
 	)
 
 	serviceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "service_informer_lag_ms",
+			Name:    "service_informer_lag_secs",
 			Help:    "The amount of time between when a Service resource is updated and when an informer observes it",
-			Buckets: informer_lag_ms_buckets,
+			Buckets: informer_lag_secs_buckets,
 		},
 	)
 
 	serverInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "server_informer_lag_ms",
+			Name:    "server_informer_lag_secs",
 			Help:    "The amount of time between when a Server resource is updated and when an informer observes it",
-			Buckets: informer_lag_ms_buckets,
+			Buckets: informer_lag_secs_buckets,
 		},
 	)
 
 	podInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "pod_informer_lag_ms",
+			Name:    "pod_informer_lag_secs",
 			Help:    "The amount of time between when a Pod resource is updated and when an informer observes it",
-			Buckets: informer_lag_ms_buckets,
+			Buckets: informer_lag_secs_buckets,
 		},
 	)
 
 	serviceProfileInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "serviceprofile_informer_lag_ms",
+			Name:    "serviceprofile_informer_lag_secs",
 			Help:    "The amount of time between when a ServiceProfile resource is updated and when an informer observes it",
-			Buckets: informer_lag_ms_buckets,
+			Buckets: informer_lag_secs_buckets,
 		},
 	)
 )

--- a/controller/api/destination/watcher/prometheus.go
+++ b/controller/api/destination/watcher/prometheus.go
@@ -50,7 +50,7 @@ var (
 	endpointsInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "endpoints_informer_lag_ms",
-			Help:    "The amount of time between when an Endpoints resources is updated and when an informer observes it",
+			Help:    "The amount of time between when an Endpoints resource is updated and when an informer observes it",
 			Buckets: informer_lag_ms_buckets,
 		},
 	)
@@ -58,7 +58,7 @@ var (
 	endpointsliceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "endpointslice_informer_lag_ms",
-			Help:    "The amount of time between when an EndpointSlice resources is updated and when an informer observes it",
+			Help:    "The amount of time between when an EndpointSlice resource is updated and when an informer observes it",
 			Buckets: informer_lag_ms_buckets,
 		},
 	)
@@ -66,7 +66,7 @@ var (
 	serviceInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "service_informer_lag_ms",
-			Help:    "The amount of time between when a Serivce resources is updated and when an informer observes it",
+			Help:    "The amount of time between when a Service resource is updated and when an informer observes it",
 			Buckets: informer_lag_ms_buckets,
 		},
 	)
@@ -74,7 +74,7 @@ var (
 	serverInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "server_informer_lag_ms",
-			Help:    "The amount of time between when a Server resources is updated and when an informer observes it",
+			Help:    "The amount of time between when a Server resource is updated and when an informer observes it",
 			Buckets: informer_lag_ms_buckets,
 		},
 	)
@@ -82,7 +82,7 @@ var (
 	podInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "pod_informer_lag_ms",
-			Help:    "The amount of time between when a Pod resources is updated and when an informer observes it",
+			Help:    "The amount of time between when a Pod resource is updated and when an informer observes it",
 			Buckets: informer_lag_ms_buckets,
 		},
 	)
@@ -90,7 +90,7 @@ var (
 	serviceProfileInformerLag = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "serviceprofile_informer_lag_ms",
-			Help:    "The amount of time between when a ServiceProfile resources is updated and when an informer observes it",
+			Help:    "The amount of time between when a ServiceProfile resource is updated and when an informer observes it",
 			Buckets: informer_lag_ms_buckets,
 		},
 	)

--- a/controller/k8s/k8s.go
+++ b/controller/k8s/k8s.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const ResyncTime = 5 * time.Minute
+const ResyncTime = 10 * time.Minute
 
 func waitForCacheSync(syncChecks []cache.InformerSynced) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/controller/k8s/k8s.go
+++ b/controller/k8s/k8s.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const ResyncTime = 10 * time.Minute
+const ResyncTime = 5 * time.Minute
 
 func waitForCacheSync(syncChecks []cache.InformerSynced) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)


### PR DESCRIPTION
In order to detect if the destination controller's k8s informers have fallen behind, we add a histogram for each resource type.  These histograms track the delta between when an update to a resource occurs and when the destination controller processes that update.  We do this by looking at the timestamps on the managed fields of the resource and looking for the most recent update and comparing that to the current time.

The histogram metrics are of the form `{kind}_informer_lag_ms_bucket_*`.

* We record a value only for updates, not for adds or deletes.  This is because when the controller starts up, it will populate its cache with an add for each resource in the cluster and the delta between the last updated time of that resource and the current time may be large.  This does not represent informer lag and should not be counted as such.
* When the informer performs resyncs, we get updates where the updated time of the old version is equal to the updated time of the new version.  This does not represent an actual update of the resource itself and so we do not record a value.
* Since we are comparing timestamps set on the manged fields of resources to the current time from the destination controller's system clock, the accuracy of these metrics depends on clock drift being minimal across the cluster.
* We use histogram buckets which range from 500ms to about 17 minutes.  In my testing, an informer lag of 500ms-1000ms is typical.  However, we wish to have enough buckets to identify cases where the informer is lagged significantly behind.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
