### PR TITLE
Reenable cni-calico-deep integration test in main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -118,8 +118,7 @@ jobs:
     strategy:
       matrix:
         test:
-          # Pending https://github.com/linkerd/linkerd2/pull/11617
-          #- cni-calico-deep
+          - cni-calico-deep
           - deep
     runs-on: ubuntu-20.04
     timeout-minutes: 15


### PR DESCRIPTION
After having fixed it via #11617 we had reenabled it for the release workflow but not for the integration workflow.