### PR TITLE
Add test for inbound policy index deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "futures",
  "http",
  "k8s-gateway-api",
+ "k8s-openapi",
  "kube",
  "kubert",
  "linkerd-policy-controller-core",

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 k8s-gateway-api = "0.15"
-k8s-openapi = { version = "0.20", features = ["schemars"] }
 kube = { version = "0.87.1", default-features = false, features = [
     "client",
     "derive",
@@ -27,6 +26,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false }
+k8s-openapi = { version = "0.20", features = ["schemars"] }
 maplit = "1"
 tokio-stream = "0.1"
 tokio-test = "0.4"

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 k8s-gateway-api = "0.15"
+k8s-openapi = { version = "0.20", features = ["schemars"] }
 kube = { version = "0.87.1", default-features = false, features = [
     "client",
     "derive",

--- a/policy-controller/k8s/index/src/inbound/index.rs
+++ b/policy-controller/k8s/index/src/inbound/index.rs
@@ -903,7 +903,9 @@ impl NamespaceIndex {
         f: impl FnOnce(&mut Namespace) -> bool,
     ) {
         if let Entry::Occupied(mut ns) = self.by_ns.entry(namespace) {
+            tracing::trace!(ns = ns.key(), "got namespace");
             if f(ns.get_mut()) {
+                tracing::trace!(ns = ns.key(), "reindexing maybe");
                 if ns.get().is_empty() {
                     tracing::debug!(namespace = ns.key(), "Removing empty namespace index");
                     ns.remove();
@@ -1699,6 +1701,9 @@ impl PolicyIndex {
         authentications: &AuthenticationNsIndex,
         probe_paths: impl Iterator<Item = &'p str>,
     ) -> HashMap<HttpRouteRef, HttpRoute> {
+        self.http_routes.iter().for_each(|(gkn, route)| {
+            tracing::trace!(?gkn, ?route, "Found HttpRoute");
+        });
         let routes = self
             .http_routes
             .iter()

--- a/policy-controller/k8s/index/src/inbound/index.rs
+++ b/policy-controller/k8s/index/src/inbound/index.rs
@@ -903,9 +903,7 @@ impl NamespaceIndex {
         f: impl FnOnce(&mut Namespace) -> bool,
     ) {
         if let Entry::Occupied(mut ns) = self.by_ns.entry(namespace) {
-            tracing::trace!(ns = ns.key(), "got namespace");
             if f(ns.get_mut()) {
-                tracing::trace!(ns = ns.key(), "reindexing maybe");
                 if ns.get().is_empty() {
                     tracing::debug!(namespace = ns.key(), "Removing empty namespace index");
                     ns.remove();
@@ -1701,9 +1699,6 @@ impl PolicyIndex {
         authentications: &AuthenticationNsIndex,
         probe_paths: impl Iterator<Item = &'p str>,
     ) -> HashMap<HttpRouteRef, HttpRoute> {
-        self.http_routes.iter().for_each(|(gkn, route)| {
-            tracing::trace!(?gkn, ?route, "Found HttpRoute");
-        });
         let routes = self
             .http_routes
             .iter()

--- a/policy-controller/k8s/index/src/inbound/tests/authorization_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/authorization_policy.rs
@@ -1,4 +1,6 @@
 use super::*;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1 as metav1;
+use linkerd_policy_controller_core::{http_route, inbound};
 
 #[test]
 fn links_authorization_policy_with_mtls_name() {
@@ -264,6 +266,129 @@ fn links_authorization_policy_with_service_account() {
     );
 }
 
+#[test]
+fn authorization_policy_prevents_index_deletion() {
+    let test = TestConfig::default();
+
+    // Create policy resources: Server, HttpRoute, AuthorizationPolicy, and NetworkAuthentication.
+    let server = mk_server(
+        "ns-0",
+        "srv-8080",
+        Port::Number(8080.try_into().unwrap()),
+        None,
+        Some(("app", "app-0")),
+        Some(k8s::policy::server::ProxyProtocol::Http1),
+    );
+    test.index.write().apply(server.clone());
+
+    let authz = ClientAuthorization {
+        networks: vec!["10.0.0.0/8".parse::<IpNet>().unwrap().into()],
+        authentication: ClientAuthentication::TlsAuthenticated(vec![IdentityMatch::Exact(
+            "foo.ns-0.serviceaccount.identity.linkerd.cluster.example.com".to_string(),
+        )]),
+    };
+    let authz_policy = k8s::policy::AuthorizationPolicy {
+        metadata: k8s::ObjectMeta {
+            namespace: Some("ns-0".to_string()),
+            name: Some("authz-foo".to_string()),
+            ..Default::default()
+        },
+        spec: k8s::policy::AuthorizationPolicySpec {
+            target_ref: LocalTargetRef {
+                group: Some("policy.linkerd.io".to_string()),
+                kind: "HTTPRoute".to_string(),
+                name: "route-foo".to_string(),
+            },
+            required_authentication_refs: vec![
+                NamespacedTargetRef {
+                    group: Some("policy.linkerd.io".to_string()),
+                    kind: "NetworkAuthentication".to_string(),
+                    name: "net-foo".to_string(),
+                    namespace: None,
+                },
+                NamespacedTargetRef {
+                    group: None,
+                    kind: "ServiceAccount".to_string(),
+                    namespace: Some("ns-0".to_string()),
+                    name: "foo".to_string(),
+                },
+            ],
+        },
+    };
+    test.index.write().apply(authz_policy.clone());
+    let route = mk_http_route("ns-0", "route-foo", "srv-8080");
+    test.index.write().apply(route.clone());
+    let net_authn = mk_network_authentication(
+        "ns-0".to_string(),
+        "net-foo".to_string(),
+        vec![k8s::policy::network_authentication::Network {
+            cidr: "10.0.0.0/8".parse().unwrap(),
+            except: None,
+        }],
+    );
+    test.index.write().apply(net_authn.clone());
+
+    // Now we delete the server, and HTTPRoute.
+    <Index as kubert::index::IndexNamespacedResource<k8s::policy::Server>>::delete(
+        &mut test.index.write(),
+        "ns-0".to_string(),
+        "srv-8080".to_string(),
+    );
+    <Index as kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute>>::delete(
+        &mut test.index.write(),
+        "ns-0".to_string(),
+        "route-foo".to_string(),
+    );
+
+    // Recreate the pod, server, and HTTPRoute.
+    test.index.write().apply(server);
+    test.index.write().apply(route);
+
+    let mut pod = mk_pod("ns-0", "pod-0", Some(("container-0", None)));
+    pod.labels_mut()
+        .insert("app".to_string(), "app-0".to_string());
+    test.index.write().apply(pod.clone());
+
+    let rx = test
+        .index
+        .write()
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
+        .expect("pod-0.ns-0 should exist");
+
+    // AuthorizationPolicy should apply.
+    assert_eq!(
+        *rx.borrow(),
+        InboundServer {
+            reference: ServerRef::Server("srv-8080".to_string()),
+            authorizations: Default::default(),
+            protocol: ProxyProtocol::Http1,
+            http_routes: hashmap!(HttpRouteRef::Linkerd(http_route::GroupKindName{
+                group: "policy.linkerd.io".into(),
+                kind: "HTTPRoute".into(),
+                name: "route-foo".into(),
+            }) => HttpRoute {
+                rules: vec![inbound::HttpRouteRule {
+                    matches: vec![http_route::HttpRouteMatch {
+                        path: Some(http_route::PathMatch::Prefix("/foo".to_string())),
+                        headers: vec![],
+                        query_params: vec![],
+                        method: None,
+                    }],
+                    filters: vec![],
+                }],
+                authorizations: hashmap!(
+                    AuthorizationRef::AuthorizationPolicy("authz-foo".to_string()) => authz.clone()
+                )
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            })
+            .into_iter()
+            .collect(),
+        },
+    );
+}
+
 fn mk_authorization_policy(
     ns: impl ToString,
     name: impl ToString,
@@ -337,5 +462,66 @@ fn mk_network_authentication(
         spec: k8s::policy::NetworkAuthenticationSpec {
             networks: networks.into_iter().collect(),
         },
+    }
+}
+
+fn mk_http_route(
+    ns: impl ToString,
+    name: impl ToString,
+    server: impl ToString,
+) -> k8s::policy::HttpRoute {
+    k8s::policy::HttpRoute {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        spec: k8s::policy::HttpRouteSpec {
+            inner: k8s_gateway_api::CommonRouteSpec {
+                parent_refs: Some(vec![k8s_gateway_api::ParentReference {
+                    group: Some("policy.linkerd.io".to_string()),
+                    kind: Some("Server".to_string()),
+                    namespace: Some(ns.to_string()),
+                    name: server.to_string(),
+                    section_name: None,
+                    port: None,
+                }]),
+            },
+            rules: Some(vec![k8s::policy::httproute::HttpRouteRule {
+                matches: Some(vec![k8s::policy::httproute::HttpRouteMatch {
+                    path: Some(k8s_gateway_api::HttpPathMatch::PathPrefix {
+                        value: "/foo".to_string(),
+                    }),
+                    ..Default::default()
+                }]),
+                filters: None,
+                backend_refs: None,
+                timeouts: None,
+            }]),
+            ..Default::default()
+        },
+        status: Some(k8s::policy::httproute::HttpRouteStatus {
+            inner: k8s_gateway_api::RouteStatus {
+                parents: vec![k8s_gateway_api::RouteParentStatus {
+                    conditions: vec![metav1::Condition {
+                        type_: "Accepted".to_string(),
+                        status: "True".to_string(),
+                        message: String::new(),
+                        reason: String::new(),
+                        last_transition_time: metav1::Time(chrono::Utc::now()),
+                        observed_generation: None,
+                    }],
+                    parent_ref: k8s_gateway_api::ParentReference {
+                        group: Some("policy.linkerd.io".to_string()),
+                        kind: Some("Server".to_string()),
+                        namespace: Some(ns.to_string()),
+                        name: server.to_string(),
+                        section_name: None,
+                        port: None,
+                    },
+                    controller_name: "linkerd.io/policy-controller".to_string(),
+                }],
+            },
+        }),
     }
 }


### PR DESCRIPTION
PR https://github.com/linkerd/linkerd2/pull/12088 fixed an issue where removing and then re-adding certain policy resources could leave the policy index in an incorrect state. We add a test for the specific condition that triggered this behavior to prevent against future regressions.

Verified that this test fails prior to https://github.com/linkerd/linkerd2/pull/12088 but passes on main.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
