### PR TITLE
Index ExternalWorkload resources in the policy controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "linkerd-policy-controller-core",
+ "linkerd-policy-controller-grpc",
  "linkerd-policy-controller-k8s-api",
  "linkerd2-proxy-api",
  "maplit",

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -243,8 +243,8 @@ rules:
       - httproutes/status
     verbs:
       - patch
-   - apiGroups:
-    - workload.linkerd.io
+  - apiGroups:
+      - workload.linkerd.io
     resources:
       - externalworkloads
     verbs:

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -243,6 +243,14 @@ rules:
       - httproutes/status
     verbs:
       - patch
+   - apiGroups:
+    - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - coordination.k8s.io
     resources:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1232,7 +1240,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1246,7 +1254,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1680,7 +1688,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1231,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1245,7 +1253,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1678,7 +1686,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1231,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1245,7 +1253,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1678,7 +1686,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1231,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1245,7 +1253,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1678,7 +1686,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1231,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1245,7 +1253,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1678,7 +1686,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1222,7 +1230,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1236,7 +1244,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1660,7 +1668,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -1329,7 +1337,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d678d93a3ae6be52fc98976b988d287fb3f8bc41d1eb9cc5f06d63fc3a3b9ee7
+        checksum/config: 23c9059f42334b0dcfa4b8bc3542d48652964fb3b1c9b414cb3a9020f73e556f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -1329,7 +1337,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d678d93a3ae6be52fc98976b988d287fb3f8bc41d1eb9cc5f06d63fc3a3b9ee7
+        checksum/config: 23c9059f42334b0dcfa4b8bc3542d48652964fb3b1c9b414cb3a9020f73e556f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -792,7 +800,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1162,7 +1170,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1176,7 +1184,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1549,7 +1557,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -230,6 +230,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -834,7 +842,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1206,7 +1214,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 387ff1ed65e66e400e556c47490d20187adcb885526d44d9f0aa75dc97f23223
+        checksum/config: d2b9e62513426ee1bac42dfc80477e8730316fd3bda7f422f1bdd27e3e59316f
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1220,7 +1228,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1657,7 +1665,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -230,6 +230,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -1304,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff01f9fed5a80929d1215ebec514a25888ac7fed762a5a753bd896928e26b951
+        checksum/config: 87abaa41d2dbabb91103c13138f417ed7b9d048fd0d559a3666a139becd41366
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -230,6 +230,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -1312,7 +1320,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff01f9fed5a80929d1215ebec514a25888ac7fed762a5a753bd896928e26b951
+        checksum/config: 87abaa41d2dbabb91103c13138f417ed7b9d048fd0d559a3666a139becd41366
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -230,6 +230,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -1294,7 +1302,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cf05a64f720a18752cb8e0e759cb4cd6e22602eb0129a2144a2093ac6ea87659
+        checksum/config: 0ad2f6f283bdfccbf428bff27240f60235400318a505eaca82af2dfcbb4865f5
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1225,7 +1233,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1239,7 +1247,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1666,7 +1674,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -236,6 +236,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -830,7 +838,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1197,7 +1205,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: d3eac3abc6cf5f1943e0f005fd15ad0107229283fa6f8db72f9ccb4766bb2228
+        checksum/config: 1b37f796a2363c75c0ecfb56a47b7b0676591bb435fe038c4f3918183c1ba7f0
         linkerd.io/created-by: CliVersion
         linkerd.io/proxy-version: ProxyVersion
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1211,7 +1219,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1648,7 +1656,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1231,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1245,7 +1253,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1678,7 +1686,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -239,6 +239,14 @@ rules:
     verbs:
       - patch
   - apiGroups:
+      - workload.linkerd.io
+    resources:
+      - externalworkloads
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -861,7 +869,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1231,7 +1239,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c6be36634a1edea1ebcad1c3981959c48eb6b78684e7093058a50eca6ba2f97
+        checksum/config: d4bf92fed9aef0313ad18729f0b373da57c319c902152dc80c605834dffe636f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
@@ -1245,7 +1253,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1678,7 +1686,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/policy-controller/grpc/src/lib.rs
+++ b/policy-controller/grpc/src/lib.rs
@@ -2,7 +2,7 @@
 #![forbid(unsafe_code)]
 
 mod http_route;
-mod workload;
 
 pub mod inbound;
 pub mod outbound;
+pub mod workload;

--- a/policy-controller/k8s/index/src/inbound.rs
+++ b/policy-controller/k8s/index/src/inbound.rs
@@ -3,9 +3,9 @@ mod http_route;
 pub mod index;
 mod meshtls_authentication;
 mod network_authentication;
-mod pod;
 mod server;
 pub mod server_authorization;
+mod workload;
 
 pub use index::{Index, SharedIndex};
 

