### PR TITLE
Add default values to `proxy-*-connect-timeout` annotations docs

### DIFF
--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -238,11 +238,11 @@ func generateAnnotationsDocs() []annotationDoc {
 		},
 		{
 			Name:        k8s.ProxyOutboundConnectTimeout,
-			Description: "Used to configure the outbound TCP connection timeout in the proxy. Defaults to `1s`",
+			Description: "Used to configure the outbound TCP connection timeout in the proxy. Defaults to `1000ms`",
 		},
 		{
 			Name:        k8s.ProxyInboundConnectTimeout,
-			Description: "Inbound TCP connection timeout in the proxy. Defaults to `300ms`",
+			Description: "Inbound TCP connection timeout in the proxy. Defaults to `100ms`",
 		},
 		{
 			Name:        k8s.ProxyOutboundDiscoveryCacheUnusedTimeout,

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -238,11 +238,11 @@ func generateAnnotationsDocs() []annotationDoc {
 		},
 		{
 			Name:        k8s.ProxyOutboundConnectTimeout,
-			Description: "Used to configure the outbound TCP connection timeout in the proxy",
+			Description: "Used to configure the outbound TCP connection timeout in the proxy. Defaults to `1s`",
 		},
 		{
 			Name:        k8s.ProxyInboundConnectTimeout,
-			Description: "Inbound TCP connection timeout in the proxy",
+			Description: "Inbound TCP connection timeout in the proxy. Defaults to `300ms`",
 		},
 		{
 			Name:        k8s.ProxyOutboundDiscoveryCacheUnusedTimeout,


### PR DESCRIPTION
Finding these values in the docs site is pretty painful

Update the documentation to follow other proxy fields in providing a default value at the end of the description for the field

Fixes #12154