### PR TITLE
Bump prom/prometheus from 2.48.0 to 2.48.1

### DIFF
--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -142,7 +142,7 @@ Kubernetes: `>=1.22.0-0`
 | prometheus.image.name | string | `"prometheus"` | Docker image name for the prometheus instance |
 | prometheus.image.pullPolicy | string | defaultImagePullPolicy | Pull policy for the prometheus instance |
 | prometheus.image.registry | string | `"prom"` | Docker registry for the prometheus instance |
-| prometheus.image.tag | string | `"v2.48.0"` | Docker image tag for the prometheus instance |
+| prometheus.image.tag | string | `"v2.48.1"` | Docker image tag for the prometheus instance |
 | prometheus.logFormat | string | defaultLogLevel | log format (plain, json) of the prometheus instance |
 | prometheus.logLevel | string | defaultLogLevel | log level of the prometheus instance |
 | prometheus.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -423,7 +423,7 @@ prometheus:
     # -- Docker image name for the prometheus instance
     name: prometheus
     # -- Docker image tag for the prometheus instance
-    tag: v2.48.0
+    tag: v2.48.1
     # -- Pull policy for the prometheus instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.0
+        image: prom/prometheus:v2.48.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -732,7 +732,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.0
+        image: prom/prometheus:v2.48.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -732,7 +732,7 @@ spec:
         - --log.level=debug
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.0
+        image: prom/prometheus:v2.48.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -736,7 +736,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.0
+        image: prom/prometheus:v2.48.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
```bash
$ grype -q prom/prometheus:v2.48.0
NAME                      INSTALLED             FIXED-IN  TYPE       VULNERABILITY        SEVERITY
busybox                   1.36.1                          binary     CVE-2023-42366       Medium
busybox                   1.36.1                          binary     CVE-2023-42365       Medium
busybox                   1.36.1                          binary     CVE-2023-42364       Medium
busybox                   1.36.1                          binary     CVE-2023-42363       Medium
github.com/docker/docker  v24.0.6+incompatible  24.0.7    go-module  GHSA-jq35-85cj-fj4p  Medium
golang.org/x/crypto       v0.14.0               0.17.0    go-module  GHSA-45x7-px36-x8w8  Medium
stdlib                    go1.21.4                        go-module  CVE-2023-45285       High
stdlib                    go1.21.4                        go-module  CVE-2023-39326       Medium

$ grype -q prom/prometheus:v2.48.1
NAME                      INSTALLED             FIXED-IN  TYPE       VULNERABILITY        SEVERITY
busybox                   1.36.1                          binary     CVE-2023-42366       Medium
busybox                   1.36.1                          binary     CVE-2023-42365       Medium
busybox                   1.36.1                          binary     CVE-2023-42364       Medium
busybox                   1.36.1                          binary     CVE-2023-42363       Medium
github.com/docker/docker  v24.0.6+incompatible  24.0.7    go-module  GHSA-jq35-85cj-fj4p  Medium
golang.org/x/crypto       v0.14.0               0.17.0    go-module  GHSA-45x7-px36-x8w8  Medium
```