### PR TITLE
ci: Retry failed integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -411,8 +411,9 @@ jobs:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
         GH_DEBUG: api
+        REF: ${{ github.head_ref }}
     steps:
-      - run: gh workflow run rerun.yml -F 'run_id=${{ github.run_id }}' --ref ${{ github.head_ref }}
+      - run: gh workflow run rerun.yml -F 'run_id=${{ github.run_id }}' --ref "$REF"
 
   integrations-ok:
     needs: [test-core, test-policy, test-ext, test-viz, test-multicluster]
@@ -431,3 +432,4 @@ jobs:
         # All jobs must succeed or be skipped.
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
+}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -432,4 +432,4 @@ jobs:
         # All jobs must succeed or be skipped.
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
-}
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -400,6 +400,20 @@ jobs:
               k3d-k8s='${{ matrix.k8s }}' \
               mc-test-run
 
+  # Try to re-run the integration tests if they fail, but only up to 3 times.
+  integrations-retry:
+    needs: [test-core, test-policy, test-ext, test-viz, test-multicluster]
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: write
+    env:
+        GH_REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ github.token }}
+        GH_DEBUG: api
+    steps:
+      - run: gh workflow run rerun.yml -F 'run_id=${{ github.run_id }}' --ref ${{ github.head_ref }}
+
   integrations-ok:
     needs: [test-core, test-policy, test-ext, test-viz, test-multicluster]
     if: always()
@@ -417,17 +431,3 @@ jobs:
         # All jobs must succeed or be skipped.
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
-
-  # Try to re-run the integration tests if they fail, but only up to 3 times.
-  integrations-retry:
-    needs: integrations-ok
-    if: failure() && fromJSON(github.run_attempt) < 3
-    runs-on: ubuntu-20.04
-    permissions:
-      actions: write
-    steps:
-      - env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          GH_DEBUG: api
-        run: gh workflow run rerun.yml -F 'run_id=${{ github.run_id }}'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -417,3 +417,17 @@ jobs:
         # All jobs must succeed or be skipped.
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
+
+  # Try to re-run the integration tests if they fail, but only up to 3 times.
+  integrations-retry:
+    needs: integrations-ok
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: write
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: gh workflow run rerun.yml -F 'run_id=${{ github.run_id }}'

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,28 @@
+# This can be invoked from any other workflow to re-run itself on failure.
+# From https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
+name: Re-run failed workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'The ID of the run to rerun'
+        required: true
+
+concurrency:
+  group:  ${{ github.workflow }}-${{ inputs.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  rerun:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      GH_DEBUG: api
+    steps:
+      - run: gh run watch ${{ inputs.run_id }}
+      - run: gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
Integration tests are inherently flakey. Our test suite has about 15% flake rate over the past month. It's not a good use of time right now to shave a few percentages off of that.

Instead, we can just retry the failed tests. To do this, we need to introduce a new 'rerun' workflow that can be triggered by the integraion test suite on failure. This rerun workflow then waits for the integration workflow to complete before triggering a rerun of failed jobs.

I've tested this on a fork:

![image](https://github.com/linkerd/linkerd2/assets/240738/a219eb62-e350-4801-bcfb-85e3b62d3829)

To confirm that retries are performed only a fixed number of times:

![image](https://github.com/linkerd/linkerd2/assets/240738/ff2f5e35-e35f-4fa3-9120-897ddbde580c)

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
