### PR TITLE
Fix annotation names and partials field

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -57,11 +57,11 @@ env:
 - name: LINKERD2_PROXY_INBOUND_DISCOVERY_IDLE_TIMEOUT
   value: {{.Values.proxy.inboundDiscoveryCacheUnusedTimeout | quote}}
 {{ end -}}
-{{ if .Values.proxy.DisableOutboundProtocolDetectTimeout -}}
+{{ if .Values.proxy.disableOutboundProtocolDetectTimeout -}}
 - name: LINKERD2_PROXY_OUTBOUND_DETECT_TIMEOUT
   value: "365d"
 {{ end -}}
-{{ if .Values.proxy.DisableInboundProtocolDetectTimeout -}}
+{{ if .Values.proxy.disableInboundProtocolDetectTimeout -}}
 - name: LINKERD2_PROXY_INBOUND_DETECT_TIMEOUT
   value: "365d"
 {{ end -}}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -241,12 +241,12 @@ const (
 	// ProxyDisableOutboundProtocolDetectTimeout can be used to disable protocol
 	// detection timeouts for outbound connections by setting them to a very
 	// high value.
-	ProxyDisableOutboundProtocolDetectTimeout = ProxyConfigAnnotationsPrefix + "/proxy-outbound-protocol-detect-timeout"
+	ProxyDisableOutboundProtocolDetectTimeout = ProxyConfigAnnotationsPrefix + "/proxy-disable-outbound-protocol-detect-timeout"
 
 	// ProxyDisableInboundProtocolDetectTimeout can be used to disable protocol
 	// detection timeouts for inbound connections by setting them to a very
 	// high value.
-	ProxyDisableInboundProtocolDetectTimeout = ProxyConfigAnnotationsPrefix + "/proxy-inbound-protocol-detect-timeout"
+	ProxyDisableInboundProtocolDetectTimeout = ProxyConfigAnnotationsPrefix + "/proxy-disable-inbound-protocol-detect-timeout"
 
 	// ProxyEnableGatewayAnnotation can be used to configure the proxy
 	// to operate as a gateway, routing requests that target the inbound router.


### PR DESCRIPTION
Prior to setting an enormous value to disable protocol detection, the field was meant to be configurable. In the refactor, the annotation name stayed the same instead of reflecting the change in the contract (i.e. not configurable but toggled). Additionally, there were two types in the proxy partials.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
