### PR TITLE
Add support for private registry in helm chart (#11672)

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -160,6 +160,7 @@ Kubernetes: `>=1.21.0-0`
 | debugContainer.image.name | string | `"cr.l5d.io/linkerd/debug"` | Docker image for the debug container |
 | debugContainer.image.pullPolicy | string | imagePullPolicy | Pull policy for the debug container image |
 | debugContainer.image.version | string | linkerdVersion | Tag for the debug container image |
+| defaultRegistry | string | `""` | Docker registry to use. If set, will overwrite the registry domain in all images. |
 | deploymentStrategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"}}` | default kubernetes deployment strategy |
 | disableHeartBeat | bool | `false` | Set to true to not start the heartbeat cronjob |
 | enableEndpointSlices | bool | `true` | enables the use of EndpointSlice informers for the destination service; enableEndpointSlices should be set to true only if EndpointSlice K8s feature gate is on |

--- a/charts/linkerd-control-plane/templates/config.yaml
+++ b/charts/linkerd-control-plane/templates/config.yaml
@@ -33,6 +33,12 @@ data:
   {{- if (empty $values.identityTrustDomain) -}}
   {{- $_ := set $values "identityTrustDomain" $values.clusterDomain}}
   {{- end -}}
+  {{- $_ := set $values "controllerImage" (include "partials.images.controller" . | trim | split ":")._0 }}
+  {{- $_ := set $values.policyController.image "name" (include "partials.images.policy" . | trim | split ":")._0 }}
+  {{- $_ := set $values.proxy.image "name" (include "partials.images.proxy" . | trim | split ":")._0 }}
+  {{- $_ := set $values.proxyInit.image "name" (include "partials.images.proxyInit" . | trim | split ":")._0 }}
+  {{- $_ := set $values.debugContainer.image "name" (include "partials.images.debug" . | trim | split ":")._0 }}
+  {{- $_ := unset $values "defaultRegistry"}}
   {{- $_ := unset $values "partials"}}
   {{- $_ := unset $values "configs"}}
   {{- $_ := unset $values "stage"}}

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -206,7 +206,7 @@ spec:
         - -default-opaque-ports={{.Values.proxy.opaquePorts}}
         - -enable-pprof={{.Values.enablePprof | default false}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
-        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
+        image: {{ include "partials.images.controller" . }}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:
@@ -242,7 +242,7 @@ spec:
         - -log-level={{.Values.controllerLogLevel}}
         - -log-format={{.Values.controllerLogFormat}}
         - -enable-pprof={{.Values.enablePprof | default false}}
-        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
+        image: {{ include "partials.images.controller" . }}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:
@@ -294,7 +294,7 @@ spec:
         {{- if .Values.policyController.probeNetworks }}
         - --probe-networks={{.Values.policyController.probeNetworks | join ","}}
         {{- end}}
-        image: {{.Values.policyController.image.name}}:{{.Values.policyController.image.version | default .Values.linkerdVersion}}
+        image: {{ include "partials.images.policy" . }}
         imagePullPolicy: {{.Values.policyController.image.pullPolicy | default .Values.imagePullPolicy}}
         livenessProbe:
           httpGet:

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -54,7 +54,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: heartbeat
-            image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
+            image: {{ include "partials.images.controller" . }}
             imagePullPolicy: {{.Values.imagePullPolicy}}
             env:
             - name: LINKERD_DISABLED

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -165,7 +165,7 @@ spec:
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"
-        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
+        image: {{ include "partials.images.controller" . }}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -79,7 +79,7 @@ spec:
         - -log-format={{.Values.controllerLogFormat}}
         - -linkerd-namespace={{.Release.Namespace}}
         - -enable-pprof={{.Values.enablePprof | default false}}
-        image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
+        image: {{ include "partials.images.controller" . }}
         imagePullPolicy: {{.Values.imagePullPolicy}}
         livenessProbe:
           httpGet:

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -291,6 +291,9 @@ networkValidator:
   # -- Include a securityContext in the network-validator pod spec
   enableSecurityContext: true
 
+# -- Docker registry to use. If set, will overwrite the registry domain in all images.
+defaultRegistry: ""
+
 # -- For Private docker registries, authentication is needed.
 #  Registry secrets are applied to the respective service accounts
 imagePullSecrets: []

--- a/charts/partials/templates/_debug.tpl
+++ b/charts/partials/templates/_debug.tpl
@@ -1,5 +1,5 @@
 {{- define "partials.debug" -}}
-image: {{.Values.debugContainer.image.name}}:{{.Values.debugContainer.image.version | default .Values.linkerdVersion}}
+image: {{ include "partials.images.debug" . }}
 imagePullPolicy: {{.Values.debugContainer.image.pullPolicy | default .Values.imagePullPolicy}}
 name: linkerd-debug
 terminationMessagePolicy: FallbackToLogsOnError

--- a/charts/partials/templates/_images.tpl
+++ b/charts/partials/templates/_images.tpl
@@ -1,0 +1,49 @@
+{{/*
+Replace the registry domain of each image with `defaultRegistry` if it is set.
+Otherwise, default to the image name provided in values.yaml
+*/}}
+
+{{- define "partials.images.controller" -}}
+{{- $ver := .Values.controllerImageVersion | default .Values.linkerdVersion -}}
+{{- if ne .Values.defaultRegistry "" -}}
+{{ .Values.controllerImage | replace (split "/" .Values.controllerImage)._0 .Values.defaultRegistry -}}:{{ $ver -}}
+{{ else -}}
+{{ .Values.controllerImage }}:{{ $ver -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "partials.images.policy" -}}
+{{- $ver := .Values.policyController.image.version | default .Values.linkerdVersion -}}
+{{- if ne .Values.defaultRegistry "" -}}
+{{ .Values.policyController.image.name | replace (split "/" .Values.policyController.image.name )._0 .Values.defaultRegistry -}}:{{ $ver -}}
+{{ else -}}
+{{ .Values.policyController.image.name }}:{{ $ver -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "partials.images.debug" -}}
+{{- $ver := .Values.debugContainer.image.version | default .Values.linkerdVersion -}}
+{{- if ne .Values.defaultRegistry "" -}}
+{{ .Values.debugContainer.image.name | replace (split "/" .Values.debugContainer.image.name )._0 .Values.defaultRegistry -}}:{{ $ver -}}
+{{ else -}}
+{{ .Values.debugContainer.image.name }}:{{ $ver -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "partials.images.proxy" -}}
+{{- $ver := .Values.proxy.image.version | default .Values.linkerdVersion -}}
+{{- if ne .Values.defaultRegistry "" -}}
+{{ .Values.proxy.image.name | replace (split "/" .Values.proxy.image.name )._0 .Values.defaultRegistry -}}:{{ $ver -}}
+{{ else -}}
+{{ .Values.proxy.image.name }}:{{ $ver -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "partials.images.proxyInit" -}}
+{{- $ver := .Values.proxyInit.image.version -}}
+{{- if ne .Values.defaultRegistry "" -}}
+{{ .Values.proxyInit.image.name | replace (split "/" .Values.proxyInit.image.name )._0 .Values.defaultRegistry -}}:{{ $ver -}}
+{{ else -}}
+{{.Values.proxyInit.image.name }}:{{ $ver -}}
+{{- end -}}
+{{- end -}}

--- a/charts/partials/templates/_network-validator.tpl
+++ b/charts/partials/templates/_network-validator.tpl
@@ -1,6 +1,6 @@
 {{- define "partials.network-validator" -}}
 name: linkerd-network-validator
-image: {{.Values.proxy.image.name}}:{{.Values.proxy.image.version | default .Values.linkerdVersion }}
+image: {{ include "partials.images.proxy" . }}
 imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPolicy}}
 {{ include "partials.resources" .Values.proxyInit.resources }}
 {{- if or .Values.networkValidator.enableSecurityContext }}

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -36,7 +36,7 @@ args:
 - --subnets-to-ignore
 - {{ .Values.proxyInit.skipSubnets | quote }}
 {{- end }}
-image: {{.Values.proxyInit.image.name}}:{{.Values.proxyInit.image.version}}
+image: {{ include "partials.images.proxyInit" . }}
 imagePullPolicy: {{.Values.proxyInit.image.pullPolicy | default .Values.imagePullPolicy}}
 name: linkerd-init
 {{ include "partials.resources" .Values.proxyInit.resources }}

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -153,7 +153,7 @@ be used in other contexts.
 - name: LINKERD2_PROXY_SHUTDOWN_GRACE_PERIOD
   value: {{.Values.proxy.shutdownGracePeriod | quote}}
 {{ end -}}
-image: {{.Values.proxy.image.name}}:{{.Values.proxy.image.version | default .Values.linkerdVersion}}
+image: {{ include "partials.images.proxy" . }}
 imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPolicy}}
 livenessProbe:
   httpGet:


### PR DESCRIPTION
Current `linkerd-control-plane` helm chart does not support setting of container registry for all images. The `linkerd-cli` support this with `--registry` argument.

Added "registry" to `values.yaml` with the default of "cr.l5d.io". This value is used in combination with the image name in each template.

Run `helm install` with `--set registry=my-private.azurecr.io` and all linkerd images will be pulled from the private registry.

Fixes #11672