### PR TITLE
Change behaviour gateway addressess override in Link command

### DIFF
--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -247,7 +247,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 				if len(gwAddresses) == 0 && opts.gatewayAddresses == "" {
 					return fmt.Errorf("Gateway %s.%s has no ingress addresses", gateway.Name, gateway.Namespace)
 				}
-				if len(gwAddresses) > 0 {
+				if len(gwAddresses) > 0 && opts.gatewayAddresses == "" {
 					gatewayAddresses = strings.Join(gwAddresses, ",")
 				} else {
 					gatewayAddresses = opts.gatewayAddresses

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -232,7 +232,6 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 					return err
 				}
 
-				gatewayAddresses := ""
 				gwAddresses := []string{}
 				for _, ingress := range gateway.Status.LoadBalancer.Ingress {
 					addr := ingress.IP
@@ -244,15 +243,14 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 					}
 					gwAddresses = append(gwAddresses, addr)
 				}
-				if len(gwAddresses) == 0 && opts.gatewayAddresses == "" {
+
+				if opts.gatewayAddresses != "" {
+					link.GatewayAddress = opts.gatewayAddresses
+				} else if len(gwAddresses) > 0 {
+					link.GatewayAddress = strings.Join(gwAddresses, ",")
+				} else {
 					return fmt.Errorf("Gateway %s.%s has no ingress addresses", gateway.Name, gateway.Namespace)
 				}
-				if len(gwAddresses) > 0 && opts.gatewayAddresses == "" {
-					gatewayAddresses = strings.Join(gwAddresses, ",")
-				} else {
-					gatewayAddresses = opts.gatewayAddresses
-				}
-				link.GatewayAddress = gatewayAddresses
 
 				gatewayIdentity, ok := gateway.Annotations[k8s.GatewayIdentity]
 				if !ok || gatewayIdentity == "" {


### PR DESCRIPTION
When linking two clusters, a `--gateway-addresses` override can be passed to the command. If applied, the override populates the Link resource with a set of addresses received from the flag, instead of reading them from Linkerd's Gateway LoadBalancer service. Currently, the override is used only when the LoadBalancer service does not exist (or does not contain any IPs).

An override should take precedence over default behaviour. As it stands, the user experience is confusing; it can also make manual testing for changes hard (when an override has to be passed) and it can inhibit users from passing in a static IP or DNS addresses to avoid relying on dynamic IPs in the LoadBalancer service.

This change makes the override behave as expected.


### Manual QA

Before:
```
# `linkerd mc link --gateway-addresses="headless-test.default.svc.cluster.loca
l" `
apiVersion: multicluster.linkerd.io/v1alpha1
kind: Link
metadata:
  name: target
  namespace: linkerd-multicluster
spec:
  gatewayAddress: 192.168.224.4
```

After:
```
# k get link -n linkerd-multicluster target -o json | jq .spec.gatewayAddress
"headless-test.default.svc.cluster.local"
```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
