### PR TITLE
Add newline to `linkerd install` error output

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -40,7 +40,8 @@ const (
 
 %s
 
-You can use the --ignore-cluster flag if you just want to generate the installation config.`
+You can use the --ignore-cluster flag if you just want to generate the installation config.
+`
 
 	errMsgLinkerdConfigResourceConflict = "Can't install the Linkerd control plane in the '%s' namespace. Reason: %s.\nRun the command `linkerd upgrade`, if you are looking to upgrade Linkerd.\n"
 )


### PR DESCRIPTION
The `errMsgCannotInitializeClient` format string did not include a trailing newline, unlike other error messages. This caused the user's prompt to appear immediately after the error without a newline.

Add a trailing newline to `errMsgCannotInitializeClient`.

Before:
```
$ linkerd install --context not-a-cluster
Unable to install the Linkerd control plane. Cannot connect to the Kubernetes cluster:

error configuring Kubernetes API client: context "not-a-cluster" does not exist

You can use the --ignore-cluster flag if you just want to generate the installation config.$
```

After:
```
$ bin/go-run cli install --context not-a-cluster
Unable to install the Linkerd control plane. Cannot connect to the Kubernetes cluster:

error configuring Kubernetes API client: context "not-a-cluster" does not exist

You can use the --ignore-cluster flag if you just want to generate the installation config.
$
```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
