### PR TITLE
discovery: add metrics to endpoints controller workqueue

### DIFF
--- a/controller/api/destination/external-workload/endpoints_controller.go
+++ b/controller/api/destination/external-workload/endpoints_controller.go
@@ -68,7 +68,8 @@ func NewEndpointsController(k8sAPI *k8s.API, hostname, controllerNs string, stop
 	ec := &EndpointsController{
 		k8sAPI: k8sAPI,
 		queue: workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{
-			Name: "endpoints_controller_workqueue",
+			Name:            "endpoints_controller_workqueue",
+			MetricsProvider: newWorkQueueMetricsProvider(),
 		}),
 		stop: stopCh,
 		log: logging.WithFields(logging.Fields{

--- a/controller/api/destination/external-workload/endpoints_controller.go
+++ b/controller/api/destination/external-workload/endpoints_controller.go
@@ -63,15 +63,18 @@ type EndpointsController struct {
 //
 // NewEndpointsController creates a new controller. The controller must be
 // started with its `Start()` method.
-func NewEndpointsController(k8sAPI *k8s.API, hostname, controllerNs string, stopCh chan struct{}) (*EndpointsController, error) {
-	// TODO: pass in a metrics provider to the queue config
+func NewEndpointsController(k8sAPI *k8s.API, hostname, controllerNs string, stopCh chan struct{}, exportQueueMetrics bool) (*EndpointsController, error) {
+	workQueueConfig := workqueue.RateLimitingQueueConfig{
+		Name: "endpoints_controller_workqueue",
+	}
+	if exportQueueMetrics {
+		workQueueConfig.MetricsProvider = newWorkQueueMetricsProvider()
+	}
+
 	ec := &EndpointsController{
 		k8sAPI: k8sAPI,
-		queue: workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{
-			Name:            "endpoints_controller_workqueue",
-			MetricsProvider: newWorkQueueMetricsProvider(),
-		}),
-		stop: stopCh,
+		queue:  workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workQueueConfig),
+		stop:   stopCh,
 		log: logging.WithFields(logging.Fields{
 			"component": "external-endpoints-controller",
 		}),

--- a/controller/api/destination/external-workload/endpoints_controller_test.go
+++ b/controller/api/destination/external-workload/endpoints_controller_test.go
@@ -326,7 +326,7 @@ func TestWorkloadServicesToUpdate(t *testing.T) {
 				t.Fatalf("unexpected error %v", err)
 			}
 
-			ec, err := NewEndpointsController(k8sAPI, "my-hostname", "controlplane-ns", make(chan struct{}))
+			ec, err := NewEndpointsController(k8sAPI, "my-hostname", "controlplane-ns", make(chan struct{}), false)
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}

--- a/controller/api/destination/external-workload/queue_metrics.go
+++ b/controller/api/destination/external-workload/queue_metrics.go
@@ -1,0 +1,116 @@
+package externalworkload
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// Code is functionally the same as usptream metrics provider. The difference is that
+// we rely on promauto instead of init() method for metrics registering as the logic
+// used to register the metrics in the upstream implementation uses k8s.io/component-base/metrics/legacyregistry
+// The latter does not work with our metrics registry and hence these metrics do not
+// end up exposed via our admin's server /metrics endpoint.
+//
+// https://github.com/kubernetes/component-base/blob/68f947b04ec3a353e63bbef2c1f935bb9ce0061d/metrics/prometheus/workqueue/metrics.go
+
+const (
+	WorkQueueSubsystem         = "workqueue"
+	DepthKey                   = "depth"
+	AddsKey                    = "adds_total"
+	QueueLatencyKey            = "queue_duration_seconds"
+	WorkDurationKey            = "work_duration_seconds"
+	UnfinishedWorkKey          = "unfinished_work_seconds"
+	LongestRunningProcessorKey = "longest_running_processor_seconds"
+	RetriesKey                 = "retries_total"
+)
+
+type queueMetricsProvider struct {
+	depth                   *prometheus.GaugeVec
+	adds                    *prometheus.CounterVec
+	latency                 *prometheus.HistogramVec
+	workDuration            *prometheus.HistogramVec
+	unfinished              *prometheus.GaugeVec
+	longestRunningProcessor *prometheus.GaugeVec
+	retries                 *prometheus.CounterVec
+}
+
+func newWorkQueueMetricsProvider() workqueue.MetricsProvider {
+	return &queueMetricsProvider{
+		depth: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Subsystem: WorkQueueSubsystem,
+			Name:      DepthKey,
+			Help:      "Current depth of workqueue",
+		}, []string{"name"}),
+
+		adds: promauto.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: WorkQueueSubsystem,
+			Name:      AddsKey,
+			Help:      "Total number of adds handled by workqueue",
+		}, []string{"name"}),
+
+		latency: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Subsystem: WorkQueueSubsystem,
+			Name:      QueueLatencyKey,
+			Help:      "How long in seconds an item stays in workqueue before being requested.",
+			Buckets:   prometheus.ExponentialBuckets(10e-9, 10, 10),
+		}, []string{"name"}),
+
+		workDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Subsystem: WorkQueueSubsystem,
+			Name:      WorkDurationKey,
+			Help:      "How long in seconds processing an item from workqueue takes.",
+			Buckets:   prometheus.ExponentialBuckets(10e-9, 10, 10),
+		}, []string{"name"}),
+
+		unfinished: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Subsystem: WorkQueueSubsystem,
+			Name:      UnfinishedWorkKey,
+			Help: "How many seconds of work has done that " +
+				"is in progress and hasn't been observed by work_duration. Large " +
+				"values indicate stuck threads. One can deduce the number of stuck " +
+				"threads by observing the rate at which this increases.",
+		}, []string{"name"}),
+
+		longestRunningProcessor: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Subsystem: WorkQueueSubsystem,
+			Name:      LongestRunningProcessorKey,
+			Help: "How many seconds has the longest running " +
+				"processor for workqueue been running.",
+		}, []string{"name"}),
+
+		retries: promauto.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: WorkQueueSubsystem,
+			Name:      RetriesKey,
+			Help:      "Total number of retries handled by workqueue",
+		}, []string{"name"}),
+	}
+}
+
+func (p queueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return p.depth.WithLabelValues(name)
+}
+
+func (p queueMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return p.adds.WithLabelValues(name)
+}
+
+func (p queueMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return p.latency.WithLabelValues(name)
+}
+
+func (p queueMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return p.workDuration.WithLabelValues(name)
+}
+
+func (p queueMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return p.unfinished.WithLabelValues(name)
+}
+
+func (p queueMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return p.longestRunningProcessor.WithLabelValues(name)
+}
+
+func (p queueMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return p.retries.WithLabelValues(name)
+}


