### PR TITLE
namespaceOverride parameter on Helm Charts

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -185,6 +185,7 @@ Kubernetes: `>=1.22.0-0`
 | kubeAPI.clientBurst | int | `200` | Burst value over clientQPS |
 | kubeAPI.clientQPS | int | `100` | Maximum QPS sent to the kube-apiserver before throttling. See [token bucket rate limiter implementation](https://github.com/kubernetes/client-go/blob/v12.0.0/util/flowcontrol/throttle.go) |
 | linkerdVersion | string | `"linkerdVersionValue"` | control plane version. See Proxy section for proxy version |
+| namespaceOverride | string | `""` | Override namespace for all components |
 | networkValidator.connectAddr | string | `"1.1.1.1:20001"` | Address to which the network-validator will attempt to connect. we expect this to be rewritten |
 | networkValidator.enableSecurityContext | bool | `true` | Include a securityContext in the network-validator pod spec |
 | networkValidator.listenAddr | string | `"0.0.0.0:4140"` | Address to which network-validator listens to requests from itself |

--- a/charts/linkerd-control-plane/templates/config-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/config-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{ include "partials.annotations.created-by" . }}
   name: ext-namespace-metadata-linkerd-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]

--- a/charts/linkerd-control-plane/templates/config.yaml
+++ b/charts/linkerd-control-plane/templates/config.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -56,7 +56,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-destination
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -70,7 +70,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator-k8s-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -108,7 +108,7 @@ webhooks:
   clientConfig:
     service:
       name: linkerd-sp-validator
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "partials.namespace" . }}
       path: "/"
     {{- if and (empty .Values.profileValidator.injectCaFrom) (empty .Values.profileValidator.injectCaFromSecret) }}
     caBundle: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.profileValidator.caBundle)) (empty .Values.profileValidator.caBundle) }}
@@ -129,7 +129,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator-k8s-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -167,7 +167,7 @@ webhooks:
   clientConfig:
     service:
       name: linkerd-policy-validator
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "partials.namespace" . }}
       path: "/"
     {{- if and (empty .Values.policyValidator.injectCaFrom) (empty .Values.policyValidator.injectCaFromSecret) }}
     caBundle: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.policyValidator.caBundle)) (empty .Values.policyValidator.caBundle) }}

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -6,7 +6,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -26,7 +26,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-dst-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -46,7 +46,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-sp-validator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -66,7 +66,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -86,7 +86,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-policy-validator
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -107,7 +107,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: linkerd-dst
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -138,7 +138,7 @@ metadata:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: linkerd-destination
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
 spec:
   replicas: {{.Values.controllerReplicas}}
   selector:

--- a/charts/linkerd-control-plane/templates/heartbeat-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat-rbac.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-heartbeat
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -21,7 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-heartbeat
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -69,7 +69,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-heartbeat
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -7,7 +7,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: linkerd-heartbeat
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     app.kubernetes.io/name: heartbeat
     app.kubernetes.io/part-of: Linkerd

--- a/charts/linkerd-control-plane/templates/identity-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/identity-rbac.yaml
@@ -41,7 +41,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -9,7 +9,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-identity-issuer
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -26,7 +26,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: linkerd-identity-trust-roots
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -41,7 +41,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -61,7 +61,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-identity-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -82,7 +82,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: linkerd-identity
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -113,7 +113,7 @@ metadata:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: linkerd-identity
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
 spec:
   replicas: {{.Values.controllerReplicas}}
   selector:

--- a/charts/linkerd-control-plane/templates/podmonitor.yaml
+++ b/charts/linkerd-control-plane/templates/podmonitor.yaml
@@ -8,7 +8,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: "linkerd-controller"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-ns: {{ .Release.Namespace }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -41,7 +41,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: "linkerd-service-mirror"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-ns: {{ .Release.Namespace }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -76,7 +76,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: "linkerd-proxy"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-ns: {{ .Release.Namespace }}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector-rbac.yaml
@@ -49,7 +49,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -63,7 +63,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector-k8s-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -103,7 +103,7 @@ webhooks:
   clientConfig:
     service:
       name: linkerd-proxy-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "partials.namespace" . }}
       path: "/"
     {{- if and (empty .Values.proxyInjector.injectCaFrom) (empty .Values.proxyInjector.injectCaFromSecret) }}
     caBundle: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.proxyInjector.caBundle)) (empty .Values.proxyInjector.caBundle) }}

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -19,7 +19,7 @@ metadata:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: linkerd-proxy-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
 spec:
   replicas: {{.Values.controllerReplicas}}
   selector:
