### PR TITLE
diagnostics endpoints: Support -token

### DIFF
--- a/cli/cmd/endpoints_test.go
+++ b/cli/cmd/endpoints_test.go
@@ -130,7 +130,7 @@ func testEndpointsCall(exp endpointsExp, t *testing.T) {
 		},
 	}
 
-	endpoints, err := requestEndpointsFromAPI(mockClient, exp.authorities)
+	endpoints, err := requestEndpointsFromAPI(mockClient, "", exp.authorities)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
The 'diagnostics endpoints' command does not allow the caller to specify a context token (indicating the requester nodeName). This change adds a command-line option to configure this value.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
