### PR TITLE
Fix issues with native sidecars

### DIFF
--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -161,7 +161,8 @@ func getContainerWithPort(pod corev1.Pod, portName string) (corev1.Container, er
 		return container, fmt.Errorf("pod not running: %s", pod.GetName())
 	}
 
-	for _, c := range pod.Spec.Containers {
+	containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+	for _, c := range containers {
 		if c.Name != k8s.ProxyContainerName {
 			continue
 		}

--- a/cli/cmd/metrics_diagnostics_util.go
+++ b/cli/cmd/metrics_diagnostics_util.go
@@ -43,7 +43,8 @@ func getAllContainersWithPort(
 	}
 	var containers []corev1.Container
 
-	for _, c := range pod.Spec.Containers {
+	allContainers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+	for _, c := range allContainers {
 		for _, p := range c.Ports {
 			if p.Name == portName {
 				containers = append(containers, c)

--- a/cli/cmd/testdata/inject_emojivoto_pod_nativesidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_nativesidecar.golden.yml
@@ -1,0 +1,228 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+    linkerd.io/proxy-version: test-inject-proxy-version
+    linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4
+  labels:
+    app: vote-bot
+    linkerd.io/control-plane-ns: linkerd
+    linkerd.io/workload-ns: emojivoto
+  name: vote-bot
+  namespace: emojivoto
+spec:
+  containers:
+  - command:
+    - emojivoto-vote-bot
+    env:
+    - name: WEB_HOST
+      value: web-svc.emojivoto:80
+    image: buoyantio/emojivoto-web:v10
+    name: vote-bot
+  initContainers:
+  - args:
+    - --incoming-proxy-port
+    - "4143"
+    - --outgoing-proxy-port
+    - "4140"
+    - --proxy-uid
+    - "2102"
+    - --inbound-ports-to-ignore
+    - 4190,4191,4567,4568
+    - --outbound-ports-to-ignore
+    - 4567,4568
+    image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+    imagePullPolicy: IfNotPresent
+    name: linkerd-init
+    resources:
+      limits:
+        cpu: 100m
+        memory: 20Mi
+      requests:
+        cpu: 100m
+        memory: 20Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /run
+      name: linkerd-proxy-init-xtables-lock
+  - env:
+    - name: _pod_name
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: _pod_ns
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: _pod_nodeName
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: LINKERD2_PROXY_LOG
+      value: warn,linkerd=info,trust_dns=error
+    - name: LINKERD2_PROXY_LOG_FORMAT
+      value: plain
+    - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
+      value: linkerd-dst-headless.linkerd.svc.cluster.local.:8086
+    - name: LINKERD2_PROXY_DESTINATION_PROFILE_NETWORKS
+      value: 10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16,fd00::/8
+    - name: LINKERD2_PROXY_POLICY_SVC_ADDR
+      value: linkerd-policy.linkerd.svc.cluster.local.:8090
+    - name: LINKERD2_PROXY_POLICY_WORKLOAD
+      value: |
+        {"ns":"$(_pod_ns)", "pod":"$(_pod_name)"}
+    - name: LINKERD2_PROXY_INBOUND_DEFAULT_POLICY
+      value: all-unauthenticated
+    - name: LINKERD2_PROXY_POLICY_CLUSTER_NETWORKS
+      value: 10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16,fd00::/8
+    - name: LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT
+      value: 3s
+    - name: LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT
+      value: 5m
+    - name: LINKERD2_PROXY_CONTROL_STREAM_LIFETIME
+      value: 1h
+    - name: LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT
+      value: 100ms
+    - name: LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT
+      value: 1000ms
+    - name: LINKERD2_PROXY_OUTBOUND_DISCOVERY_IDLE_TIMEOUT
+      value: 5s
+    - name: LINKERD2_PROXY_INBOUND_DISCOVERY_IDLE_TIMEOUT
+      value: 90s
+    - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+      value: 0.0.0.0:4190
+    - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+      value: 0.0.0.0:4191
+    - name: LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR
+      value: 127.0.0.1:4140
+    - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+      value: 0.0.0.0:4143
+    - name: LINKERD2_PROXY_INBOUND_IPS
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIPs
+    - name: LINKERD2_PROXY_INBOUND_PORTS
+    - name: LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES
+      value: svc.cluster.local.
+    - name: LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE
+      value: 10000ms
+    - name: LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION
+      value: 25,587,3306,4444,5432,6379,9300,11211
+    - name: LINKERD2_PROXY_DESTINATION_CONTEXT
+      value: |
+        {"ns":"$(_pod_ns)", "nodeName":"$(_pod_nodeName)", "pod":"$(_pod_name)"}
+    - name: _pod_sa
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.serviceAccountName
+    - name: _l5d_ns
+      value: linkerd
+    - name: _l5d_trustdomain
+      value: cluster.local
+    - name: LINKERD2_PROXY_IDENTITY_DIR
+      value: /var/run/linkerd/identity/end-entity
+    - name: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS
+      value: |
+        -----BEGIN CERTIFICATE-----
+        MIIBwTCCAWagAwIBAgIQeDZp5lDaIygQ5UfMKZrFATAKBggqhkjOPQQDAjApMScw
+        JQYDVQQDEx5pZGVudGl0eS5saW5rZXJkLmNsdXN0ZXIubG9jYWwwHhcNMjAwODI4
+        MDcxMjQ3WhcNMzAwODI2MDcxMjQ3WjApMScwJQYDVQQDEx5pZGVudGl0eS5saW5r
+        ZXJkLmNsdXN0ZXIubG9jYWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARqc70Z
+        l1vgw79rjB5uSITICUA6GyfvSFfcuIis7B/XFSkkwAHU5S/s1AAP+R0TX7HBWUC4
+        uaG4WWsiwJKNn7mgo3AwbjAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB
+        /wIBATAdBgNVHQ4EFgQU5YtjVVPfd7I7NLHsn2C26EByGV0wKQYDVR0RBCIwIIIe
+        aWRlbnRpdHkubGlua2VyZC5jbHVzdGVyLmxvY2FsMAoGCCqGSM49BAMCA0kAMEYC
+        IQCN7lBFLDDvjx6V0+XkjpKERRsJYf5adMvnloFl48ilJgIhANtxhndcr+QJPuC8
+        vgUC0d2/9FMueIVMb+46WTCOjsqr
+        -----END CERTIFICATE-----
+    - name: LINKERD2_PROXY_IDENTITY_TOKEN_FILE
+      value: /var/run/secrets/tokens/linkerd-identity-token
+    - name: LINKERD2_PROXY_IDENTITY_SVC_ADDR
+      value: linkerd-identity-headless.linkerd.svc.cluster.local.:8080
+    - name: LINKERD2_PROXY_IDENTITY_LOCAL_NAME
+      value: $(_pod_sa).$(_pod_ns).serviceaccount.identity.linkerd.cluster.local
+    - name: LINKERD2_PROXY_IDENTITY_SVC_NAME
+      value: linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local
+    - name: LINKERD2_PROXY_DESTINATION_SVC_NAME
+      value: linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local
+    - name: LINKERD2_PROXY_POLICY_SVC_NAME
+      value: linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local
+    image: cr.l5d.io/linkerd/proxy:test-inject-proxy-version
+    imagePullPolicy: IfNotPresent
+    lifecycle:
+      postStart:
+        exec:
+          command:
+          - /usr/lib/linkerd/linkerd-await
+          - --timeout=2m
+          - --port=4191
+    livenessProbe:
+      httpGet:
+        path: /live
+        port: 4191
+      initialDelaySeconds: 10
+      timeoutSeconds: 1
+    name: linkerd-proxy
+    ports:
+    - containerPort: 4143
+      name: linkerd-proxy
+    - containerPort: 4191
+      name: linkerd-admin
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 4191
+      initialDelaySeconds: 2
+      timeoutSeconds: 1
+    restartPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 2102
+      seccompProfile:
+        type: RuntimeDefault
+    startupProbe:
+      failureThreshold: 120
+      httpGet:
+        path: /ready
+        port: 4191
+        scheme: HTTP
+      periodSeconds: 1
+      successThreshold: 1
+      timeoutSeconds: 1
+    terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /var/run/linkerd/identity/end-entity
+      name: linkerd-identity-end-entity
+    - mountPath: /var/run/secrets/tokens
+      name: linkerd-identity-token
+  volumes:
+  - emptyDir: {}
+    name: linkerd-proxy-init-xtables-lock
+  - emptyDir:
+      medium: Memory
+    name: linkerd-identity-end-entity
+  - name: linkerd-identity-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          audience: identity.l5d.io
+          expirationSeconds: 86400
+          path: linkerd-identity-token
+---

--- a/cli/cmd/uninject_test.go
+++ b/cli/cmd/uninject_test.go
@@ -62,6 +62,11 @@ func TestUninjectYAML(t *testing.T) {
 			reportFileName: "inject_emojivoto_pod_uninject.report",
 		},
 		{
+			inputFileName:  "inject_emojivoto_pod_nativesidecar.golden.yml",
+			goldenFileName: "inject_emojivoto_pod.input.yml",
+			reportFileName: "inject_emojivoto_pod_uninject.report",
+		},
+		{
 			inputFileName:  "inject_emojivoto_deployment_udp.golden.yml",
 			goldenFileName: "inject_emojivoto_deployment_udp.input.yml",
 			reportFileName: "inject_emojivoto_deployment_udp_uninject.report",

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -665,7 +665,8 @@ func newEmptyAddressSet() watcher.AddressSet {
 // getInboundPort gets the inbound port from the proxy container's environment
 // variable.
 func getInboundPort(podSpec *corev1.PodSpec) (uint32, error) {
-	for _, containerSpec := range podSpec.Containers {
+	containers := append(podSpec.InitContainers, podSpec.Containers...)
+	for _, containerSpec := range containers {
 		if containerSpec.Name != pkgK8s.ProxyContainerName {
 			continue
 		}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2257,7 +2257,8 @@ func GetMeshedPodsIdentityData(ctx context.Context, api kubernetes.Interface, da
 	}
 	pods := []MeshedPodIdentityData{}
 	for _, pod := range podList.Items {
-		for _, containerSpec := range pod.Spec.Containers {
+		containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+		for _, containerSpec := range containers {
 			if containerSpec.Name != k8s.ProxyContainerName {
 				continue
 			}
@@ -2937,7 +2938,8 @@ func CheckIfDataPlanePodsExist(pods []corev1.Pod) error {
 }
 
 func containsProxy(pod corev1.Pod) bool {
-	for _, containerSpec := range pod.Spec.Containers {
+	containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+	for _, containerSpec := range containers {
 		if containerSpec.Name == k8s.ProxyContainerName {
 			return true
 		}

--- a/pkg/healthcheck/sidecar.go
+++ b/pkg/healthcheck/sidecar.go
@@ -10,7 +10,8 @@ import (
 // HasExistingSidecars returns true if the pod spec already has the proxy init
 // and sidecar containers injected. Otherwise, it returns false.
 func HasExistingSidecars(podSpec *corev1.PodSpec) bool {
-	for _, container := range podSpec.Containers {
+	containers := append(podSpec.InitContainers, podSpec.Containers...)
+	for _, container := range containers {
 		if strings.HasPrefix(container.Image, "cr.l5d.io/linkerd/proxy:") ||
 			strings.HasPrefix(container.Image, "gcr.io/istio-release/proxyv2:") ||
 			container.Name == k8s.ProxyContainerName ||

--- a/pkg/healthcheck/sidecar_test.go
+++ b/pkg/healthcheck/sidecar_test.go
@@ -46,6 +46,16 @@ func TestHasExistingSidecars(t *testing.T) {
 		},
 		{
 			podSpec: &corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name: k8s.ProxyContainerName,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						Name: "istio-proxy",

--- a/pkg/inject/uninject.go
+++ b/pkg/inject/uninject.go
@@ -36,10 +36,13 @@ func (conf *ResourceConfig) uninjectPodSpec(report *Report) {
 	t := conf.pod.spec
 	initContainers := []v1.Container{}
 	for _, container := range t.InitContainers {
-		if container.Name != k8s.InitContainerName {
-			initContainers = append(initContainers, container)
-		} else {
+		switch container.Name {
+		case k8s.InitContainerName:
 			report.Uninjected.ProxyInit = true
+		case k8s.ProxyContainerName:
+			report.Uninjected.Proxy = true
+		default:
+			initContainers = append(initContainers, container)
 		}
 	}
 	t.InitContainers = initContainers

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -323,7 +323,8 @@ func GetProxyReady(pod corev1.Pod) bool {
 
 // GetProxyVersion returns the container proxy's version, if any
 func GetProxyVersion(pod corev1.Pod) string {
-	for _, container := range pod.Spec.Containers {
+	containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+	for _, container := range containers {
 		if container.Name == ProxyContainerName {
 			if strings.Contains(container.Image, "@") {
 				// Proxy container image is specified with digest instead of

--- a/pkg/k8s/api.go
+++ b/pkg/k8s/api.go
@@ -229,11 +229,16 @@ func (kubeAPI *KubernetesAPI) GetNamespaceWithExtensionLabel(ctx context.Context
 
 // GetPodStatus receives a pod and returns the pod status, based on `kubectl` logic.
 // This logic is imported and adapted from the github.com/kubernetes/kubernetes project:
-// https://github.com/kubernetes/kubernetes/blob/33a3e325f754d179b25558dee116fca1c67d353a/pkg/printers/internalversion/printers.go#L558-L640
+// https://github.com/kubernetes/kubernetes/blob/v1.31.0-alpha.0/pkg/printers/internalversion/printers.go#L860
 func GetPodStatus(pod corev1.Pod) string {
 	reason := string(pod.Status.Phase)
 	if pod.Status.Reason != "" {
 		reason = pod.Status.Reason
+	}
+
+	initContainers := make(map[string]*corev1.Container)
+	for i := range pod.Spec.InitContainers {
+		initContainers[pod.Spec.InitContainers[i].Name] = &pod.Spec.InitContainers[i]
 	}
 
 	initializing := false
@@ -241,6 +246,9 @@ func GetPodStatus(pod corev1.Pod) string {
 		container := pod.Status.InitContainerStatuses[i]
 		switch {
 		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0 && container.State.Terminated.Signal == 0:
+			continue
+		case isRestartableInitContainer(initContainers[container.Name]) &&
+			container.Started != nil && *container.Started && container.Ready:
 			continue
 		case container.State.Terminated != nil:
 			// initialization is failed
@@ -292,9 +300,20 @@ func GetPodStatus(pod corev1.Pod) string {
 	return reason
 }
 
+// Borrowed from
+// https://github.com/kubernetes/kubernetes/blob/v1.31.0-alpha.0/pkg/printers/internalversion/printers.go#L3209
+func isRestartableInitContainer(initContainer *corev1.Container) bool {
+	if initContainer.RestartPolicy == nil {
+		return false
+	}
+
+	return *initContainer.RestartPolicy == corev1.ContainerRestartPolicyAlways
+}
+
 // GetProxyReady returns true if the pod contains a proxy that is ready
 func GetProxyReady(pod corev1.Pod) bool {
-	for _, container := range pod.Status.ContainerStatuses {
+	statuses := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
+	for _, container := range statuses {
 		if container.Name == ProxyContainerName {
 			return container.Ready
 		}

--- a/pkg/k8s/api_test.go
+++ b/pkg/k8s/api_test.go
@@ -30,6 +30,30 @@ status:
 `,
 		},
 		{
+			desc:     "Pod with proxy native sidecar is running",
+			expected: "Running",
+			pod: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: emoji
+  namespace: emojivoto
+  labels:
+    app: emoji-svc
+    linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: linkerd-proxy
+      restartPolicy: Always
+status:
+  phase: Running
+  initContainerStatuses:
+  - name: linkerd-proxy
+    ready: true
+    started: true
+`,
+		},
+		{
 			desc:     "Pod's reason is filled",
 			expected: "podReason",
 			pod: `
@@ -165,6 +189,9 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: foo
 status:
   phase: Running
   containerStatuses:
@@ -172,7 +199,8 @@ status:
       running:
         startedAt: 1995-02-10T00:42:42Z
   initContainerStatuses:
-  - state:
+  - name: foo
+    state:
       terminated:
         exitCode: 0
         reason: Completed
@@ -190,14 +218,21 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: foo
+    containers:
+    - name: bar
 status:
   phase: Running
   containerStatuses:
-  - state:
+  - name: bar
+    state:
       running:
         startedAt: 1995-02-10T00:42:42Z
   initContainerStatuses:
-  - state:
+  - name: foo
+    state:
       terminated:
         exitCode: 2
 `,
@@ -214,14 +249,21 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: foo
+    containers:
+    - name: bar
 status:
   phase: Running
   containerStatuses:
-  - state:
+  - name: bar
+    state:
       running:
         startedAt: 1995-02-10T00:42:42Z
   initContainerStatuses:
-  - state:
+  - name: foo
+    state:
       terminated:
         signal: 9
 `,
@@ -238,10 +280,14 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: foo
 status:
   phase: Pending
   initContainerStatuses:
-  - state:
+  - name: foo
+    state:
       terminated:
         exitCode: 2
         reason: CrashLoopBackOff
@@ -259,17 +305,21 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: foo
 status:
   phase: Pending
   initContainerStatuses:
-  - state:
+  - name: foo
+    state:
       waiting:
         reason: someReason
 `,
 		},
 		{
 			desc:     "Pod init container is waiting on PodInitializing",
-			expected: "Init:0/0",
+			expected: "Init:0/1",
 			pod: `
 apiVersion: v1
 kind: Pod
@@ -279,10 +329,14 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: foo
 status:
   phase: Pending
   initContainerStatuses:
-  - state:
+  - name: foo
+    state:
       waiting:
         reason: PodInitializing
 `,

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -239,7 +239,8 @@ func PodIdentity(pod *corev1.Pod) (string, error) {
 
 	podsa := pod.Spec.ServiceAccountName
 	podns := pod.ObjectMeta.Namespace
-	for _, c := range pod.Spec.Containers {
+	containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+	for _, c := range containers {
 		if c.Name == ProxyContainerName {
 			for _, env := range c.Env {
 				if env.Name == "LINKERD2_PROXY_IDENTITY_LOCAL_NAME" {

--- a/viz/metrics-api/stat_summary_test.go
+++ b/viz/metrics-api/stat_summary_test.go
@@ -229,10 +229,14 @@ metadata:
   labels:
     app: emoji-svc
     linkerd.io/control-plane-ns: linkerd
+spec:
+    initContainers:
+    - name: foo
 status:
   phase: Pending
   initContainerStatuses:
-  - state:
+  - name: foo
+    state:
       waiting:
         reason: PodInitializing
 `,
@@ -249,7 +253,7 @@ status:
 					TimeWindow: "1m",
 				},
 				expectedResponse: GenStatSummaryResponse("emoji", pkgK8s.Pod, []string{"emojivoto"}, &PodCounts{
-					Status:      "Init:0/0",
+					Status:      "Init:0/1",
 					MeshedPods:  1,
 					RunningPods: 1,
 					FailedPods:  0,
@@ -259,7 +263,8 @@ status:
 								{
 									Error: &pb.PodErrors_PodError_Container{
 										Container: &pb.PodErrors_PodError_ContainerError{
-											Reason: "PodInitializing",
+											Container: "foo",
+											Reason:    "PodInitializing",
 										},
 									},
 								},

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -474,7 +474,8 @@ func (hc *HealthChecker) checkPromAuthorized(ctx context.Context) error {
 			// default inbound policy is `deny`, there won't be an override
 			// annotation, but the proxy-injector will have set the env variable
 			// directly.
-			for _, c := range pod.Spec.Containers {
+			containers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+			for _, c := range containers {
 				if c.Name == k8s.ProxyContainerName {
 					for _, env := range c.Env {
 						if env.Name == "LINKERD2_PROXY_INBOUND_DEFAULT_POLICY" && env.Value == "deny" {


### PR DESCRIPTION
Closes #12395

Failing to iterate over init containers as well as regular containers for finding the proxy in various parts of the code when the proxy is injected as a native sidecar resulted in:

- `Get` Destination API failing in the presence of opaque ports
- Failure having the injector detecting already injected pods
- Various CLI issues

This PR is split into the following commits addressing each issue separately:

a8ebe76e3 - Fix injection check for existing sidecars
44e9625e0 - Fix 'linkerd uninject'
62694965d - Fix 'linkerd version --proxy'
42dbdaddf - Fix 'linkerd identity'
39db823fe - Fix 'linkerd check'
7359f371d - Fix 'linkerd dg proxy-metrics'
f8f73c47c - Fix destination controller

