### PR TITLE
Add PDB on linkerd-viz Helm chart

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -98,6 +98,7 @@ Kubernetes: `>=1.21.0-0`
 | defaultUID | int | `2103` | UID for all the viz components |
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
+| enablePodDisruptionBudget | bool | `false` | enables the creation of pod disruption budgets for tap and tap-injector components |
 | grafana.externalUrl | string | `nil` | url of a Grafana instance hosted off-cluster. Cannot be set if grafana.url is set. The reverse proxy will not be used for this URL. |
 | grafana.uidPrefix | string | `nil` | prefix for Grafana dashboard UID's, used when grafana.externalUrl is set. |
 | grafana.url | string | `nil` | url of an in-cluster Grafana instance with reverse proxy configured, used by the Linkerd viz web dashboard to provide direct links to specific Grafana dashboards. Cannot be set if grafana.externalUrl is set. See the [Linkerd documentation](https://linkerd.io/2/tasks/grafana) for more information |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -98,7 +98,7 @@ Kubernetes: `>=1.21.0-0`
 | defaultUID | int | `2103` | UID for all the viz components |
 | enablePSP | bool | `false` | Create Roles and RoleBindings to associate this extension's ServiceAccounts to the control plane PSP resource. This requires that `enabledPSP` is set to true on the control plane install. Note PSP has been deprecated since k8s v1.21 |
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
-| enablePodDisruptionBudget | bool | `false` | enables the creation of pod disruption budgets for tap and tap-injector components |
+| enablePodDisruptionBudget | bool | `false` | enables the creation of pod disruption budgets for tap, tap-injector, web and metrics-api components |
 | grafana.externalUrl | string | `nil` | url of a Grafana instance hosted off-cluster. Cannot be set if grafana.url is set. The reverse proxy will not be used for this URL. |
 | grafana.uidPrefix | string | `nil` | prefix for Grafana dashboard UID's, used when grafana.externalUrl is set. |
 | grafana.url | string | `nil` | url of an in-cluster Grafana instance with reverse proxy configured, used by the Linkerd viz web dashboard to provide direct links to specific Grafana dashboards. Cannot be set if grafana.externalUrl is set. See the [Linkerd documentation](https://linkerd.io/2/tasks/grafana) for more information |

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -123,3 +123,24 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: metrics-api
+{{- if and .Values.enablePodDisruptionBudget (gt (int .Values.metricsAPI.replicas) 1) }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: metrics-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: metrics-api
+    namespace: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: viz
+      component: metrics-api
+{{- end }}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -127,7 +127,7 @@ spec:
       - name: tls
         secret:
           secretName: tap-injector-k8s-tls
-{{- if .Values.enablePodDisruptionBudget }}
+{{- if and .Values.enablePodDisruptionBudget (gt (int .Values.tapInjector.replicas) 1) }}
 ---
 kind: PodDisruptionBudget
 apiVersion: policy/v1

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -127,3 +127,24 @@ spec:
       - name: tls
         secret:
           secretName: tap-injector-k8s-tls
+{{- if .Values.enablePodDisruptionBudget }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: tap-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: tap-injector
+    namespace: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: viz
+      component: tap-injector
+{{- end }}

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -142,7 +142,7 @@ spec:
       - name: tls
         secret:
           secretName: tap-k8s-tls
-{{- if .Values.enablePodDisruptionBudget }}
+{{- if and .Values.enablePodDisruptionBudget (gt (int .Values.tap.replicas) 1) }}
 ---
 kind: PodDisruptionBudget
 apiVersion: policy/v1

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -142,3 +142,24 @@ spec:
       - name: tls
         secret:
           secretName: tap-k8s-tls
+{{- if .Values.enablePodDisruptionBudget }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: tap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: tap
+    namespace: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: viz
+      component: tap
+{{- end }}

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -139,3 +139,24 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: web
+{{- if and .Values.enablePodDisruptionBudget (gt (int .Values.dashboard.replicas) 1) }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    linkerd.io/extension: viz
+    component: web
+    namespace: {{.Release.Namespace}}
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      linkerd.io/extension: viz
+      component: web
+{{- end }}

--- a/viz/charts/linkerd-viz/values-ha.yaml
+++ b/viz/charts/linkerd-viz/values-ha.yaml
@@ -3,6 +3,7 @@
 #   helm install -f values.yaml -f values-ha.yaml
 
 enablePodAntiAffinity: true
+enablePodDisruptionBudget: true
 
 # nodeAffinity:
 

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -50,7 +50,7 @@ tolerations: &default_tolerations
 # Enable this only when you have multiple replicas of components.
 enablePodAntiAffinity: false
 
-# -- enables the creation of pod disruption budgets for tap and tap-injector components
+# -- enables the creation of pod disruption budgets for tap, tap-injector, web and metrics-api components
 enablePodDisruptionBudget: false
 
 # -- NodeAffinity section, See the

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -50,6 +50,9 @@ tolerations: &default_tolerations
 # Enable this only when you have multiple replicas of components.
 enablePodAntiAffinity: false
 
+# -- enables the creation of pod disruption budgets for tap and tap-injector components
+enablePodDisruptionBudget: false
+
 # -- NodeAffinity section, See the
 # [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
 # for more information


### PR DESCRIPTION
To avoid disruption during cluster nodes rolling or scaling, it's desired to complement the maxUnavailable from the rolling strategy with a PodDisruptionBudget.

This commit adds the respective PDB objects following the core components implementation to the `tap`, `tap-injector`, `web` and `metrics-api` deployments. It can be enabled with the enablePodDisruptionBudget helm chart value and are installed only if each of those components have more than 1 replica.

Fixes https://github.com/linkerd/linkerd2/issues/11248

Previous PR was close due inactivity (https://github.com/linkerd/linkerd2/pull/11249), sorry about that.

> I'm wondering if the PodDisruptionBudgets should apply to the other deployments in linkerd-viz as well, namely web, prometheus, and metrics-api. What do you think?

As requested there, I added in this new PR PDBs for `web` and `metrics-api`. `prometheus` has only fixed 1 replica; so it doesn't really make sense to add a PDB for it.