### PR TITLE
Update to latest version of kube_codegen.sh

### DIFF
--- a/bin/update-codegen.sh
+++ b/bin/update-codegen.sh
@@ -7,12 +7,14 @@ set -o pipefail
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SCRIPT_ROOT="$(dirname "${SCRIPT_DIR}")"
 GEN_VER=$( awk '/k8s.io\/code-generator/ { print $2 }' "${SCRIPT_ROOT}/go.mod" )
-CODEGEN_PKG=target/code-generator-${GEN_VER}
+KUBE_OPEN_API_VER=$( awk '/k8s.io\/kube-openapi/ { print $2 }' "${SCRIPT_ROOT}/go.mod" )
+CODEGEN_PKG=$(mktemp -d -t "code-generator-${GEN_VER}.XXX")/code-generator
 
-if [[ ! -d "$CODEGEN_PKG" ]]; then
-    mkdir -p "$CODEGEN_PKG"
-    git clone --depth 1 --branch "$GEN_VER" https://github.com/kubernetes/code-generator "$CODEGEN_PKG"
-fi
+git clone --depth 1 --branch "$GEN_VER" https://github.com/kubernetes/code-generator "$CODEGEN_PKG"
+(
+    cd "$CODEGEN_PKG"
+    go get k8s.io/kube-openapi/pkg/common@"$KUBE_OPEN_API_VER"
+)
 
 # Remove previously generated code
 rm -rf "${SCRIPT_ROOT}/controller/gen/client/clientset/*"
@@ -34,9 +36,8 @@ mkdir -p "${SCRIPT_ROOT}/github.com/linkerd"
 ln -s "$(realpath "${SCRIPT_ROOT}")" "${SCRIPT_ROOT}/github.com/linkerd/linkerd2"
 
 kube::codegen::gen_helpers \
-    --input-pkg-root github.com/linkerd/linkerd2/controller/gen/apis \
-    --output-base "${SCRIPT_ROOT}" \
-    --boilerplate "${SCRIPT_ROOT}/controller/gen/boilerplate.go.txt"
+    --boilerplate "${SCRIPT_ROOT}/controller/gen/boilerplate.go.txt" \
+    github.com/linkerd/linkerd2/controller/gen/apis
 
 if [[ -n "${API_KNOWN_VIOLATIONS_DIR:-}" ]]; then
     report_filename="${API_KNOWN_VIOLATIONS_DIR}/codegen_violation_exceptions.list"
@@ -46,19 +47,19 @@ if [[ -n "${API_KNOWN_VIOLATIONS_DIR:-}" ]]; then
 fi
 
 kube::codegen::gen_openapi \
-    --input-pkg-root github.com/linkerd/linkerd2/controller/gen/apis \
-    --output-pkg-root github.com/linkerd/linkerd2/controller/gen\
-    --output-base "${SCRIPT_ROOT}" \
+    --output-pkg github.com/linkerd/linkerd2/controller/gen \
+    --output-dir "${SCRIPT_ROOT}/controller/gen/client" \
     --report-filename "${report_filename:-"/dev/null"}" \
     ${update_report:+"${update_report}"} \
-    --boilerplate "${SCRIPT_ROOT}/controller/gen/boilerplate.go.txt"
+    --boilerplate "${SCRIPT_ROOT}/controller/gen/boilerplate.go.txt" \
+    github.com/linkerd/linkerd2/controller/gen/apis
 
 kube::codegen::gen_client \
     --with-watch \
-    --input-pkg-root github.com/linkerd/linkerd2/controller/gen/apis \
-    --output-pkg-root github.com/linkerd/linkerd2/controller/gen/client \
-    --output-base "${SCRIPT_ROOT}" \
-    --boilerplate "${SCRIPT_ROOT}/controller/gen/boilerplate.go.txt"
+    --output-pkg github.com/linkerd/linkerd2/controller/gen/client \
+    --output-dir "${SCRIPT_ROOT}/controller/gen/client" \
+    --boilerplate "${SCRIPT_ROOT}/controller/gen/boilerplate.go.txt" \
+    github.com/linkerd/linkerd2/controller/gen/apis
 
 # Once the code has been generated, we can remove the symlink.
 rm -rf "${SCRIPT_ROOT}/github.com"


### PR DESCRIPTION
We use the `kube_codegen.sh` script from the [kubernetes/code-generator](https://github.com/kubernetes/code-generator) repo to generate Go bindings for CRDs defined in this repo. The arguments and flags for that script changed in Kubernetes 1.30, which broke our usage of that script when this repo's Kubernetes dependencies were updated in #12463.

For the full set of changes, see: https://github.com/kubernetes/code-generator/compare/599d00c...de98b55#diff-beaa4412ca0edb2451061daa9570ce25858ec41951938fc60f17e2370462ad8e

In this change, I'm updating `bin/update-codegen.sh` to work with the latest version of the `kube_codegen.sh` script.

To validate, check out this branch and run `bin/update-codegen.sh`. The script should exit cleanly, and there should be no changes to the previously-generated Go bindings.