### PR TITLE
ci: Relax version validation in git-commit-proxy-version

### DIFF
--- a/bin/git-commit-proxy-version
+++ b/bin/git-commit-proxy-version
@@ -7,10 +7,6 @@ if [ $# -ne 1 ]; then
     exit 64
 fi
 new_proxy_version="v${1#v}"
-if [[ "$new_proxy_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then :; else
-    echo "Invalid version: $new_proxy_version" >&2
-    exit 1
-fi
 
 bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )


### PR DESCRIPTION
This version validation does nothing useful. The real test is whether the named release exists.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
