### PR TITLE
Add `additionalArgs` helm Settings

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -205,6 +205,9 @@ spec:
         - -identity-trust-domain={{.Values.identityTrustDomain | default .Values.clusterDomain}}
         - -default-opaque-ports={{.Values.proxy.opaquePorts}}
         - -enable-pprof={{.Values.enablePprof | default false}}
+        {{- range (.Values.destinationController).additionalArgs }}
+        - {{ . }}
+        {{- end }}
         {{- range (.Values.destinationController).experimentalArgs }}
         - {{ . }}
         {{- end }}
@@ -305,6 +308,9 @@ spec:
         {{- if .Values.policyController.probeNetworks }}
         - --probe-networks={{.Values.policyController.probeNetworks | join ","}}
         {{- end}}
+        {{- range .Values.policyController.additionalArgs }}
+        - {{ . }}
+        {{- end }}
         {{- range .Values.policyController.experimentalArgs }}
         - {{ . }}
         {{- end }}


### PR DESCRIPTION
Add `additionalArgs` helm settings to the destination and policy controller manifests alongside the existing `experimentalArgs` ones.