### PR TITLE
destination: Fix GetProfile endpoint buffering

### DIFF
--- a/controller/api/destination/endpoint_profile_translator.go
+++ b/controller/api/destination/endpoint_profile_translator.go
@@ -1,11 +1,12 @@
 package destination
 
 import (
-	"fmt"
-
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	logging "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/proto"
 )
 
 type endpointProfileTranslator struct {
@@ -13,39 +14,104 @@ type endpointProfileTranslator struct {
 	controllerNS        string
 	identityTrustDomain string
 	defaultOpaquePorts  map[uint32]struct{}
-	stream              pb.Destination_GetProfileServer
-	lastMessage         string
+
+	stream    pb.Destination_GetProfileServer
+	endStream chan struct{}
+
+	updates chan *watcher.Address
+	stop    chan struct{}
+
+	current *pb.DestinationProfile
 
 	log *logging.Entry
 }
 
-// newEndpointProfileTranslator translates pod updates and protocol updates to
+// endpointProfileUpdatesQueueOverflowCounter is a prometheus counter that is incremented
+// whenever the profile updates queue overflows.
+//
+// We omit ip and port labels because they are high cardinality.
+var endpointProfileUpdatesQueueOverflowCounter = promauto.NewCounter(
+	prometheus.CounterOpts{
+		Name: "endpoint_profile_updates_queue_overflow",
+		Help: "A counter incremented whenever the endpoint profile updates queue overflows",
+	},
+)
+
+// newEndpointProfileTranslator translates pod updates and profile updates to
 // DestinationProfiles for endpoints
 func newEndpointProfileTranslator(
 	enableH2Upgrade bool,
 	controllerNS,
 	identityTrustDomain string,
 	defaultOpaquePorts map[uint32]struct{},
-	log *logging.Entry,
 	stream pb.Destination_GetProfileServer,
+	endStream chan struct{},
+	log *logging.Entry,
 ) *endpointProfileTranslator {
 	return &endpointProfileTranslator{
 		enableH2Upgrade:     enableH2Upgrade,
 		controllerNS:        controllerNS,
 		identityTrustDomain: identityTrustDomain,
 		defaultOpaquePorts:  defaultOpaquePorts,
-		stream:              stream,
-		log:                 log.WithField("component", "endpoint-profile-translator"),
+
+		stream:    stream,
+		endStream: endStream,
+		updates:   make(chan *watcher.Address, updateQueueCapacity),
+		stop:      make(chan struct{}),
+
+		log: log.WithField("component", "endpoint-profile-translator"),
 	}
+}
+
+// Start initiates a goroutine which processes update events off of the
+// endpointProfileTranslator's internal queue and sends to the grpc stream as
+// appropriate. The goroutine calls non-thread-safe Send, therefore Start must
+// not be called more than once.
+func (ept *endpointProfileTranslator) Start() {
+	go func() {
+		for {
+			select {
+			case update := <-ept.updates:
+				ept.update(update)
+			case <-ept.stop:
+				return
+			}
+		}
+	}()
+}
+
+// Stop terminates the goroutine started by Start.
+func (ept *endpointProfileTranslator) Stop() {
+	close(ept.stop)
 }
 
 // Update sends a DestinationProfile message into the stream, if the same
 // message hasn't been sent already. If it has, false is returned.
 func (ept *endpointProfileTranslator) Update(address *watcher.Address) (bool, error) {
+	select {
+	case ept.updates <- address:
+		// Update has been successfully enqueued.
+	default:
+		// We are unable to enqueue because the channel does not have capacity.
+		// The stream has fallen too far behind and should be closed.
+		endpointProfileUpdatesQueueOverflowCounter.Inc()
+		select {
+		case <-ept.endStream:
+			// The endStream channel has already been closed so no action is
+			// necessary.
+		default:
+			ept.log.Error("Profile update queue full; aborting stream")
+			close(ept.endStream)
+		}
+	}
+	return true, nil
+}
+
+func (ept *endpointProfileTranslator) update(address *watcher.Address) {
 	opaquePorts := watcher.GetAnnotatedOpaquePorts(address.Pod, ept.defaultOpaquePorts)
 	endpoint, err := ept.createEndpoint(*address, opaquePorts)
 	if err != nil {
-		return false, fmt.Errorf("failed to create endpoint: %w", err)
+		ept.log.Error(err)
 	}
 
 	profile := &pb.DestinationProfile{
@@ -53,17 +119,18 @@ func (ept *endpointProfileTranslator) Update(address *watcher.Address) (bool, er
 		Endpoint:       endpoint,
 		OpaqueProtocol: address.OpaqueProtocol,
 	}
-	msg := profile.String()
-	if msg == ept.lastMessage {
-		return false, nil
-	}
-	ept.lastMessage = msg
-	ept.log.Debugf("sending protocol update: %+v", profile)
-	if err := ept.stream.Send(profile); err != nil {
-		return false, fmt.Errorf("failed to send protocol update: %w", err)
+	if proto.Equal(profile, ept.current) {
+		ept.log.Debugf("Ignoring redundant profile update: %+v", profile)
+		return
 	}
 
-	return true, nil
+	ept.log.Debugf("Sending profile update: %+v", profile)
+	if err := ept.stream.Send(profile); err != nil {
+		ept.log.Errorf("failed to send profile update: %s", err)
+		return
+	}
+
+	ept.current = profile
 }
 
 func (ept *endpointProfileTranslator) createEndpoint(address watcher.Address, opaquePorts map[uint32]struct{}) (*pb.WeightedAddr, error) {

--- a/controller/api/destination/endpoint_profile_translator_test.go
+++ b/controller/api/destination/endpoint_profile_translator_test.go
@@ -1,0 +1,111 @@
+package destination
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
+	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
+	consts "github.com/linkerd/linkerd2/pkg/k8s"
+	logging "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEndpointProfileTranslator(t *testing.T) {
+	// logging.SetLevel(logging.TraceLevel)
+	// defer logging.SetLevel(logging.PanicLevel)
+
+	addr := &watcher.Address{
+		IP:   "10.10.11.11",
+		Port: 8080,
+	}
+	podAddr := &watcher.Address{
+		IP:   "10.10.11.11",
+		Port: 8080,
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					consts.ProxyOpaquePortsAnnotation: "8080",
+				},
+			},
+		},
+	}
+
+	t.Run("Sends update", func(t *testing.T) {
+		mockGetProfileServer := &mockDestinationGetProfileServer{
+			profilesReceived: make(chan *pb.DestinationProfile, 1),
+		}
+		log := logging.WithField("test", t.Name())
+		translator := newEndpointProfileTranslator(
+			true, "cluster", "identity", make(map[uint32]struct{}),
+			mockGetProfileServer,
+			nil,
+			log,
+		)
+		translator.Start()
+		defer translator.Stop()
+
+		translator.Update(addr)
+		select {
+		case p := <-mockGetProfileServer.profilesReceived:
+			log.Debugf("Received update: %v", p)
+		case <-time.After(1 * time.Second):
+			t.Fatal("No update received")
+		}
+
+		translator.Update(addr)
+		select {
+		case p := <-mockGetProfileServer.profilesReceived:
+			t.Fatalf("Duplicate update sent: %v", p)
+		case <-time.After(1 * time.Second):
+		}
+
+		translator.Update(podAddr)
+		select {
+		case p := <-mockGetProfileServer.profilesReceived:
+			log.Debugf("Received update: %v", p)
+		case <-time.After(1 * time.Second):
+		}
+	})
+
+	t.Run("Handles overflow", func(t *testing.T) {
+		mockGetProfileServer := &mockDestinationGetProfileServer{
+			profilesReceived: make(chan *pb.DestinationProfile, 1),
+		}
+		log := logging.WithField("test", t.Name())
+		endStream := make(chan struct{})
+		translator := newEndpointProfileTranslator(
+			true, "cluster", "identity", make(map[uint32]struct{}),
+			mockGetProfileServer,
+			endStream,
+			log,
+		)
+		translator.Start()
+		defer translator.Stop()
+
+		for i := 0; i < updateQueueCapacity/2; i++ {
+			translator.Update(podAddr)
+			select {
+			case <-endStream:
+				t.Fatal("Stream ended prematurely")
+			default:
+			}
+
+			translator.Update(addr)
+			select {
+			case <-endStream:
+				t.Fatal("Stream ended prematurely")
+			default:
+			}
+		}
+
+		translator.Update(podAddr)
+		select {
+		case <-endStream:
+		default:
+			t.Fatal("Stream should have ended")
+		}
+
+	})
+}

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -464,7 +464,7 @@ spec:
 		t.Fatalf("NewFakeMetadataAPI returned an error: %s", err)
 	}
 	log := logging.WithField("test", t.Name())
