### PR TITLE
Improve server-side validation for ExternalWorkload

### DIFF
--- a/charts/linkerd-crds/templates/workload/external-workload.yaml
+++ b/charts/linkerd-crds/templates/workload/external-workload.yaml
@@ -103,8 +103,7 @@ spec:
                       type: string
             type: object
             required:
-            - ports
-            - workloadIPs
+            - meshTls
           status:
             type: object
             properties:

--- a/charts/linkerd-crds/templates/workload/external-workload.yaml
+++ b/charts/linkerd-crds/templates/workload/external-workload.yaml
@@ -65,12 +65,14 @@ spec:
                     minLength: 1
                     maxLength: 253
                 type: object
+                required:
+                - identity
+                - serverName
               ports:
                 type: array
                 description: ports describes a list of ports exposed by the
                   workload
                 items:
-                  type: object
                   properties:
                     name:
                       type: string
@@ -87,6 +89,9 @@ spec:
                         TCP. Defaults to TCP.
                       type: string
                       default: "TCP"
+                  type: object
+                  required:
+                  - port
               workloadIPs:
                 type: array
                 description: workloadIPs contains a list of IP addresses that

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -10241,8 +10241,7 @@ spec:
                       type: string
             type: object
             required:
-            - ports
-            - workloadIPs
+            - meshTls
           status:
             type: object
             properties:

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -10203,12 +10203,14 @@ spec:
                     minLength: 1
                     maxLength: 253
                 type: object
+                required:
+                - identity
+                - serverName
               ports:
                 type: array
                 description: ports describes a list of ports exposed by the
                   workload
                 items:
-                  type: object
                   properties:
                     name:
                       type: string
@@ -10225,6 +10227,9 @@ spec:
                         TCP. Defaults to TCP.
                       type: string
                       default: "TCP"
+                  type: object
+                  required:
+                  - port
               workloadIPs:
                 type: array
                 description: workloadIPs contains a list of IP addresses that

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -10221,12 +10221,14 @@ spec:
                     minLength: 1
                     maxLength: 253
                 type: object
+                required:
+                - identity
+                - serverName
               ports:
                 type: array
                 description: ports describes a list of ports exposed by the
                   workload
                 items:
-                  type: object
                   properties:
                     name:
                       type: string
@@ -10243,6 +10245,9 @@ spec:
                         TCP. Defaults to TCP.
                       type: string
                       default: "TCP"
+                  type: object
+                  required:
+                  - port
               workloadIPs:
                 type: array
                 description: workloadIPs contains a list of IP addresses that

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -10259,8 +10259,7 @@ spec:
                       type: string
             type: object
             required:
-            - ports
-            - workloadIPs
+            - meshTls
           status:
             type: object
             properties:

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -10221,12 +10221,14 @@ spec:
                     minLength: 1
                     maxLength: 253
                 type: object
+                required:
+                - identity
+                - serverName
               ports:
                 type: array
                 description: ports describes a list of ports exposed by the
                   workload
                 items:
-                  type: object
                   properties:
                     name:
                       type: string
@@ -10243,6 +10245,9 @@ spec:
                         TCP. Defaults to TCP.
                       type: string
                       default: "TCP"
+                  type: object
+                  required:
+                  - port
               workloadIPs:
                 type: array
                 description: workloadIPs contains a list of IP addresses that

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -10259,8 +10259,7 @@ spec:
                       type: string
             type: object
             required:
-            - ports
-            - workloadIPs
+            - meshTls
           status:
             type: object
             properties:

