### PR TITLE
Relax validation for ExternalWorkload Status fields

### DIFF
--- a/charts/linkerd-crds/templates/workload/external-workload.yaml
+++ b/charts/linkerd-crds/templates/workload/external-workload.yaml
@@ -154,8 +154,5 @@ spec:
                       maxLength: 32768
                       type: string
                 required:
-                - lastTransitionTime
                 - status
                 - type
-                - reason
-                - message

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -10382,8 +10382,5 @@ spec:
                       maxLength: 32768
                       type: string
                 required:
-                - lastTransitionTime
                 - status
                 - type
-                - reason
-                - message

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -10400,8 +10400,5 @@ spec:
                       maxLength: 32768
                       type: string
                 required:
-                - lastTransitionTime
                 - status
                 - type
-                - reason
-                - message

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -10400,8 +10400,5 @@ spec:
                       maxLength: 32768
                       type: string
                 required:
-                - lastTransitionTime
                 - status
                 - type
-                - reason
-                - message

--- a/controller/gen/apis/externalworkload/v1alpha1/types.go
+++ b/controller/gen/apis/externalworkload/v1alpha1/types.go
@@ -111,12 +111,15 @@ type WorkloadCondition struct {
 	// +optional
 	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty"`
 	// Last time a condition transitioned from one status to another.
-	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 	// Unique one word reason in CamelCase that describes the reason for a
 	// transition.
-	Reason string `json:"reason"`
+	// +optional
+	Reason string `json:"reason,omitempty"`
 	// Human readable message that describes details about last transition.
-	Message string `json:"message"`
+	// +optional
+	Message string `json:"message,omitempty"`
 }
 
 // WorkloadConditionType is a value for the type of a condition in an

--- a/policy-controller/k8s/api/src/external_workload.rs
+++ b/policy-controller/k8s/api/src/external_workload.rs
@@ -77,14 +77,14 @@ pub struct Condition {
     /// Can be True, False, Unknown
     status: ConditionStatus,
     /// Last time a condition transitioned from one status to another.
-    last_transition_time: crate::apimachinery::pkg::apis::meta::v1::Time,
+    last_transition_time: Option<crate::apimachinery::pkg::apis::meta::v1::Time>,
     /// Last time an ExternalWorkload was probed for a condition.
     last_probe_time: Option<crate::apimachinery::pkg::apis::meta::v1::Time>,
     /// Unique one word reason in CamelCase that describes the reason for a
     /// transition.
-    reason: String,
+    reason: Option<String>,
     /// Human readable message that describes details about last transition.
-    message: String,
+    message: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]


### PR DESCRIPTION
ExternalWorkload resources require that status condition has almost all of its fields set (with the exception of a date field). The original inspiration for this design was the HTTPRoute object.

When using the resource, it is more practical to handle many of the fields as optional; it is cumbersome to fill out the fields when creating an ExternalWorkload. We change the settings to be in-line with a [Pod] object instead.

[Pod]: https://github.com/kubernetes/api/blob/7d1a2f7a7336547258f7dc8594d7e35f0399e966/core/v1/types.go#L3063-L3084

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
