### PR TITLE
Add support for loadBalancerCluster to multi-cluster gateway service

### DIFF
--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -77,6 +77,7 @@ Kubernetes: `>=1.22.0-0`
 | gateway.UID | int | `2103` | User id under which the gateway shall be ran |
 | gateway.deploymentAnnotations | object | `{}` | Annotations to add to the gateway deployment |
 | gateway.enabled | bool | `true` | If the gateway component should be installed |
+| gateway.loadBalancerClass | string | `""` | Set loadBalancerClass on gateway service |
 | gateway.loadBalancerIP | string | `""` | Set loadBalancerIP on gateway service |
 | gateway.loadBalancerSourceRanges | list | `[]` | Set loadBalancerSourceRanges on gateway service |
 | gateway.name | string | `"linkerd-gateway"` | The name of the gateway that will be installed |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -124,6 +124,9 @@ spec:
   selector:
     app: {{.Values.gateway.name}}
   type: {{ .Values.gateway.serviceType }}
+{{- if .Values.gateway.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.gateway.loadBalancerClass }}
+{{- end }}
 {{- if .Values.gateway.loadBalancerIP }}
   loadBalancerIP: {{ .Values.gateway.loadBalancerIP }}
 {{- end }}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -25,6 +25,8 @@ gateway:
   serviceAnnotations: {}
   # -- Annotations to add to the gateway deployment
   deploymentAnnotations: {}
+  # -- Set loadBalancerClass on gateway service
+  loadBalancerClass: ""
   # -- Set loadBalancerIP on gateway service
   loadBalancerIP: ""
   # -- Set loadBalancerSourceRanges on gateway service


### PR DESCRIPTION
The multicluster helm chart currently does not support the `loadBalancerClass` field. This is required by some loadbalance services like Tailscale.

Add a conditional `loadBalancerClass` key to the helm chart values and gateway svc.

Once merged, deploy the multicluster helm chart and configure `.Values.gateway.loadBalancerClass` to a value, ensure that is part of the resulting resource. Unset the value, ensure it is _not_ part of the resulting resource.

Fixes #12100

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