--- a/policy-controller/k8s/index/src/inbound/index.rs
+++ b/policy-controller/k8s/index/src/inbound/index.rs
@@ -8,7 +8,7 @@
 
 use super::{
     authorization_policy, http_route::RouteBinding, meshtls_authentication, network_authentication,
-    pod, server, server_authorization,
+    server, server_authorization, workload,
 };
 use crate::{
     http_route::{gkn_for_gateway_http_route, gkn_for_linkerd_http_route, gkn_for_resource},
@@ -65,10 +65,11 @@ struct AuthenticationNsIndex {
     by_ns: HashMap<String, AuthenticationIndex>,
 }
 
-/// Holds `Pod`, `Server`, and `ServerAuthorization` indices for a single namespace.
+/// Holds `Pod`, `ExternalWorkload`, `Server`, and `ServerAuthorization` indices for a single namespace.
 #[derive(Debug)]
 struct Namespace {
     pods: PodIndex,
+    external_workloads: ExternalIndex,
     policy: PolicyIndex,
 }
 
@@ -85,7 +86,7 @@ struct PodIndex {
 /// or as `Server` resources select a port.
 #[derive(Debug)]
 struct Pod {
-    meta: pod::Meta,
+    meta: workload::Meta,
 
     /// The pod's named container ports. Used by `Server` port selectors.
     ///
@@ -97,7 +98,7 @@ struct Pod {
     /// `Namespace::reindex`--when a port is selected by a `Server`--or by
     /// `Namespace::get_pod_server` when a client discovers a port that has no
     /// configured server (and i.e. uses the default policy).
-    port_servers: PortMap<PodPortServer>,
+    port_servers: PortMap<WorkloadPortServer>,
 
     /// The pod's probe ports and their respective paths.
     ///
@@ -107,16 +108,43 @@ struct Pod {
     probes: PortMap<BTreeSet<String>>,
 }
 
-/// Holds the state of a single port on a pod.
+/// Holds the state of a single port on a workload (e.g. a pod or an external
+/// workload).
 #[derive(Debug)]
-struct PodPortServer {
+struct WorkloadPortServer {
     /// The name of the server resource that matches this port. Unset when no
     /// server resources match this pod/port (and, i.e., the default policy is
     /// used).
     name: Option<String>,
 
-    /// A sender used to broadcast pod port server updates.
+    /// A sender used to broadcast workload port server updates.
     watch: watch::Sender<InboundServer>,
+}
+
+/// Holds all external workload data for a single namespace
+#[derive(Debug)]
+struct ExternalIndex {
+    namespace: String,
+    by_name: HashMap<String, ExternalWorkload>,
+}
+
+/// Holds data for a single external workload, with server watches for all known
+/// ports.
+///
+/// The set of ports / servers is updated as clients discover server
+/// configuration or as `Server` resources select a port.
+#[derive(Debug)]
+struct ExternalWorkload {
+    meta: workload::Meta,
+
+    // The workload's named container ports. Used by `Server` port selectors.
+    //
+    // A workload will not have multiple ports with the same name, e.g. two
+    // `admin-http` ports pointing to different numerical values.
+    port_names: HashMap<String, NonZeroU16>,
+
+    /// All known TCP server ports.
+    port_servers: PortMap<WorkloadPortServer>,
 }
 
 /// Holds the state of policy resources for a single namespace.
@@ -311,15 +339,15 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for Index {
         let port_names = pod
             .spec
             .as_ref()
-            .map(pod::tcp_ports_by_name)
+            .map(workload::pod_tcp_ports_by_name)
             .unwrap_or_default();
         let probes = pod
             .spec
             .as_ref()
-            .map(pod::pod_http_probes)
+            .map(workload::pod_http_probes)
             .unwrap_or_default();
 
-        let meta = pod::Meta::from_metadata(pod.metadata);
+        let meta = workload::Meta::from_metadata(pod.metadata);
 
         // Add or update the pod. If the pod was not already present in the
         // index with the same metadata, index it against the policy resources,
@@ -341,6 +369,57 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for Index {
             // watches will complete.  No other parts of the index need to be
             // updated.
             if ns.get_mut().pods.by_name.remove(&name).is_some() && ns.get().is_empty() {
+                ns.remove();
+            }
+        }
+    }
+
+    // Since apply only reindexes a single pod at a time, there's no need to
+    // handle resets specially.
+}
+
+impl kubert::index::IndexNamespacedResource<k8s::external_workload::ExternalWorkload> for Index {
+    fn apply(&mut self, ext_workload: k8s::external_workload::ExternalWorkload) {
+        let ns = ext_workload.namespace().unwrap();
+        let name = ext_workload.name_unchecked();
+        let _span = info_span!("apply", %ns, %name).entered();
+
+        // Extract ports and settings.
+        // Note: external workloads do not have any probe paths to synthesise
+        // default policies for.
+        let port_names = workload::external_tcp_ports_by_name(&ext_workload.spec);
+        let meta = workload::Meta::from_metadata(ext_workload.metadata);
+
+        // Add or update the workload.
+        //
+        // If the resource is present in the index, but its metadata has
+        // changed, then it means the watches need to get an update.
+        let ns = self.namespaces.get_or_default(ns);
+        match ns.external_workloads.update(name, meta, port_names) {
+            // No update
+            Ok(None) => {}
+            // Update, so re-index
+            Ok(Some(workload)) => workload.reindex_servers(&ns.policy, &self.authentications),
+            Err(error) => {
+                tracing::error!(%error, "Illegal external workload update");
+            }
+        }
+    }
+
+    fn delete(&mut self, ns: String, name: String) {
+        tracing::debug!(%ns, %name, "delete");
+        if let Entry::Occupied(mut ns) = self.namespaces.by_ns.entry(ns) {
+            // Once the pod is removed, there's nothing else to update. Any open
+            // watches will complete.  No other parts of the index need to be
+            // updated.
+            if ns
+                .get_mut()
+                .external_workloads
+                .by_name
+                .remove(&name)
+                .is_some()
+                && ns.get().is_empty()
+            {
                 ns.remove();
             }
         }
@@ -828,6 +907,10 @@ impl Namespace {
                 namespace: namespace.clone(),
                 by_name: HashMap::default(),
             },
+            external_workloads: ExternalIndex {
+                namespace: namespace.clone(),
+                by_name: HashMap::default(),
+            },
             policy: PolicyIndex {
                 namespace,
                 cluster_info,
@@ -842,12 +925,13 @@ impl Namespace {
     /// Returns true if the index does not include any resources.
     #[inline]
     fn is_empty(&self) -> bool {
-        self.pods.is_empty() && self.policy.is_empty()
+        self.pods.is_empty() && self.policy.is_empty() && self.external_workloads.is_empty()
     }
 
     #[inline]
     fn reindex(&mut self, authns: &AuthenticationNsIndex) {
         self.pods.reindex(&self.policy, authns);
+        self.external_workloads.reindex(&self.policy, authns);
     }
 }
 
@@ -862,7 +946,7 @@ impl PodIndex {
     fn update(
         &mut self,
         name: String,
-        meta: pod::Meta,
+        meta: workload::Meta,
         port_names: HashMap<String, PortSet>,
         probes: PortMap<BTreeSet<String>>,
     ) -> Result<Option<&mut Pod>> {
@@ -975,7 +1059,7 @@ impl Pod {
             Entry::Vacant(entry) => {
                 tracing::trace!(port = %port, server = %name, "Creating server");
                 let (watch, _) = watch::channel(server);
-                entry.insert(PodPortServer {
+                entry.insert(WorkloadPortServer {
                     name: Some(name.to_string()),
                     watch,
                 });
@@ -1013,7 +1097,7 @@ impl Pod {
 
     /// Updates a pod-port to use the given named server.
     fn set_default_server(&mut self, port: NonZeroU16, config: &ClusterInfo) {
-        let server = Self::default_inbound_server(
+        let server = PolicyIndex::default_inbound_server(
             port,
             &self.meta.settings,
             self.probes
@@ -1027,7 +1111,7 @@ impl Pod {
             Entry::Vacant(entry) => {
                 tracing::debug!(%port, server = %config.default_policy, "Creating default server");
                 let (watch, _) = watch::channel(server);
-                entry.insert(PodPortServer { name: None, watch });
+                entry.insert(WorkloadPortServer { name: None, watch });
             }
 
             Entry::Occupied(mut entry) => {
@@ -1068,11 +1152,11 @@ impl Pod {
         &mut self,
         port: NonZeroU16,
         config: &ClusterInfo,
-    ) -> &mut PodPortServer {
+    ) -> &mut WorkloadPortServer {
         match self.port_servers.entry(port) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let (watch, _) = watch::channel(Self::default_inbound_server(
+                let (watch, _) = watch::channel(PolicyIndex::default_inbound_server(
                     port,
                     &self.meta.settings,
                     self.probes
@@ -1082,45 +1166,237 @@ impl Pod {
                         .map(|p| p.as_str()),
                     config,
                 ));
-                entry.insert(PodPortServer { name: None, watch })
+                entry.insert(WorkloadPortServer { name: None, watch })
+            }
+        }
+    }
+}
+
+// === impl ExternalIndex ===
+
+impl ExternalIndex {
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+
+    /// Indexes an external workload resource and computes any changes in the
+    /// workload's state.
+    ///
+    /// If the workload is indexed for the first time, or some of its settings
+    /// have changed (e.g. metadata) then indexing will trigger a namespace-wide
+    /// server re-index to push new state to the clients.
+    ///
+    /// Otherwise, if nothing has changed, do not trigger re-indexing.
+    fn update(
+        &mut self,
+        name: String,
+        meta: workload::Meta,
+        port_names: HashMap<String, NonZeroU16>,
+    ) -> Result<Option<&mut ExternalWorkload>> {
+        let workload = match self.by_name.entry(name.clone()) {
+            Entry::Vacant(entry) => entry.insert(ExternalWorkload {
+                meta,
+                port_names,
+                port_servers: PortMap::default(),
+            }),
+            Entry::Occupied(entry) => {
+                let workload = entry.into_mut();
+
+                if workload.meta == meta && workload.port_names == port_names {
+                    tracing::debug!(external_workload = %name, "No changes");
+                    return Ok(None);
+                }
+
+                if workload.meta != meta {
+                    tracing::trace!(external_workload = %name, "Updating workload's metadata");
+                    workload.meta = meta;
+                }
+
+                if workload.port_names != port_names {
+                    tracing::trace!(external_workload = %name, "Updating workload's ports");
+                    workload.port_names = port_names;
+                }
+
+                tracing::debug!(external_workload = %name, "Updating");
+                workload
+            }
+        };
+        Ok(Some(workload))
+    }
+
+    /// For each external workload in a namespace, re-compute the server and
+    /// authorization policy states to determine if new changes need to be
+    /// pushed to clients.
+    fn reindex(&mut self, policy: &PolicyIndex, authns: &AuthenticationNsIndex) {
+        let _span = info_span!("reindex", ns = %self.namespace).entered();
+        for (name, ext_workload) in self.by_name.iter_mut() {
+            let _span = info_span!("external_workload", external_workload = %name).entered();
+            ext_workload.reindex_servers(policy, authns);
+        }
+    }
+}
+
+//
+impl ExternalWorkload {
+    /// Determines the policies for ports on this workload
+    fn reindex_servers(&mut self, policy: &PolicyIndex, authentications: &AuthenticationNsIndex) {
+        // Keep track of ports that are already known so that they may receive
+        // default policies if they are still not selected by a server.
+        //
+        // TODO (matei): we could eagerly fill this out if we require users to
+        // always document a workload's ports. i.e. right now a non-named port
+        // will be lazily discovered only when traffic is sent, we could eagerly
+        // set policies for it (but I feel like for now, this should be similar in
+        // behaviour to a pod)
+        //
+        let mut unmatched_ports = self.port_servers.keys().copied().collect::<PortSet>();
+
+        // Keep track of which ports have been matched with servers so that we
+        // can detect when more than one server matches a single port.
+        let mut matched_ports = PortMap::with_capacity_and_hasher(
+            unmatched_ports.len(),
+            std::hash::BuildHasherDefault::<PortHasher>::default(),
+        );
+
+        for (srvname, server) in policy.servers.iter() {
+            if let Selector::ExternalWorkload(selector) = &server.selector {
+                if selector.matches(&self.meta.labels) {
+                    // Each server selects exactly one port on an
+                    // external workload
+                    //
+                    // Note: an external workload has only one set of ports. A
+                    // pod has a union, each container declares its own set.
+                    let port = if let Some(srv_port) = self.selects_port(&server.port_ref) {
+                        srv_port
+                    } else {
+                        // If server references a named port, and our workload
+                        // contains no such port, then skip this server.
+                        continue;
+                    };
+
+                    if let Some(prior) = matched_ports.get(&port) {
+                        // If a different server has already matched this
+                        tracing::warn!(
+                        %port,
+                        server = %prior,
+                        conflict = %srvname,
+                        "Port already matched by another server; skipping"
+                        );
+                        continue;
+                    }
+
+                    let s = policy.inbound_server(
+                        srvname.clone(),
+                        server,
+                        authentications,
+                        Vec::new().into_iter(),
+                    );
+
+                    self.update_server(port, srvname, s);
+                    matched_ports.insert(port, srvname.clone());
+                    unmatched_ports.remove(&port);
+                }
+            }
+        }
+
+        // Reset all other ports that were previously selected to defaults
+        for port in unmatched_ports.into_iter() {
+            self.set_default_server(port, &policy.cluster_info);
+        }
+    }
+
+    /// Updates an external workload-port to use a given named server.
+    ///
+    /// We use name explicitly (and not derived from the 'server') to ensure we
+    /// are not handling a default server.
+    fn update_server(&mut self, port: NonZeroU16, name: &str, server: InboundServer) {
+        match self.port_servers.entry(port) {
+            Entry::Vacant(entry) => {
+                tracing::trace!(port = %port, server = %name, "Creating server");
+                let (watch, _) = watch::channel(server);
+                entry.insert(WorkloadPortServer {
+                    name: Some(name.to_string()),
+                    watch,
+                });
+            }
+
+            Entry::Occupied(mut entry) => {
+                let ps = entry.get_mut();
+
+                ps.watch.send_if_modified(|current| {
+                    if ps.name.as_deref() == Some(name) && *current == server {
+                        tracing::trace!(port = %port, server = %name, "Skipped redundant server update");
+                        tracing::trace!(?server);
+                        return false;
+                    }
+
+                    // If the port's server previously matched a different server,
+                    // this can either mean that multiple servers currently match
+                    // the pod:port, or that we're in the middle of an update. We
+                    // make the opportunistic choice to assume the cluster is
+                    // configured coherently so we take the update. The admission
+                    // controller should prevent conflicts.
+                    tracing::trace!(port = %port, server = %name, "Updating server");
+                    if ps.name.as_deref() != Some(name) {
+                        ps.name = Some(name.to_string());
+                    }
+
+                    *current = server;
+                    true
+                });
+            }
+        }
+
+        tracing::debug!(port = %port, server = %name, "Updated server");
+    }
+
+    /// Updates a workload-port to use a given named server.
+    fn set_default_server(&mut self, port: NonZeroU16, config: &ClusterInfo) {
+        // Create a default server policy, without authorising any probe paths
+        let server = PolicyIndex::default_inbound_server(
+            port,
+            &self.meta.settings,
+            Vec::new().into_iter(),
+            config,
+        );
+        match self.port_servers.entry(port) {
+            Entry::Vacant(entry) => {
+                tracing::debug!(%port, server = %config.default_policy, "Creating default server");
+                let (watch, _) = watch::channel(server);
+                entry.insert(WorkloadPortServer { name: None, watch });
+            }
+
+            Entry::Occupied(mut entry) => {
+                // A server must have selected this before; override with
+                // default policy
+                let ps = entry.get_mut();
+                ps.watch.send_if_modified(|current| {
+                    // Avoid sending redundant updates
+                    if *current == server {
+                        tracing::trace!(%port, server = %config.default_policy, "Default server already set");
+                        return false;
+                    }
+
+                    tracing::debug!(%port, server = %config.default_policy, "Setting default server");
+                    ps.name = None;
+                    *current = server;
+                    true
+                });
             }
         }
     }
 
-    fn default_inbound_server<'p>(
-        port: NonZeroU16,
-        settings: &pod::Settings,
-        probe_paths: impl Iterator<Item = &'p str>,
-        config: &ClusterInfo,
-    ) -> InboundServer {
-        let protocol = if settings.opaque_ports.contains(&port) {
-            ProxyProtocol::Opaque
-        } else {
-            ProxyProtocol::Detect {
-                timeout: config.default_detect_timeout,
-            }
-        };
-
-        let mut policy = settings.default_policy.unwrap_or(config.default_policy);
-        if settings.require_id_ports.contains(&port) {
-            if let DefaultPolicy::Allow {
-                ref mut authenticated_only,
-                ..
-            } = policy
-            {
-                *authenticated_only = true;
-            }
-        }
-
-        let authorizations = policy.default_authzs(config);
-
-        let http_routes = config.default_inbound_http_routes(probe_paths);
-
-        InboundServer {
-            reference: ServerRef::Default(policy.as_str()),
-            protocol,
-            authorizations,
-            http_routes,
+    /// Returns an optional port when a server references a known external
+    /// workload port.
+    ///
+    /// Unlike a pod, an external workload has only one set of ports. Names
+    /// within the set are unique, and as a result, only one port will ever
+    /// match a given name.
+    fn selects_port(&mut self, port_ref: &Port) -> Option<NonZeroU16> {
+        match port_ref {
+            Port::Number(p) => Some(*p),
+            Port::Name(name) => self.port_names.get(name).cloned(),
         }
     }
 }
@@ -1185,6 +1461,43 @@ impl PolicyIndex {
             }
         }
         true
+    }
+
+    fn default_inbound_server<'p>(
+        port: NonZeroU16,
+        settings: &workload::Settings,
+        probe_paths: impl Iterator<Item = &'p str>,
+        config: &ClusterInfo,
+    ) -> InboundServer {
+        let protocol = if settings.opaque_ports.contains(&port) {
+            ProxyProtocol::Opaque
+        } else {
+            ProxyProtocol::Detect {
+                timeout: config.default_detect_timeout,
+            }
+        };
+
+        let mut policy = settings.default_policy.unwrap_or(config.default_policy);
+        if settings.require_id_ports.contains(&port) {
+            if let DefaultPolicy::Allow {
+                ref mut authenticated_only,
+                ..
+            } = policy
+            {
+                *authenticated_only = true;
+            }
+        }
+
+        let authorizations = policy.default_authzs(config);
+
+        let http_routes = config.default_inbound_http_routes(probe_paths);
+
+        InboundServer {
+            reference: ServerRef::Default(policy.as_str()),
+            protocol,
+            authorizations,
+            http_routes,
+        }
     }
 
     fn inbound_server<'p>(

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -170,6 +170,13 @@ async fn main() -> Result<()> {
         kubert::index::namespaced(inbound_index.clone(), pods).instrument(info_span!("pods")),
     );
 
+    let external_workloads =
+        runtime.watch_all::<k8s::external_workload::ExternalWorkload>(watcher::Config::default());
+    tokio::spawn(
+        kubert::index::namespaced(inbound_index.clone(), external_workloads)
+            .instrument(info_span!("external_workloads")),
+    );
+
     let servers = runtime.watch_all::<k8s::policy::Server>(watcher::Config::default());
     let servers_indexes = IndexList::new(inbound_index.clone())
         .push(status_index.clone())

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -14,6 +14,7 @@ k8s-gateway-api = "0.15"
 k8s-openapi = { version = "0.20", features = ["v1_22"] }
 linkerd-policy-controller-core = { path = "../policy-controller/core" }
 linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
+linkerd-policy-controller-grpc = { path = "../policy-controller/grpc"}
 maplit = "1"
 rand = "0.8"
 serde = "1"

--- a/policy-test/src/grpc.rs
+++ b/policy-test/src/grpc.rs
@@ -9,8 +9,8 @@ use linkerd2_proxy_api::{
     inbound::inbound_server_policies_client::InboundServerPoliciesClient,
     outbound::outbound_policies_client::OutboundPoliciesClient,
 };
+use linkerd_policy_controller_grpc::workload;
 use linkerd_policy_controller_k8s_api::{self as k8s, ResourceExt};
-use serde::{Deserialize, Serialize};
 use tokio::io;
 
 #[macro_export]
@@ -99,22 +99,6 @@ pub struct InboundPolicyClient {
 #[derive(Debug)]
 pub struct OutboundPolicyClient {
     client: OutboundPoliciesClient<GrpcHttp>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub enum Kind {
-    #[serde(rename = "external_workload")]
-    External(String),
-    #[serde(rename = "pod")]
-    Pod(String),
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct Workload {
-    #[serde(flatten)]
-    pub kind: Kind,
-    #[serde(rename = "ns")]
-    pub namespace: String,
 }
 
 #[derive(Debug)]
@@ -218,8 +202,8 @@ impl InboundPolicyClient {
         name: &str,
         port: u16,
     ) -> Result<inbound::Server, tonic::Status> {
-        let token = serde_json::to_string(&Workload {
-            kind: Kind::External(name.into()),
+        let token = serde_json::to_string(&workload::Workload {
+            kind: workload::Kind::External(name.into()),
             namespace: ns.into(),
         })
         .unwrap();
@@ -240,8 +224,8 @@ impl InboundPolicyClient {
         name: &str,
         port: u16,
     ) -> Result<tonic::Streaming<inbound::Server>, tonic::Status> {
-        let token = serde_json::to_string(&Workload {
-            kind: Kind::External(name.into()),
+        let token = serde_json::to_string(&workload::Workload {
+            kind: workload::Kind::External(name.into()),
             namespace: ns.into(),
         })
         .unwrap();

--- a/policy-test/tests/inbound_api_external_workload.rs
+++ b/policy-test/tests/inbound_api_external_workload.rs
@@ -355,9 +355,6 @@ async fn external_workload_srv_with_http_route() {
 #[tokio::test(flavor = "current_thread")]
 async fn external_workload_default_http_route() {
     with_temp_ns(|client, ns| async move {
-        // Create a pod that does nothing. It's injected with a proxy, so we can
-        // attach policies to its admin server.
-
         // Create an external workload object.
         let ext_workload = create(&client, mk_external_workload(&ns, "wkld-1")).await;
 

--- a/policy-test/tests/inbound_api_external_workload.rs
+++ b/policy-test/tests/inbound_api_external_workload.rs
@@ -1,0 +1,467 @@
+use std::{num::NonZeroU16, time::Duration};
+
+use futures::prelude::*;
+use k8s::policy::LocalTargetRef;
+use kube::ResourceExt;
+use linkerd_policy_controller_core::{Ipv4Net, Ipv6Net};
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_test::{
+    assert_default_all_unauthenticated_labels, assert_is_default_all_unauthenticated,
+    assert_protocol_detect_external, create, grpc, with_temp_ns,
+};
+use maplit::{btreemap, convert_args, hashmap};
+use tokio::time;
+
+#[tokio::test(flavor = "current_thread")]
+async fn external_workload_srv_with_authorization_policy() {
+    with_temp_ns(|client, ns| async move {
+        // Create an external workload object.
+        let ext_workload = create(&client, mk_external_workload(&ns, "wkld-1")).await;
+
+        tracing::trace!(
+            external_workload = %ext_workload.name_any(),
+            ip = ?ext_workload.spec.workload_ips.as_ref().unwrap()[0]
+        );
+
+        let mut rx = retry_watch_server(&client, &ns, &ext_workload.name_any()).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+        assert_is_default_all_unauthenticated!(config);
+        assert_protocol_detect_external!(config);
+
+        // Create a server that selects the http port on the workload and ensure
+        // the update now uses this server (which has no authorizations)
+        let server = create(&client, mk_http_server(&ns, "external-http")).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        assert_eq!(
+            config.protocol,
+            Some(grpc::defaults::proxy_protocol_external())
+        );
+        assert_eq!(config.authorizations, vec![]);
+        assert_eq!(
+            config.labels,
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "server",
+                "name" => "external-http"
+            )),
+        );
+
+        // Create a server authorization that refers to the `linkerd-admin`
+        // server (by name) and ensure that the update now reflects this
+        // authorization.
+        create(
+            &client,
+            k8s::policy::AuthorizationPolicy {
+                metadata: kube::api::ObjectMeta {
+                    namespace: Some(ns.clone()),
+                    name: Some("all-http".to_string()),
+                    ..Default::default()
+                },
+                spec: k8s::policy::AuthorizationPolicySpec {
+                    target_ref: LocalTargetRef {
+                        group: Some("policy.linkerd.io".to_string()),
+                        kind: "server".to_string(),
+                        name: server.name_any(),
+                    },
+                    required_authentication_refs: vec![],
+                },
+            },
+        )
+        .await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an updated config");
+        tracing::trace!(?config);
+        assert_eq!(
+            config.protocol,
+            Some(grpc::defaults::proxy_protocol_external())
+        );
+        assert_eq!(
+            config.authorizations.first().unwrap().labels,
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "authorizationpolicy",
+                "name" => "all-http",
+            )),
+        );
+        assert_eq!(
+            *config
+                .authorizations
+                .first()
+                .unwrap()
+                .authentication
+                .as_ref()
+                .unwrap(),
+            grpc::inbound::Authn {
+                permit: Some(grpc::inbound::authn::Permit::Unauthenticated(
+                    grpc::inbound::authn::PermitUnauthenticated {}
+                )),
+            }
+        );
+        assert_eq!(
+            config.labels,
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "server",
+                "name" => server.name_unchecked()
+            ))
+        );
+
+        // Delete the `Server` and ensure that the update reverts to the
+        // default.
+        kube::Api::<k8s::policy::Server>::namespaced(client.clone(), &ns)
+            .delete(
+                &server.name_unchecked(),
+                &kube::api::DeleteParams::default(),
+            )
+            .await
+            .expect("Server must be deleted");
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an updated config");
+
+        assert_is_default_all_unauthenticated!(config);
+        assert_protocol_detect_external!(config);
+    })
+    .await
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn external_workload_srv_with_http_route() {
+    with_temp_ns(|client, ns| async move {
+        // Create an external workload object.
+        let ext_workload = create(&client, mk_external_workload(&ns, "wkld-1")).await;
+
+        tracing::trace!(
+            external_workload = %ext_workload.name_any(),
+            ip = ?ext_workload.spec.workload_ips.as_ref().unwrap()[0]
+        );
+
+        let mut rx = retry_watch_server(&client, &ns, &ext_workload.name_any()).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+        assert_is_default_all_unauthenticated!(config);
+        assert_protocol_detect_external!(config);
+
+        // Create a server that selects the http port on the workload and ensure
+        // the update now uses this server (which has no authorizations)
+        let server = create(&client, mk_http_server(&ns, "external-http")).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        assert_eq!(
+            config.protocol,
+            Some(grpc::defaults::proxy_protocol_external())
+        );
+        assert_eq!(config.authorizations, vec![]);
+        assert_eq!(
+            config.labels,
+            convert_args!(hashmap!(
+                "group" => "policy.linkerd.io",
+                "kind" => "server",
+                "name" => "external-http"
+            )),
+        );
+
+        let created_route = {
+            use k8s::policy::httproute as api;
+            let http_route = api::HttpRoute {
+                metadata: kube::api::ObjectMeta {
+                    namespace: Some(ns.to_string()),
+                    name: Some("http-route".to_string()),
+                    ..Default::default()
+                },
+                spec: api::HttpRouteSpec {
+                    inner: api::CommonRouteSpec {
+                        parent_refs: Some(vec![api::ParentReference {
+                            group: Some("policy.linkerd.io".to_string()),
+                            kind: Some("Server".to_string()),
+                            name: server.name_any(),
+                            namespace: None,
+                            section_name: None,
+                            port: None,
+                        }]),
+                    },
+                    hostnames: None,
+                    rules: Some(vec![api::HttpRouteRule {
+                        matches: Some(vec![api::HttpRouteMatch {
+                            path: Some(api::HttpPathMatch::Exact {
+                                value: "/endpoint".to_string(),
+                            }),
+                            headers: None,
+                            query_params: None,
+                            method: Some("GET".to_string()),
+                        }]),
+                        filters: None,
+                        backend_refs: None,
+                        timeouts: None,
+                    }]),
+                },
+                status: None,
+            };
+
+            create(&client, http_route).await
+        };
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        let kind = config
+            .protocol
+            .as_ref()
+            .expect("must have proxy protocol")
+            .kind
+            .as_ref()
+            .expect("must have kind");
+        let routes = if let grpc::inbound::proxy_protocol::Kind::Http1(ref http1) = kind {
+            &http1.routes[..]
+        } else {
+            panic!("proxy protocol must be 'Http1'; actually got:\n{kind:#?}");
+        };
+
+        assert_eq!(routes.len(), 1);
+        let route = routes.first().expect("must have route");
+        // Route should have no authz policy by default
+        assert_eq!(route.authorizations, vec![]);
+        assert_eq!(
+            route.metadata.to_owned().expect("route must have metadata"),
+            grpc::meta::Metadata {
+                kind: Some(grpc::meta::metadata::Kind::Resource(grpc::meta::Resource {
+                    group: "policy.linkerd.io".to_string(),
+                    kind: "HTTPRoute".to_string(),
+                    name: "http-route".to_string(),
+                    ..Default::default()
+                }))
+            }
+        );
+
+        // Route has path match
+        let rule_match = route
+            .rules
+            .first()
+            .expect("must have rule")
+            .matches
+            .first()
+            .expect("must have match");
+        assert_eq!(
+            rule_match
+                .path
+                .to_owned()
+                .expect("must have path match")
+                .kind
+                .expect("must have kind"),
+            grpc::http_route::path_match::Kind::Exact("/endpoint".to_string())
+        );
+
+        // Create a network authn and a policy that refers to the route
+        let all_networks = create(
+            &client,
+            k8s::policy::NetworkAuthentication {
+                metadata: kube::api::ObjectMeta {
+                    namespace: Some(ns.clone()),
+                    name: Some("all-net".to_string()),
+                    ..Default::default()
+                },
+                spec: k8s::policy::NetworkAuthenticationSpec {
+                    networks: vec![
+                        k8s::policy::network_authentication::Network {
+                            cidr: Ipv4Net::default().into(),
+                            except: None,
+                        },
+                        k8s::policy::network_authentication::Network {
+                            cidr: Ipv6Net::default().into(),
+                            except: None,
+                        },
+                    ],
+                },
+            },
+        )
+        .await;
+        create(
+            &client,
+            k8s::policy::AuthorizationPolicy {
+                metadata: kube::api::ObjectMeta {
+                    namespace: Some(ns.clone()),
+                    name: Some("all-net".to_string()),
+                    ..Default::default()
+                },
+                spec: k8s::policy::AuthorizationPolicySpec {
+                    target_ref: k8s::policy::LocalTargetRef::from_resource(&created_route),
+                    required_authentication_refs: vec![
+                        k8s::policy::NamespacedTargetRef::from_resource(&all_networks),
+                    ],
+                },
+            },
+        )
+        .await;
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        let http1 = if let grpc::inbound::proxy_protocol::Kind::Http1(http1) = config
+            .protocol
+            .expect("must have proxy protocol")
+            .kind
+            .expect("must have kind")
+        {
+            http1
+        } else {
+            panic!("proxy protocol must be HTTP1");
+        };
+        let h1_route = http1.routes.first().expect("must have route");
+        assert_eq!(h1_route.authorizations.len(), 1, "must have authorizations");
+
+        // Delete the `HttpRoute` and ensure that the update reverts to the
+        // default.
+        kube::Api::<k8s::policy::HttpRoute>::namespaced(client.clone(), &ns)
+            .delete("http-route", &kube::api::DeleteParams::default())
+            .await
+            .expect("HttpRoute must be deleted");
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        assert_eq!(
+            config.protocol,
+            Some(grpc::defaults::proxy_protocol_external())
+        );
+    })
+    .await;
+}
+#[tokio::test(flavor = "current_thread")]
+async fn external_workload_default_http_route() {
+    with_temp_ns(|client, ns| async move {
+        // Create a pod that does nothing. It's injected with a proxy, so we can
+        // attach policies to its admin server.
+
+        // Create an external workload object.
+        let ext_workload = create(&client, mk_external_workload(&ns, "wkld-1")).await;
+
+        tracing::trace!(
+            external_workload = %ext_workload.name_any(),
+            ip = ?ext_workload.spec.workload_ips.as_ref().unwrap()[0]
+        );
+
+        let mut rx = retry_watch_server(&client, &ns, &ext_workload.name_any()).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+        assert_is_default_all_unauthenticated!(config);
+        assert_protocol_detect_external!(config);
+
+        let kind = config
+            .protocol
+            .as_ref()
+            .expect("must have proxy protocol")
+            .kind
+            .as_ref()
+            .expect("must have kind");
+        let routes = if let grpc::inbound::proxy_protocol::Kind::Detect(ref detect) = kind {
+            &detect.http_routes[..]
+        } else {
+            panic!("proxy protocol must be 'Detect'; actually got:\n{kind:#?}");
+        };
+
+        assert_eq!(routes.len(), 1);
+        let route_authzs = &routes[0].authorizations;
+        assert_eq!(route_authzs.len(), 0);
+    })
+    .await
+}
+
+fn mk_external_workload(ns: &str, name: &str) -> k8s::external_workload::ExternalWorkload {
+    k8s::external_workload::ExternalWorkload {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.into()),
+            name: Some(name.into()),
+            labels: Some(convert_args!(btreemap!(
+                        "app" => "ext",
+            ))),
+            ..Default::default()
+        },
+        spec: k8s::external_workload::ExternalWorkloadSpec {
+            mesh_tls: k8s::external_workload::MeshTls {
+                identity: "some-identity".to_string(),
+                server_name: "some-sni".to_string(),
+            },
+            ports: Some(vec![k8s::external_workload::PortSpec {
+                name: Some("http".into()),
+                port: NonZeroU16::new(80).unwrap(),
+                protocol: Default::default(),
+            }]),
+            workload_ips: Some(vec![k8s::external_workload::WorkloadIP {
+                ip: "192.0.2.0".to_string(),
+            }]),
+        },
+        status: None,
+    }
+}
+
+async fn retry_watch_server(
+    client: &kube::Client,
+    ns: &str,
+    workload_name: &str,
+) -> tonic::Streaming<grpc::inbound::Server> {
+    let mut policy_api = grpc::InboundPolicyClient::port_forwarded(client).await;
+    loop {
+        match policy_api
+            .watch_port_for_external_workload(ns, workload_name, 80)
+            .await
+        {
+            Ok(rx) => return rx,
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    ns,
+                    workload_name,
+                    "failed to watch policy for port 80"
+                );
+                time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+fn mk_http_server(ns: &str, name: &str) -> k8s::policy::Server {
+    k8s::policy::Server {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        spec: k8s::policy::ServerSpec {
+            selector: k8s::policy::server::Selector::ExternalWorkload(
+                k8s::labels::Selector::default(),
+            ),
+            port: k8s::policy::server::Port::Name("http".to_string()),
+            proxy_protocol: Some(k8s::policy::server::ProxyProtocol::Http1),
+        },
+    }
+}


### PR DESCRIPTION
ExternalWorkload resources represent as a resource configuration associated with a process (or a group of processes) that are foreign to a Kubernetes cluster. It allows Linkerd to read / write and store configuration for mesh expansion. Since VMs will be able to receive inbound traffic from a variety of resources, the proxy should be able to dynamically discover inbound authorisation policies.

This change introduces a set of callbacks in the indexer that will apply (or delete) ExternalWorkload resources. In addition, we ensure that ExternalWorkloads can be processed in a similar fashion to pods (where applicable, of course) wrt to server matching and defaulting. To serve discovery requests for a VM, the policy controller will now also start a watcher for external workloads and allow requests to reference an `external_workload` target

A quick list of changes:

* ExternalWorkloads can now be indexed in the inbound (policy) index.
* Renamed the pod module in the inbound index to be more generic ("workload"); the module has some re-usable building blocks that we can use for external workloads.
* Moved common functions (e.g. building a default inbound server) around to share what's already been done without abstracting more or introducing generics.
* Changed gRPC target types to a tuple of `(Workload, port)` from a tuple of `(String, String, port)`
* Added RBAC to watch external workloads.
---

### Note to reviewers

I intended only to do the index but the gRPC part wasn't that complicated. I chose to do both since the gRPC integration is important for functional testing.

To do some manual QA, I'd recommend these steps:

1. Install linkerd (most recent edge would be best); ensure there's support for the new crd.
2. Create some authentication resources
3. Run the policy controller and send discovery requests with a client such as `grpcurl`

```
HOSTNAME="foo" cargo run --features rustls-tls -- --admission-controller-disabled --server-tls-key "" --server-tls-certs "" --default-opaque-ports ""
```

<details>

<summary> Here's what I did: </summary>


* Manifests

```yaml
 apiVersion: workload.linkerd.io/v1alpha1
 kind: ExternalWorkload
 metadata:
  name: test-policy
  labels:
    app: nginx
 spec:
  meshTls:
    serverName: "foo"
    identity: "foo"
  workloadIPs:
  - ip: "192.0.2.0"
  ports:
  - port: 80
---
apiVersion: policy.linkerd.io/v1beta2
kind: Server
metadata:
  namespace: default
  name: external-nginx-server
spec:
  externalWorkloadSelector:
    matchLabels:
      app: nginx
  port: 80
  proxyProtocol: HTTP/1
---
apiVersion: policy.linkerd.io/v1alpha1
kind: AuthorizationPolicy
metadata:
  name: workload-authn
  namespace: default
spec:
  targetRef:
    group: policy.linkerd.io
    kind: Server
    name: external-nginx-server
  requiredAuthenticationRefs:
    - name: external-workload-meshtls
      kind: MeshTLSAuthentication
      group: policy.linkerd.io
---
apiVersion: policy.linkerd.io/v1alpha1
kind: MeshTLSAuthentication
metadata:
  name: external-workload-meshtls
  namespace: default
spec:
  identities:
    - "*.non-default.serviceaccount.identity.linkerd.cluster.local"
```

* grpcurl to do discovery

1. Test authn policies are discovered and bound to our declared server:

```
# I'm in the proxy-api /proto directory here
grpcurl --plaintext --proto inbound.proto -d '{"workload": "{ \"external_workload\": \"test-policy\", \"ns\": \"default\"}", "port": 80}'  localhost:8090 io.linkerd.proxy.inbound.InboundServerPolicies.GetPort
```

```
{
  "protocol": {
    "http1": {
      "routes": [
        {
          "metadata": {
            "default": "default"
          },
          "rules": [
            {
              "matches": [
                {
                  "path": {
                    "prefix": "/"
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  },
  "authorizations": [
    {
      "networks": [
        {
          "net": {
            "ip": {
              "ipv4": 0
            }
          }
        },
        {
          "net": {
            "ip": {
              "ipv6": {

              }
            }
          }
        }
      ],
      "authentication": {
        "meshTLS": {
          "identities": {
            "suffixes": [
              {
                "parts": [
                  "non-default",
                  "serviceaccount",
                  "identity",
                  "linkerd",
                  "cluster",
                  "local"
                ]
              }
            ]
          }
        }
      },
      "labels": {
        "group": "policy.linkerd.io",
        "kind": "authorizationpolicy",
        "name": "workload-authn"
      },
      "metadata": {
        "resource": {
          "group": "policy.linkerd.io",
          "kind": "authorizationpolicy",
          "name": "workload-authn"
        }
      }
    }
  ],
  "labels": {
    "group": "policy.linkerd.io",
    "kind": "server",
    "name": "external-nginx-server"
  }
}
```

2. Test that a non-documented port gets a default policy

```
:; grpcurl --plaintext --proto inbound.proto -d '{"workload": "{ \"external_workload\": \"test-policy\", \"ns\": \"default\"}", "port": 8080}'  localhost:8090 io.linkerd.proxy.inbound.InboundServerPolicies.GetPort
```

```
{
  "protocol": {
    "detect": {
      "timeout": "10s",
      "httpRoutes": [
        {
          "metadata": {
            "default": "default"
          },
          "rules": [
            {
              "matches": [
                {
                  "path": {
                    "prefix": "/"
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  },
  "authorizations": [
    {
      "networks": [
        {
          "net": {
            "ip": {
              "ipv4": 0
            }
          }
        },
        {
          "net": {
            "ip": {
              "ipv6": {

              }
            }
          }
        }
      ],
      "authentication": {
        "unauthenticated": {

        }
      },
      "labels": {
        "group": "",
        "kind": "default",
        "name": "all-unauthenticated"
      },
      "metadata": {
        "default": "all-unauthenticated"
      }
    }
  ],
  "labels": {
    "group": "",
    "kind": "default",
    "name": "all-unauthenticated"
  }
}
```

4. Check that an annotation set on the workload changes default policy (I've set mine to deny through `config.linkerd.io/default-inbound-policy="deny"`).

```
:; grpcurl --plaintext --proto inbound.proto -d '{"workload": "{ \"external_workload\": \"test-policy\", \"ns\": \"default\"}", "port": 8080}'  localhost:8090 io.linkerd.proxy.inbound.InboundServerPolicies.GetPort
```

```
{
  "protocol": {
    "detect": {
      "timeout": "10s",
      "httpRoutes": [
        {
          "metadata": {
            "default": "default"
          },
          "rules": [
            {
              "matches": [
                {
                  "path": {
                    "prefix": "/"
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  },
  "labels": {
    "group": "",
    "kind": "default",
    "name": "deny"
  }
}
```

5. Test a route:

```yaml
apiVersion: policy.linkerd.io/v1beta3
kind: HTTPRoute
metadata:
  name: server-route
spec:
  parentRefs:
    - name: external-nginx-server
      kind: Server
      group: policy.linkerd.io
  rules:
  - matches:
    - path:
        value: "/test-this"
      method: GET
```

```
:; grpcurl --plaintext --proto inbound.proto -d '{"workload": "{ \"external_workload\": \"test-policy\", \"ns\": \"default\"}", "port": 80}'  localhost:8090 io.linkerd.proxy.inbound.InboundServerPolicies.GetPort
```

```
{
  "protocol": {
    "http1": {
      "routes": [
        {
          "metadata": {
            "resource": {
              "group": "policy.linkerd.io",
              "kind": "HTTPRoute",
              "name": "server-route"
            }
          },
          "rules": [
            {
              "matches": [
                {
                  "path": {
                    "prefix": "/test-this"
                  },
                  "method": {
                    "registered": "GET"
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  },
```

6. And finally, delete the server  and observe default route for documented port (80):

```
:; grpcurl --plaintext --proto inbound.proto -d '{"workload": "{ \"external_workload\": \"test-policy\", \"ns\": \"default\"}", "port": 80}'  localhost:8090 io.linkerd.proxy.inbound.InboundServerPolicies.GetPort
```


```
{
  "protocol": {
    "detect": {
      "timeout": "10s",
      "httpRoutes": [
        {
          "metadata": {
            "default": "default"
          },
          "rules": [
            {
              "matches": [
                {
                  "path": {
                    "prefix": "/"
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  },
  "labels": {
    "group": "",
    "kind": "default",
    "name": "deny"
  }
}

```

</details>
