### PR TITLE
ci: Enable verbose test output in multicluster tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -528,7 +528,7 @@ mc-flat-network-init:
 # Run the multicluster tests without any setup
 mc-test-run:
     LINKERD_DOCKER_REGISTRY='{{ DOCKER_REGISTRY }}' \
-        go test -test.timeout=20m --failfast --mod=readonly \
+        go test -v -test.timeout=15m --failfast --mod=readonly \
             ./test/integration/multicluster/... \
                 -integration-tests \
                 -linkerd='{{ justfile_directory() }}/bin/linkerd' \


### PR DESCRIPTION
7e4f29f enabled verbose logging in the deep tests. This commit does the same for the multicluster tests.

This change also sets the timeout to 15 minutes to match our CI config.
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
