### PR TITLE
update governance to introduce a director role

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,13 +23,24 @@ Linkerd GitHub org must follow the guidelines in [CONTRIBUTING.md][contrib].
 Whether these contributions are merged into the project is the prerogative of
 the maintainers.
 
-## Maintainer Expectations
+## Directors
+
+Directors are responsible for non-technical leadership functions within the
+project. This includes representing Linkerd and its maintainers to the
+community, to press, and to the outside world; interfacing with CNCF and other
+governance entities; and participating in project decision-making processes when
+appropriate.
+
+Directors may be elected by a majority vote of the maintainers.
+
+## Maintainers
 
 Maintainers have the ability to merge code into the project. Anyone can
 become a Linkerd maintainer (see "Becoming a maintainer" below.)
 
-As such, there are certain expectations for maintainers. Linkerd maintainers
-are expected to:
+### Expectations
+
+Linkerd maintainers are expected to:
 
 * Review pull requests, triage issues, and fix bugs in their areas of
   expertise, ensuring that all changes go through the project's code review
@@ -43,12 +54,6 @@ If a maintainer is no longer interested in or cannot perform the duties
 listed above, they should move themselves to emeritus status. If necessary,
 this can also occur through the decision-making process outlined below.
 
-### Maintainer decision-making
-
-Ideally, all project decisions are resolved by maintainer consensus. If this
-is not possible, maintainers may call a vote. The voting process is a simple
-majority in which each maintainer receives one vote.
-
 ### Becoming a maintainer
 
 Anyone can become a Linkerd maintainer. Maintainers should be extremely
@@ -61,6 +66,12 @@ Existing maintainers will then ask you to demonstrate the qualifications
 above by contributing PRs, doing code reviews, and other such tasks under
 their guidance. After several months of working together, maintainers will
 decide whether to grant maintainer status.
+
+## Project decision-making process
+
+Ideally, all project decisions are resolved by consensus of maintainers and
+directors. If this is not possible, a vote will be called. The voting process is
+a simple majority in which each maintainer and director receives one vote.
 
 [coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [contrib]: https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-# Maintainers
+## Maintainers
 
 The Linkerd maintainers are:
 
@@ -8,14 +8,15 @@ The Linkerd maintainers are:
 * Matei David <matei@buoyant.io> @mateiidavid
 * Zahari Dichev <zahari@buoyant.io> @zaharidichev
 
+## Directors
+
+The Linkerd directors are:
+
+* William Morgan <william@buoyant.io> @wmorgan
+
 ## Steering Committee
 
 The Linkerd Steering Committee members are:
-
-* Chris Campbell @campbel (HP)
-* Christian Hüning @christianhuening (finleap connect)
-* Justin Turner @justin-turner-heb (HEB)
-* William King @quentusrex (Subspace)
 
 ## Emeriti
 

--- a/STEERING.md
+++ b/STEERING.md
@@ -2,9 +2,9 @@
 
 The goal of the Linkerd Steering Committee is to ensure that Linkerd meets the
 needs of its current and future users. The Steering Committee represents the
-voice of the user, and works with the Linkerd maintainers to help guide
-development efforts towards solving concrete and immediate problems for Linkerd
-adopters.
+voice of the user, and works with the Linkerd maintainers and directors to help
+guide development efforts towards solving concrete and immediate problems for
+Linkerd adopters.
 
 ## Responsibilities
 
@@ -32,10 +32,9 @@ membership in the Steering Committee, you must:
 3. Abide by Linkerd's Code of Conduct.
 
 Candidates for membership will be nominated by current Steering Committee
-members or by Linkerd maintainers. If there are more nominations than Steering
-Committee seats remaining, the same group shall vote on the candidates, and the
-candidates with the most votes will become Steering Committee members. Any ties
-will be broken by Linkerd maintainers.
+members or by Linkerd maintainers and directors. Once nominated, inclusion in
+the Steering Committee will be determined by the normal project decision-making
+process.
 
 Membership expires if any of the eligibility conditions is unmet, or after one
 year. Members may seek reinstatement immediately in accordance with the rules
@@ -49,4 +48,4 @@ minutes will be posted publicly.
 ## Changes to this charter
 
 Changes to this charter must be approved by a majority of Steering Committee
-members and a majority of Linkerd maintainers.
+members and a majority of Linkerd maintainers and directors.


### PR DESCRIPTION
As requested by the TOC, this PR updates Linkerd's governance to introduce a director role, which is initially William Morgan. This is a non-technical leadership role with voting power for decisions.

It also clarifies the decision-making process for steering committee members: once nominated, there is also a vote to determine inclusion. (Previously nominations themselves were technically sufficient until the participation limit was hit.)
