### PR TITLE
Add `additionalEnv` helm settings

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -208,9 +208,14 @@ spec:
         {{- range (.Values.destinationController).experimentalArgs }}
         - {{ . }}
         {{- end }}
-        {{- with (.Values.destinationController).experimentalEnv }}
+        {{- if or (.Values.destinationController).additionalEnv (.Values.destinationController).experimentalEnv }}
         env:
+        {{- with (.Values.destinationController).additionalEnv }}
         {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with (.Values.destinationController).experimentalEnv }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
         {{- end }}
         {{- include "partials.linkerd.trace" . | nindent 8 -}}
         image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
@@ -249,9 +254,14 @@ spec:
         - -log-level={{.Values.controllerLogLevel}}
         - -log-format={{.Values.controllerLogFormat}}
         - -enable-pprof={{.Values.enablePprof | default false}}
-        {{- with (.Values.spValidator).experimentalEnv }}
+        {{- if or (.Values.spValidator).additionalEnv (.Values.spValidator).experimentalEnv }}
         env:
+        {{- with (.Values.spValidator).additionalEnv }}
         {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with (.Values.spValidator).experimentalEnv }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
         {{- end }}
         image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}

--- a/charts/linkerd-control-plane/templates/heartbeat.yaml
+++ b/charts/linkerd-control-plane/templates/heartbeat.yaml
@@ -59,6 +59,9 @@ spec:
             env:
             - name: LINKERD_DISABLED
               value: "the heartbeat controller does not use the proxy"
+            {{- with (.Values.heartbeat).additionalEnv }}
+            {{- toYaml . | nindent 12 -}}
+            {{- end }}
             {{- with (.Values.heartbeat).experimentalEnv }}
             {{- toYaml . | nindent 12 -}}
             {{- end }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -165,6 +165,9 @@ spec:
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"
+        {{- with (.Values.identity).additionalEnv }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
         {{- with (.Values.identity).experimentalEnv }}
         {{- toYaml . | nindent 8 -}}
         {{- end }}

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -79,9 +79,14 @@ spec:
         - -log-format={{.Values.controllerLogFormat}}
         - -linkerd-namespace={{.Release.Namespace}}
         - -enable-pprof={{.Values.enablePprof | default false}}
-        {{- with (.Values.proxyInjector).experimentalEnv }}
+        {{- if or (.Values.proxyInjector).additionalEnv (.Values.proxyInjector).experimentalEnv }}
         env:
+        {{- with (.Values.proxyInjector).additionalEnv }}
         {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with (.Values.proxyInjector).experimentalEnv }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
         {{- end }}
         image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion | default .Values.linkerdVersion}}
         imagePullPolicy: {{.Values.imagePullPolicy}}

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -160,6 +160,9 @@ be used in other contexts.
 - name: LINKERD2_PROXY_SHUTDOWN_GRACE_PERIOD
   value: {{.Values.proxy.shutdownGracePeriod | quote}}
 {{ end -}}
+{{ if .Values.proxy.additionalEnv -}}
+{{ toYaml .Values.proxy.additionalEnv }}
+{{ end -}}
 {{ if .Values.proxy.experimentalEnv -}}
 {{ toYaml .Values.proxy.experimentalEnv }}
 {{ end -}}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1051,7 +1052,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1388,7 +1388,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1825,7 +1824,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1387,7 +1387,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1823,7 +1822,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1387,7 +1387,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1823,7 +1822,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1387,7 +1387,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1823,7 +1822,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1387,7 +1387,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1823,7 +1822,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1378,7 +1378,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1805,7 +1804,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -663,6 +663,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1127,7 +1128,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1504,7 +1504,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1976,7 +1975,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -663,6 +663,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1127,7 +1128,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1504,7 +1504,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1976,7 +1975,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -567,6 +567,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -981,7 +982,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1318,7 +1318,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1694,7 +1693,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -613,6 +613,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1023,7 +1024,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1362,7 +1362,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1802,7 +1801,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -640,6 +640,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1100,7 +1101,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1479,7 +1479,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1955,7 +1954,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -644,6 +644,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1108,7 +1109,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1491,7 +1491,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1975,7 +1974,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -635,6 +635,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1090,7 +1091,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1469,7 +1469,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"
@@ -1945,7 +1944,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             memory: "250Mi"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1381,7 +1381,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1811,7 +1810,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -616,6 +616,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control: null
@@ -1348,7 +1349,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             cpu: "cpu-limit"
@@ -1788,7 +1788,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
           limits:
             cpu: "cpu-limit"

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1387,7 +1387,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1823,7 +1822,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -636,6 +636,7 @@ data:
     prometheusUrl: ""
     proxy:
       accessLog: ""
+      additionalEnv: null
       await: true
       capabilities: null
       control:
@@ -1050,7 +1051,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1387,7 +1387,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false
@@ -1823,7 +1822,6 @@ spec:
             port: 4191
           initialDelaySeconds: 2
           timeoutSeconds: 1
-          initialDelaySeconds: 2
         resources:
         securityContext:
           allowPrivilegeEscalation: false

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -139,9 +139,14 @@ spec:
         {{- end }}
         - -enable-pprof={{.Values.enablePprof | default false}}
         - {{.Values.targetClusterName}}
-        {{- with .Values.serviceMirrorExperimentalEnv }}
+        {{- if or .Values.serviceMirrorAdditionalEnv .Values.serviceMirrorExperimentalEnv }}
         env:
+        {{- with .Values.serviceMirrorAdditionalEnv }}
         {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with .Values.serviceMirrorExperimentalEnv }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
         {{- end }}
         image: {{.Values.controllerImage}}:{{.Values.controllerImageVersion}}
         name: service-mirror

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -125,6 +125,7 @@ type (
 		LivenessProbe                        *Probe           `json:"livenessProbe"`
 		Control                              *ProxyControl    `json:"control"`
 
+		AdditionalEnv   []corev1.EnvVar `json:"additionalEnv"`
 		ExperimentalEnv []corev1.EnvVar `json:"experimentalEnv"`
 	}
 


### PR DESCRIPTION
Add `additionalEnv` helm settings to the proxy and controller manifests alongside the existing `experimentalEnv` ones.