### PR TITLE
dev: v43

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "linkerd2",
-    "image": "ghcr.io/linkerd/dev:v42",
+    "image": "ghcr.io/linkerd/dev:v43",
     // "dockerFile": "./Dockerfile",
     // "context": "..",
     "customizations": {

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: just-dev lint-actions
 
   devcontainer-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: just-dev check-action-images

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -51,12 +51,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: docker://rust:1.73.0
+      image: docker://rust:1.76.0
       options: --security-opt seccomp=unconfined
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - shell: bash
-        run: mkdir -p target && cd target && bin/scurl -v https://github.com/xd009642/tarpaulin/releases/download/0.18.0/cargo-tarpaulin-0.18.0-travis.tar.gz | tar zxvf - && chmod 755 cargo-tarpaulin
+        run: mkdir -p target && cd target && bin/scurl -v https://github.com/xd009642/tarpaulin/releases/download/0.27.3/cargo-tarpaulin-x86_64-unknown-linux-musl.tar.gz | tar zxvf - && chmod 755 cargo-tarpaulin
       - run: target/cargo-tarpaulin tarpaulin --workspace --out Xml
       - uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044
         with:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -39,6 +39,6 @@ jobs:
   devcontainer-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: just-dev pull-dev-image

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   rust-version:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v42-rust
+    container: ghcr.io/linkerd/dev:v43-rust
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
   go-lint:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v42-go
+    container: ghcr.io/linkerd/dev:v43-go
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -25,7 +25,7 @@ jobs:
   go-format:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v42-go
+    container: ghcr.io/linkerd/dev:v43-go
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -34,7 +34,7 @@ jobs:
   go-test:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v42-go
+    container: ghcr.io/linkerd/dev:v43-go
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: helm-docs
       - run: git diff --exit-code -- **/charts/**/README.md

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -15,7 +15,7 @@ jobs:
   proto-diff:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    container: ghcr.io/linkerd/dev:v42-go
+    container: ghcr.io/linkerd/dev:v43-go
     steps:
       - run: apt update && apt install -y unzip
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
   fmt:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v42-rust
+    container: ghcr.io/linkerd/dev:v43-rust
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -52,7 +52,7 @@ jobs:
   clippy:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v42-rust
+    container: ghcr.io/linkerd/dev:v43-rust
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -63,7 +63,7 @@ jobs:
   check:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v42-rust
+    container: ghcr.io/linkerd/dev:v43-rust
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -74,7 +74,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: ghcr.io/linkerd/dev:v42-rust
+    container: ghcr.io/linkerd/dev:v43-rust
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v42
+      - uses: linkerd/dev/actions/setup-tools@v43
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: just sh-lint
 

--- a/justfile
+++ b/justfile
@@ -50,6 +50,8 @@ rs-check-fmt:
 rs-clippy:
     {{ _cargo }} clippy --frozen --workspace --all-targets --no-deps {{ _features }} {{ _fmt }}
 
+alias clippy := rs-clippy
+
 # Audit Rust dependencies.
 rs-audit-deps:
     {{ _cargo }} deny {{ _features }} check

--- a/policy-controller/Dockerfile
+++ b/policy-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v42-rust-musl as controller
+FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v43-rust-musl as controller
 ARG BUILD_TYPE="release"
 WORKDIR /build
 RUN mkdir -p target/bin

--- a/policy-controller/k8s/index/src/inbound/tests/http_routes.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/http_routes.rs
@@ -149,7 +149,7 @@ fn routes_created_for_probes() {
         .http_routes
         .get(&HttpRouteRef::Default("probe"))
         .unwrap();
-    let probes_rules = probes.rules.get(0).unwrap();
+    let probes_rules = probes.rules.first().unwrap();
     assert!(
         probes_rules.matches.contains(&liveness_match),
         "matches: {:#?}",
@@ -181,7 +181,7 @@ fn routes_created_for_probes() {
         .http_routes
         .get(&HttpRouteRef::Default("probe"))
         .unwrap();
-    let probes_rules = probes.rules.get(0).unwrap();
+    let probes_rules = probes.rules.first().unwrap();
     assert!(
         probes_rules.matches.contains(&liveness_match),
         "matches: {:#?}",

--- a/policy-test/src/bb.rs
+++ b/policy-test/src/bb.rs
@@ -11,9 +11,9 @@ pub struct Terminus {
 
 impl Terminus {
     const PORT: i32 = 80;
-    const PORT_NAME: &str = "http";
-    const APP: &str = "bb-terminus";
-    pub const SERVICE_NAME: &str = Self::APP;
+    const PORT_NAME: &'static str = "http";
+    const APP: &'static str = "bb-terminus";
+    pub const SERVICE_NAME: &'static str = Self::APP;
 
     /// Builds a `bb-terminus` pod that can be configured to fail some (or all)
     /// requests.

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -27,7 +27,7 @@ pub struct Execable {
 }
 
 impl Runner {
-    const CURL_IMAGE: &str = "docker.io/curlimages/curl:latest";
+    const CURL_IMAGE: &'static str = "docker.io/curlimages/curl:latest";
 
     pub async fn init(client: &kube::Client, ns: &str) -> Runner {
         let runner = Runner {

--- a/policy-test/tests/inbound_api.rs
+++ b/policy-test/tests/inbound_api.rs
@@ -388,9 +388,9 @@ async fn http_routes_ordered_by_creation() {
         match routes
             .get(idx)?
             .rules
-            .get(0)?
+            .first()?
             .matches
-            .get(0)?
+            .first()?
             .path
             .as_ref()?
             .kind

--- a/policy-test/tests/outbound_api_gateway.rs
+++ b/policy-test/tests/outbound_api_gateway.rs
@@ -1444,7 +1444,7 @@ fn assert_backend_matches_service(
 #[track_caller]
 fn assert_singleton<T>(ts: &[T]) -> &T {
     assert_eq!(ts.len(), 1);
-    ts.get(0).unwrap()
+    ts.first().unwrap()
 }
 
 #[track_caller]

--- a/policy-test/tests/outbound_api_linkerd.rs
+++ b/policy-test/tests/outbound_api_linkerd.rs
@@ -1471,7 +1471,7 @@ fn assert_backend_matches_service(
 #[track_caller]
 fn assert_singleton<T>(ts: &[T]) -> &T {
     assert_eq!(ts.len(), 1);
-    ts.get(0).unwrap()
+    ts.first().unwrap()
 }
 
 #[track_caller]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.76.0"


### PR DESCRIPTION
## Go v1.22
* Go tooling updated to latest

## Rust v1.76
* cargo-deny v0.14.11
* cargo-nextest v0.9.67
* cargo-tarpaulin v0.27.3

## tools
* helm v3.11.3
* helm-docs v1.11.0
* just 1.24.0
* kubectl v1.29.2
* step-cli v0.25.2
* actionlint v1.6.26
* shellcheck v0.9.0
* taplo removed