### PR TITLE
Add queuing to profile translator

### DIFF
--- a/controller/api/destination/destination_fuzzer.go
+++ b/controller/api/destination/destination_fuzzer.go
@@ -91,12 +91,11 @@ func FuzzProfileTranslatorUpdate(data []byte) int {
 		return 0
 	}
 	t := &testing.T{}
-	mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: []*pb.DestinationProfile{}}
+	mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-	translator := &profileTranslator{
-		stream: mockGetProfileServer,
-		log:    logging.WithField("test", t.Name()),
-	}
+	translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+	translator.Start()
+	defer translator.Stop()
 	translator.Update(profile)
 	return 1
 }

--- a/controller/api/destination/profile_translator_test.go
+++ b/controller/api/destination/profile_translator_test.go
@@ -423,7 +423,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Sends update", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -442,7 +442,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Request match with more than one field becomes ALL", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -461,7 +461,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Ignores request match without any fields", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -476,7 +476,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Response match with more than one field becomes ALL", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -495,7 +495,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Ignores response match without any fields", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -510,7 +510,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Ignores response match with invalid status range", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -525,7 +525,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Sends update for one sided status range", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -542,7 +542,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Sends empty update", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 
@@ -561,7 +561,7 @@ func TestProfileTranslator(t *testing.T) {
 	t.Run("Sends update with custom timeout", func(t *testing.T) {
 		mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+		translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "", 80, nil)
 		translator.Start()
 		defer translator.Stop()
 

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -567,11 +567,11 @@ func (m *mockDestinationGetServer) Send(update *pb.Update) error {
 
 type mockDestinationGetProfileServer struct {
 	util.MockServerStream
-	profilesReceived []*pb.DestinationProfile
+	profilesReceived chan *pb.DestinationProfile
 }
 
 func (m *mockDestinationGetProfileServer) Send(profile *pb.DestinationProfile) error {
-	m.profilesReceived = append(m.profilesReceived, profile)
+	m.profilesReceived <- profile
 	return nil
 }
 


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/pull/11491 changed the EndpointTranslator to use a queue to avoid calling `Send` on a gRPC stream directly from an informer callback goroutine.  This change updates the ProfileTranslator in the same way, adding a queue to ensure we do not block the informer thread.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
