### PR TITLE
Fix GetProfiles error when address is opaque and unmeshed

### DIFF
--- a/controller/api/destination/endpoint_profile_translator.go
+++ b/controller/api/destination/endpoint_profile_translator.go
@@ -65,11 +65,11 @@ func (ept *endpointProfileTranslator) Update(address *watcher.Address) (bool, er
 		} else if endpoint.ProtocolHint.OpaqueTransport == nil {
 			port, err := getInboundPort(&address.Pod.Spec)
 			if err != nil {
-				return false, err
-			}
-
-			endpoint.ProtocolHint.OpaqueTransport = &pb.ProtocolHint_OpaqueTransport{
-				InboundPort: port,
+				ept.log.Error(err)
+			} else {
+				endpoint.ProtocolHint.OpaqueTransport = &pb.ProtocolHint_OpaqueTransport{
+					InboundPort: port,
+				}
 			}
 		}
 

--- a/controller/api/destination/server_test.go
+++ b/controller/api/destination/server_test.go
@@ -417,6 +417,23 @@ func TestGetProfiles(t *testing.T) {
 		}
 	})
 
+	t.Run("Return profile with no opaque transport when pod does not have label and port is opaque", func(t *testing.T) {
+		server := makeServer(t)
+		defer server.clusterStore.UnregisterGauges()
+
+		// port 3306 is in the default opaque port list
+		stream := profileStream(t, server, podIP2, 3306, "")
+		defer stream.Cancel()
+		profile := assertSingleProfile(t, stream.Updates())
+		if profile.Endpoint == nil {
+			t.Fatalf("Expected response to have endpoint field")
+		}
+
+		if profile.Endpoint.GetProtocolHint().GetOpaqueTransport() != nil {
+			t.Fatalf("Expected no opaque transport but found one")
+		}
+	})
+
 	t.Run("Return profile with no protocol hint when pod does not have label", func(t *testing.T) {
 		server := makeServer(t)
 		defer server.clusterStore.UnregisterGauges()


### PR DESCRIPTION
When we do a `GetProfile` lookup for an opaque port on an unmeshed pod, we attempt to look up the inbound listen port of that pod's proxy.  Since that pod has no proxy, this fails and we return an error to the `GetProfile` API call.  This causes the proxy to fail to be able to resolve the profile and be unable to route the traffic.

We revert to the previous behavior of only logging when we cannot look up the inbound listen port instead of returning an error.  

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