@@ -168,7 +168,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: linkerd-proxy-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
@@ -190,7 +190,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: linkerd-proxy-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/charts/linkerd-control-plane/templates/psp.yaml
+++ b/charts/linkerd-control-plane/templates/psp.yaml
@@ -69,7 +69,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: linkerd-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -84,7 +84,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "partials.namespace" . }}
   labels:
     linkerd.io/control-plane-ns: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -5,6 +5,9 @@
 # -- Kubernetes DNS Domain name to use
 clusterDomain: cluster.local
 
+# -- Override namespace for all components
+namespaceOverride: ""
+
 # -- The cluster networks for which service discovery is performed. This should
 # include the pod and service networks, but need not include the node network.
 #

--- a/charts/partials/templates/_namespace.tpl
+++ b/charts/partials/templates/_namespace.tpl
@@ -1,0 +1,3 @@
+{{- define "partials.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -118,6 +118,7 @@ Kubernetes: `>=1.22.0-0`
 | namespaceMetadata.image.tag | string | `"v0.1.0"` | Docker image tag for the namespace-metadata instance |
 | namespaceMetadata.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | namespaceMetadata.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
+| namespaceOverride | string | `""` | Override namespace for all components |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | podLabels | object | `{}` | Additional labels to add to all pods |
 | tolerations | string | `nil` | Default tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |

--- a/jaeger/charts/linkerd-jaeger/templates/_helpers.tpl
+++ b/jaeger/charts/linkerd-jaeger/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "jaeger.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector-policy.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-injector-webhook
   labels:
     linkerd.io/extension: jaeger
@@ -21,7 +21,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-injector
   labels:
     linkerd.io/extension: jaeger
@@ -42,7 +42,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: kube-api-server
   labels:
     linkerd.io/extension: viz

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -14,7 +14,7 @@ metadata:
     component: jaeger-injector
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: jaeger-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
 spec:
   replicas: {{ .Values.webhook.replicas }}
   selector:
@@ -104,7 +104,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: jaeger-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     component: jaeger-injector

--- a/jaeger/charts/linkerd-jaeger/templates/psp.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/psp.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: jaeger-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/rbac.yaml
@@ -7,7 +7,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -84,7 +84,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: jaeger-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -97,7 +97,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: jaeger-injector-k8s-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -137,7 +137,7 @@ webhooks:
   clientConfig:
     service:
       name: jaeger-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "jaeger.namespace" . }}
       path: "/"
     {{- if and (empty .Values.webhook.injectCaFrom) (empty .Values.webhook.injectCaFromSecret) }}
     caBundle: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.webhook.caBundle)) (empty .Values.webhook.caBundle) }}
@@ -160,7 +160,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: jaeger
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/jaeger/charts/linkerd-jaeger/templates/tracing-policy.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing-policy.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-otlp
   labels:
     linkerd.io/extension: jaeger
@@ -21,7 +21,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-otlp-http
   labels:
     linkerd.io/extension: jaeger
@@ -38,7 +38,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-opencensus
   labels:
     linkerd.io/extension: jaeger
@@ -56,7 +56,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-zipkin
   labels:
     linkerd.io/extension: jaeger
@@ -73,7 +73,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-jaeger-thrift
   labels:
     linkerd.io/extension: jaeger
@@ -90,7 +90,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-jaeger-grpc
   labels:
     linkerd.io/extension: jaeger
@@ -107,7 +107,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-admin
   labels:
     linkerd.io/extension: jaeger
@@ -125,7 +125,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-otlp
   labels:
     linkerd.io/extension: jaeger
@@ -144,7 +144,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-otlp-http
   labels:
     linkerd.io/extension: jaeger
