### PR TITLE
linkerd-control-plane(helm-chart): Add support for extra manifest object `extraObjects` creation

### DIFF
--- a/charts/linkerd-control-plane/templates/extra-manifests.yaml
+++ b/charts/linkerd-control-plane/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/linkerd-control-plane/values-ha.yaml
+++ b/charts/linkerd-control-plane/values-ha.yaml
@@ -14,7 +14,7 @@ deploymentStrategy:
 # -- add PodAntiAffinity to each control plane workload
 enablePodAntiAffinity: true
 
-# nodeAffinity: 
+# nodeAffinity:
 
 # proxy configuration
 proxy:
@@ -58,3 +58,19 @@ policyControllerResources: *controller_resources
 
 # flag for linkerd check
 highAvailability: true
+
+# Optional: support to deploy extra manifest objects along with your chart
+# Example:
+# extraObjects:
+# - kind: ExternalSecret
+#   apiVersion: kubernetes-client.io/v1
+#   metadata:
+#     name: linkerd-identity-issuer
+#   spec:
+#     backendType: secretsManager
+#     data:
+#       - key: prod/eks-prod/linkerd/linkerd2-secret-key-pem
+#         name: crt.pem
+#       - key: prod/eks-prod/linkerd/linkerd2-secret-crt-pem
+#         name: key.pem
+extraObjects: []

--- a/charts/linkerd-control-plane/values-ha.yaml
+++ b/charts/linkerd-control-plane/values-ha.yaml
@@ -62,15 +62,10 @@ highAvailability: true
 # Optional: support to deploy extra manifest objects along with your chart
 # Example:
 # extraObjects:
-# - kind: ExternalSecret
-#   apiVersion: kubernetes-client.io/v1
+# - kind: ConfigMap
+#   apiVersion: v1
 #   metadata:
-#     name: linkerd-identity-issuer
-#   spec:
-#     backendType: secretsManager
-#     data:
-#       - key: prod/eks-prod/linkerd/linkerd2-secret-key-pem
-#         name: crt.pem
-#       - key: prod/eks-prod/linkerd/linkerd2-secret-crt-pem
-#         name: key.pem
+#     name: extra-config-map
+#   data:
+#     key: value
 extraObjects: []

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -580,3 +580,19 @@ podMonitor:
   proxy:
     # -- Enables the creation of PodMonitor for the data-plane
     enabled: true
+
+# Optional: support to deploy extra manifest objects along with your chart
+# Example: 
+# extraObjects:
+# - kind: ExternalSecret
+#   apiVersion: kubernetes-client.io/v1
+#   metadata:
+#     name: linkerd-identity-issuer
+#   spec:
+#     backendType: secretsManager
+#     data:
+#       - key: prod/eks-prod/linkerd/linkerd2-secret-key-pem
+#         name: crt.pem
+#       - key: prod/eks-prod/linkerd/linkerd2-secret-crt-pem
+#         name: key.pem
+extraObjects: []

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -584,15 +584,10 @@ podMonitor:
 # Optional: support to deploy extra manifest objects along with your chart
 # Example:
 # extraObjects:
-# - kind: ExternalSecret
-#   apiVersion: kubernetes-client.io/v1
+# - kind: ConfigMap
+#   apiVersion: v1
 #   metadata:
-#     name: linkerd-identity-issuer
-#   spec:
-#     backendType: secretsManager
-#     data:
-#       - key: prod/eks-prod/linkerd/linkerd2-secret-key-pem
-#         name: crt.pem
-#       - key: prod/eks-prod/linkerd/linkerd2-secret-crt-pem
-#         name: key.pem
+#     name: extra-config-map
+#   data:
+#     key: value
 extraObjects: []

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -582,7 +582,7 @@ podMonitor:
     enabled: true
 
 # Optional: support to deploy extra manifest objects along with your chart
-# Example: 
+# Example:
 # extraObjects:
 # - kind: ExternalSecret
 #   apiVersion: kubernetes-client.io/v1


### PR DESCRIPTION
### Subject: 
**linkerd-control-plane(helm-chart)**
Add support for extra manifest object `extraObjects` in source chart

### Problem: 
Inability to use the upstream chart by just overriding the `values.yaml` since the chart does not support creating/deploying and extra manifests

As an example:  we use ExternalSecret managed by AWS secret manager.
Hence the secret are not managed by helm and rather the ExternalSecret controller.
We need to be able to create external secret manifest using the toggles in values files 

> [!NOTE]
> The extra manifest or object creation is not limiting to any vendor but can be used to create any additional kubernetes object as part of the chart 

### Solution:
An additional toggle to enable creation of extra manifest object extraObjects

Validation

Fixes #11822 