### PR TITLE
ci: Update fetch-proxy to lookup versions by name

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,7 @@ jobs:
             **/Dockerfile*
             charts/**
             justfile
+            bin/fetch-proxy
             bin/_test-helper.sh
           files_ignore: |
             .devcontainer/**

--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -19,7 +19,6 @@ COPY bin/fetch-proxy bin/fetch-proxy
 COPY bin/scurl bin/scurl
 ARG TARGETARCH
 ARG LINKERD2_PROXY_REPO="linkerd/linkerd2-proxy"
-ARG LINKERD2_PROXY_RELEASE_PREFIX="release/"
 ARG LINKERD2_PROXY_VERSION=""
 RUN --mount=type=secret,id=github \
     export GITHUB_TOKEN_FILE=/run/secrets/github; \

--- a/bin/docker-build-proxy
+++ b/bin/docker-build-proxy
@@ -30,7 +30,6 @@ get_extra_options() {
 docker_build proxy "${TAG:-$(head_root_tag)}" "$dockerfile" \
   --build-arg LINKERD_VERSION="${TAG:-$(head_root_tag)}" \
   --build-arg LINKERD2_PROXY_REPO="${LINKERD2_PROXY_REPO:-linkerd/linkerd2-proxy}" \
-  --build-arg LINKERD2_PROXY_RELEASE_PREFIX="${LINKERD2_PROXY_RELEASE_PREFIX:-release/}" \
   --build-arg LINKERD2_PROXY_VERSION="${LINKERD2_PROXY_VERSION:-$(cat .proxy-version)}" \
   --secret id=github,env=LINKERD2_PROXY_GITHUB_TOKEN \
   $(get_extra_options)

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -17,7 +17,6 @@ if [ -z "$proxy_repo" ]; then
 fi
 
 releases_url=https://api.github.com/repos/"$proxy_repo"/releases
-release_prefix="${LINKERD2_PROXY_RELEASE_PREFIX:-release/}"
 
 github_token="${GITHUB_TOKEN:-}"
 if [ -z "$github_token" ] && [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
@@ -37,10 +36,9 @@ cd "$builddir"
 
 version=${1:-latest}
 arch=${2:-amd64}
-tag="${release_prefix}${version}"
-release_url="$releases_url"/tags/"$(printf "$tag" | jq -sRr @uri)"
-if ! ghcurl "$release_url" > release.json ; then
-  echo "Failed to fetch $release_url" >&2
+
+if ! ghcurl "$releases_url" | jq '.[] | select(.name == "'"$version"'")' > release.json ; then
+  echo "Failed to fetch $releases_url" >&2
   exit 1
 fi
 


### PR DESCRIPTION
We previously relied on knowing the tag structure, but this is brittle if we change anything in the proxy repo. Instead, we now use the GitHub API to list all releases, and we match the version by name.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
