### PR TITLE
testutil: Mark test helper functions

### DIFF
--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -369,6 +369,7 @@ func (h *KubernetesHelper) URLFor(ctx context.Context, namespace, deployName str
 // WaitRollout blocks until all the given deployments have been completely
 // rolled out (and their pods are ready)
 func (h *KubernetesHelper) WaitRollout(t *testing.T, deploys map[string]DeploySpec) {
+	t.Helper()
 	// Use default context
 	h.WaitRolloutWithContext(t, deploys, h.k8sContext)
 }
@@ -376,6 +377,7 @@ func (h *KubernetesHelper) WaitRollout(t *testing.T, deploys map[string]DeploySp
 // WaitRolloutWithContext blocks until all the given deployments in a provided
 // k8s context have been completely rolled out (and their pods are ready)
 func (h *KubernetesHelper) WaitRolloutWithContext(t *testing.T, deploys map[string]DeploySpec, context string) {
+	t.Helper()
 	for deploy, deploySpec := range deploys {
 		stat, err := h.KubectlWithContext("", context, "--namespace="+deploySpec.Namespace,
 			"rollout", "status", "--timeout=5m", "deploy/"+deploy)


### PR DESCRIPTION
Our Go kubernetes test helpers take a testing.T without calling t.Helper() to ignore the stack frame.

This change adds t.Helper() so that failure annotations will mark the relevant test instead of the helper.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
