### PR TITLE
Add IPv6 support for the destination controller

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -205,6 +205,7 @@ spec:
         - -cluster-domain={{.Values.clusterDomain}}
         - -identity-trust-domain={{.Values.identityTrustDomain | default .Values.clusterDomain}}
         - -default-opaque-ports={{.Values.proxy.opaquePorts}}
+        - -enable-ipv6={{not .Values.disableIPv6}}
         - -enable-pprof={{.Values.enablePprof | default false}}
         {{- if (.Values.destinationController).meshedHttp2ClientProtobuf }}
         - --meshed-http2-client-params={{ toJson .Values.destinationController.meshedHttp2ClientProtobuf }}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1466,6 +1466,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         - -trace-collector=collector.linkerd-jaeger.svc.cluster.local:55678

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1465,6 +1465,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1465,6 +1465,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: my.custom.registry/linkerd-io/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1465,6 +1465,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1465,6 +1465,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1454,6 +1454,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1587,6 +1587,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1587,6 +1587,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1396,6 +1396,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -1440,6 +1440,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=test.trust.domain
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:linkerd-version

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -1562,6 +1562,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=test.trust.domain
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:linkerd-version

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1574,6 +1574,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=test.trust.domain
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:linkerd-version

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1552,6 +1552,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=test.trust.domain
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:linkerd-version

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1459,6 +1459,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1397,6 +1397,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,443,587,3306,5432,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         image: ControllerImage:LinkerdVersion
         imagePullPolicy: ImagePullPolicy

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1465,6 +1465,7 @@ spec:
         - -cluster-domain=cluster.local
         - -identity-trust-domain=cluster.local
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1465,6 +1465,7 @@ spec:
         - -cluster-domain=example.com
         - -identity-trust-domain=example.com
         - -default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - -enable-ipv6=true
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
         image: cr.l5d.io/linkerd/controller:install-control-plane-version

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -41,6 +41,8 @@ type (
 
 		enableH2Upgrade,
 		enableEndpointFiltering,
+		enableIPv6,
+
 		extEndpointZoneWeights bool
 
 		meshedHTTP2ClientParams *pb.Http2ClientParams
@@ -84,6 +86,7 @@ func newEndpointTranslator(
 	identityTrustDomain string,
 	enableH2Upgrade,
 	enableEndpointFiltering,
+	enableIPv6,
 	extEndpointZoneWeights bool,
 	meshedHTTP2ClientParams *pb.Http2ClientParams,
 	service string,
@@ -115,6 +118,7 @@ func newEndpointTranslator(
 		defaultOpaquePorts,
 		enableH2Upgrade,
 		enableEndpointFiltering,
+		enableIPv6,
 		extEndpointZoneWeights,
 		meshedHTTP2ClientParams,
 
@@ -240,6 +244,7 @@ func (et *endpointTranslator) noEndpoints(exists bool) {
 
 func (et *endpointTranslator) sendFilteredUpdate() {
 	filtered := et.filterAddresses()
+	filtered = et.selectAddressFamily(filtered)
 	diffAdd, diffRemove := et.diffEndpoints(filtered)
 
 	if len(diffAdd.Addresses) > 0 {
@@ -250,6 +255,33 @@ func (et *endpointTranslator) sendFilteredUpdate() {
 	}
 
 	et.filteredSnapshot = filtered
+}
+
+func (et *endpointTranslator) selectAddressFamily(addresses watcher.AddressSet) watcher.AddressSet {
+	filtered := make(map[watcher.ID]watcher.Address)
+	for id, addr := range addresses.Addresses {
+		if id.IPFamily == corev1.IPv6Protocol && !et.enableIPv6 {
+			continue
+		}
+
+		if id.IPFamily == corev1.IPv4Protocol && et.enableIPv6 {
+			// Only consider IPv4 address for which there's not already an IPv6
+			// alternative
+			altID := id
+			altID.IPFamily = corev1.IPv6Protocol
+			if _, ok := addresses.Addresses[altID]; ok {
+				continue
+			}
+		}
+
+		filtered[id] = addr
+	}
+
+	return watcher.AddressSet{
+		Addresses:          filtered,
+		Labels:             addresses.Labels,
+		LocalTrafficPolicy: addresses.LocalTrafficPolicy,
+	}
 }
 
 // filterAddresses is responsible for filtering endpoints based on the node's

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -32,6 +32,7 @@ type (
 
 		EnableH2Upgrade,
 		EnableEndpointSlices,
+		EnableIPv6,
 		ExtEndpointZoneWeights bool
 
 		MeshedHttp2ClientParams *pb.Http2ClientParams
@@ -188,6 +189,7 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 			remoteConfig.TrustDomain,
 			s.config.EnableH2Upgrade,
 			false, // Disable endpoint filtering for remote discovery.
+			s.config.EnableIPv6,
 			s.config.ExtEndpointZoneWeights,
 			s.config.MeshedHttp2ClientParams,
 			fmt.Sprintf("%s.%s.svc.%s:%d", remoteSvc, service.Namespace, remoteConfig.ClusterDomain, port),
@@ -220,6 +222,7 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 			s.config.IdentityTrustDomain,
 			s.config.EnableH2Upgrade,
 			true,
+			s.config.EnableIPv6,
 			s.config.ExtEndpointZoneWeights,
 			s.config.MeshedHttp2ClientParams,
 			dest.GetPath(),

--- a/controller/api/destination/server_ipv6_test.go
+++ b/controller/api/destination/server_ipv6_test.go
@@ -1,0 +1,179 @@
+package destination
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
+	"github.com/linkerd/linkerd2/controller/api/util"
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestIPv6(t *testing.T) {
+	port := int32(port)
+	protocol := corev1.ProtocolTCP
+
+	server := makeServer(t)
+	defer server.clusterStore.UnregisterGauges()
+
+	stream := &bufferingGetStream{
+		updates:          make(chan *pb.Update, 50),
+		MockServerStream: util.NewMockServerStream(),
+	}
+	defer stream.Cancel()
+
+	t.Run("Return only IPv6 endpoint for dual-stack service", func(t *testing.T) {
+		testReturnEndpointsForServer(t, server, stream, fullyQualifiedNameDual, podIPv6Dual, uint32(port))
+	})
+
+	t.Run("Returns only IPv4 endpoint when service becomes single-stack IPv4", func(t *testing.T) {
+		patch := []byte(`{"spec":{"clusterIPs": ["172.17.13.0"], "ipFamilies":["IPv4"]}}`)
+		_, err := server.k8sAPI.Client.CoreV1().Services("ns").Patch(context.Background(), "name-ds", types.MergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			t.Fatalf("Failed patching name-ds service: %s", err)
+		}
+		if err = server.k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Delete(context.Background(), "name-ds-ipv6", metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("Failed deleting name-ds-ipv6 ES: %s", err)
+		}
+
+		update := <-stream.updates
+		if updateAddAddress(t, update)[0] != "172.17.0.19:8989" {
+			t.Fatalf("Expected %s but got %s", "172.17.0.19:8989", updateAddAddress(t, update)[0])
+		}
+
+		update = <-stream.updates
+		if updateRemoveAddress(t, update)[0] != "[2001:db8::94]:8989" {
+			t.Fatalf("Expected %s but got %s", "[2001:db8::94]:8989", updateRemoveAddress(t, update)[0])
+		}
+	})
+
+	t.Run("Returns only IPv6 endpoint when service becomes dual-stack again", func(t *testing.T) {
+		// We patch the service to become dual-stack again and we add the IPv6
+		// ES. We should receive the events for the removal of the IPv4 ES and
+		// the addition of the IPv6 one.
+		patch := []byte(`{"spec":{"clusterIPs": ["172.17.13.0","2001:db8::88"], "ipFamilies":["IPv4","IPv6"]}}`)
+		_, err := server.k8sAPI.Client.CoreV1().Services("ns").Patch(context.Background(), "name-ds", types.MergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			t.Fatalf("Failed patching name-ds service: %s", err)
+		}
+
+		es := &discovery.EndpointSlice{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "EndpointSlice",
+				APIVersion: "discovery.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name-ds-ipv6",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"kubernetes.io/service-name": "name-ds",
+				},
+			},
+			AddressType: discovery.AddressTypeIPv6,
+			Ports: []discovery.EndpointPort{
+				{
+					Port:     &port,
+					Protocol: &protocol,
+				},
+			},
+			Endpoints: []discovery.Endpoint{
+				{
+					Addresses: []string{"2001:db8::94"},
+					TargetRef: &corev1.ObjectReference{
+						Kind:      "Pod",
+						Namespace: "ns",
+						Name:      "name-ds",
+					},
+				},
+			},
+		}
+		if _, err := server.k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Create(context.Background(), es, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed creating name-ds-ipv6 ES: %s", err)
+		}
+
+		update := <-stream.updates
+		if updateAddAddress(t, update)[0] != "[2001:db8::94]:8989" {
+			t.Fatalf("Expected %s but got %s", "[2001:db8::94]:8989", updateAddAddress(t, update)[0])
+		}
+
+		update = <-stream.updates
+		if updateRemoveAddress(t, update)[0] != "172.17.0.19:8989" {
+			t.Fatalf("Expected %s but got %s", "172.17.0.19:8989", updateRemoveAddress(t, update)[0])
+		}
+	})
+
+	t.Run("Doesn't return anything when adding an IPv4 to the dual-stack service", func(t *testing.T) {
+		es := &discovery.EndpointSlice{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "EndpointSlice",
+				APIVersion: "discovery.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "name-ds-ipv4-2",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"kubernetes.io/service-name": "name-ds",
+				},
+			},
+			AddressType: discovery.AddressTypeIPv4,
+			Ports: []discovery.EndpointPort{
+				{
+					Port:     &port,
+					Protocol: &protocol,
+				},
+			},
+			Endpoints: []discovery.Endpoint{
+				{
+					Addresses: []string{"172.17.0.20"},
+					TargetRef: &corev1.ObjectReference{
+						Kind:      "Pod",
+						Namespace: "ns",
+						Name:      "name-ds",
+					},
+				},
+			},
+		}
+		if _, err := server.k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Create(context.Background(), es, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed creating name-ds-ipv4-2 ES: %s", err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		if len(stream.updates) != 0 {
+			t.Fatalf("Expected no events but got %#v", stream.updates)
+		}
+	})
+
+	t.Run("Doesn't return anything when removing an IPv4 ES from the dual-stack service", func(t *testing.T) {
+		if err := server.k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Delete(context.Background(), "name-ds-ipv4-2", metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("Failed deleting name-ds-ipv4-2 ES: %s", err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		if len(stream.updates) != 0 {
+			t.Fatalf("Expected no events but got %#v", stream.updates)
+		}
+	})
+
+	t.Run("Doesn't return anything when the service becomes single-stack IPv6", func(t *testing.T) {
+		patch := []byte(`{"spec":{"clusterIPs": ["2001:db8::88"], "ipFamilies":["IPv6"]}}`)
+		_, err := server.k8sAPI.Client.CoreV1().Services("ns").Patch(context.Background(), "name-ds", types.MergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			t.Fatalf("Failed patching name-ds service: %s", err)
+		}
+		if err := server.k8sAPI.Client.DiscoveryV1().EndpointSlices("ns").Delete(context.Background(), "name-ds-ipv4", metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("Failed deleting name-ds-ipv4 ES: %s", err)
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		if len(stream.updates) != 0 {
+			t.Fatalf("Expected no events but got %#v", stream.updates)
+		}
+	})
+}

--- a/controller/api/destination/watcher/k8s.go
+++ b/controller/api/destination/watcher/k8s.go
@@ -33,6 +33,9 @@ type (
 	ID struct {
 		Namespace string
 		Name      string
+
+		// Only used for PodID
+		IPFamily corev1.IPFamily
 	}
 	// ServiceID is the namespace-qualified name of a service.
 	ServiceID = ID

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -36,6 +36,8 @@ func Main(args []string) {
 		"Enable transparently upgraded HTTP2 connections among pods in the service mesh")
 	enableEndpointSlices := cmd.Bool("enable-endpoint-slices", true,
 		"Enable the usage of EndpointSlice informers and resources")
+	enableIPv6 := cmd.Bool("enable-ipv6", true,
+		"Set to true to allow discovering IPv6 endpoints and preferring IPv6 when both IPv4 and IPv6 are available")
 	trustDomain := cmd.String("identity-trust-domain", "", "configures the name suffix used for identities")
 	clusterDomain := cmd.String("cluster-domain", "", "kubernetes cluster domain")
 	defaultOpaquePorts := cmd.String("default-opaque-ports", "", "configures the default opaque ports")
@@ -61,6 +63,10 @@ func Main(args []string) {
 		"HTTP/2 client parameters for meshed connections in JSON format")
 
 	flags.ConfigureAndParse(cmd, args)
+
+	if *enableIPv6 && !*enableEndpointSlices {
+		log.Fatal("If --enable-ipv6=true then --enable-endpoint-slices needs to be true")
+	}
 
 	var meshedHTTP2ClientParams *pb.Http2ClientParams
 	if meshedHTTP2ClientParamsJSON != nil && *meshedHTTP2ClientParamsJSON != "" {
@@ -167,6 +173,7 @@ func Main(args []string) {
 		DefaultOpaquePorts:      opaquePorts,
 		EnableH2Upgrade:         *enableH2Upgrade,
 		EnableEndpointSlices:    *enableEndpointSlices,
+		EnableIPv6:              *enableIPv6,
 		ExtEndpointZoneWeights:  *extEndpointZoneWeights,
 		MeshedHttp2ClientParams: meshedHTTP2ClientParams,
 	}


### PR DESCRIPTION
Services in dual-stack mode result in the creation of two EndpointSlices, one for each IP family. Before this change, the Get Destination API would nondeterministically return the address for any of those ES, depending on which one was processed last by the controller because they would overwrite each other.

As part of the ongoing effort to support IPv6/dual-stack networks, this change fixes that behavior giving preference to IPv6 addresses whenever a service exposes both families.

We introduce a new field `ipv6Only` for the `servicePublisher` struct that is set to `true` for any service that exposes an IPv6 address. Whenever an ES is added or updated, if `ipv6Only` is true, it's ignored if its addressType is IPv4.

Also the server unit tests were updated to segregate the tests and resources dealing with the IPv4/IPv6/dual-stack cases.