### PR TITLE
Add subresource marker to workload CRD

### DIFF
--- a/charts/linkerd-crds/templates/workload/external-workload.yaml
+++ b/charts/linkerd-crds/templates/workload/external-workload.yaml
@@ -163,6 +163,8 @@ spec:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: >-

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -10391,6 +10391,8 @@ spec:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: >-

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -10409,6 +10409,8 @@ spec:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: >-

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -10409,6 +10409,8 @@ spec:
   - name: v1beta1
     served: true
     storage: true
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         description: >-


### PR DESCRIPTION
Our ExternalWorkload resource has a status field, but the status is not marked as a subresource in the object's schema. Status patches are done in libraries through a separate interface; without marking the status as a subresource, the API Server will respond to patch requests with a 404. This makes ExternalWorkload resource statuses unpatachable from controllers.

We fix the issue by marking the status as a subresource in the `v1beta1` schema. No codegen changes are necessary. The version is not bumped since this does not change the existing contract offered by an ExternalWorkload; it only allows the API Server to treat its status as a subresource when patching it (i.e. we can use the `patch_status` interface).

Additional context:
 * In Kubernetes, each resource has its own declarative API that can be used to change its state.
 * Resources may optionally include other declarative APIs that are decoupled from the main resource's state; this includes `Scale` and `Status` subresources. They can be thought of as a set of shared interfaces that add additional information to a resource.
 * Statuses are meant to be patched through a separate interface as a result. This allows both:
   * A separation of concerns: either patch the spec or the status but not both to avoid overwriting or deleting fields
   * Principle of least privileged: fine-grained RBAC can be used to isolate spec writes from status writes.
 * Subresources get their own API paths, writing to a subresource means we are effectively sending a requested to a nested path (e.g. `/status` on a pod). The API server needs to know this path is available.
 * CRDs require that fields are marked as a subresource, without doing so, the API Server will reply with a 404 Not Found when attempting to modify a status, since the path doesn't exist (I assume).

See:
* [Kubernetes docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#scale-kubectl-patch)
* [API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status)


### Testing

I tested we can patch the status with a toy controller. `kubectl patch --subresource='status'` should work as well.

I also tested we can upgrade from edge to current build:
* Install edge.
* Upgrade CRDs
* Restart workloads
* Upgrade linkerd

To test patching works, apply:

```yaml
apiVersion: workload.linkerd.io/v1beta1
kind: ExternalWorkload
metadata:
  name: test-external
  namespace: default
spec:
  workloadIPs:
  - ip: 192.0.2.0
  meshTLS:
    identity: test-external.default.svc.cluster.local
    serverName: test-external.default.svc.cluster.local
  ports:
  - port: 80
```

Before the change, patch requests receive a 404 Not Found
```
:; kubectl patch externalworkloads.workload.linkerd.io test-external --subresource='status' --type='merge' -p '{"status":{"conditions": {"type": "test"}}}'
Error from server (NotFound): externalworkloads.workload.linkerd.io "test-external" not found
```

After, patch requests are processed
```
Warning: unknown field "status.conditions.type"
The ExternalWorkload "test-external" is invalid:
* status.conditions: Invalid value: "object": status.conditions in body must be of type array: "object"
* status.conditions.status: Required value
* status.conditions.type: Required value

```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
