### PR TITLE
Bump prometheus to v2.48.0

### DIFF
--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -418,7 +418,7 @@ prometheus:
     # -- Docker image name for the prometheus instance
     name: prometheus
     # -- Docker image tag for the prometheus instance
-    tag: v2.47.0
+    tag: v2.48.0
     # -- Pull policy for the prometheus instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""
@@ -440,7 +440,7 @@ prometheus:
     scrape_interval: 10s
     scrape_timeout: 10s
     evaluation_interval: 10s
-  
+
   # -- annotations for the prometheus pod
   podAnnotations: {}
 

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -732,7 +732,7 @@ spec:
         - --log.level=debug
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -736,7 +736,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This gets rids of most CVEs:

```bash
$ grype -q prom/prometheus:v2.47.0
NAME                                                           INSTALLED             FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/docker/docker                                       v24.0.4+incompatible  24.0.7    go-module  GHSA-jq35-85cj-fj4p  Medium
github.com/prometheus/alertmanager                             v0.25.0               0.25.1    go-module  GHSA-v86x-5fm3-5p7j  Medium
github.com/prometheus/alertmanager                             v0.25.0                         go-module  CVE-2023-40577       Medium
go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp  v0.42.0               0.44.0    go-module  GHSA-rcjv-mgp8-qvmr  High
golang.org/x/net                                               v0.12.0               0.17.0    go-module  GHSA-4374-p667-p6c8  High
golang.org/x/net                                               v0.12.0               0.17.0    go-module  GHSA-qppj-fm5r-hxr3  Medium
golang.org/x/net                                               v0.12.0               0.13.0    go-module  GHSA-2wrh-6pvc-2jm9  Medium
google.golang.org/grpc                                         v1.56.2               1.56.3    go-module  GHSA-m425-mq94-257g  High
google.golang.org/grpc                                         v1.56.2               1.56.3    go-module  GHSA-qppj-fm5r-hxr3  Medium

$ grype -q prom/prometheus:v2.48.0
NAME                      INSTALLED             FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/docker/docker  v24.0.6+incompatible  24.0.7    go-module  GHSA-jq35-85cj-fj4p  Medium
```