-	logging.SetLevel(logging.TraceLevel)
+	// logging.SetLevel(logging.TraceLevel)
 	defaultOpaquePorts := map[uint32]struct{}{
 		25:    {},
 		443:   {},

--- a/controller/api/destination/watcher/pod_watcher.go
+++ b/controller/api/destination/watcher/pod_watcher.go
@@ -53,7 +53,7 @@ type (
 
 	// PodUpdateListener is the interface subscribers must implement.
 	PodUpdateListener interface {
-		Update(*Address) (bool, error)
+		Update(*Address) error
 	}
 )
 
@@ -115,13 +115,10 @@ func (pw *PodWatcher) Subscribe(service *ServiceID, hostname, ip string, port Po
 		return "", err
 	}
 
-	sent, err := listener.Update(&address)
-	if err != nil {
-		return "", err
+	if err = listener.Update(&address); err != nil {
+		return "", fmt.Errorf("failed to send initial update: %w", err)
 	}
-	if sent {
-		pp.metrics.incUpdates()
-	}
+	pp.metrics.incUpdates()
 
 	return pp.ip, nil
 }
@@ -277,11 +274,11 @@ func (pw *PodWatcher) updateServers(_ any) {
 					pw.log.Errorf("Error creating address for pod: %s", err)
 					continue
 				}
-				sent, err := listener.Update(&addr)
-				if err != nil {
-					pw.log.Errorf("Error calling pod watcher listener for server update: %s", err)
+				if err = listener.Update(&addr); err != nil {
+					pw.log.Warnf("Error sending update to listener: %s", err)
+					continue
 				}
-				updated = updated || sent
+				updated = true
 			}
 			if updated {
 				pp.metrics.incUpdates()
@@ -480,11 +477,11 @@ func (pp *podPublisher) updatePod(pod *corev1.Pod) {
 				pp.log.Errorf("Error creating address for pod: %s", err)
 				continue
 			}
-			sent, err := l.Update(&addr)
-			if err != nil {
-				pp.log.Errorf("Error calling pod watcher listener for pod update: %s", err)
+			if err = l.Update(&addr); err != nil {
+				pp.log.Warnf("Error sending update to listener: %s", err)
+				continue
 			}
-			updated = updated || sent
+			updated = true
 		}
 		if updated {
 			pp.metrics.incUpdates()
@@ -503,11 +500,11 @@ func (pp *podPublisher) updatePod(pod *corev1.Pod) {
 				pp.log.Errorf("Error creating address for pod: %s", err)
 				continue
 			}
-			sent, err := l.Update(&addr)
-			if err != nil {
-				pp.log.Errorf("Error calling pod watcher listener for pod deletion: %s", err)
+			if err = l.Update(&addr); err != nil {
+				pp.log.Warnf("Error sending update to listener: %s", err)
+				continue
 			}
-			updated = updated || sent
+			updated = true
 		}
 		if updated {
 			pp.metrics.incUpdates()


### PR DESCRIPTION
In 71635cb and 357a1d3 we updated the endpoint and profile translators to prevent backpressure from stalling the informer tasks. This change updates the endpoint profile translator with the same fix, so that updates are buffered and can detect when when a gRPC stream is stalled.

Furthermore, the update method is updated to use a protobuf-aware comparison method instead of using serialization and string comparison.

A test is added for the endpoint profile translator, since none existed previously.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
