### PR TITLE
edge-23.12.2 change notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Changes
 
+## edge-23.12.2
+
+This edge release includes a restructuring of the proxy's balancer along with
+accompanying new metrics. The new minimum supported Kubernetes version is 1.22.
+
+* Restructured the proxy's balancer ([#11750]): balancer changes may now occur
+  independently of request processing. Fail-fast circuit breaking is enforced on
+  the balancer's queue so that requests can't get stuck in a queue indefinitely.
+  This new balancer is instrumented with new metrics: request (in-queue) latency
+  histograms, failfast states, discovery updates counts, and balancer endpoint
+  pool sizes.
+* Changed how the policy controller updates HTTPRoute status so that it doesn't
+  affect statuses from other non-linkerd controllers ([#11705]; fixes [#11659])
+
+[#11750]: https://github.com/linkerd/linkerd2/pull/11750
+[#11705]: https://github.com/linkerd/linkerd2/pull/11705
+[#11659]: https://github.com/linkerd/linkerd2/pull/11659
+
 ## edge-23.12.1
 
 This edge release introduces new configuration values in the identity

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.18.0-edge
+version: 1.18.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.18.0-edge](https://img.shields.io/badge/Version-1.18.0--edge-informational?style=flat-square)
+![Version: 1.18.1-edge](https://img.shields.io/badge/Version-1.18.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - name: partials
   version: 0.1.0
   repository: file://../partials
-version: 1.9.0-edge
+version: 1.9.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -3,7 +3,7 @@
 Linkerd gives you observability, reliability, and security
 for your microservices — with no code change required.
 
-![Version: 1.9.0-edge](https://img.shields.io/badge/Version-1.9.0--edge-informational?style=flat-square)
+![Version: 1.9.1-edge](https://img.shields.io/badge/Version-1.9.1--edge-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 **Homepage:** <https://linkerd.io>

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -9,4 +9,4 @@ description: |
 kubeVersion: ">=1.22.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
-version: 30.13.1-edge
+version: 30.13.2-edge

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -6,7 +6,7 @@ Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
 up your pod's network so  incoming and outgoing traffic is proxied through the
 data plane.
 
-![Version: 30.13.1-edge](https://img.shields.io/badge/Version-30.13.1--edge-informational?style=flat-square)
+![Version: 30.13.2-edge](https://img.shields.io/badge/Version-30.13.2--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -6,7 +6,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -105,7 +105,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -5321,7 +5321,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -5409,7 +5409,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -5462,7 +5462,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -5728,7 +5728,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: policy.linkerd.io
@@ -5863,7 +5863,7 @@ metadata:
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
 spec:
   group: linkerd.io
@@ -6137,7 +6137,7 @@ metadata:
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/cli dev-undefined
   labels:
-    helm.sh/chart: linkerd-crds-1.9.0-edge
+    helm.sh/chart: linkerd-crds-1.9.1-edge
     linkerd.io/control-plane-ns: linkerd
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.22.0-0"
 name: linkerd-jaeger
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.14.0-edge
+version: 30.14.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Jaeger extension adds distributed tracing to Linkerd using
 OpenCensus and Jaeger.
 
-![Version: 30.14.0-edge](https://img.shields.io/badge/Version-30.14.0--edge-informational?style=flat-square)
+![Version: 30.14.1-edge](https://img.shields.io/badge/Version-30.14.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.22.0-0"
 name: "linkerd-multicluster"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.12.9-edge
+version: 30.12.10-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Multicluster extension contains resources to support multicluster
 linking to remote clusters
 
-![Version: 30.12.9-edge](https://img.shields.io/badge/Version-30.12.9--edge-informational?style=flat-square)
+![Version: 30.12.10-edge](https://img.shields.io/badge/Version-30.12.10--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.22.0-0"
 name: "linkerd-viz"
 sources:
 - https://github.com/linkerd/linkerd2/
-version: 30.14.0-edge
+version: 30.14.1-edge
 icon: https://linkerd.io/images/logo-only-200h.png
 maintainers:
   - name: Linkerd authors

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -3,7 +3,7 @@
 The Linkerd-Viz extension contains observability and visualization
 components for Linkerd.
 
-![Version: 30.14.0-edge](https://img.shields.io/badge/Version-30.14.0--edge-informational?style=flat-square)
+![Version: 30.14.1-edge](https://img.shields.io/badge/Version-30.14.1--edge-informational?style=flat-square)
 
 ![AppVersion: edge-XX.X.X](https://img.shields.io/badge/AppVersion-edge--XX.X.X-informational?style=flat-square)
 


### PR DESCRIPTION
## edge-23.12.2

This edge release includes a restructuring of the proxy's balancer along with accompanying new metrics. The new minimum supported Kubernetes version is 1.22.

* Restructured the proxy's balancer ([#11750]): balancer changes may now occur independently of request processing. Fail-fast circuit breaking is enforced on the balancer's queue so that requests can't get stuck in a queue indefinitely. This new balancer is instrumented with new metrics: request (in-queue) latency histograms, failfast states, discovery updates counts, and balancer endpoint pool sizes.
* Changed how the policy controller updates HTTPRoute status so that it doesn't affect statuses from other non-linkerd controllers ([#11705]; fixes [#11659])

[#11750]: https://github.com/linkerd/linkerd2/pull/11750
[#11705]: https://github.com/linkerd/linkerd2/pull/11705
[#11659]: https://github.com/linkerd/linkerd2/pull/11659