### PR TITLE
Bump CNI plugin version to v1.3.0 in Go pkg

### DIFF
--- a/cli/cmd/install-cni-plugin_test.go
+++ b/cli/cmd/install-cni-plugin_test.go
@@ -16,7 +16,7 @@ func TestRenderCNIPlugin(t *testing.T) {
 
 	image := cniPluginImage{
 		name:       "my-docker-registry.io/awesome/cni-plugin-test-image",
-		version:    "v1.2.2",
+		version:    "v1.3.0",
 		pullPolicy: nil,
 	}
 	fullyConfiguredOptions := &cniPluginOptions{

--- a/cli/cmd/install_cni_helm_test.go
+++ b/cli/cmd/install_cni_helm_test.go
@@ -35,7 +35,7 @@ func TestRenderCniHelm(t *testing.T) {
   			"logLevel": "debug",
 			"image": {
 				"name": "cr.l5d.io/linkerd/cni-plugin",
-				"version": "v1.2.2"
+				"version": "v1.3.0"
 			},
   			"proxyUID": 1111,
   			"destCNINetDir": "/etc/cni/net.d-test",

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -118,7 +118,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.2.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.3.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -119,7 +119,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.2.2
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.3.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -119,7 +119,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.2.2
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.3.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -119,7 +119,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.2.2
+        image: my-docker-registry.io/awesome/cni-plugin-test-image:v1.3.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -119,7 +119,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.2.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.3.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -112,7 +112,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.2.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.3.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2495,7 +2495,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.2.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.3.0
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var Version = undefinedVersion
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
 var ProxyInitVersion = "v2.2.3"
-var LinkerdCNIVersion = "v1.2.2"
+var LinkerdCNIVersion = "v1.3.0"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
We released a new version of the CNI plugin. The chart has been updated to reference the new version, however, some of the tests and the Go `version` pkg still reference the old version (v1.2.2). When installing through the CLI, I noticed that even though the chart value renders an image for the new repair controller, the image used is still v1.2.2, and as such, the container won't be started due to a missing binary.

This change bumps the version to v1.3.0 everywhere.


Before:

```
:; bin/linkerd install-cni --set "repairController.enabled=true" | k apply -f -
namespace/linkerd-cni created
serviceaccount/linkerd-cni created
clusterrole.rbac.authorization.k8s.io/linkerd-cni unchanged
clusterrolebinding.rbac.authorization.k8s.io/linkerd-cni unchanged
configmap/linkerd-cni-config created
daemonset.apps/linkerd-cni created

:; kgp -n linkerd-cni
NAME                READY   STATUS              RESTARTS     AGE
linkerd-cni-lzkbz   1/2     RunContainerError   1 (2s ago)   3s

:; k get po -n linkerd-cni linkerd-cni-lzkbz
NAME                READY   STATUS             RESTARTS     AGE
linkerd-cni-lzkbz   1/2     CrashLoopBackOff   1 (9s ago)   10s


  Normal   Created    15s (x2 over 15s)  kubelet            Created container repair-controller
  Warning  Failed     15s (x2 over 15s)  kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/usr/lib/linkerd/linkerd-cni-repair-controller": stat /usr/lib/linkerd/linkerd-cni-repair-controller: no such file or directory: unknown
  Warning  BackOff    5s (x4 over 14s)   kubelet            Back-off restarting failed container
```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