--- a/controller/gen/apis/externalworkload/v1alpha1/types.go
+++ b/controller/gen/apis/externalworkload/v1alpha1/types.go
@@ -60,10 +60,10 @@ type ExternalWorkloadSpec struct {
 type MeshTls struct {
 	// Identity associated with the workload. Used by peers to perform
 	// verification in the mTLS handshake
-	Identity string `json:"identity,omitempty"`
+	Identity string `json:"identity"`
 	// ServerName is the DNS formatted name associated with the workload. Used
 	// to terminate TLS using the SNI extension.
-	ServerName string `json:"serverName,omitempty"`
+	ServerName string `json:"serverName"`
 }
 
 // PortSpec represents a network port in a single workload.

--- a/controller/gen/apis/externalworkload/v1alpha1/types.go
+++ b/controller/gen/apis/externalworkload/v1alpha1/types.go
@@ -46,14 +46,16 @@ type ExternalWorkloadList struct {
 // ExternalWorkloadSpec represents the desired state of an external workload
 type ExternalWorkloadSpec struct {
 	// MeshTls describes TLS settings associated with an external workload
+	MeshTls MeshTls `json:"meshTls"`
+	// Ports describes a set of ports exposed by the workload
 	//
 	// +optional
-	MeshTls MeshTls `json:"meshTls,omitempty"`
-	// Ports describes a set of ports exposed by the workload
-	Ports []PortSpec `json:"ports"`
+	Ports []PortSpec `json:"ports,omitempty"`
 	// List of IP addresses that can be used to send traffic to an external
 	// workload
-	WorkloadIPs []WorkloadIP `json:"workloadIPs"`
+	//
+	// +optional
+	WorkloadIPs []WorkloadIP `json:"workloadIPs,omitempty"`
 }
 
 // MeshTls describes TLS settings associated with an external workload

--- a/policy-controller/k8s/api/src/external_workload.rs
+++ b/policy-controller/k8s/api/src/external_workload.rs
@@ -31,11 +31,11 @@ pub struct ExternalWorkloadSpec {
 pub struct MeshTls {
     /// Identity associated with the workload. Used by peers to perform
     /// verification in the mTLS handshake
-    pub identity: Option<String>,
+    pub identity: String,
     /// ServerName is the DNS formatted name associated with the workload. Used
     /// to terminate TLS using the SNI extension.
     #[serde(rename = "serverName")]
-    pub server_name: Option<String>,
+    pub server_name: String,
 }
 
 /// PortSpec represents a network port in a single workload.
@@ -54,15 +54,15 @@ pub struct PortSpec {
     pub protocol: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-pub struct ExternalWorkloadStatus {
-    pub conditions: Vec<Condition>,
-}
-
 /// WorkloadIPs contains a list of IP addresses exposed by an ExternalWorkload
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub struct WorkloadIP {
     pub ip: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub struct ExternalWorkloadStatus {
+    pub conditions: Vec<Condition>,
 }
 
 /// WorkloadCondition represents the service state of an ExternalWorkload

--- a/policy-controller/k8s/api/src/external_workload.rs
+++ b/policy-controller/k8s/api/src/external_workload.rs
@@ -17,13 +17,13 @@ use serde::{Deserialize, Serialize};
 pub struct ExternalWorkloadSpec {
     /// MeshTls describes TLS settings associated with an external workload
     #[serde(rename = "meshTls")]
-    pub mesh_tls: Option<MeshTls>,
+    pub mesh_tls: MeshTls,
     /// Ports describes a set of ports exposed by the workload
-    pub ports: Vec<PortSpec>,
+    pub ports: Option<Vec<PortSpec>>,
     /// List of IP addresses that can be used to send traffic to an external
     /// workload
     #[serde(rename = "workloadIPs")]
-    pub workload_ips: Vec<WorkloadIP>,
+    pub workload_ips: Option<Vec<WorkloadIP>>,
 }
 
 /// MeshTls describes TLS settings associated with an external workload


### PR DESCRIPTION
We introduced an ExternalWorkload CRD along with bindings for mesh expansion. Currently, the CRD allows users to create ExternalWorkload resources without adding a meshTls strategy.

This change adds some more validation restrictions to the CRD definition (i.e. server side validation). When a meshTls strategy is used, we require both identity and serverName to be present. Furthermore, we require that when a list of ports is specified, each item in the list must contain a numeric port.

The change also touches on the bindings (Go & Rust types) to remove optionality from meshTls fields.

## Additional background
---

In https://github.com/linkerd/linkerd2/pull/11888#discussion_r1444312506 it was pointed out that we might have to think through optionality for meshTls. @zaharidichev and I caught up off-GitHub to discuss it. When a user provides meshTls settings we should enforce that both serverName and identity are present. We would never use one without the other (in the proxy-api we always set both fields).

On the topic of optionality, we also discussed an interesting scenario for mesh expansion. A VM may want to send traffic to a Kubernetes cluster (but not receive any traffic from a client in a Kubernetes cluster). A resource still needs to exist for policy discovery. Although both `workloadIPs` and `ports` are required fields, they can be set to empty in the event that a user may desire this behaviour.

For the purpose of this PR, I came up with a list of resources that I've created in-cluster. I annotated the manifest with where validation should fail and where it should succeed. To show that the above user story is fulfilled (i.e. an external workload that exists purely to satisfy policy discovery) we set ports and workloadIPs to empty arrays.

```yaml
# validation will fail
# missing workloadIPs and ports
apiVersion: workload.linkerd.io/v1alpha1
kind: ExternalWorkload
metadata:
  name: test-2
spec:
  meshTls: {}
---
# validation will fail
# missing workloadIPs
apiVersion: workload.linkerd.io/v1alpha1
kind: ExternalWorkload
metadata:
  name: test-3
spec:
  meshTls:
    identity: "foo"
    serverName: "foo"
  ports: []
---
# validation will work
apiVersion: workload.linkerd.io/v1alpha1
kind: ExternalWorkload
metadata:
  name: test-4
spec:
  meshTls:
    identity: "foo"
    serverName: "foo"
  ports: []
  workloadIPs: []
---
# validation will fail
# missing serverName
apiVersion: workload.linkerd.io/v1alpha1
kind: ExternalWorkload
metadata:
  name: test-5
spec:
  meshTls:
    identity: "foo"
  ports: []
  workloadIPs: []
---
# validation will work
apiVersion: workload.linkerd.io/v1alpha1
kind: ExternalWorkload
metadata:
  name: test-6
spec:
  meshTls:
    identity: "foo"
    serverName: "foo"
  ports: []
  workloadIPs:
  - ip: "192.0.2.0"
---
# validation will work
apiVersion: workload.linkerd.io/v1alpha1
kind: ExternalWorkload
metadata:
  name: test-7
spec:
  meshTls:
    identity: "foo"
    serverName: "foo"
  ports:
  # only requires a port to be present in each list item.
  - port: 8080
  workloadIPs: []
```

```
# Only these 3 were accepted by the API Server
NAME     IDENTITY   AGE
test-4   foo        37m
test-7   foo        23m
test-6   foo        23m

```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
