### PR TITLE
ignore proxy imagees with digests when checking version

### DIFF
--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -306,6 +306,11 @@ func GetProxyReady(pod corev1.Pod) bool {
 func GetProxyVersion(pod corev1.Pod) string {
 	for _, container := range pod.Spec.Containers {
 		if container.Name == ProxyContainerName {
+			if strings.Contains(container.Image, "@") {
+				// Proxy container image is specified with digest instead of
+				// tag. We are unable to determine version.
+				return ""
+			}
 			parts := strings.Split(container.Image, ":")
 			return parts[len(parts)-1]
 		}


### PR DESCRIPTION
Fixes #12058

When proxy images are specified by digest rather than by tag, `linkerd check` will erroneously assume that the digest is a tag and attempt to compare it to the current Linkerd version.

Instead, we ignore images with digests since there isn't an easy way to determine what version a digest corresponds to.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
