### PR TITLE
fix: pass in LocalTrafficPolicy for remove AddressSet

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -1451,7 +1451,8 @@ func diffAddresses(oldAddresses, newAddresses AddressSet) (add, remove AddressSe
 		LocalTrafficPolicy: newAddresses.LocalTrafficPolicy,
 	}
 	remove = AddressSet{
-		Addresses: removeAddresses,
+		Addresses:          removeAddresses,
+		LocalTrafficPolicy: newAddresses.LocalTrafficPolicy,
 	}
 	return add, remove
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[12311]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
Fixes #12311

Missing `LocalTrafficPolicy` for `remove` AddressSet is causing endpoints diff incorrectly calculated and filtering being skipped in [endpoint_translator](https://github.com/yc185050/linkerd2/blob/ea8107edbd6e7be3de8128b91f906c755eca0efd/controller/api/destination/endpoint_translator.go#L275). Thus causing wrong updates were made to the endpoints.