### PR TITLE
Fix CodeQL check with go v1.22

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ main, stable-* ]
     paths:
+    - .github/workflows/codeql.yml
     - '**/*.go'
     - '**/*.js'
     - '**/*.jsx'
@@ -13,6 +14,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ main, stable-* ]
     paths:
+    - .github/workflows/codeql.yml
     - '**/*.go'
     - '**/*.js'
     - '**/*.jsx'
@@ -34,6 +36,9 @@ jobs:
         - javascript
 
     steps:
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+      with:
+        go-version: '1.22'
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 


### PR DESCRIPTION
The CodeQL check for go started failing (sporadically) after upgrading to go v1.22, with "go: download go1.22 for linux/amd64: toolchain not available":
https://github.com/linkerd/linkerd2/actions/runs/8071751074/job/22142449967?pr=12167#step:4:89

A previous successful run recommended using actions/setup-go:
> The go.mod file requires version v1.22 of Go, but version v1.20.14 is installed. Consider adding an actions/setup-go step to your workflow.
https://github.com/linkerd/linkerd2/actions/runs/8066300149/job/22034010793#step:4:88

So this is exactly what we do here.