### PR TITLE
Return NotFound for unknown pod names

### DIFF
--- a/controller/api/destination/watcher/pod_watcher.go
+++ b/controller/api/destination/watcher/pod_watcher.go
@@ -399,7 +399,7 @@ func (pw *PodWatcher) getEndpointByHostname(hostname string, svcID *ServiceID) (
 		}
 	}
 
-	return nil, fmt.Errorf("no pod found in Endpoints %s/%s for hostname %s", svcID.Namespace, svcID.Name, hostname)
+	return nil, status.Errorf(codes.NotFound, "no pod found in Endpoints %s/%s for hostname %s", svcID.Namespace, svcID.Name, hostname)
 }
 
 func (pp *podPublisher) subscribe(listener PodUpdateListener) {

--- a/controller/api/destination/watcher/pod_watcher.go
+++ b/controller/api/destination/watcher/pod_watcher.go
@@ -277,7 +277,7 @@ func (pw *PodWatcher) getOrNewPodPublisher(service *ServiceID, hostname, ip stri
 	if hostname != "" {
 		pod, err = pw.getEndpointByHostname(hostname, service)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get pod for hostname %s: %w", hostname, err)
+			return nil, err
 		}
 		ip = pod.Status.PodIP
 	} else {


### PR DESCRIPTION
Fixes #11065

When an inbound proxy receives a request with a canonical name of the form `hostname.service.namespace.svc.cluster.domain`, we assume that `hostname` is the hostname of the pod as described in https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields.  However, pods are also addressable with `pod-ip.service.namespace.svc.cluster.domain`.  When the destination controller gets a profile request of this form, we attempt to find a pod with hostname of `pod-ip` and return an error with gRPC status `Unknown` since this will not exist.

It is expected that this profile lookup will fail since we cannot have service profiles for individual pods.  However, returning a gRPC status `Unknown` for these requests brings the reported success rate of the destination controller down.  Instead we should return these as gRPC status `NotFound` so that these responses don't get reported as server errors.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
