### PR TITLE
Bump min Kubernetes API to v1.22

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -171,7 +171,7 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.21
+          - v1.22
           - v1.28
     steps:
       - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -350,7 +350,7 @@ jobs:
     strategy:
       matrix:
         k8s:
-          - v1.21
+          - v1.22
           - v1.28
     steps:
       - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -4,8 +4,8 @@
 # proper messages
 set +e
 
-k8s_version_min='+v1.21'
-k8s_version_max='+v1.26'
+k8s_version_min='+v1.22'
+k8s_version_max='+v1.28'
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 testdir="$bindir"/../test/integration

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 name: "linkerd-control-plane"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -11,8 +11,8 @@ for your microservices — with no code change required.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.22+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -11,7 +11,7 @@ for your microservices — with no code change required.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.22+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
@@ -135,7 +135,7 @@ extensions:
 
 ## Requirements
 
-Kubernetes: `>=1.21.0-0`
+Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd-control-plane/README.md.gotmpl
+++ b/charts/linkerd-control-plane/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes 1.22+ cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/charts/linkerd-control-plane/README.md.gotmpl
+++ b/charts/linkerd-control-plane/README.md.gotmpl
@@ -9,8 +9,8 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.22+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 name: "linkerd-crds"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -60,7 +60,7 @@ helm install linkerd-crds -n linkerd --create-namespace linkerd/linkerd-crds
 
 ## Requirements
 
-Kubernetes: `>=1.21.0-0`
+Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -10,8 +10,8 @@ for your microservices — with no code change required.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].

--- a/charts/linkerd-crds/README.md.gotmpl
+++ b/charts/linkerd-crds/README.md.gotmpl
@@ -9,8 +9,8 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
   up your pod's network so  incoming and outgoing traffic is proxied through the
   data plane.
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
 version: 30.13.1-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -12,7 +12,7 @@ data plane.
 
 ## Requirements
 
-Kubernetes: `>=1.21.0-0`
+Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -11,7 +11,7 @@ OpenCensus and Jaeger.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -62,7 +62,7 @@ helm install linkerd-jaeger -n linkerd-jaeger --create-namespace linkerd/linkerd
 
 ## Requirements
 
-Kubernetes: `>=1.21.0-0`
+Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/jaeger/charts/linkerd-jaeger/README.md.gotmpl
+++ b/jaeger/charts/linkerd-jaeger/README.md.gotmpl
@@ -9,7 +9,7 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See
 the [Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd

--- a/multicluster/charts/linkerd-multicluster-link/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   `cluster-credentials` secret and the Link CR, which are not found in this
   chart. Therefore this chart is not a replacement for that command, and
   shouldn't be used as-is unless you really know what you're doing ;-)
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd-multicluster-link"
 version: 0.2.0

--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -15,7 +15,7 @@ shouldn't be used as-is unless you really know what you're doing ;-)
 
 ## Requirements
 
-Kubernetes: `>=1.21.0-0`
+Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -60,7 +60,7 @@ helm install linkerd-multicluster -n linkerd-multicluster --create-namespace lin
 
 ## Requirements
 
-Kubernetes: `>=1.21.0-0`
+Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -11,8 +11,8 @@ linking to remote clusters
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].

--- a/multicluster/charts/linkerd-multicluster/README.md.gotmpl
+++ b/multicluster/charts/linkerd-multicluster/README.md.gotmpl
@@ -9,8 +9,8 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -27,7 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-var minAPIVersion = [3]int{1, 21, 0}
+var minAPIVersion = [3]int{1, 22, 0}
 
 // KubernetesAPI provides a client for accessing a Kubernetes cluster.
 // TODO: support ServiceProfile ClientSet. A prerequisite is moving the

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
 k8s-gateway-api = "0.13"
-k8s-openapi = { version = "0.19", features = ["v1_20"] }
+k8s-openapi = { version = "0.19", features = ["v1_22"] }
 hyper = { version = "0.14", features = ["http1", "http2", "runtime", "server"] }
 ipnet = { version = "2", default-features = false }
 linkerd-policy-controller-core = { path = "./core" }

--- a/policy-controller/k8s/api/Cargo.toml
+++ b/policy-controller/k8s/api/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 k8s-openapi = { version = "0.19", default-features = false, features = [
-    "v1_20",
+    "v1_22",
 ] }
 k8s-gateway-api = "0.13"
 kube = { version = "0.85", default-features = false, features = [

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -11,7 +11,7 @@ hyper = { version = "0.14", features = ["client", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2"
 k8s-gateway-api = "0.13"
-k8s-openapi = { version = "0.19", features = ["v1_20"] }
+k8s-openapi = { version = "0.19", features = ["v1_22"] }
 linkerd-policy-controller-core = { path = "../policy-controller/core" }
 linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
 maplit = "1"

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
 - service-mesh
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -11,8 +11,8 @@ components for Linkerd.
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -60,7 +60,7 @@ helm install linkerd-viz -n linkerd-viz --create-namespace linkerd/linkerd-viz
 
 ## Requirements
 
-Kubernetes: `>=1.21.0-0`
+Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/viz/charts/linkerd-viz/README.md.gotmpl
+++ b/viz/charts/linkerd-viz/README.md.gotmpl
@@ -9,8 +9,8 @@
 
 ## Quickstart and documentation
 
-You can run Linkerd on any Kubernetes 1.21+ cluster in a matter of seconds. See
-the [Linkerd Getting Started Guide][getting-started] for how.
+You can run Linkerd on any Kubernetes cluster in a matter of seconds. See the
+[Linkerd Getting Started Guide][getting-started] for how.
 
 For more comprehensive documentation, start with the [Linkerd
 docs][linkerd-docs].


### PR DESCRIPTION
New versions of the k8s-openapi crate drop support for Kubernetes 1.21. Kubernetes v1.22 has been considered EOL by the upstream project since 2022-07-08. Major cloud providers have EOL'd it as well (GKE's current MSKV is 1.24).

This change updates the MSKV to v1.22. It also updates the max version in _test-helpers.sh to v1.28.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
