### PR TITLE
ci: Fix rust test compilation

### DIFF
--- a/justfile
+++ b/justfile
@@ -66,8 +66,7 @@ rs-doc *flags:
 rs-test-build:
     {{ _cargo-test }} --no-run --frozen \
         --workspace --exclude=linkerd-policy-test \
-        {{ _features }} \
-        {{ _fmt }}
+        {{ _features }}
 
 # Run Rust unit tests
 rs-test *flags:
@@ -144,7 +143,7 @@ policy-test-run *flags:
 
 # Build the policy tests without running them.
 policy-test-build:
-    cd policy-test && {{ _cargo-test }} --no-run {{ _fmt }}
+    cd policy-test && {{ _cargo-test }} --no-run
 
 # Delete all test namespaces and remove linkerd from the cluster.
 policy-test-cleanup:


### PR DESCRIPTION
We expect to run test compilation independently of test execution, but a change to test runner has dropped support for --message-format=json (in favor of --message-format=libtest-json, etc).

This commit updates the test runner invocation to stop formatting output in these steps.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
