### PR TITLE
identity: tweak token validation log levels

### DIFF
--- a/pkg/identity/service.go
+++ b/pkg/identity/service.go
@@ -209,7 +209,7 @@ func (svc *Service) Certify(ctx context.Context, req *pb.CertifyRequest) (*pb.Ce
 		}
 		var ite InvalidToken
 		if errors.As(err, &ite) {
-			log.Debugf("invalid token provided for %s: %s", reqIdentity, ite)
+			log.Infof("invalid token provided for %s: %s", reqIdentity, ite)
 			return nil, status.Error(codes.InvalidArgument, ite.Error())
 		}
 
@@ -222,7 +222,7 @@ func (svc *Service) Certify(ctx context.Context, req *pb.CertifyRequest) (*pb.Ce
 	if reqIdentity != tokIdentity {
 		msg := fmt.Sprintf("requested identity did not match provided token: requested=%s; found=%s",
 			reqIdentity, tokIdentity)
-		log.Debug(msg)
+		log.Infof(msg)
 		return nil, status.Error(codes.FailedPrecondition, msg)
 	}
 

--- a/pkg/identity/service.go
+++ b/pkg/identity/service.go
@@ -222,7 +222,7 @@ func (svc *Service) Certify(ctx context.Context, req *pb.CertifyRequest) (*pb.Ce
 	if reqIdentity != tokIdentity {
 		msg := fmt.Sprintf("requested identity did not match provided token: requested=%s; found=%s",
 			reqIdentity, tokIdentity)
-		log.Infof(msg)
+		log.Info(msg)
 		return nil, status.Error(codes.FailedPrecondition, msg)
 	}
 


### PR DESCRIPTION
Currently when an invalid token has been provided by the proxy to the destination's `Certify` method, the error is logged at debug level. We ideally want to make that more visible, hence changing to info.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>