@@ -163,7 +163,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-opencensus
   labels:
     linkerd.io/extension: jaeger
@@ -182,7 +182,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-zipkin
   labels:
     linkerd.io/extension: jaeger
@@ -201,7 +201,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-jaeger-thrift
   labels:
     linkerd.io/extension: jaeger
@@ -220,7 +220,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: collector-jaeger-grpc
   labels:
     linkerd.io/extension: jaeger
@@ -239,7 +239,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-grpc
   labels:
     linkerd.io/extension: jaeger
@@ -257,7 +257,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-grpc
   labels:
     linkerd.io/extension: jaeger
@@ -278,7 +278,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-admin
   labels:
     linkerd.io/extension: jaeger
@@ -296,7 +296,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-admin
   labels:
     linkerd.io/extension: jaeger
@@ -318,7 +318,7 @@ spec:
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-ui
   labels:
     linkerd.io/extension: jaeger
@@ -336,7 +336,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   name: jaeger-ui
   labels:
     linkerd.io/extension: jaeger

--- a/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/tracing.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: collector-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     component: collector
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     component: collector
@@ -66,7 +66,7 @@ metadata:
     component: collector
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
 spec:
   replicas: {{ .Values.collector.replicas }}
   selector:
@@ -180,7 +180,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: jaeger
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
   labels:
     linkerd.io/extension: jaeger
     component: jaeger
@@ -208,7 +208,7 @@ metadata:
     component: jaeger
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: jaeger
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "jaeger.namespace" . }}
 spec:
   replicas: 1
   selector:

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -1,6 +1,9 @@
 # -- Namespace of the Linkerd core control-plane install
 linkerdNamespace: linkerd
 
+# -- Override namespace for all components
+namespaceOverride: ""
+
 # -- Additional labels to add to all pods
 podLabels: {}
 

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -102,6 +102,7 @@ Kubernetes: `>=1.22.0-0`
 | namespaceMetadata.image.tag | string | `"v0.1.0"` | Docker image tag for the namespace-metadata instance |
 | namespaceMetadata.nodeSelector | object | `{}` | Node selectors for the namespace-metadata instance |
 | namespaceMetadata.tolerations | list | `[]` | Tolerations for the namespace-metadata instance |
+| namespaceOverride | string | `""` | Override namespace for all components |
 | podLabels | object | `{}` | Additional labels to add to all pods |
 | proxyOutboundPort | int | `4140` | The port on which the proxy accepts outbound traffic |
 | remoteMirrorServiceAccount | bool | `true` | If the remote mirror service account should be installed |

--- a/multicluster/charts/linkerd-multicluster/templates/_helpers.tpl
+++ b/multicluster/charts/linkerd-multicluster/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "linkerd-multicluster.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/gateway-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway-policy.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   name: linkerd-gateway
   labels:
     linkerd.io/extension: multicluster
@@ -20,7 +20,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   name: linkerd-gateway
   labels:
     linkerd.io/extension: multicluster
@@ -37,16 +37,16 @@ spec:
     - group: policy.linkerd.io
       kind: MeshTLSAuthentication
       name: any-meshed
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "linkerd-multicluster.namespace" . }}
     - group: policy.linkerd.io
       kind: NetworkAuthentication
       name: source-cluster
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "linkerd-multicluster.namespace" . }}
 ---
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   name: any-meshed
   labels:
     linkerd.io/extension: multicluster
