### PR TITLE
ci: Fix PAT configuration in sync-proxy

### DIFF
--- a/.github/workflows/sync-proxy.yml
+++ b/.github/workflows/sync-proxy.yml
@@ -59,7 +59,7 @@ jobs:
           fi
       - if: steps.changed.outputs.changed == 'true'
         env:
-          LINKERD2_PROXY_GITHUB_TOKEN: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
           EDITOR: "true"
         run: |
           set -eu

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -37,23 +37,28 @@ cd "$builddir"
 
 version=${1:-latest}
 arch=${2:-amd64}
-if [ "$version" = latest ]; then
-  ghcurl "$releases_url"/latest > release.json
-  version=$(jq -r .tag_name release.json | sed 's,^'"${release_prefix}"',,')
-else
-  tag="${release_prefix}${version}"
-  ghcurl "$releases_url"/tags/"$(printf "$tag" | jq -sRr @uri)" > release.json
+tag="${release_prefix}${version}"
+release_url="$releases_url"/tags/"$(printf "$tag" | jq -sRr @uri)"
+if ! ghcurl "$release_url" > release.json ; then
+  echo "Failed to fetch $release_url" >&2
+  exit 1
 fi
 
 pkgname="linkerd2-proxy-${version}-${arch}"
 
 pkgfile="${pkgname}.tar.gz"
 pkgurl=$(jq -r '.assets[] | select(.name == "'"$pkgfile"'") | .url' release.json)
-ghcurl -H 'Accept: application/octet-stream' -o "$pkgfile" "$pkgurl"
+if ! ghcurl -H 'Accept: application/octet-stream' -o "$pkgfile" "$pkgurl" ; then
+  echo "Failed to fetch $pkgurl" >&2
+  exit 1
+fi
 
 shafile="${pkgname}.txt"
 shaurl=$(jq -r '.assets[] | select(.name == "'"$shafile"'") | .url' release.json)
-ghcurl -H 'Accept: application/octet-stream' -o "$shafile" "$shaurl"
+if ! ghcurl -H 'Accept: application/octet-stream' -o "$shafile" "$shaurl" ; then
+  echo "Failed to fetch $shaurl" >&2
+  exit 1
+fi
 
 tar -zxvf "$pkgfile" >&2
 expected=$(awk '{print $1}' "$shafile")


### PR DESCRIPTION
The fetch-proxy script uses the GITHUB_TOKEN environment variable. This fixes this and also improves error handling in fetch-proxy.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