### PR DESCRIPTION
This PR adds metrics to the work queue that is used in the external workload endpoints controller. 

To test: 
1. Apply the following diff to this branch: 
```diff
diff --git a/controller/cmd/destination/main.go b/controller/cmd/destination/main.go
index 4edddbde5..b7e170819 100644
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -9,6 +9,7 @@ import (
        "syscall"

        "github.com/linkerd/linkerd2/controller/api/destination"
+       externalworkload "github.com/linkerd/linkerd2/controller/api/destination/external-workload"
        "github.com/linkerd/linkerd2/controller/api/destination/watcher"
        "github.com/linkerd/linkerd2/controller/k8s"
        "github.com/linkerd/linkerd2/pkg/admin"
@@ -159,6 +160,9 @@ func Main(args []string) {
        metadataAPI.Sync(nil)
        clusterStore.Sync(nil)

+       ec, _ := externalworkload.NewEndpointsController(k8sAPI, "my-hostname", "default", done)
+       ec.Start()
+
        go func() {
                log.Infof("starting gRPC server on %s", *addr)
                if err := server.Serve(lis); err != nil {
```
2. Create the following resources: 
```
apiVersion: v1
kind: Service
metadata:
  name: nginx-svc
spec:
  selector:
    app: nginx
  ports:
    - name: http
      protocol: TCP
      port: 80
---
 apiVersion: workload.linkerd.io/v1alpha1
 kind: ExternalWorkload
 metadata:
  name: test
  labels:
    app: nginx
 spec:
  meshTls:
    serverName: "foo"
    identity: "foo"
  workloadIPs:
  - ip: "192.0.2.0"
  ports:
  - port: 80
```
3. Hit the /metrics endpoint of the destination controller:
4. Observe that queue metrics are present: 
```
# HELP workqueue_adds_total Total number of adds handled by workqueue
# TYPE workqueue_adds_total counter
workqueue_adds_total{name="endpoints_controller_workqueue"} 9
# HELP workqueue_depth Current depth of workqueue
# TYPE workqueue_depth gauge
workqueue_depth{name="endpoints_controller_workqueue"} 0
# HELP workqueue_longest_running_processor_seconds How many seconds has the longest running processor for workqueue been running.
# TYPE workqueue_longest_running_processor_seconds gauge
workqueue_longest_running_processor_seconds{name="endpoints_controller_workqueue"} 0
# HELP workqueue_queue_duration_seconds How long in seconds an item stays in workqueue before being requested.
# TYPE workqueue_queue_duration_seconds histogram
workqueue_queue_duration_seconds_bucket{name="endpoints_controller_workqueue",le="1e-08"} 0
workqueue_queue_duration_seconds_bucket{name="endpoints_controller_workqueue",le="1e-07"} 0
workqueue_queue_duration_seconds_bucket{name="endpoints_controller_workqueue",le="1e-06"} 0
```

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
