### PR TITLE
boilerplate ingress object

### DIFF
--- a/viz/charts/linkerd-viz/templates/ingress.yaml
+++ b/viz/charts/linkerd-viz/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     linkerd.io/extension: viz
     {{- with .Values.ingress.annotations }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
   - host: {{ required "Ingress host required" .Values.ingress.host }}
     http:

--- a/viz/charts/linkerd-viz/templates/ingress.yaml
+++ b/viz/charts/linkerd-viz/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    linkerd.io/extension: viz
+    {{- with .Values.ingress.annotations }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ required "Ingress host required" .Values.ingress.host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web
+            port:
+              number: 8084
+{{- end }}

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -416,6 +416,7 @@ grafana:
 
 ingress:
   enabled: false
+  className: nginx
   host: ""
   annotations:
     nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -414,6 +414,18 @@ grafana:
   # set.
   uidPrefix:
 
+ingress:
+  enabled: false
+  host: ""
+  annotations:
+    nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Origin "";
+      proxy_hide_header l5d-remote-ip;
+      proxy_hide_header l5d-server-id;
+    nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+
 prometheus:
   # -- toggle field to enable or disable prometheus
   enabled: true


### PR DESCRIPTION
```
helm template . -s templates/ingress.yaml --set ingress.enabled=true --set ingress.host=example.com
---
# Source: linkerd-viz/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: web
  namespace: default
  annotations:
    linkerd.io/extension: viz
    nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
    nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
    nginx.ingress.kubernetes.io/configuration-snippet: |
      proxy_set_header Origin "";
      proxy_hide_header l5d-remote-ip;
      proxy_hide_header l5d-server-id;
    nginx.ingress.kubernetes.io/upstream-vhost: $service_name.$namespace.svc.cluster.local:8084
spec:
  ingressClassName: nginx
  rules:
  - host: example.com
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: web
            port:
              number: 8084
```