### PR TITLE
discovery: fix Server version support check

### DIFF
--- a/pkg/k8s/authz.go
+++ b/pkg/k8s/authz.go
@@ -113,7 +113,7 @@ func ServiceProfilesAccess(ctx context.Context, k8sClient kubernetes.Interface) 
 // ServersAccess checks whether the Server CRD is installed on the cluster
 // and the client is authorized to access Servers.
 func ServersAccess(ctx context.Context, k8sClient kubernetes.Interface) error {
-	groupVersion := fmt.Sprintf("%s/%s", PolicyAPIGroup, PolicyAPIVersion)
+	groupVersion := fmt.Sprintf("%s/%s", PolicyAPIGroup, PolicyServerCRDVersion)
 	res, err := k8sClient.Discovery().ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func ServersAccess(ctx context.Context, k8sClient kubernetes.Interface) error {
 			}
 		}
 	}
-	return errors.New("Server CRD not found")
+	return fmt.Errorf("server CRD (%s) not found", groupVersion)
 }
 
 // ExtWorkloadAccess checks whether the ExternalWorkload CRD is installed on the

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -38,8 +38,8 @@ const (
 	AuthorizationPolicy   = "authorizationpolicy"
 	HTTPRoute             = "httproute"
 
-	PolicyAPIGroup   = "policy.linkerd.io"
-	PolicyAPIVersion = "v1beta1"
+	PolicyAPIGroup         = "policy.linkerd.io"
+	PolicyServerCRDVersion = "v1beta2"
 
 	ServiceProfileAPIVersion = "linkerd.io/v1alpha2"
 	ServiceProfileKind       = "ServiceProfile"


### PR DESCRIPTION
Problem
Currently upon initializing the Kubernetes API, the destinations controller checks whether v1beta1 of the Server resource is supported on the cluster. We however use v1beta2 bindings. In the situation where the cluster does not have v1beta2 resource installed, this check passes and the destinations service fails when trying to init the API. One situation where this can happen is when we are adding a remote cluster in the cluster store. If this cluster does not have the v1beta2 CRD installed, the destination service will get stuck upon initialization.

Solution
This PR fixed the support check. This should handle incompatible clusters gracefully by logging an error and not adding them to the cluster store.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>