### PR TITLE
Bump proxy-init and CNI plugin versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -205,7 +205,7 @@ Kubernetes: `>=1.22.0-0`
 | policyController.image.version | string | linkerdVersion | Tag for the policy controller container image |
 | policyController.logLevel | string | `"info"` | Log level for the policy controller |
 | policyController.probeNetworks | list | `["0.0.0.0/0","::/0"]` | The networks from which probes are performed.  By default, all networks are allowed so that all probes are authorized. |
-| policyController.resources | object | destinationResources | policy controller resource requests & limits |
+| policyController.resources | object | `{"cpu":{"limit":"","request":""},"ephemeral-storage":{"limit":"","request":""},"memory":{"limit":"","request":""}}` | policy controller resource requests & limits |
 | policyController.resources.cpu.limit | string | `""` | Maximum amount of CPU units that the policy controller can use |
 | policyController.resources.cpu.request | string | `""` | Amount of CPU units that the policy controller requests |
 | policyController.resources.ephemeral-storage.limit | string | `""` | Maximum amount of ephemeral storage that the policy controller can use |
@@ -272,7 +272,7 @@ Kubernetes: `>=1.22.0-0`
 | proxyInit.ignoreOutboundPorts | string | `"4567,4568"` | Default set of outbound ports to skip via iptables - Galera (4567,4568) |
 | proxyInit.image.name | string | `"cr.l5d.io/linkerd/proxy-init"` | Docker image for the proxy-init container |
 | proxyInit.image.pullPolicy | string | imagePullPolicy | Pull policy for the proxy-init container image |
-| proxyInit.image.version | string | `"v2.3.0"` | Tag for the proxy-init container image |
+| proxyInit.image.version | string | `"v2.4.0"` | Tag for the proxy-init container image |
 | proxyInit.iptablesMode | string | `"legacy"` | Variant of iptables that will be used to configure routing. Currently, proxy-init can be run either in 'nft' or in 'legacy' mode. The mode will control which utility binary will be called. The host must support whichever mode will be used |
 | proxyInit.kubeAPIServerPorts | string | `"443,6443"` | Default set of ports to skip via iptables for control plane components so they can communicate with the Kubernetes API Server |
 | proxyInit.logFormat | string | plain | Log format (`plain` or `json`) for the proxy-init |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -268,7 +268,7 @@ proxyInit:
     # @default -- imagePullPolicy
     pullPolicy: ""
     # -- Tag for the proxy-init container image
-    version: v2.3.0
+    version: v2.4.0
   resources:
     cpu:
       # -- Maximum amount of CPU units that the proxy-init container can use

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -32,7 +32,7 @@ Kubernetes: `>=1.22.0-0`
 | ignoreOutboundPorts | string | `""` | Default set of outbound ports to skip via iptables |
 | image.name | string | `"cr.l5d.io/linkerd/cni-plugin"` | Docker image for the CNI plugin |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the linkerd-cni container |
-| image.version | string | `"v1.4.0"` | Tag for the CNI container Docker image |
+| image.version | string | `"v1.5.0"` | Tag for the CNI container Docker image |
 | imagePullSecrets | list | `[]` |  |
 | inboundProxyPort | int | `4143` | Inbound port for the proxy container |
 | iptablesMode | string | `"legacy"` | Variant of iptables that will be used to configure routing |

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -57,7 +57,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.4.0"
+  version: "v1.5.0"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -181,7 +181,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -181,7 +181,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -404,7 +404,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -181,7 +181,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -221,7 +221,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -192,7 +192,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -426,7 +426,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -660,7 +660,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -894,7 +894,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -192,7 +192,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -195,7 +195,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -184,7 +184,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -205,7 +205,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -209,7 +209,7 @@ spec:
         - 4190,9998,7777,8888
         - --outbound-ports-to-ignore
         - "9999"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -192,7 +192,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -426,7 +426,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -205,7 +205,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -192,7 +192,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -193,7 +193,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
