### PR TITLE
Update steering committee membership requirements

### DIFF
--- a/STEERING.md
+++ b/STEERING.md
@@ -24,7 +24,8 @@ The Steering Committee’s responsibilities are to:
 The Steering Committee comprises at most 7 people. To be eligible for
 membership in the Steering Committee, you must:
 
-1. Be responsible for a production Linkerd deployment of non-trivial size
+1. Have been responsible for a production Linkerd deployment of non-trivial
+   size within the past two years.
 2. Be willing and able to attend regularly-scheduled Steering Committee
    meetings
 3. Abide by Linkerd's Code of Conduct.

--- a/STEERING.md
+++ b/STEERING.md
@@ -24,10 +24,11 @@ The Steering Committee’s responsibilities are to:
 The Steering Committee comprises at most 7 people. To be eligible for
 membership in the Steering Committee, you must:
 
-1. Have been responsible for a production Linkerd deployment of non-trivial
-   size within the past two years.
+1. Be currently responsible for a production Linkerd deployment of non-trivial
+   size, or have been responsible for such a deployment within the past two
+   years.
 2. Be willing and able to attend regularly-scheduled Steering Committee
-   meetings
+   meetings.
 3. Abide by Linkerd's Code of Conduct.
 
 Candidates for membership will be nominated by current Steering Committee


### PR DESCRIPTION
We'd like to change the requirement for Steering Committee members such that it's OK for committee members to have been responsible for a nontrivial Linkerd deployment in production within the last two years, rather than requiring responsibility currently. This change is meant to better reflect the reality of job moves in the tech industry: a member who, for example, changes jobs to an organization in the process of adopting Linkerd shouldn't be instantly disqualified because they don't yet have a production deployment to be responsible for!
