### PR TITLE
Add error counter for k8s client

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -62,6 +62,14 @@ var (
 		[]string{"client", "code", "method"},
 	)
 
+	clientErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_client_errors_total",
+			Help: "A counter for errors from the wrapped client.",
+		},
+		[]string{"client", "method"},
+	)
+
 	clientLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "http_client_request_latency_seconds",
@@ -128,17 +136,30 @@ func ClientWithTelemetry(name string, wt func(http.RoundTripper) http.RoundTripp
 	latency := clientLatency.MustCurryWith(prometheus.Labels{"client": name})
 	counter := clientCounter.MustCurryWith(prometheus.Labels{"client": name})
 	inFlight := clientInFlight.With(prometheus.Labels{"client": name})
+	errors := clientErrorCounter.MustCurryWith(prometheus.Labels{"client": name})
 
 	return func(rt http.RoundTripper) http.RoundTripper {
 		if wt != nil {
 			rt = wt(rt)
 		}
 
-		return promhttp.InstrumentRoundTripperInFlight(inFlight,
-			promhttp.InstrumentRoundTripperCounter(counter,
-				promhttp.InstrumentRoundTripperDuration(latency, rt),
+		return InstrumentErrorCounter(errors,
+			promhttp.InstrumentRoundTripperInFlight(inFlight,
+				promhttp.InstrumentRoundTripperCounter(counter,
+					promhttp.InstrumentRoundTripperDuration(latency, rt),
+				),
 			),
 		)
+	}
+}
+
+func InstrumentErrorCounter(counter *prometheus.CounterVec, next http.RoundTripper) promhttp.RoundTripperFunc {
+	return func(r *http.Request) (*http.Response, error) {
+		resp, err := next.RoundTrip(r)
+		if err != nil {
+			counter.With(prometheus.Labels{"method": r.Method}).Inc()
+		}
+		return resp, err
 	}
 }
 

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -105,7 +105,7 @@ var (
 func init() {
 	prometheus.MustRegister(
 		serverCounter, serverLatency, serverResponseSize, clientCounter,
-		clientLatency, clientInFlight, clientQPS, clientBurst,
+		clientLatency, clientInFlight, clientQPS, clientBurst, clientErrorCounter,
 	)
 }
 


### PR DESCRIPTION
We add a `http_client_errors_total` counter metric to control plane components to measure when requests to the k8s API fail without a response.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
