### PR TITLE
Introduce a new check for extension namespace configuration

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -175,6 +175,7 @@ func configureAndRunChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, o
 			checks = append(checks, healthcheck.LinkerdOpaquePortsDefinitionChecks)
 		} else {
 			checks = append(checks, healthcheck.LinkerdControlPlaneVersionChecks)
+			checks = append(checks, healthcheck.LinkerdExtensionChecks)
 		}
 		checks = append(checks, healthcheck.LinkerdCNIPluginChecks)
 		checks = append(checks, healthcheck.LinkerdHAChecks)

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2741,9 +2741,7 @@ func (hc *HealthChecker) checkExtensionNsLabels(ctx context.Context) error {
 		freq[ext] = append(freq[ext], fmt.Sprintf("\t\t* %s", ns.Name))
 	}
 
-	errs := []string{
-		"some extensions have invalid configuration:",
-	}
+	errs := []string{}
 	for ext, namespaces := range freq {
 		if len(namespaces) == 1 {
 			continue
@@ -2751,8 +2749,9 @@ func (hc *HealthChecker) checkExtensionNsLabels(ctx context.Context) error {
 		errs = append(errs, fmt.Sprintf("\t* label \"%s=%s\" is present on more than one namespace:\n%s", k8s.LinkerdExtensionLabel, ext, strings.Join(namespaces, "\n")))
 	}
 
-	if len(errs) > 1 {
-		return errors.New(strings.Join(errs, "\n"))
+	if len(errs) > 0 {
+		return errors.New(strings.Join(
+			append([]string{"some extensions have invalid configuration"}, errs...), "\n"))
 	}
 
 	return nil

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -138,6 +138,10 @@ const (
 	// corresponding pods
 	LinkerdOpaquePortsDefinitionChecks CategoryID = "linkerd-opaque-ports-definition"
 
+	// LinkerdExtensionChecks adds checks to validate configuration for all
+	// extensions discovered in the cluster at runtime
+	LinkerdExtensionChecks CategoryID = "linkerd-extension-checks"
+
 	// LinkerdCNIResourceLabel is the label key that is used to identify
 	// whether a Kubernetes resource is related to the install-cni command
 	// The value is expected to be "true", "false" or "", where "false" and
@@ -1414,6 +1418,20 @@ func (hc *HealthChecker) allCategories() []*Category {
 			},
 			false,
 		),
+		NewCategory(
+			LinkerdExtensionChecks,
+			[]Checker{
+				{
+					description: "namespace configuration for extensions",
+					warning:     true,
+					hintAnchor:  "l5d-extension-namespaces",
+					check: func(ctx context.Context) error {
+						return hc.checkExtensionNsLabels(ctx)
+					},
+				},
+			},
+			false,
+		),
 	}
 }
 
@@ -2673,7 +2691,7 @@ func (hc *HealthChecker) checkExtensionAPIServerAuthentication(ctx context.Conte
 func (hc *HealthChecker) checkClockSkew(ctx context.Context) error {
 	if hc.kubeAPI == nil {
 		// we should never get here
-		return fmt.Errorf("unexpected error: Kubernetes ClientSet not initialized")
+		return errors.New("unexpected error: Kubernetes ClientSet not initialized")
 	}
 
 	var clockSkewNodes []string
@@ -2700,6 +2718,55 @@ func (hc *HealthChecker) checkClockSkew(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (hc *HealthChecker) checkExtensionNsLabels(ctx context.Context) error {
+	if hc.kubeAPI == nil {
+		// oops something wrong happened
+		return errors.New("unexpected error: Kubernetes ClientSet not initialized")
+	}
+
+	namespaces, err := hc.kubeAPI.GetAllNamespacesWithExtensionLabel(ctx)
+	if err != nil {
+		return fmt.Errorf("unexpected error when retrieving namespaces: %s", err)
+	}
+
+	freq := make(map[string][]string)
+	for _, ns := range namespaces {
+		// We can guarantee the namespace has the extension label since we used
+		// a label selector when retrieving namespaces
+		ext := ns.Labels[k8s.LinkerdExtensionLabel]
+		// To make it easier to print, store already error-formatted namespace
+		// in freq table
+		freq[ext] = append(freq[ext], fmt.Sprintf("\t * %s", ns.Name))
+	}
+
+	errs := []string{}
+	for ext, namespaces := range freq {
+		if len(namespaces) == 1 {
+			continue
+		}
+		errs = append(errs, fmt.Sprintf("* label \"%s=%s\" is present on more than one namespace:\n%s", k8s.LinkerdExtensionLabel, ext, strings.Join(namespaces, "\n")))
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n "))
+	}
+
+	return nil
+
+	/*
+		if err != nil {
+			return false, false, err
+		}
+		nsLabels := []string{}
+		for _, ns := range namespaces {
+			ext := ns.Labels[k8s.LinkerdExtensionLabel]
+			nsLabels = append(nsLabels, ext)
+		}
+
+	*/
+
 }
 
 // CheckRoles checks that the expected roles exist.

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2728,7 +2728,7 @@ func (hc *HealthChecker) checkExtensionNsLabels(ctx context.Context) error {
 
 	namespaces, err := hc.kubeAPI.GetAllNamespacesWithExtensionLabel(ctx)
 	if err != nil {
-		return fmt.Errorf("unexpected error when retrieving namespaces: %v", err)
+		return fmt.Errorf("unexpected error when retrieving namespaces: %w", err)
 	}
 
 	freq := make(map[string][]string)

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2728,7 +2728,7 @@ func (hc *HealthChecker) checkExtensionNsLabels(ctx context.Context) error {
 
 	namespaces, err := hc.kubeAPI.GetAllNamespacesWithExtensionLabel(ctx)
 	if err != nil {
-		return fmt.Errorf("unexpected error when retrieving namespaces: %s", err)
+		return fmt.Errorf("unexpected error when retrieving namespaces: %v", err)
 	}
 
 	freq := make(map[string][]string)
@@ -2738,35 +2738,24 @@ func (hc *HealthChecker) checkExtensionNsLabels(ctx context.Context) error {
 		ext := ns.Labels[k8s.LinkerdExtensionLabel]
 		// To make it easier to print, store already error-formatted namespace
 		// in freq table
-		freq[ext] = append(freq[ext], fmt.Sprintf("\t * %s", ns.Name))
+		freq[ext] = append(freq[ext], fmt.Sprintf("\t\t* %s", ns.Name))
 	}
 
-	errs := []string{}
+	errs := []string{
+		"some extensions have invalid configuration:",
+	}
 	for ext, namespaces := range freq {
 		if len(namespaces) == 1 {
 			continue
 		}
-		errs = append(errs, fmt.Sprintf("* label \"%s=%s\" is present on more than one namespace:\n%s", k8s.LinkerdExtensionLabel, ext, strings.Join(namespaces, "\n")))
+		errs = append(errs, fmt.Sprintf("\t* label \"%s=%s\" is present on more than one namespace:\n%s", k8s.LinkerdExtensionLabel, ext, strings.Join(namespaces, "\n")))
 	}
 
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "\n "))
+	if len(errs) > 1 {
+		return errors.New(strings.Join(errs, "\n"))
 	}
 
 	return nil
-
-	/*
-		if err != nil {
-			return false, false, err
-		}
-		nsLabels := []string{}
-		for _, ns := range namespaces {
-			ext := ns.Labels[k8s.LinkerdExtensionLabel]
-			nsLabels = append(nsLabels, ext)
-		}
-
-	*/
-
 }
 
 // CheckRoles checks that the expected roles exist.

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -516,7 +516,7 @@ metadata:
 			description: "fails invalid configuration",
 			k8sConfigs:  []string{namespaces["vizOne"], namespaces["mcOne"], namespaces["mcTwo"]},
 			results: []string{
-				"linkerd-extension-checks namespace configuration for extensions: some extensions have invalid configuration:\n\t* label \"linkerd.io/extension=multicluster\" is present on more than one namespace:\n\t\t* mc-1\n\t\t* mc-2",
+				"linkerd-extension-checks namespace configuration for extensions: some extensions have invalid configuration\n\t* label \"linkerd.io/extension=multicluster\" is present on more than one namespace:\n\t\t* mc-1\n\t\t* mc-2",
 			},
 		},
 	}

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -473,6 +473,80 @@ status:
 
 }
 
