### PR TITLE
Process ExternalWorkload targetRefs when updating slices

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -985,6 +985,11 @@ func (pp *portPublisher) endpointSliceToIDs(es *discovery.EndpointSlice) []ID {
 				Name:      endpoint.TargetRef.Name,
 				Namespace: endpoint.TargetRef.Namespace,
 			})
+		} else if endpoint.TargetRef.Kind == endpointTargetRefExternalWorkload {
+			ids = append(ids, ExternalWorkloadID{
+				Name:      endpoint.TargetRef.Name,
+				Namespace: endpoint.TargetRef.Namespace,
+			})
 		}
 
 	}

--- a/controller/api/destination/watcher/endpoints_watcher_test.go
+++ b/controller/api/destination/watcher/endpoints_watcher_test.go
@@ -2895,7 +2895,7 @@ status:
 
 // Test that when an endpointslice's endpoints change their readiness status to
 // not ready, this is correctly picked up by the subscribers
-func TestEndpointSliceChangeToUnready(t *testing.T) {
+func TestEndpointSliceChangeNotReady(t *testing.T) {
 	k8sConfigsWithES := []string{`
 kind: APIResourceList
 apiVersion: v1
@@ -3037,7 +3037,7 @@ status:
 }
 
 // Test that when an endpointslice's endpoints change their readiness status to
-// not ready, this is correctly picked up by the subscribers
+// ready, this is correctly picked up by the subscribers
 func TestEndpointSliceChangeToReady(t *testing.T) {
 	k8sConfigsWithES := []string{`
 kind: APIResourceList


### PR DESCRIPTION
If the readiness of an external workload endpoint changes while traffic is being sent to it, the update will not be propagated to clients. This can lead to issues where an endpoint that is marked as `notReady` continues to figure out as being `ready` by the endpoints watcher.

The issue stems from how endpoint slices are diffed. A utility function responsible for processing addresses does not consider endpoints whose targetRef is an external workload. We fix the problem and add two module tests to validate readiness is propagated to clients correctly.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
