### PR TITLE
wait for ready addresses in policy tests

### DIFF
--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -173,7 +173,13 @@ pub async fn await_route_status(
 // Wait for the endpoints controller to populate the Endpoints resource.
 pub fn endpoints_ready(obj: Option<&k8s::Endpoints>) -> bool {
     if let Some(ep) = obj {
-        return ep.subsets.iter().flatten().count() > 0;
+        return ep
+            .subsets
+            .iter()
+            .flatten()
+            .flat_map(|subset| subset.addresses.iter().flatten())
+            .count()
+            > 0;
     }
     false
 }

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -176,7 +176,9 @@ pub fn endpoints_ready(obj: Option<&k8s::Endpoints>) -> bool {
         return ep
             .subsets
             .iter()
-            .any(|s| s.addresses.iter().any(|a| a.is_some()));
+            .flatten()
+            .flat_map(|s| &s.addresses)
+            .any(|a| !a.is_empty());
     }
     false
 }

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -176,10 +176,7 @@ pub fn endpoints_ready(obj: Option<&k8s::Endpoints>) -> bool {
         return ep
             .subsets
             .iter()
-            .flatten()
-            .flat_map(|subset| subset.addresses.iter().flatten())
-            .count()
-            > 0;
+            .any(|s| s.addresses.iter().any(|a| a.is_some()));
     }
     false
 }


### PR DESCRIPTION
In the policy controller integration tests, we often create a curl pod but block it from sending any requests until the endpoints it would send to become available.  We do this by waiting for the Endpoints kubernetes resources to have a non-zero number of EndpointSubsets.  However, each EndpointSubset may contain ready and not-ready addresses.  This means that there may be an EndpointsSubset but no ready addresses, causing curl to fire its requests before the endpoints are ready.  This may be the cause of some flaky tests.

We, instead, wait until there are a non-zero number of ready addresses before unblocking curl.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
