### PR TITLE
ci: Automatically sync new proxy releases

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ env:
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
   YQ_VERSION: v4.25.1
-  LINKERD2_PROXY_REPO: ${{ vars.LINKERD2_PROXY_REPO }}
+  LINKERD2_PROXY_REPO: ${{ vars.LINKERD2_PROXY_REPO || 'linkerd/linkerd2-proxy '}}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   YQ_VERSION: v4.25.1
   LINKERD2_PROXY_REPO: ${{ vars.LINKERD2_PROXY_REPO || 'linkerd/linkerd2-proxy' }}
+  LINKERD2_PROXY_RELEASE_PREFIX: ${{ vars.LINKERD2_PROXY_RELEASE_PREFIX || 'release/' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -157,13 +158,13 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - uses: ./.github/actions/docker-build
         id: build
+        env:
+          LINKERD2_PROXY_GITHUB_TOKEN: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
         with:
           docker-registry: ${{ env.DOCKER_REGISTRY }}
           docker-target: linux-amd64
           component: ${{ matrix.component }}
           tag: ${{ needs.meta.outputs.tag }}
-        env:
-          LINKERD2_PROXY_GITHUB_TOKEN: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN }}
       - name: Run docker save
         run: |
           mkdir -p /home/runner/archives

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ env:
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
   YQ_VERSION: v4.25.1
-  LINKERD2_PROXY_REPO: ${{ vars.LINKERD2_PROXY_REPO || 'linkerd/linkerd2-proxy '}}
+  LINKERD2_PROXY_REPO: ${{ vars.LINKERD2_PROXY_REPO || 'linkerd/linkerd2-proxy' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/sync-proxy.yml
+++ b/.github/workflows/sync-proxy.yml
@@ -1,0 +1,73 @@
+name: Sync proxy
+
+on:
+  # Hourly
+  schedule:
+    - cron: "15 * * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of the proxy to sync"
+        required: true
+        default: "latest"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  meta:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    env:
+      GH_REPO: ${{ vars.LINKERD2_PROXY_REPO || 'linkerd/linkerd2-proxy' }}
+      GH_TOKEN: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
+    steps:
+      - if: inputs.version == 'latest' || inputs.version == ''
+        id: latest
+        run: echo version="$(gh release view --json name -q .name)" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: ${{ steps.latest.outputs.version || inputs.version }}
+
+  sync-proxy:
+    needs: meta
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    env:
+      LINKERD2_PROXY_REPO: ${{ vars.LINKERD2_PROXY_REPO || 'linkerd/linkerd2-proxy' }}
+      VERSION: ${{ needs.meta.outputs.version }}
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Configure git
+        env:
+          GITHUB_USERNAME: ${{ vars.LINKERD2_PROXY_GITHUB_USERNAME || 'github-actions[bot]' }}
+        run: |
+          git config --global --add safe.directory "$PWD" # actions/runner#2033
+          git config --global user.name "$GITHUB_USERNAME"
+          git config --global user.email "$GITHUB_USERNAME"@users.noreply.github.com
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          token: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
+      - id: changed
+        run: |
+          if [ "$(cat .proxy-version)" != "$VERSION" ]; then
+            echo changed=true >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.changed.outputs.changed == 'true'
+        run: |
+          set -eu
+          git fetch origin bot/sync-proxy/"$VERSION" || true
+          git switch -c bot/sync-proxy/"$VERSION"
+          EDITOR=true bin/git-commit-proxy-version "$VERSION"
+          git push origin bot/sync-proxy/"$VERSION"
+      - if: steps.changed.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
+        run: |
+          gh pr create \
+            --title "proxy: $VERSION" \
+            --fill \
+            --label 'bot/sync-proxy'


### PR DESCRIPTION
This adds a new scheduled workflow to automatically open PRs when new proxy versions are available.

This uses specialized github tokens, if available, so that the PRs trigger integration tests.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
