### PR TITLE
Add native sidecar deep integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -185,6 +185,7 @@ jobs:
         test:
           - cni-calico-deep
           - deep
+          - deep-native-sidecar
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -12,7 +12,7 @@ testdir="$bindir"/../test/integration
 
 ##### Test setup helpers #####
 
-export default_test_names=(deep viz external helm-upgrade uninstall upgrade-edge default-policy-deny rsa-ca)
+export default_test_names=(deep deep-native-sidecar viz external helm-upgrade uninstall upgrade-edge default-policy-deny rsa-ca)
 export external_resource_test_names=(external-resources)
 export all_test_names=(cluster-domain cni-calico-deep multicluster "${default_test_names[*]}" "${external_resource_test_names[*]}")
 images_load_default=(proxy controller policy-controller web metrics-api tap)
@@ -23,7 +23,7 @@ tests_usage() {
 
 Optionally specify a test with the --name flag: [${all_test_names[*]}]
 
-Note: The cluster-domain, cni-calico-deep and multicluster tests require a custom cluster configuration (see bin/_test-helpers.sh)
+Note: The cluster-domain, deep-native-sidecar cni-calico-deep and multicluster tests require a custom cluster configuration (see bin/_test-helpers.sh)
 
 Usage:
     ${progname} [--images docker|archive|skip] [--name test-name] [--skip-cluster-create] /path/to/linkerd
@@ -442,6 +442,10 @@ run_multicluster_test() {
 
 run_deep_test() {
   run_test "$testdir/deep/..."
+}
+
+run_deep-native-sidecar_test() {
+  run_test "$testdir/deep/..." --native-sidecar
 }
 
 run_default-policy-deny_test() {

--- a/test/integration/deep/install_test.go
+++ b/test/integration/deep/install_test.go
@@ -122,6 +122,10 @@ func TestInstall(t *testing.T) {
 		cmd = append(cmd, "--linkerd-cni-enabled")
 	}
 
+	if TestHelper.NativeSidecar() {
+		cmd = append(cmd, "--set", "proxy.nativeSidecar=true")
+	}
+
 	// Pipe cmd & args to `linkerd`
 	out, err = TestHelper.LinkerdRun(cmd...)
 	if err != nil {
@@ -134,5 +138,9 @@ func TestInstall(t *testing.T) {
 			"'kubectl apply' command failed\n%s", out)
 	}
 
-	TestHelper.WaitRollout(t, testutil.LinkerdDeployReplicasEdge)
+	out, err = TestHelper.LinkerdRun("check", "--wait=3m")
+	if err != nil {
+		testutil.AnnotatedFatalf(t, "'linkerd check' command failed",
+			"'linkerd check' command failed\n%s", out)
+	}
 }

--- a/test/integration/viz/install_test.go
+++ b/test/integration/viz/install_test.go
@@ -84,6 +84,10 @@ func TestInstallVizHA(t *testing.T) {
 		"--ha",
 	}
 
+	if TestHelper.NativeSidecar() {
+		cmd = append(cmd, "--set", "proxy.nativeSidecar=true")
+	}
+
 	out, err := TestHelper.LinkerdRun(cmd...)
 	if err != nil {
 		testutil.AnnotatedFatal(t, "'linkerd viz install' command failed", err)

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -38,6 +38,7 @@ type TestHelper struct {
 	uninstall            bool
 	cni                  bool
 	calico               bool
+	nativeSidecar        bool
 	defaultInboundPolicy string
 	httpClient           http.Client
 	KubernetesHelper
@@ -207,6 +208,7 @@ func NewTestHelper() *TestHelper {
 	uninstall := flag.Bool("uninstall", false, "whether to run the 'linkerd uninstall' integration test")
 	cni := flag.Bool("cni", false, "whether to install linkerd with CNI enabled")
 	calico := flag.Bool("calico", false, "whether to install calico CNI plugin")
+	nativeSidecar := flag.Bool("native-sidecar", false, "whether to install using native sidecar injection")
 	defaultInboundPolicy := flag.String("default-inbound-policy", "", "if non-empty, passed to --set proxy.defaultInboundPolicy at linkerd's install time")
 	flag.Parse()
 
@@ -252,6 +254,7 @@ func NewTestHelper() *TestHelper {
 		externalPrometheus:   *externalPrometheus,
 		cni:                  *cni,
 		calico:               *calico,
+		nativeSidecar:        *nativeSidecar,
 		uninstall:            *uninstall,
 		defaultInboundPolicy: *defaultInboundPolicy,
 	}
@@ -394,6 +397,11 @@ func (h *TestHelper) CNI() bool {
 // Calico determines whether Calico CNI plug-in is enabled
 func (h *TestHelper) Calico() bool {
 	return h.calico
+}
+
+// NativeSidecar determines whether native sidecar injection is enabled
+func (h *TestHelper) NativeSidecar() bool {
+	return h.nativeSidecar
 }
 
 // AddInstalledExtension adds an extension name to installedExtensions to


### PR DESCRIPTION
Added the test `deep-native-sidecar` which runs the `deep` test with the new flag `--native-sidecar`.

Also replaced the final `WaitRollout` call in `install_test.go` with a `linkerd check` call, to also allow us verifying that command is working as intended.