@@ -61,7 +61,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   name: source-cluster
   labels:
     linkerd.io/extension: multicluster

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -15,7 +15,7 @@ metadata:
     linkerd.io/extension: multicluster
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: {{.Values.gateway.name}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
 spec:
   replicas: {{.Values.gateway.replicas}}
   selector:
@@ -76,7 +76,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: {{.Values.gateway.name}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   labels:
     app: {{.Values.gateway.name}}
     linkerd.io/extension: multicluster
@@ -94,7 +94,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{.Values.gateway.name}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -138,7 +138,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{.Values.gateway.name}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/multicluster/charts/linkerd-multicluster/templates/psp.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/psp.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: linkerd-multicluster-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   labels:
     linkerd.io/extension: multicluster
     namespace: {{.Release.Namespace}}

--- a/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   name: service-mirror
   labels:
     linkerd.io/extension: multicluster
@@ -18,7 +18,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-multicluster.namespace" . }}
   name: service-mirror
   labels:
     linkerd.io/extension: multicluster

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -44,6 +44,8 @@ gateway:
 
 # -- Control plane version
 linkerdVersion: linkerdVersionValue
+# -- Override namespace for all components
+namespaceOverride: ""
 # -- Additional labels to add to all pods
 podLabels: {}
 # -- Labels to apply to all resources

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -133,6 +133,7 @@ Kubernetes: `>=1.22.0-0`
 | namespaceMetadata.image.tag | string | `"v0.1.0"` | Docker image tag for the namespace-metadata instance |
 | namespaceMetadata.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | NodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | namespaceMetadata.tolerations | string | `nil` | Tolerations section, See the [K8S documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information |
+| namespaceOverride | string | `""` | Override namespace for all components |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Default nodeSelector section, See the [K8S documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector) for more information |
 | podLabels | object | `{}` | Additional labels to add to all pods |
 | prometheus.alertRelabelConfigs | string | `nil` | Alert relabeling is applied to alerts before they are sent to the Alertmanager. |

--- a/viz/charts/linkerd-viz/templates/_helpers.tpl
+++ b/viz/charts/linkerd-viz/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "linkerd-viz.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/viz/charts/linkerd-viz/templates/admin-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/admin-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: kubelet
   labels:
     linkerd.io/extension: viz

--- a/viz/charts/linkerd-viz/templates/metrics-api-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: metrics-api
   labels:
     linkerd.io/extension: viz
@@ -21,7 +21,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: metrics-api
   labels:
     linkerd.io/extension: viz
@@ -42,7 +42,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: MeshTLSAuthentication
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: metrics-api-web
   labels:
     linkerd.io/extension: viz

--- a/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api-rbac.yaml
@@ -48,7 +48,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: metrics-api
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: metrics-api

--- a/viz/charts/linkerd-viz/templates/metrics-api.yaml
+++ b/viz/charts/linkerd-viz/templates/metrics-api.yaml
@@ -6,7 +6,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: metrics-api
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: metrics-api
@@ -41,7 +41,7 @@ metadata:
     component: metrics-api
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: metrics-api
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
 spec:
   replicas: {{.Values.metricsAPI.replicas}}
   selector:
@@ -129,7 +129,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: metrics-api
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: metrics-api

--- a/viz/charts/linkerd-viz/templates/prometheus-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: prometheus-admin
   labels:
     linkerd.io/extension: viz
@@ -21,7 +21,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: prometheus-admin
   labels:
     linkerd.io/extension: viz

--- a/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus-rbac.yaml
@@ -37,7 +37,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: prometheus

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -7,7 +7,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: prometheus-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: prometheus
@@ -163,7 +163,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: prometheus
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: prometheus
@@ -198,7 +198,7 @@ metadata:
     namespace: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: prometheus
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
 spec:
   replicas: 1
   {{- if .Values.prometheus.persistence }}
@@ -324,7 +324,7 @@ metadata:
     component: prometheus
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: prometheus
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
 spec:
   accessModes:
     - {{ .Values.prometheus.persistence.accessMode | quote }}

--- a/viz/charts/linkerd-viz/templates/psp.yaml
+++ b/viz/charts/linkerd-viz/templates/psp.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: viz-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     namespace: {{.Release.Namespace}}

--- a/viz/charts/linkerd-viz/templates/service-profiles.yaml
+++ b/viz/charts/linkerd-viz/templates/service-profiles.yaml
@@ -3,7 +3,7 @@ apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
   name: metrics-api.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -43,7 +43,7 @@ apiVersion: linkerd.io/v1alpha2
 kind: ServiceProfile
 metadata:
   name: prometheus.{{.Release.Namespace}}.svc.{{.Values.clusterDomain}}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}

--- a/viz/charts/linkerd-viz/templates/tap-injector-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: tap-injector-webhook
   labels:
     linkerd.io/extension: viz
@@ -21,7 +21,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: tap-injector
   labels:
     linkerd.io/extension: viz
@@ -42,7 +42,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: NetworkAuthentication
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: kube-api-server
   labels:
     linkerd.io/extension: viz

--- a/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector-rbac.yaml
@@ -34,7 +34,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: tap-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
@@ -47,7 +47,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: tap-injector-k8s-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
   labels:
@@ -89,7 +89,7 @@ webhooks:
   clientConfig:
     service:
       name: tap-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "linkerd-viz.namespace" . }}
       path: "/"
     {{- if and (empty .Values.tapInjector.injectCaFrom) (empty .Values.tapInjector.injectCaFromSecret) }}
     caBundle: {{ ternary (b64enc (trim $ca.Cert)) (b64enc (trim .Values.tapInjector.caBundle)) (empty .Values.tapInjector.caBundle) }}

