### PR TITLE
ci: Disable sync-proxy hourly schedule

### DIFF
--- a/.github/workflows/sync-proxy.yml
+++ b/.github/workflows/sync-proxy.yml
@@ -1,9 +1,6 @@
 name: Sync proxy
 
 on:
-  # Hourly
-  schedule:
-    - cron: "15 * * * *"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This removes the sync-proxy hourly schedule.

The proxy's release process has been [updated](https://github.com/linkerd/linkerd2-proxy/pull/2835) to trigger a sync so that a the schedules do not need to be tuned.