### PR TITLE
Return INVALID_ARGUMENT status codes properly from GetProfile

### DIFF
--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -280,6 +280,11 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 	if ip := net.ParseIP(host); ip != nil {
 		err = s.getProfileByIP(token, ip, port, log, stream)
 		if err != nil {
+			var ise watcher.InvalidService
+			if errors.As(err, &ise) {
+				log.Debugf("Invalid service %s", dest.GetPath())
+				return status.Errorf(codes.InvalidArgument, "Invalid authority: %s", dest.GetPath())
+			}
 			log.Errorf("Failed to subscribe to profile by ip %q: %q", dest.GetPath(), err)
 		}
 		return err
@@ -287,6 +292,11 @@ func (s *server) GetProfile(dest *pb.GetDestination, stream pb.Destination_GetPr
 
 	err = s.getProfileByName(token, host, port, log, stream)
 	if err != nil {
+		var ise watcher.InvalidService
+		if errors.As(err, &ise) {
+			log.Debugf("Invalid service %s", dest.GetPath())
+			return status.Errorf(codes.InvalidArgument, "Invalid authority: %s", dest.GetPath())
+		}
 		log.Errorf("Failed to subscribe to profile by name %q: %q", dest.GetPath(), err)
 	}
 	return err

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -492,6 +492,17 @@ status:
   conditions:
   ready: true`,
 	}
+	extenalNameResources := []string{
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  name: externalname
+  namespace: ns
+spec:
+  type: ExternalName
+  externalName: linkerd.io`,
+	}
 
 	res := append(meshedPodResources, clientSP...)
 	res = append(res, unmeshedPod)
@@ -504,6 +515,7 @@ status:
 	res = append(res, mirrorServiceResources...)
 	res = append(res, destinationCredentialsResources...)
 	res = append(res, externalWorkloads...)
+	res = append(res, extenalNameResources...)
 	k8sAPI, l5dClient, err := k8s.NewFakeAPIWithL5dClient(res...)
 	if err != nil {
 		t.Fatalf("NewFakeAPIWithL5dClient returned an error: %s", err)


### PR DESCRIPTION
When the destination controller receives a GetProfile request for an ExternalName service, it should return gRPC status code INVALID_ARGUMENT to signal to the proxy that ExternalName services do not have endpoints and service discovery should not be used.  However, the destination controller is returning gRPC status code UNKNOWN instead.  This causes the proxy to retry these requests, resulting in a flurry of warning logs in the destination controller.

We fix the destination controller to properly return INVALID_ARGUMENT instead of UNKNOWN for ExternalName services.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