+func TestNamespaceExtCfg(t *testing.T) {
+	namespaces := map[string]string{
+		"vizOne": `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: viz-1
+  labels:
+    linkerd.io/extension: viz
+`,
+		"mcOne": `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mc-1
+  labels:
+    linkerd.io/extension: multicluster
+`,
+		"mcTwo": `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mc-2
+  labels:
+    linkerd.io/extension: multicluster
+`}
+
+	testCases := []struct {
+		description string
+		k8sConfigs  []string
+		results     []string
+	}{
+		{
+			description: "successfully passes checks",
+			k8sConfigs:  []string{namespaces["vizOne"], namespaces["mcOne"]},
+			results: []string{
+				"linkerd-extension-checks namespace configuration for extensions",
+			},
+		},
+		{
+			description: "fails invalid configuration",
+			k8sConfigs:  []string{namespaces["vizOne"], namespaces["mcOne"], namespaces["mcTwo"]},
+			results: []string{
+				"linkerd-extension-checks namespace configuration for extensions: some extensions have invalid configuration:\n\t* label \"linkerd.io/extension=multicluster\" is present on more than one namespace:\n\t\t* mc-1\n\t\t* mc-2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		// pin tc
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			hc := NewHealthChecker(
+				[]CategoryID{LinkerdExtensionChecks},
+				&Options{
+					ControlPlaneNamespace: "test-ns",
+				},
+			)
+
+			var err error
+			hc.kubeAPI, err = k8s.NewFakeAPI(tc.k8sConfigs...)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			obs := newObserver()
+			hc.RunChecks(obs.resultFn)
+			if diff := deep.Equal(obs.results, tc.results); diff != nil {
+				t.Fatalf("%+v", diff)
+			}
+		})
+	}
+}
+
 func TestConfigExists(t *testing.T) {
 
 	namespace := []string{`


### PR DESCRIPTION
Linkerd's extension model requires that each namespace that "owns" an extension to be labelled with the extension name. Core extensions in particular strictly follow this pattern. For example, the namespace viz is installed in would be labelled with `linkerd.io/extension=viz`.

The extension is used by the CLI in many different instances. It is used in checks, it is used in uninstalls, and so on. Whenever a namespace contains a duplicate label value (e.g. two namespaces are registered as the owner of "viz") we introduce undefined behaviour. Extension checks or uninstalls may or may not work correctly. These issues are not straightforward to debug. Misconfiguration can be introduced due to a variety of reasons.

This change adds a new "core" category (`linkerd-extension-checks`) and a new checker that asserts all extension namespaces are configured properly. There are two reasons why this has been made a "core" extension:

* Extensions may have their own health checking library. It is hard to share a common abstraction here without duplicating the logic. For example, viz imports the healthchecking package whereas the multicluster extension has its own. A dedicated core check will work better with all extensions that opt-in to use linkerd's extension label.
* Being part of the core checks means this is going to run before any of the other extension checks do which might improve visibility.

The change is straightforward; if an extension value is used for the label key more than once across the cluster, the check issues a warning along with the namespaces the label key and value tuple exists on.

This should be followed-up with a docs change.

Closes #11509

---

## Manual QA

Failure:

```
:; k get ns -l linkerd.io/extension=multicluster
NAME                   STATUS   AGE
linkerd-multicluster   Active   23h
default            

kubernetes-api
--------------
√ can initialize the client
√ can query the Kubernetes API

linkerd-webhooks-and-apisvc-tls
-------------------------------
√ proxy-injector webhook has valid cert
√ proxy-injector cert is valid for at least 60 days
√ sp-validator webhook has valid cert
√ sp-validator cert is valid for at least 60 days
√ policy-validator webhook has valid cert
√ policy-validator cert is valid for at least 60 days

linkerd-version
---------------
√ can determine the latest version
‼ cli is up-to-date
    unsupported version channel: dev-78a5ec56-matei
    see https://linkerd.io/2/checks/#l5d-version-cli for hints

...

linkerd-extension-checks
------------------------
‼ namespace configuration for extensions
    some extensions have invalid configuration:
        * label "linkerd.io/extension=multicluster" is present on more than one namespace:
                * linkerd-multicluster
                * default
        * label "linkerd.io/extension=viz" is present on more than one namespace:
                * test
                * test2
    see https://linkerd.io/2/checks/#l5d-extension-namespaces for hints


linkerd-multicluster
--------------------
√ Link CRD exists
√ Link resources are valid
        * target

Status check results are √
```

Success:

```
:; k label ns default linkerd.io/extension=m --overwrite
namespace/default labeled

linkerd-extension-checks
------------------------
√ namespace configuration for extensions

linkerd-multicluster
--------------------
√ Link CRD exists
√ Link resources are valid
        * target
√ remote cluster access credentials are valid
        * target
√ clusters share trust anchors
        * target
√ service mirror controller has required permissions
        * target
```

## Alternatives

* We could fail the check instead of issuing a warning


<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