@@ -48,7 +48,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -193,7 +193,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -193,7 +193,7 @@ spec:
         - 4190,1234,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -194,7 +194,7 @@ spec:
         - 4190,4191,22,8100-8102
         - --outbound-ports-to-ignore
         - "5432"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -194,7 +194,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -194,7 +194,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -422,7 +422,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -194,7 +194,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:
@@ -422,7 +422,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.0
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -176,7 +176,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -179,7 +179,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -178,7 +178,7 @@ spec:
     - 4190,4191,22,8100-8102
     - --outbound-ports-to-ignore
     - "5432"
-    image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -187,7 +187,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.0
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -193,7 +193,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -194,7 +194,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -430,7 +430,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -254,7 +254,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -121,7 +121,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.4.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.5.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -122,7 +122,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.4.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.5.0
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -114,7 +114,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.4.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.5.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -115,7 +115,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.5.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.4.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -115,7 +115,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.4.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.5.0
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,6 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - args:
         - identity
@@ -1086,7 +1087,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1275,6 +1276,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -1556,7 +1558,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1710,6 +1712,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
+      
       containers:
       - env:
         - name: _pod_name
@@ -1905,7 +1908,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1086,7 +1086,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1275,7 +1275,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1556,7 +1556,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1710,7 +1710,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1906,7 +1906,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: my.custom.registry/linkerd-io/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1086,7 +1086,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.3.0
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1275,7 +1275,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1556,7 +1556,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.3.0
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1710,7 +1710,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1906,7 +1906,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.3.0
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1086,7 +1086,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1275,7 +1275,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1556,7 +1556,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1710,7 +1710,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1906,7 +1906,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1086,7 +1086,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1275,7 +1275,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1556,7 +1556,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1710,7 +1710,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1906,7 +1906,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1084,7 +1084,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1266,7 +1266,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1545,7 +1545,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1692,7 +1692,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1886,7 +1886,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -736,7 +736,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1168,7 +1168,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1684,7 +1684,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2070,7 +2070,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -736,7 +736,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1168,7 +1168,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1684,7 +1684,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2070,7 +2070,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -640,7 +640,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -820,7 +820,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1017,7 +1017,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1206,7 +1206,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1487,7 +1487,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1581,7 +1581,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1777,7 +1777,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1269,7 +1269,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1698,7 +1698,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1086,7 +1086,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1275,7 +1275,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1556,7 +1556,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1710,7 +1710,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1906,7 +1906,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -709,7 +709,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.3.0
+        version: v2.4.0
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -889,7 +889,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - args:
         - identity
@@ -1086,7 +1086,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1275,7 +1275,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1556,7 +1556,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1710,7 +1710,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       containers:
       - env:
         - name: _pod_name
@@ -1906,7 +1906,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.3.0
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.0
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -58,7 +58,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.3.0",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.0",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -68,7 +68,7 @@
         "--outbound-ports-to-ignore",
         "34567"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.3.0",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.0",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -58,7 +58,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.3.0",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.0",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": {

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2396,7 +2396,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.4.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.5.0
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,8 +15,8 @@ var Version = undefinedVersion
 // ProxyInitVersion is the pinned version of the proxy-init, from
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
-var ProxyInitVersion = "v2.3.0"
-var LinkerdCNIVersion = "v1.4.0"
+var ProxyInitVersion = "v2.4.0"
+var LinkerdCNIVersion = "v1.5.0"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -20,7 +20,7 @@ linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"
 prometheus-client = { version = "0.22.0", default-features = false }
 serde = "1"
-serde_json = "1.0.115"
+serde_json = "1.0.116"
 thiserror = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing = "0.1.40"


### PR DESCRIPTION
A new release has been cut for both. The new release adds a new `GID` feature that allows iptables to skip traffic originating from a process running under the specified GID. The CNI plugin also includes a fix for native sidecar containers.

* Bump proxy-init from `v2.3.0` to `v2.4.0`
* Bump CNI plugin from `v1.4.0` to `v1.5.0`

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
