### PR TITLE
ci: fix default Rust toolchain in `test-policy`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,8 @@ on:
       - policy-test/**
       - viz/**
       - '!.devcontainer/**'
+      - rust-toolchain.toml
+      - bin/rust-toolchain-version
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -187,8 +187,18 @@ jobs:
       - name: Setup deps
         shell: bash
         run: |
+          # Extract current Rust version from the toolchain file.
+          version_regex='channel = "([0-9]+\.[0-9]+\.[0-9]+)"'
+          toolchain=$(cat rust-toolchain.toml)
+          if [[ $toolchain =~ $version_regex ]]; then
+            toolchain_version=${BASH_REMATCH[1]}
+          else
+            echo "::error file=rust-toolchain.toml::failed to parse rust-toolchain.toml"
+            exit 1
+          fi
+
           rm -rf "$HOME/.cargo"
-          bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain "$(cat rust-toolchain)"
+          bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain "$toolchain_version"
           # shellcheck disable=SC1090
           source ~/.cargo/env
           echo "PATH=$PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -187,18 +187,8 @@ jobs:
       - name: Setup deps
         shell: bash
         run: |
-          # Extract current Rust version from the toolchain file.
-          version_regex='channel = "([0-9]+\.[0-9]+\.[0-9]+)"'
-          toolchain=$(cat rust-toolchain.toml)
-          if [[ $toolchain =~ $version_regex ]]; then
-            toolchain_version=${BASH_REMATCH[1]}
-          else
-            echo "::error file=rust-toolchain.toml::failed to parse rust-toolchain.toml"
-            exit 1
-          fi
-
           rm -rf "$HOME/.cargo"
-          bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain "$toolchain_version"
+          bin/scurl -v https://sh.rustup.rs | sh -s -- -y --default-toolchain "$(./bin/rust-toolchain-version)"
           # shellcheck disable=SC1090
           source ~/.cargo/env
           echo "PATH=$PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,15 +87,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - shell: bash
         run: |
-          # Extract current Rust version from the toolchain file.
-          version_regex='channel = "([0-9]+\.[0-9]+\.[0-9]+)"'
-          toolchain=$(cat rust-toolchain.toml)
-          if [[ $toolchain =~ $version_regex ]]; then
-            toolchain_version=${BASH_REMATCH[1]}
-          else
-            echo "::error file=rust-toolchain.toml::failed to parse rust-toolchain.toml"
-            exit 1
-          fi
+          toolchain_version="$(./bin/rust-toolchain-version)"
 
           ex=0
           # Check this workflow against the version in rust-toolchain.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,8 @@ on:
       - deny.toml
       - '**/*.rs'
       - policy-*/Dockerfile
-      - rust-toolchain
+      - rust-toolchain.toml
+      - bin/rust-toolchain-version
 
 permissions:
   contents: read

--- a/bin/rust-toolchain-version
+++ b/bin/rust-toolchain-version
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+# Extracts the current Rust version from the toolchain file.
+
+bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
+rootdir=$( cd "$bindir"/.. && pwd )
+
+version_regex='channel = "(.+)"'
+toolchain=$(cat "$rootdir"/rust-toolchain.toml)
+
+# If the `rust-toolchain.toml` file contains a line matching the channel regex,
+# extract the channel and echo it.
+if [[ $toolchain =~ $version_regex ]]; then
+    echo "${BASH_REMATCH[1]}"
+    exit 0;
+fi
+
+# Otherwise, no matching line was found, so print an error.
+if [[ "${GITHUB_ACTIONS:-false}" ==  "true" ]]; then
+    echo "::error file=rust-toolchain.toml::failed to parse rust-toolchain.toml"
+else
+    echo "failed to parse rust-toolchain.toml"
+fi
+
+exit 1


### PR DESCRIPTION
PR #11528 changed the `rust-toolchain` file to use the TOML format rather than the plaintext format. Unfortunately, this broke the `test-policy` CI job, which `cat`s the contents of the `rust-toolchain` file to determine which Rust version to install, and that file now no longer exists (since it's now in `rust-toolchain.toml`). See: https://github.com/linkerd/linkerd2/actions/runs/6649430068/job/18068192854?pr=11535

This branch fixes that by changing the CI job to use a regex to extract the Rust toolchain version instead.

It looks like the CI job didn't run on #11528 because the integration workflow isn't configured to run when the `rust-toolchain` file changes.