### PR TITLE
Removes should not change local traffic policy

### DIFF
--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -199,7 +199,10 @@ func (et *endpointTranslator) add(set watcher.AddressSet) {
 		et.availableEndpoints.Addresses[id] = address
 	}
 
-	et.sendFilteredUpdate(set)
+	et.availableEndpoints.Labels = set.Labels
+	et.availableEndpoints.LocalTrafficPolicy = set.LocalTrafficPolicy
+
+	et.sendFilteredUpdate()
 }
 
 func (et *endpointTranslator) remove(set watcher.AddressSet) {
@@ -207,7 +210,7 @@ func (et *endpointTranslator) remove(set watcher.AddressSet) {
 		delete(et.availableEndpoints.Addresses, id)
 	}
 
-	et.sendFilteredUpdate(set)
+	et.sendFilteredUpdate()
 }
 
 func (et *endpointTranslator) noEndpoints(exists bool) {
@@ -230,13 +233,7 @@ func (et *endpointTranslator) noEndpoints(exists bool) {
 	}
 }
 
-func (et *endpointTranslator) sendFilteredUpdate(set watcher.AddressSet) {
-	et.availableEndpoints = watcher.AddressSet{
-		Addresses:          et.availableEndpoints.Addresses,
-		Labels:             set.Labels,
-		LocalTrafficPolicy: set.LocalTrafficPolicy,
-	}
-
+func (et *endpointTranslator) sendFilteredUpdate() {
 	filtered := et.filterAddresses()
 	diffAdd, diffRemove := et.diffEndpoints(filtered)
 

--- a/controller/api/destination/endpoint_translator_test.go
+++ b/controller/api/destination/endpoint_translator_test.go
@@ -770,10 +770,6 @@ func TestEndpointTranslatorForLocalTrafficPolicy(t *testing.T) {
 	})
 }
 
-func TestRemovesCannotChangeLocalTrafficPolicy(t *testing.T) {
-
-}
-
 // TestConcurrency, to be triggered with `go test -race`, shouldn't report a race condition
 func TestConcurrency(t *testing.T) {
 	_, translator := makeEndpointTranslator(t)


### PR DESCRIPTION
Fixes: #12311

When the endpoint translator receives a `remove` call, it was updating it's local traffic policy based on the address set passed to remove.  However, since `remove` is only meant to remove addresses and not change the address metadata, the endpoints watcher was not setting local traffic policy on these calls to `remove`.  This can result in calls to `remove` temporarily turning off local traffic policy which will cause non-local addresses to be sent to clients.

Since `remove` should not change address metadata, we now disregard any metadata in the call to `remove`, including any changes to the local traffic policy.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