--- a/viz/charts/linkerd-viz/templates/tap-injector.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-injector.yaml
@@ -6,7 +6,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: tap-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap-injector
@@ -40,7 +40,7 @@ metadata:
     component: tap-injector
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: tap-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
 spec:
   replicas: {{.Values.tapInjector.replicas}}
   selector:
@@ -133,7 +133,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: tap-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap-injector

--- a/viz/charts/linkerd-viz/templates/tap-policy.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy.linkerd.io/v1beta2
 kind: Server
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: tap-api
   labels:
     linkerd.io/extension: viz
@@ -21,7 +21,7 @@ spec:
 apiVersion: policy.linkerd.io/v1alpha1
 kind: AuthorizationPolicy
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   name: tap
   labels:
     linkerd.io/extension: viz

--- a/viz/charts/linkerd-viz/templates/tap-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/tap-rbac.yaml
@@ -75,7 +75,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: tap
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap
@@ -109,7 +109,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: tap-k8s-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap

--- a/viz/charts/linkerd-viz/templates/tap.yaml
+++ b/viz/charts/linkerd-viz/templates/tap.yaml
@@ -6,7 +6,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: tap
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap
@@ -46,7 +46,7 @@ metadata:
     namespace: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: tap
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
 spec:
   replicas: {{.Values.tap.replicas}}
   selector:
@@ -148,7 +148,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: tap
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: tap

--- a/viz/charts/linkerd-viz/templates/web-rbac.yaml
+++ b/viz/charts/linkerd-viz/templates/web-rbac.yaml
@@ -146,7 +146,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: web
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/charts/linkerd-viz/templates/web.yaml
+++ b/viz/charts/linkerd-viz/templates/web.yaml
@@ -6,7 +6,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: web
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: web
@@ -46,7 +46,7 @@ metadata:
     namespace: {{.Release.Namespace}}
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   name: web
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
 spec:
   replicas: {{.Values.dashboard.replicas}}
   selector:
@@ -149,7 +149,7 @@ kind: PodDisruptionBudget
 apiVersion: policy/v1
 metadata:
   name: web
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "linkerd-viz.namespace" . }}
   labels:
     linkerd.io/extension: viz
     component: web

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -6,6 +6,8 @@
 
 # -- control plane version. See Proxy section for proxy version
 linkerdVersion: linkerdVersionValue
+# -- Override namespace for all components
+namespaceOverride: ""
 # -- Kubernetes DNS Domain name to use
 clusterDomain: cluster.local
 # -- Additional labels to add to all pods


### PR DESCRIPTION
**Subject**: namespaceOverride parameter on Helm Charts

**Problem:** All charts are using `.Release.Name` for the namespace. I'd like to be able to override that using values.yaml.

**Solution:** Create a helper function inside `_helpers.tpl` that defaults to `.Release.Name` if `.Values.namespaceOverride` is not informed.

**Validation:**
1. Set namespaceOverride inside values.yaml, like `namespaceOverride: test`
2. Render the chart and check the namespace.

`$ bin/helm template <chart folder> | grep namespace`

**Fixes** [12048](https://github.com/linkerd/linkerd2/issues/12048)

**Signed-off-by:** Mateus Muller <mateus.muller@trustly.com>