### PR TITLE
Fix how names are generated for external EndpointSlice resources

### DIFF
--- a/controller/api/destination/external-workload/endpoints_reconciler.go
+++ b/controller/api/destination/external-workload/endpoints_reconciler.go
@@ -433,7 +433,7 @@ func newEndpointSlice(svc *corev1.Service, meta *endpointMeta, controllerName st
 	ownerRef := metav1.NewControllerRef(svc, schema.GroupVersionKind{Version: "v1", Kind: "Service"})
 	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:    fmt.Sprintf("linkerd-external-%s", svc.Name),
+			GenerateName:    fmt.Sprintf("linkerd-external-%s-", svc.Name),
 			Namespace:       svc.Namespace,
 			Labels:          map[string]string{},
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},


### PR DESCRIPTION
Any slices generated for a group of external workloads follow a similar convention: `linkerd-external-<svc-name>-<hash>`. Currently the hash is appended directly to the service name making it less readable. We add a `-` to the generate name value so that random hashes are not part of the service name. This is similar to the upstream implementation.

e.g. 

```
# Ours
linkerd-external-external-workload-18wm5k      IPv4          80        172.22.0.4                     
# Upstream's
external-workload-1-7qfhm                      IPv4          <unset>   <unset>                            5s
```

```
external-workload-1-qt84r                       IPv4          <unset>   <unset>                            100s
external-workload-3-x9mcb                       IPv4          <unset>   <unset>                            100s
legacy-app-vm-headless-mb9cn                    IPv4          <unset>   <unset>                            100s
legacy-app-cluster-mcmv6                        IPv4          80        10.42.0.15                         100s
external-workload-2-m9zfh                       IPv4          <unset>   <unset>                            100s
legacy-app-hq5rc                                IPv4          80        10.42.0.15                         100s
linkerd-external-external-workload-2-vk2wl      IPv4          80        172.22.0.5                         6s
linkerd-external-external-workload-3-wztkv      IPv4          80        172.22.0.6                         6s
linkerd-external-legacy-app-lmftg               IPv4          80        172.22.0.4,172.22.0.5,172.22.0.6   6s
linkerd-external-legacy-app-vm-headless-8gpbh   IPv4          80        172.22.0.4,172.22.0.5,172.22.0.6   6s
linkerd-external-external-workload-1-7q8l6      IPv4          80        172.22.0.4                         6s

```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
