### PR TITLE
stable-2.14.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,31 @@
 # Changes
 
+## stable-2.14.6
+
+This stable release back-ports bugfixes and improvements from recent edge
+releases.
+
+* multicluster: Added an `imagePullSecrets` configuration to
+  linkerd-multicluster Helm chart (thanks @lhaussknecht!). ([#11287])
+* multicluster: Updated the service mirror to support gateways exposed on
+  multiple IP addresses (thanks @MrFreezeex!) ([#11499])
+* Updated control plane logging so that client-go may emit error logs. This will
+  also ensures that all logs are emitted in JSON when the json log format is
+  enabled. ([#11632])
+* Added `kubeAPI.clientBurst` and `kubeAPI.clientQPS` configurations that allow
+  users to configure the burst and QPS rate limits for the Kubernetes API
+  clients used by the control plane. The default burst and qps values are now
+  set at 200 and 100, respectively. The prior defaults limited bursts 10 and QPS
+  to 5, which could cause throttling issues in clusters that schedule many pods
+  quickly. ([#11644])
+* viz: Update the default prometheus version to v2.48.0. ([#11633])
+
+[#11287]: https://github.com/linkerd/linkerd2/pull/11287
+[#11499]: https://github.com/linkerd/linkerd2/pull/11499
+[#11632]: https://github.com/linkerd/linkerd2/pull/11632
+[#11644]: https://github.com/linkerd/linkerd2/pull/11644
+[#11633]: https://github.com/linkerd/linkerd2/pull/11633
+
 ## stable-2.14.5
 
 This stable release fixes a proxy regression where bursts of TCP connections

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.16.6
+version: 1.16.7
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -175,11 +175,15 @@ Kubernetes: `>=1.21.0-0`
 | identity.issuer.tls | object | `{"crtPEM":"","keyPEM":""}` | Which scheme is used for the identity issuer secret format |
 | identity.issuer.tls.crtPEM | string | `""` | Issuer certificate (ECDSA). It must be provided during install. |
 | identity.issuer.tls.keyPEM | string | `""` | Key for the issuer certificate (ECDSA). It must be provided during install |
+| identity.kubeAPI.clientBurst | int | `200` | Burst value over clientQPS |
+| identity.kubeAPI.clientQPS | int | `100` | Maximum QPS sent to the kube-apiserver before throttling. See [token bucket rate limiter implementation](https://github.com/kubernetes/client-go/blob/v12.0.0/util/flowcontrol/throttle.go) |
 | identity.serviceAccountTokenProjection | bool | `true` | Use [Service Account token Volume projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) for pod validation instead of the default token |
 | identityTrustAnchorsPEM | string | `""` | Trust root certificate (ECDSA). It must be provided during install. |
 | identityTrustDomain | string | clusterDomain | Trust domain used for identity |
 | imagePullPolicy | string | `"IfNotPresent"` | Docker image pull policy |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
+| kubeAPI.clientBurst | int | `200` | Burst value over clientQPS |
+| kubeAPI.clientQPS | int | `100` | Maximum QPS sent to the kube-apiserver before throttling. See [token bucket rate limiter implementation](https://github.com/kubernetes/client-go/blob/v12.0.0/util/flowcontrol/throttle.go) |
 | linkerdVersion | string | `"linkerdVersionValue"` | control plane version. See Proxy section for proxy version |
 | networkValidator.connectAddr | string | `"1.1.1.1:20001"` | Address to which the network-validator will attempt to connect. we expect this to be rewritten |
 | networkValidator.enableSecurityContext | bool | `true` | Include a securityContext in the network-validator pod spec |

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -159,6 +159,8 @@ spec:
         - -identity-clock-skew-allowance={{.Values.identity.issuer.clockSkewAllowance}}
         - -identity-scheme={{.Values.identity.issuer.scheme}}
         - -enable-pprof={{.Values.enablePprof | default false}}
+        - -kube-apiclient-qps={{.Values.identity.kubeAPI.clientQPS}}
+        - -kube-apiclient-burst={{.Values.identity.kubeAPI.clientBurst}}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
         env:
         - name: LINKERD_DISABLED

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -48,6 +48,13 @@ identityTrustAnchorsPEM: |
 # -- Trust domain used for identity
 # @default -- clusterDomain
 identityTrustDomain: ""
+kubeAPI: &kubeapi
+  # -- Maximum QPS sent to the kube-apiserver before throttling.
+  # See [token bucket rate limiter
+  # implementation](https://github.com/kubernetes/client-go/blob/v12.0.0/util/flowcontrol/throttle.go)
+  clientQPS: 100
+  # -- Burst value over clientQPS
+  clientBurst: 200
 # -- Additional annotations to add to all pods
 podAnnotations: {}
 # -- Additional labels to add to all pods
@@ -327,6 +334,7 @@ identity:
 
   # -- Use [Service Account token Volume projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) for pod validation instead of the default token
   serviceAccountTokenProjection: true
+
   issuer:
     scheme: linkerd.io/tls
 
@@ -344,6 +352,8 @@ identity:
       # -- Key for the issuer certificate (ECDSA). It must be provided during
       # install
       keyPEM: |
+
+  kubeAPI: *kubeapi
 
 # -|- CPU, Memory and Ephemeral Storage resources required by the identity controller (see `proxy.resources` for sub-fields)
 #identityResources:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         - -trace-collector=collector.linkerd-jaeger.svc.cluster.local:55678
         env:
         - name: LINKERD_DISABLED

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: false
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -538,6 +538,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources:
@@ -925,6 +928,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -538,6 +538,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources:
@@ -925,6 +928,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -451,6 +451,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -785,6 +788,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -509,6 +509,9 @@ data:
         scheme: linkerd.io/tls
         tls:
           crtPEM: test-crt-pem
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -827,6 +830,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -527,6 +527,9 @@ data:
         scheme: linkerd.io/tls
         tls:
           crtPEM: test-crt-pem
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources:
@@ -898,6 +901,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -527,6 +527,9 @@ data:
         scheme: linkerd.io/tls
         tls:
           crtPEM: test-crt-pem
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources:
@@ -906,6 +909,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -522,6 +522,9 @@ data:
         scheme: linkerd.io/tls
         tls:
           crtPEM: test-crt-pem
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources:
@@ -888,6 +891,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -513,6 +513,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -830,6 +833,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -520,6 +520,9 @@ data:
             AiAtuoI5XuCtrGVRzSmRTl2ra28aV9MyTU7d5qnTAFHKSgIgRKCvluOSgA5O21p5
             51tdrmkHEZRr0qlLSJdHYgEfMzk=
             -----END CERTIFICATE-----
+      kubeAPI:
+        clientBurst: 200
+        clientQPS: 100
       serviceAccountTokenProjection: true
     identityProxyResources: null
     identityResources: null
@@ -854,6 +857,8 @@ spec:
         - -identity-clock-skew-allowance=20s
         - -identity-scheme=linkerd.io/tls
         - -enable-pprof=false
+        - -kube-apiclient-qps=100
+        - -kube-apiclient-burst=200
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -424,6 +424,7 @@ func testUpgradeOptions() (flagOptions, error) {
 }
 
 func testOptions(t *testing.T) (*charts.Values, flagOptions) {
+	t.Helper()
 	installValues, err := testInstallOptions()
 	if err != nil {
 		t.Fatalf("failed to create install options: %s", err)
@@ -444,10 +445,12 @@ func replaceVersions(manifest string) string {
 }
 
 func generateIssuerCerts(t *testing.T, b64encode bool) issuerCerts {
+	t.Helper()
 	return generateCerts(t, "identity.linkerd.cluster.local", b64encode)
 }
 
 func generateCerts(t *testing.T, name string, b64encode bool) issuerCerts {
+	t.Helper()
 	ca, err := tls.GenerateRootCAWithDefaults("test")
 	if err != nil {
 		t.Fatal(err)
@@ -572,6 +575,7 @@ func pathMatch(path []string, template []string) bool {
 }
 
 func renderInstall(t *testing.T, values *charts.Values) *bytes.Buffer {
+	t.Helper()
 	var buf bytes.Buffer
 	if err := renderCRDs(&buf, valuespkg.Options{}); err != nil {
 		t.Fatalf("could not render install manifests: %s", err)
@@ -599,6 +603,7 @@ func renderUpgrade(installManifest string, upgradeOpts []flag.Flag, templateOpts
 }
 
 func renderInstallAndUpgrade(t *testing.T, installOpts *charts.Values, upgradeOpts []flag.Flag, templateOpts valuespkg.Options) (*bytes.Buffer, *bytes.Buffer, error) {
+	t.Helper()
 	err := validateValues(context.Background(), nil, installOpts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to validate values: %w", err)

--- a/controller/k8s/api.go
+++ b/controller/k8s/api.go
@@ -79,7 +79,7 @@ func InitializeAPI(ctx context.Context, kubeConfig string, ensureClusterWideAcce
 		return nil, err
 	}
 
-	k8sClient, err := k8s.NewAPIForConfig(config, "", []string{}, 0)
+	k8sClient, err := k8s.NewAPIForConfig(config, "", []string{}, 0, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func InitializeAPI(ctx context.Context, kubeConfig string, ensureClusterWideAcce
 
 // InitializeAPIForConfig creates Kubernetes clients and returns an initialized API wrapper.
 func InitializeAPIForConfig(ctx context.Context, kubeConfig *rest.Config, ensureClusterWideAccess bool, cluster string, resources ...APIResource) (*API, error) {
-	k8sClient, err := k8s.NewAPIForConfig(kubeConfig, "", []string{}, 0)
+	k8sClient, err := k8s.NewAPIForConfig(kubeConfig, "", []string{}, 0, 0, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/webhook/launcher.go
+++ b/controller/webhook/launcher.go
@@ -44,7 +44,7 @@ func Launch(
 		log.Fatalf("error building Kubernetes API config: %s", err)
 	}
 
-	k8sAPI, err := pkgk8s.NewAPIForConfig(config, "", []string{}, 0)
+	k8sAPI, err := pkgk8s.NewAPIForConfig(config, "", []string{}, 0, 0, 0)
 	if err != nil {
 		//nolint:gocritic
 		log.Fatalf("error configuring Kubernetes API client: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1
+	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/prometheus/client_model v0.4.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bombsimon/logrusr/v4 v4.1.0 h1:uZNPbwusB0eUXlO8hIUwStE6Lr5bLN6IgYgG+75kuh4=
+github.com/bombsimon/logrusr/v4 v4.1.0/go.mod h1:pjfHC5e59CvjTBIU3V3sGhFWFAnsnhOR03TRc6im0l8=
 github.com/briandowns/spinner v0.0.0-20190212173954-5cf08d0ac778 h1:Dmz6bJXocvwkw7BOz4jpyVZReGrkjs+fBDWKn5tBES4=
 github.com/briandowns/spinner v0.0.0-20190212173954-5cf08d0ac778/go.mod h1:hw/JEQBIE+c/BLI4aKM8UU8v+ZqrD3h7HC27kKt8JQU=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuPGoOVeF2fE4Og9otCc70=

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.6
+version: 30.12.7
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.12.6](https://img.shields.io/badge/Version-30.12.6-informational?style=flat-square)
+![Version: 30.12.7](https://img.shields.io/badge/Version-30.12.7-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -33,6 +33,7 @@ Kubernetes: `>=1.21.0-0`
 | enablePodAntiAffinity | bool | `false` | Enables Pod Anti Affinity logic to balance the placement of replicas across hosts and zones for High Availability. Enable this only when you have multiple replicas of components. |
 | gateway.enabled | bool | `true` | Controls whether link will create a probe service for the gateway |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
+| imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
 | logFormat | string | `"plain"` | Log format (`plain` or `json`) |
 | logLevel | string | `"info"` | Log level for the Multicluster components |
 | nodeSelector | object | `{}` | Node selectors for the Service mirror pod |

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -84,6 +84,7 @@ metadata:
     component: service-mirror
     mirror.linkerd.io/cluster-name: {{.Values.targetClusterName}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/multicluster/charts/linkerd-multicluster-link/values.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/values.yaml
@@ -3,6 +3,9 @@
 controllerImage: cr.l5d.io/linkerd/controller
 # -- Tag for the Service Mirror container Docker image
 controllerImageVersion: linkerdVersionValue
+# -- For Private docker registries, authentication is needed.
+#  Registry secrets are applied to the respective service accounts
+imagePullSecrets: []
 # -- Additional annotations to add to all pods
 podAnnotations: {}
 # -- Additional labels to add to all pods

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.11.6
+version: 30.11.7
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.11.6](https://img.shields.io/badge/Version-30.11.6-informational?style=flat-square)
+![Version: 30.11.7](https://img.shields.io/badge/Version-30.11.7-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -92,6 +92,7 @@ Kubernetes: `>=1.21.0-0`
 | gateway.tolerations | list | `[]` | Tolerations for the gateway pod |
 | identityTrustDomain | string | `"cluster.local"` | Identity Trust Domain of the certificate authority |
 | imagePullPolicy | string | `"IfNotPresent"` | Docker imagePullPolicy for all multicluster components |
+| imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed.  Registry secrets are applied to the respective service accounts |
 | linkerdNamespace | string | `"linkerd"` | Namespace of linkerd installation |
 | linkerdVersion | string | `"linkerdVersionValue"` | Control plane version |
 | namespaceMetadata.image.name | string | `"extension-init"` | Docker image name for the namespace-metadata instance |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -142,4 +142,5 @@ metadata:
   labels:
     linkerd.io/extension: multicluster
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata-rbac.yaml
@@ -11,6 +11,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   name: namespace-metadata
   namespace: {{.Release.Namespace}}
+{{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/remote-access-service-mirror-rbac.yaml
@@ -48,6 +48,7 @@ metadata:
     {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     {{ include "partials.annotations.created-by" $ }}
+{{- include "partials.image-pull-secrets" $.Values.imagePullSecrets }}
 ---
 apiVersion: v1
 kind: Secret

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -50,6 +50,10 @@ podLabels: {}
 commonLabels: {}
 # -- Docker imagePullPolicy for all multicluster components
 imagePullPolicy: IfNotPresent
+# -- For Private docker registries, authentication is needed.
+#  Registry secrets are applied to the respective service accounts
+imagePullSecrets: []
+# - name: my-private-docker-registry-login-secret
 # -- The port on which the proxy accepts outbound traffic
 proxyOutboundPort: 4140
 # -- If the remote mirror service account should be installed

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -349,7 +349,7 @@ func (hc *healthChecker) checkRemoteClusterConnectivity(ctx context.Context) err
 			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %w", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue
 		}
-		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, healthcheck.RequestTimeout)
+		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, healthcheck.RequestTimeout, 0, 0)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %w", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue
@@ -397,7 +397,7 @@ func (hc *healthChecker) checkRemoteClusterAnchors(ctx context.Context, localAnc
 			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %s", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue
 		}
-		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, healthcheck.RequestTimeout)
+		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, healthcheck.RequestTimeout, 0, 0)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %s", secret.Namespace, secret.Name, link.TargetClusterName, err))
 			continue

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -229,9 +229,10 @@ type (
 	// Identity contains the fields to set the identity variables in the proxy
 	// sidecar container
 	Identity struct {
-		ExternalCA                    bool    `json:"externalCA"`
-		ServiceAccountTokenProjection bool    `json:"serviceAccountTokenProjection"`
-		Issuer                        *Issuer `json:"issuer"`
+		ExternalCA                    bool     `json:"externalCA"`
+		ServiceAccountTokenProjection bool     `json:"serviceAccountTokenProjection"`
+		Issuer                        *Issuer  `json:"issuer"`
+		KubeAPI                       *KubeAPI `json:"kubeAPI"`
 	}
 
 	// Issuer has the Helm variables of the identity issuer
@@ -240,6 +241,12 @@ type (
 		ClockSkewAllowance string     `json:"clockSkewAllowance"`
 		IssuanceLifetime   string     `json:"issuanceLifetime"`
 		TLS                *IssuerTLS `json:"tls"`
+	}
+
+	// KubeAPI contains the kube-apiserver client config
+	KubeAPI struct {
+		ClientQPS   float32 `json:"clientQPS"`
+		ClientBurst int     `json:"clientBurst"`
 	}
 
 	// Webhook Helm variables for a webhook

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -179,6 +179,10 @@ func TestNewValues(t *testing.T) {
 				TLS:                &IssuerTLS{},
 				Scheme:             "linkerd.io/tls",
 			},
+			KubeAPI: &KubeAPI{
+				ClientQPS:   100,
+				ClientBurst: 200,
+			},
 		},
 		NodeSelector: map[string]string{
 			"kubernetes.io/os": "linux",

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -6,6 +6,8 @@ import (
 	"os"
 
 	"github.com/linkerd/linkerd2/pkg/version"
+
+	"github.com/bombsimon/logrusr/v4"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"helm.sh/helm/v3/pkg/cli/values"
@@ -28,11 +30,6 @@ const (
 // func calls flag.Parse(), so it should be called after all other flags have
 // been configured.
 func ConfigureAndParse(cmd *flag.FlagSet, args []string) {
-	klog.InitFlags(nil)
-	flag.Set("stderrthreshold", "FATAL")
-	flag.Set("logtostderr", "false")
-	flag.Set("log_file", "/dev/null")
-	flag.Set("v", "0")
 	logLevel := cmd.String("log-level", log.InfoLevel.String(),
 		"log level, must be one of: panic, fatal, error, warn, info, debug, trace")
 	logFormat := cmd.String("log-format", "plain",
@@ -44,8 +41,10 @@ func ConfigureAndParse(cmd *flag.FlagSet, args []string) {
 	//nolint:errcheck
 	cmd.Parse(args)
 
-	// set log timestamps
 	log.SetFormatter(getFormatter(*logFormat))
+
+	klog.InitFlags(nil)
+	klog.SetLogger(logrusr.New(log.StandardLogger()))
 
 	setLogLevel(*logLevel)
 	maybePrintVersionAndExit(*printVersion)
@@ -66,16 +65,26 @@ func setLogLevel(logLevel string) {
 	}
 	log.SetLevel(level)
 
-	if level >= log.DebugLevel {
-		flag.Set("stderrthreshold", "INFO")
-		flag.Set("logtostderr", "true")
+	// Loosely based on k8s logging conventions, except for 'tracing' that we
+	// bump to 10 (we can see in client-go source code that level is actually
+	// used) and `debug` to 6 (given that at level 7 and higher auth tokens get
+	// logged)
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+	switch level {
+	case log.PanicLevel:
+		flag.Set("v", "0")
+	case log.FatalLevel:
+		flag.Set("v", "0")
+	case log.ErrorLevel:
+		flag.Set("v", "0")
+	case log.WarnLevel:
+		flag.Set("v", "0")
+	case log.InfoLevel:
+		flag.Set("v", "2")
+	case log.DebugLevel:
 		flag.Set("v", "6")
-		// pipe klog entries to logrus
-		klog.SetOutput(log.StandardLogger().Writer())
-	}
-
-	if level >= log.TraceLevel {
-		flag.Set("v", "12") // At 7 and higher, authorization tokens get logged.
+	case log.TraceLevel:
+		flag.Set("v", "10")
 	}
 }
 

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -78,12 +78,26 @@ var (
 		},
 		[]string{"client"},
 	)
+	clientQPS = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "http_client_qps",
+			Help: "Max QPS used for the client config.",
+		},
+		[]string{"client"},
+	)
+	clientBurst = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "http_client_burst",
+			Help: "Burst used for the client config.",
+		},
+		[]string{"client"},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(
-		serverCounter, serverLatency, serverResponseSize,
-		clientCounter, clientLatency, clientInFlight,
+		serverCounter, serverLatency, serverResponseSize, clientCounter,
+		clientLatency, clientInFlight, clientQPS, clientBurst,
 	)
 }
 
@@ -126,4 +140,12 @@ func ClientWithTelemetry(name string, wt func(http.RoundTripper) http.RoundTripp
 			),
 		)
 	}
+}
+
+func SetClientQPS(name string, qps float32) {
+	clientQPS.With(prometheus.Labels{"client": name}).Set(float64(qps))
+}
+
+func SetClientBurst(name string, burst int) {
+	clientBurst.With(prometheus.Labels{"client": name}).Set(float64(burst))
 }

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.21.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.6
+version: 30.12.7
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -141,7 +141,7 @@ Kubernetes: `>=1.21.0-0`
 | prometheus.image.name | string | `"prometheus"` | Docker image name for the prometheus instance |
 | prometheus.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the prometheus instance |
 | prometheus.image.registry | string | `"prom"` | Docker registry for the prometheus instance |
-| prometheus.image.tag | string | `"v2.47.0"` | Docker image tag for the prometheus instance |
+| prometheus.image.tag | string | `"v2.48.0"` | Docker image tag for the prometheus instance |
 | prometheus.logFormat | string | defaultLogLevel | log format (plain, json) of the prometheus instance |
 | prometheus.logLevel | string | defaultLogLevel | log level of the prometheus instance |
 | prometheus.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.12.6](https://img.shields.io/badge/Version-30.12.6-informational?style=flat-square)
+![Version: 30.12.7](https://img.shields.io/badge/Version-30.12.7-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -418,7 +418,7 @@ prometheus:
     # -- Docker image name for the prometheus instance
     name: prometheus
     # -- Docker image tag for the prometheus instance
-    tag: v2.47.0
+    tag: v2.48.0
     # -- Pull policy for the prometheus instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -732,7 +732,7 @@ spec:
         - --log.level=debug
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -736,7 +736,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.47.0
+        image: prom/prometheus:v2.48.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
* 0a72f1f99 Add imagePullSecrets to the multicluster chart. (#11287)
* 284d76b55 service-mirror: support gateway resolving to multiple addresses (#11499)
* 64bccd9f7 Improve klog (client-go logs) handling (#11632)
* 6a07e2c7e Add ability to configure client-go's `QPS` and `Burst` settings (#11644)
* e294c7875 Bump prometheus to v2.48.0 (#11633)