### PR TITLE
Nominate Steve, Christian, and Dan to the Linkerd Steering Committee

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,7 +20,7 @@ The Linkerd Steering Committee members are:
 
 * Steve Gray (ZeroFlucs) @steve-gray
 * Christian Hüning (BWI) @christianhuening
-* Dan Williams (LoveHolidays) @dwilliam782
+* Dan Williams (LoveHolidays) @dwilliams782
 
 ## Emeriti
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,10 @@ The Linkerd directors are:
 
 The Linkerd Steering Committee members are:
 
+* Steve Gray (ZeroFlucs) @steve-gray
+* Christian Hüning (BWI) @christianhuening
+* Dan Williams (LoveHolidays) @dwilliam782
+
 ## Emeriti
 
 Former maintainers include:


### PR DESCRIPTION
Nominate Steve Gray (ZeroFlucs), Christian Hüning (BWI), and Dan Williams (LoveHolidays) for the Linkerd Steering Committee.

@steve-gray @christianhuening @dwilliams782: I've spoken to you all about this, but anything has changed, please let me know. (And feel free to refresh your memories with the [Steering Committee Charter](https://github.com/linkerd/linkerd2/blob/main/STEERING.md) for what you're signing up for.)

@linkerd/maintainers: please each submit a review to capture your vote. E.g. PR approval = yes to all, reject = no to all, comment = other.

Thank you all!