### PR TITLE
ci: Only rerun integrations on test failure

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -403,10 +403,26 @@ jobs:
               k3d-k8s='${{ matrix.k8s }}' \
               mc-test-run
 
+  build-ok:
+    needs: [build-cli, build-core, build-ext]
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Results
+        run: |
+          echo 'needs.build-cli.result: ${{ needs.build-cli.result }}'
+          echo 'needs.build-core.result: ${{ needs.build-core.result }}'
+          echo 'needs.build-ext.result: ${{ needs.build-ext.result }}'
+      - name: Verify jobs
+        # All jobs must succeed or be skipped.
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
   # Try to re-run the integration tests if they fail, but only up to 3 times.
   integrations-retry:
-    needs: [test-core, test-policy, test-ext, test-viz, test-multicluster]
-    if: failure() && fromJSON(github.run_attempt) < 3
+    needs:
+      [build-ok, test-core, test-policy, test-ext, test-viz, test-multicluster]
+    if: failure() && fromJSON(github.run_attempt) < 3 && needs.build-ok.result == 'success'
     runs-on: ubuntu-22.04
     permissions:
       actions: write
@@ -430,7 +446,6 @@ jobs:
           echo 'needs.test-ext.result: ${{ needs.test-ext.result }}'
           echo 'needs.test-viz.result: ${{ needs.test-viz.result }}'
           echo 'needs.test-multicluster.result: ${{ needs.test-multicluster.result }}'
-
       - name: Verify jobs
         # All jobs must succeed or be skipped.
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')


### PR DESCRIPTION
Build failures rarely require retries, as composed with integration test execution.

This change updates the integration workflow to only rerun when builds have succeeded.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
