### PR TITLE
Update workload watcher and server tests to use EndpointSlices

### DIFF
--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -86,7 +86,7 @@ func NewServer(
 		return nil, err
 	}
 
-	workloads, err := watcher.NewWorkloadWatcher(k8sAPI, metadataAPI, log, config.DefaultOpaquePorts)
+	workloads, err := watcher.NewWorkloadWatcher(k8sAPI, metadataAPI, log, config.EnableEndpointSlices, config.DefaultOpaquePorts)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -38,20 +38,24 @@ spec:
   ports:
   - port: 8989`,
 		`
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: name1
   namespace: ns
-subsets:
+  labels:
+    kubernetes.io/service-name: name1
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 172.17.0.12
-    targetRef:
-      kind: Pod
-      name: name1-1
-      namespace: ns
-  ports:
-  - port: 8989`,
+  - 172.17.0.12
+  targetRef:
+    kind: Pod
+    name: name1-1
+    namespace: ns
+ports:
+- port: 8989
+  protocol: TCP`,
 		`
 apiVersion: v1
 kind: Pod
@@ -159,20 +163,24 @@ spec:
   ports:
   - port: 4242`,
 		`
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: name3
   namespace: ns
-subsets:
+  labels:
+    kubernetes.io/service-name: name3
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 172.17.0.14
-    targetRef:
-      kind: Pod
-      name: name3
-      namespace: ns
-  ports:
-  - port: 4242`,
+  - 172.17.0.14
+  targetRef:
+    kind: Pod
+    name: name3
+    namespace: ns
+ports:
+- port: 4242
+  protocol: TCP`,
 		`
 apiVersion: v1
 kind: Pod
@@ -220,20 +228,24 @@ spec:
   ports:
   - port: 24224`,
 		`
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: name5
   namespace: ns
-subsets:
+  labels:
+    kubernetes.io/service-name: name5
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 172.17.0.15
-    targetRef:
-      kind: Pod
-      name: name5
-      namespace: ns
-  ports:
-  - port: 24224`,
+  - 172.17.0.15
+  targetRef:
+    kind: Pod
+    name: name5
+    namespace: ns
+ports:
+- port: 24224
+  protocol: TCP`,
 		`
 apiVersion: v1
 kind: Pod
@@ -270,21 +282,25 @@ spec:
   ports:
   - port: 8989`,
 		`
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name:	statefulset-svc
   namespace: ns
-subsets:
+  labels:
+    kubernetes.io/service-name: statefulset-svc
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 172.17.13.15
-    hostname: pod-0
-    targetRef:
-      kind: Pod
-      name: pod-0
-      namespace: ns
-  ports:
-  - port: 8989`,
+  - 172.17.13.15
+  hostname: pod-0
+  targetRef:
+    kind: Pod
+    name: pod-0
+    namespace: ns
+ports:
+- port: 8989
+  protocol: TCP`,
 		`
 apiVersion: v1
 kind: Pod
@@ -313,20 +329,24 @@ spec:
   ports:
   - port: 80`,
 		`
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: policy-test
   namespace: ns
-subsets:
+  labels:
+    kubernetes.io/service-name: policy-test
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 172.17.0.16
-    targetRef:
-      kind: Pod
-      name: pod-policyResources
-      namespace: ns
-  ports:
-  - port: 80`,
+  - 172.17.0.16
+  targetRef:
+    kind: Pod
+    name: pod-policyResources
+    namespace: ns
+ports:
+- port: 80
+  protocol: TCP`,
 		`
 apiVersion: v1
 kind: Pod
@@ -418,20 +438,24 @@ spec:
   ports:
   - port: 80`,
 		`
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: foo
   namespace: ns
-subsets:
+  labels:
+    kubernetes.io/service-name: foo
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 172.17.55.1
-    targetRef:
-      kind: Pod
-      name: foo-1
-      namespace: ns
-  ports:
-  - port: 80`,
+  - 172.17.55.1
+  targetRef:
+    kind: Pod
+    name: foo-1
+    namespace: ns
+ports:
+- port: 80
+  protocol: TCP`,
 		`
 apiVersion: v1
 kind: Pod
@@ -538,20 +562,24 @@ spec:
   ports:
   - port: 80`,
 		`
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: policy-test-external-workload
   namespace: ns
-subsets:
+  labels:
+    kubernetes.io/service-name: policy-test-external-workload
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 200.1.1.2
-    targetRef:
-      kind: ExternalWorkload
-      name: policy-test-workload
-      namespace: ns
-  ports:
-  - port: 80`,
+  - 200.1.1.2
+  targetRef:
+    kind: ExternalWorkload
+    name: policy-test-workload
+    namespace: ns
+ports:
+- port: 80
+  protocol: TCP`,
 	}
 	extenalNameResources := []string{
 		`
@@ -601,11 +629,11 @@ spec:
 		t.Fatalf("initializeIndexers returned an error: %s", err)
 	}
 
-	workloads, err := watcher.NewWorkloadWatcher(k8sAPI, metadataAPI, log, defaultOpaquePorts)
+	workloads, err := watcher.NewWorkloadWatcher(k8sAPI, metadataAPI, log, true, defaultOpaquePorts)
 	if err != nil {
 		t.Fatalf("can't create Workloads watcher: %s", err)
 	}
-	endpoints, err := watcher.NewEndpointsWatcher(k8sAPI, metadataAPI, log, false, "local")
+	endpoints, err := watcher.NewEndpointsWatcher(k8sAPI, metadataAPI, log, true, "local")
 	if err != nil {
 		t.Fatalf("can't create Endpoints watcher: %s", err)
 	}
@@ -618,7 +646,7 @@ spec:
 		t.Fatalf("can't create profile watcher: %s", err)
 	}
 
-	clusterStore, err := watcher.NewClusterStoreWithDecoder(k8sAPI.Client, "linkerd", false, watcher.CreateMockDecoder(exportedServiceResources...))
+	clusterStore, err := watcher.NewClusterStoreWithDecoder(k8sAPI.Client, "linkerd", true, watcher.CreateMockDecoder(exportedServiceResources...))
 	if err != nil {
 		t.Fatalf("can't create cluster store: %s", err)
 	}


### PR DESCRIPTION
Fixes #12032

The Destination controller server tests test the destination server with `enableEndpointSlices=false`.  The default for this value is true, meaning that these tests do not test the default configuration.

We update the tests to test with `enableEndpointSlices=true` and update the corresponding mock kubernetes Endpoints resources to be EndpointSlices instead.  We also fix an instance where the workload watcher was using Endpoints even when in EndpointSlices mode.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
