### PR TITLE
destination: Log queue length in flakey test

### DIFF
--- a/controller/api/destination/endpoint_profile_translator.go
+++ b/controller/api/destination/endpoint_profile_translator.go
@@ -110,6 +110,10 @@ func (ept *endpointProfileTranslator) Update(address *watcher.Address) error {
 	}
 }
 
+func (ept *endpointProfileTranslator) queueLen() int {
+	return len(ept.updates)
+}
+
 func (ept *endpointProfileTranslator) update(address *watcher.Address) {
 	var opaquePorts map[uint32]struct{}
 	if address.Pod != nil {

--- a/controller/api/destination/endpoint_profile_translator_test.go
+++ b/controller/api/destination/endpoint_profile_translator_test.go
@@ -110,9 +110,13 @@ func TestEndpointProfileTranslator(t *testing.T) {
 			}
 		}
 
+		// XXX(ver): This assertion sometimes fails in CI. It's not clear why.
+		// For now, let's log the queue length and capacity.
+		t.Logf("Queue length=%d capacity=%d", translator.queueLen(), updateQueueCapacity)
 		if err := translator.Update(podAddr); err == nil {
-			t.Fatal("Expected update to fail")
+			t.Fatalf("Expected update to fail; queue=%d; capacity=%d", translator.queueLen(), updateQueueCapacity)
 		}
+
 		select {
 		case <-endStream:
 		default:


### PR DESCRIPTION
For unknown reasons, the TestEndpointProfileTranslator test fails in CI occaisionally. This change adds logging to help diagnose the issue.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
