### PR TITLE
Fix service-mirror template when running in HA mode

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -86,7 +86,6 @@ metadata:
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
-{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -121,9 +120,13 @@ spec:
         mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
+    {{- if .Values.enablePodAntiAffinity}}
+    {{- with $tree := deepCopy . }}
     {{- $_ := set $tree "component" .Values.targetClusterName -}}
     {{- $_ := set $tree "label" "mirror.linkerd.io/cluster-name" -}}
     {{- include "linkerd.affinity" $tree | nindent 6 }}
+    {{- end }}
+    {{- end }}
       containers:
       - args:
         - service-mirror

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -86,6 +86,7 @@ metadata:
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
+{{- $tree := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -120,10 +121,9 @@ spec:
         mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
-    {{- if .Values.enablePodAntiAffinity -}}
-    {{- $local := dict "label" "mirror.linkerd.io/cluster-name" "component" .Values.targetClusterName -}}
-    {{- include "linkerd.pod-affinity" $local | nindent 6 -}}
-    {{- end }}
+    {{- $_ := set $tree "component" .Values.targetClusterName -}}
+    {{- $_ := set $tree "label" "mirror.linkerd.io/cluster-name" -}}
+    {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       - args:
         - service-mirror

--- a/multicluster/cmd/link_test.go
+++ b/multicluster/cmd/link_test.go
@@ -20,7 +20,15 @@ func TestServiceMirrorRender(t *testing.T) {
 		{
 			linkValues,
 			nil,
-			"serivce_mirror_default.golden",
+			"service_mirror_default.golden",
+		},
+
+		{
+			linkValues,
+			map[string]interface{}{
+				"enablePodAntiAffinity": true,
+			},
+			"service_mirror_ha.golden",
 		},
 	}
 	for i, tc := range testCases {

--- a/multicluster/cmd/testdata/service_mirror_default.golden
+++ b/multicluster/cmd/testdata/service_mirror_default.golden
@@ -1,0 +1,151 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-access-local-resources-test-cluster
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+rules:
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["list", "get", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-access-local-resources-test-cluster
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-service-mirror-access-local-resources-test-cluster
+subjects:
+- kind: ServiceAccount
+  name: linkerd-service-mirror-test-cluster
+  namespace: test
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-read-remote-creds-test-cluster
+  namespace: test
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["cluster-credentials-test-cluster"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["multicluster.linkerd.io"]
+    resources: ["links"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-service-mirror-read-remote-creds-test-cluster
+  namespace: test
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: linkerd-service-mirror-read-remote-creds-test-cluster
+subjects:
+  - kind: ServiceAccount
+    name: linkerd-service-mirror-test-cluster
+    namespace: test
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: linkerd-service-mirror-test-cluster
+  namespace: test
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    linkerd.io/extension: multicluster
+    component: service-mirror
+    mirror.linkerd.io/cluster-name: test-cluster
+  name: linkerd-service-mirror-test-cluster
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: linkerd-service-mirror
+      mirror.linkerd.io/cluster-name: test-cluster
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
+      labels:
+        linkerd.io/extension: multicluster
+        component: linkerd-service-mirror
+        mirror.linkerd.io/cluster-name: test-cluster
+    spec:
+      containers:
+      - args:
+        - service-mirror
+        - -log-level=info
+        - -log-format=plain
+        - -event-requeue-limit=3
+        - -namespace=test
+        - -enable-pprof=false
+        - test-cluster
+        image: cr.l5d.io/linkerd/controller:dev-undefined
+        name: service-mirror
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2103
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - containerPort: 9999
+          name: admin-http
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: linkerd-service-mirror-test-cluster
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: probe-gateway-test-cluster
+  namespace: test
+  labels:
+    linkerd.io/extension: multicluster
+    mirror.linkerd.io/mirrored-gateway: "true"
+    mirror.linkerd.io/cluster-name: test-cluster
+spec:
+  ports:
+  - name: mc-probe
+    port: 4191
+    protocol: TCP

--- a/multicluster/cmd/testdata/service_mirror_ha.golden
+++ b/multicluster/cmd/testdata/service_mirror_ha.golden
@@ -95,6 +95,9 @@ spec:
     matchLabels:
       component: linkerd-service-mirror
       mirror.linkerd.io/cluster-name: test-cluster
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       annotations:
@@ -106,6 +109,26 @@ spec:
         component: linkerd-service-mirror
         mirror.linkerd.io/cluster-name: test-cluster
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: mirror.linkerd.io/cluster-name
+                  operator: In
+                  values:
+                  - test-cluster
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mirror.linkerd.io/cluster-name
+                operator: In
+                values:
+                - test-cluster
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - service-mirror
@@ -134,6 +157,22 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: linkerd-service-mirror-test-cluster
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: linkerd-service-mirror-test-cluster
+  namespace: test
+  labels:
+    component: linkerd-service-mirror
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: linkerd-service-mirror
+      mirror.linkerd.io/cluster-name: test-cluster
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Two clusters can be linked in HA mode. When HA values are used, the service-mirror deployment receives some pod affinity rules to ensure fair scheduling of pods across a cluster's nodes.

The service-mirror Deployment's template seems to be broken at the moment when using HA values. Affinity rules are incorrectly grouped under a top-level `podAntiAffinity` field. The Kubernetes API requires the rules to be grouped under a top-level `affinity` field. This change rectifies that by introducing the missing parent.

Fixes #11603

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->

---

### Tests

* The issue was introduced since we avoided including the entire `linkerd.affinity` subchart (i.e. partial). Instead of bringing in parts of the subchart, we are now copying the install values and including the entire partial template. Based on the values, it should populate the affinity rules.
* I encourage reviewers to do their own testing.


Before:

```
:; linkerd --context=k3d-target mc link --cluster-name target --api-server-address="https://192.168.224.4:6443" --ha | k apply -f -
secret/cluster-credentials-target created
secret/cluster-credentials-target created
link.multicluster.linkerd.io/target created
clusterrole.rbac.authorization.k8s.io/linkerd-service-mirror-access-local-resources-target created
clusterrolebinding.rbac.authorization.k8s.io/linkerd-service-mirror-access-local-resources-target created
role.rbac.authorization.k8s.io/linkerd-service-mirror-read-remote-creds-target created
rolebinding.rbac.authorization.k8s.io/linkerd-service-mirror-read-remote-creds-target created
serviceaccount/linkerd-service-mirror-target created
error: error validating "STDIN": error validating data: ValidationError(Deployment.spec.template.spec): unknown field "podAntiAffinity" in io.k8s.api.core.v1.PodSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

After:

```
:; bin/linkerd --context=k3d-target mc link --cluster-name target --api-server-address="https://192.168.224.4:6443" --ha | k apply -f -
secret/cluster-credentials-target configured
secret/cluster-credentials-target configured
link.multicluster.linkerd.io/target unchanged
clusterrole.rbac.authorization.k8s.io/linkerd-service-mirror-access-local-resources-target unchanged
clusterrolebinding.rbac.authorization.k8s.io/linkerd-service-mirror-access-local-resources-target unchanged
role.rbac.authorization.k8s.io/linkerd-service-mirror-read-remote-creds-target unchanged
rolebinding.rbac.authorization.k8s.io/linkerd-service-mirror-read-remote-creds-target unchanged
serviceaccount/linkerd-service-mirror-target unchanged
deployment.apps/linkerd-service-mirror-target configured
poddisruptionbudget.policy/linkerd-service-mirror-target configured
service/probe-gateway-target unchanged
```

We're not breaking non-ha:

```
:; bin/linkerd --context=k3d-target mc link --cluster-name target --api-server-address="https://192.168.224.4:6443" | k apply -f -
secret/cluster-credentials-target configured
secret/cluster-credentials-target configured
link.multicluster.linkerd.io/target unchanged
clusterrole.rbac.authorization.k8s.io/linkerd-service-mirror-access-local-resources-target unchanged
clusterrolebinding.rbac.authorization.k8s.io/linkerd-service-mirror-access-local-resources-target unchanged
role.rbac.authorization.k8s.io/linkerd-service-mirror-read-remote-creds-target unchanged
rolebinding.rbac.authorization.k8s.io/linkerd-service-mirror-read-remote-creds-target unchanged
serviceaccount/linkerd-service-mirror-target unchanged
deployment.apps/linkerd-service-mirror-target configured
service/probe-gateway-target unchanged
```


Render diff:

```
# < : bug.yaml
# > : fix.yaml
161,164c161,174
<       podAntiAffinity:
<         preferredDuringSchedulingIgnoredDuringExecution:
<         - podAffinityTerm:
<             labelSelector:
---
>       affinity:
>         podAntiAffinity:
>           preferredDuringSchedulingIgnoredDuringExecution:
>           - podAffinityTerm:
>               labelSelector:
>                 matchExpressions:
>                 - key: mirror.linkerd.io/cluster-name
>                   operator: In
>                   values:
>                   - target
>               topologyKey: topology.kubernetes.io/zone
>             weight: 100
>           requiredDuringSchedulingIgnoredDuringExecution:
>           - labelSelector:
170,179c180
<             topologyKey: topology.kubernetes.io/zone
<           weight: 100
<         requiredDuringSchedulingIgnoredDuringExecution:
<         - labelSelector:
<             matchExpressions:
<             - key: mirror.linkerd.io/cluster-name
<               operator: In
<               values:
<               - target
<           topologyKey: kubernetes.io/hostname
---
>             topologyKey: kubernetes.io/hostname
189c190
<         image: cr.l5d.io/linkerd/controller:stable-2.14.0
---
>         image: cr.l5d.io/linkerd/controller:git-006f6e2c
217c218
<     linkerd.io/created-by: linkerd/cli stable-2.14.0
---
>     linkerd.io/created-by: linkerd/cli git-006f6e2c
```