### PR TITLE
Use the correct resources attribute values for repair-controller

### DIFF
--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -331,8 +331,8 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         {{- end }}
-        {{- if .Values.resources }}
-        {{- include "partials.resources" .Values.resources | nindent 8 }}
+        {{- if .Values.repairController.resources }}
+        {{- include "partials.resources" .Values.repairController.resources | nindent 8 }}
         {{- end }}
       {{- end }}
       volumes:


### PR DESCRIPTION
The repair-controller was incorrectly configured to use the same resources attribute values as the install-cni container even though it defines its own under `repairController`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
