### PR TITLE
Change notes for edge-23.11.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,16 +8,17 @@ logic.
 
 * Fixed an issue where the Destination controller could stop processing service
   profile updates, if a proxy subscribed to those updates stops reading them;
-  this is a followup to the issue [#11491] fixed in edge-23.10.3 ([#11546])
+  this is a followup to the issue [#11491] fixed in [edge-23.10.3] ([#11546])
 * In the Destination controller, added informer lag histogram metrics to track
-  whenever the objects tracked are falling behind the state in the
-  kube-apiserver ([#11534])
+  whenever the Kubernetes objects watched by the controller are falling behind
+  the state in the kube-apiserver ([#11534])
 * In the multicluster service mirror, extended the target gateway resolution
   logic to take into account all the possible IPs a hostname might resolve to,
-  not just the first one (thanks @MrFreezeex!) ([#11499])
+  rather than just the first one (thanks @MrFreezeex!) ([#11499])
 * Added probes to the debug container to appease environments requiring probes
   for all containers ([#11308])
 
+[edge-23.10.3]: https://github.com/linkerd/linkerd2/releases/tag/edge-23.10.3
 [#11546]: https://github.com/linkerd/linkerd2/pull/11546
 [#11534]: https://github.com/linkerd/linkerd2/pull/11534
 [#11499]: https://github.com/linkerd/linkerd2/pull/11499

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,6 @@ logic.
 * Added probes to the debug container to appease environments requiring probes
   for all containers ([#11308])
 
-[#11491]: https://github.com/linkerd/linkerd2/pull/11491
 [#11546]: https://github.com/linkerd/linkerd2/pull/11546
 [#11534]: https://github.com/linkerd/linkerd2/pull/11534
 [#11499]: https://github.com/linkerd/linkerd2/pull/11499

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,29 @@
 # Changes
 
+## edge-23.11.2
+
+This edge release contains observability improvements and bug fixes to the
+Destination controller, and a refinement to the multicluster gateway resolution
+logic.
+
+* Fixed an issue where the Destination controller could stop processing service
+  profile updates, if a proxy subscribed to those updates stops reading them;
+  this is a followup to the issue [#11491] fixed in edge-23.10.3 ([#11546])
+* In the Destination controller, added informer lag histogram metrics to track
+  whenever the objects tracked are falling behind the state in the
+  kube-apiserver ([#11534])
+* In the multicluster service mirror, extended the target gateway resolution
+  logic to take into account all the possible IPs a hostname might resolve to,
+  not just the first one (thanks @MrFreezeex!) ([#11499])
+* Added probes to the debug container to appease environments requiring probes
+  for all containers ([#11308])
+
+[#11491]: https://github.com/linkerd/linkerd2/pull/11491
+[#11546]: https://github.com/linkerd/linkerd2/pull/11546
+[#11534]: https://github.com/linkerd/linkerd2/pull/11534
+[#11499]: https://github.com/linkerd/linkerd2/pull/11499
+[#11308]: https://github.com/linkerd/linkerd2/pull/11308
+
 ## edge-23.11.1
 
 This edge release fixes two bugs in the Destination controller that could cause

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.17.6-edge
+version: 1.17.7-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.17.6-edge](https://img.shields.io/badge/Version-1.17.6--edge-informational?style=flat-square)
+![Version: 1.17.7-edge](https://img.shields.io/badge/Version-1.17.7--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.6-edge
+version: 30.13.7-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.13.6-edge](https://img.shields.io/badge/Version-30.13.6--edge-informational?style=flat-square)
+![Version: 30.13.7-edge](https://img.shields.io/badge/Version-30.13.7--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.5-edge
+version: 30.12.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.12.5-edge](https://img.shields.io/badge/Version-30.12.5--edge-informational?style=flat-square)
+![Version: 30.12.6-edge](https://img.shields.io/badge/Version-30.12.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.5-edge
+version: 30.13.6-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.13.5-edge](https://img.shields.io/badge/Version-30.13.5--edge-informational?style=flat-square)
+![Version: 30.13.6-edge](https://img.shields.io/badge/Version-30.13.6--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.11.2

This edge release contains observability improvements and bug fixes to the
Destination controller, and a refinement to the multicluster gateway resolution
logic.

* Fixed an issue where the Destination controller could stop processing service
  profile updates, if a proxy subscribed to those updates stops reading them;
  this is a followup to the issue [#11491] fixed in [edge-23.10.3] ([#11546])
* In the Destination controller, added informer lag histogram metrics to track
  whenever the Kubernetes objects watched by the controller are falling behind
  the state in the kube-apiserver ([#11534])
* In the multicluster service mirror, extended the target gateway resolution
  logic to take into account all the possible IPs a hostname might resolve to,
  rather than just the first one (thanks @MrFreezeex!) ([#11499])
* Added probes to the debug container to appease environments requiring probes
  for all containers ([#11308])

[edge-23.10.3]: https://github.com/linkerd/linkerd2/releases/tag/edge-23.10.3
[#11546]: https://github.com/linkerd/linkerd2/pull/11546
[#11534]: https://github.com/linkerd/linkerd2/pull/11534
[#11499]: https://github.com/linkerd/linkerd2/pull/11499
[#11308]: https://github.com/linkerd/linkerd2/pull/11308
