### PR TITLE
edge-23.11.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,11 @@
 
 ## edge-23.11.4
 
-This edge release introduces support for the native sidecar containers added in
-Kubernetes 1.29, improving proxy sidecar compatibility for jobs and
-initContainers. In addition, it includes Helm chart improvements, and
-improvements to the multicluster extension.
+This edge release introduces support for the native sidecar containers entering
+beta support in Kubernetes 1.29. This improves the startup and shutdown ordering
+for the proxy relative to other containers, such as `job`s and `initContainer`s.
+In addition, this edge release includes Helm chart improvements, and improvements
+to the multicluster extension.
 
 * Added a new `config.alpha.linkerd.io/proxy-enable-native-sidecar` annotation
   and `Proxy.NativeSidecar` Helm option that causes the proxy container to run

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,35 @@
 # Changes
 
+## edge-23.11.4
+
+This edge release introduces support for the native sidecar containers added in
+Kubernetes 1.29, improving proxy sidecar compatibility for jobs and
+initContainers. In addition, it includes Helm chart improvements, and
+improvements to the multicluster extension.
+
+* Added a new `config.alpha.linkerd.io/proxy-enable-native-sidecar` annotation
+  and `Proxy.NativeSidecar` Helm option that causes the proxy container to run
+  as an init-container (thanks @teejaded!) ([#11465]; fixes [#11461])
+* Fixed broken affinity rules for the multicluster `service-mirror` when running
+  in HA mode ([#11609]; fixes [#11603])
+* Added a new check to `linkerd check` that ensures all extension namespaces are
+  configured properly ([#11629]; fixes [#11509])
+* Updated the Prometheus Docker image used by the `linkerd-viz` extension to
+  v2.48.0, resolving a number of CVEs in older Prometheus versions ([#11633])
+* Added `nodeAffinity` to `deployment` templates in the `linkerd-viz` and
+  `linkerd-jaeger` Helm charts (thanks @naing2victor!) ([#11464]; fixes
+  [#10680])
+
+[#11465]: https://github.com/linkerd/linkerd2/pull/11465
+[#11461]: https://github.com/linkerd/linkerd2/issues/11461
+[#11609]: https://github.com/linkerd/linkerd2/pull/11609
+[#11603]: https://github.com/linkerd/linkerd2/issues/11603
+[#11629]: https://github.com/linkerd/linkerd2/pull/11629
+[#11509]: https://github.com/linkerd/linkerd2/issues/11509
+[#11633]: https://github.com/linkerd/linkerd2/pull/11633
+[#11464]: https://github.com/linkerd/linkerd2/pull/11464
+[#10680]: https://github.com/linkerd/linkerd2/issues/10680
+
 ## edge-23.11.3
 
 This edge release fixes a bug where Linkerd could cause EOF errors during bursts

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,10 @@
 
 This edge release introduces support for the native sidecar containers entering
 beta support in Kubernetes 1.29. This improves the startup and shutdown ordering
-for the proxy relative to other containers, such as `job`s and `initContainer`s.
+for the proxy relative to other containers, fixing the long-standing
+shutdown issue with injected `Job`s. Furthermore, traffic from other
+`initContainer`s can now be proxied by Linkerd.
+
 In addition, this edge release includes Helm chart improvements, and improvements
 to the multicluster extension.
 

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.17.8-edge
+version: 1.17.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.17.8-edge](https://img.shields.io/badge/Version-1.17.8--edge-informational?style=flat-square)
+![Version: 1.17.9-edge](https://img.shields.io/badge/Version-1.17.9--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.8-edge
+version: 30.13.9-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.13.8-edge](https://img.shields.io/badge/Version-30.13.8--edge-informational?style=flat-square)
+![Version: 30.13.9-edge](https://img.shields.io/badge/Version-30.13.9--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.7-edge
+version: 30.12.8-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.12.7-edge](https://img.shields.io/badge/Version-30.12.7--edge-informational?style=flat-square)
+![Version: 30.12.8-edge](https://img.shields.io/badge/Version-30.12.8--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.13.7-edge
+version: 30.13.8-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.13.7-edge](https://img.shields.io/badge/Version-30.13.7--edge-informational?style=flat-square)
+![Version: 30.13.8-edge](https://img.shields.io/badge/Version-30.13.8--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.11.4

This edge release introduces support for the native sidecar containers
added in Kubernetes 1.29, improving proxy sidecar compatibility for jobs
and initContainers. In addition, it includes Helm chart improvements,
and improvements to the multicluster extension.

* Added a new `config.alpha.linkerd.io/proxy-enable-native-sidecar`
  annotation and `Proxy.NativeSidecar` Helm option that causes the proxy
  container to run as an init-container (thanks @teejaded!) (#11465;
  fixes #11461)
* Fixed broken affinity rules for the multicluster `service-mirror` when
  running in HA mode (#11609; fixes #11603)
* Added a new check to `linkerd check` that ensures all extension
  namespaces are configured properly (#11629; fixes #11509)
* Updated the Prometheus Docker image used by the `linkerd-viz`
  extension to v2.48.0, resolving a number of CVEs in older Prometheus
  versions (#11633)
* Added `nodeAffinity` to `deployment` templates in the `linkerd-viz`
  and `linkerd-jaeger` Helm charts (thanks @naing2victor!) (#11464;
  fixes #10680)