### PR TITLE
chore!: Update the minimum Kubernetes version to 1.25

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -4,7 +4,7 @@
 # proper messages
 set +e
 
-k8s_version_min='+v1.22'
+k8s_version_min='+v1.25'
 k8s_version_max='+v1.29'
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )

--- a/charts/linkerd-control-plane/Chart.yaml
+++ b/charts/linkerd-control-plane/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 home: https://linkerd.io
 keywords:
   - service-mesh
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.25.0-0"
 name: "linkerd-control-plane"
 sources:
   - https://github.com/linkerd/linkerd2/

--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -130,7 +130,7 @@ extensions:
 
 ## Requirements
 
-Kubernetes: `>=1.22.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd-crds/Chart.yaml
+++ b/charts/linkerd-crds/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 home: https://linkerd.io
 keywords:
   - service-mesh
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.25.0-0"
 name: "linkerd-crds"
 sources:
   - https://github.com/linkerd/linkerd2/

--- a/charts/linkerd-crds/README.md
+++ b/charts/linkerd-crds/README.md
@@ -55,7 +55,7 @@ helm install linkerd-crds -n linkerd --create-namespace linkerd/linkerd-crds
 
 ## Requirements
 
-Kubernetes: `>=1.22.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/linkerd2-cni/Chart.yaml
+++ b/charts/linkerd2-cni/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   Linkerd [CNI plugin](https://linkerd.io/2/features/cni/) takes care of setting
   up your pod's network so  incoming and outgoing traffic is proxied through the
   data plane.
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.25.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd2-cni"
 # this version will be updated by the CI before publishing the Helm tarball

--- a/charts/linkerd2-cni/README.md
+++ b/charts/linkerd2-cni/README.md
@@ -12,7 +12,7 @@ data plane.
 
 ## Requirements
 
-Kubernetes: `>=1.22.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/jaeger/charts/linkerd-jaeger/Chart.yaml
+++ b/jaeger/charts/linkerd-jaeger/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
   - service-mesh
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.25.0-0"
 name: linkerd-jaeger
 sources:
   - https://github.com/linkerd/linkerd2/

--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -57,7 +57,7 @@ helm install linkerd-jaeger -n linkerd-jaeger --create-namespace linkerd/linkerd
 
 ## Requirements
 
-Kubernetes: `>=1.22.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/multicluster/charts/linkerd-multicluster-link/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   `cluster-credentials` secret and the Link CR, which are not found in this
   chart. Therefore this chart is not a replacement for that command, and
   shouldn't be used as-is unless you really know what you're doing ;-)
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.25.0-0"
 icon: https://linkerd.io/images/logo-only-200h.png
 name: "linkerd-multicluster-link"
 version: 0.2.0

--- a/multicluster/charts/linkerd-multicluster-link/README.md
+++ b/multicluster/charts/linkerd-multicluster-link/README.md
@@ -15,7 +15,7 @@ shouldn't be used as-is unless you really know what you're doing ;-)
 
 ## Requirements
 
-Kubernetes: `>=1.22.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/multicluster/charts/linkerd-multicluster/Chart.yaml
+++ b/multicluster/charts/linkerd-multicluster/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
   - service-mesh
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.25.0-0"
 name: "linkerd-multicluster"
 sources:
   - https://github.com/linkerd/linkerd2/

--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -55,7 +55,7 @@ helm install linkerd-multicluster -n linkerd-multicluster --create-namespace lin
 
 ## Requirements
 
-Kubernetes: `>=1.22.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/viz/charts/linkerd-viz/Chart.yaml
+++ b/viz/charts/linkerd-viz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 home: https://linkerd.io
 keywords:
   - service-mesh
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.25.0-0"
 name: "linkerd-viz"
 sources:
   - https://github.com/linkerd/linkerd2/

--- a/viz/charts/linkerd-viz/README.md
+++ b/viz/charts/linkerd-viz/README.md
@@ -55,7 +55,7 @@ helm install linkerd-viz -n linkerd-viz --create-namespace linkerd/linkerd-viz
 
 ## Requirements
 
-Kubernetes: `>=1.22.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|


### PR DESCRIPTION
Kubernetes 1.25 introduces and 1.29 stabilizes a new CRD validation feature. This feature is used by newer versions of the Gateway API CRDs. The Gateway API maintains compatibility with "at least the last 5" Kubernetes minor releases. Now that 1.30 has been released, they have dropped support for versions 1.24 and older.

We are going to have to update our Minimum Kubernetes version in the near future anyway, as we update our kube-rs dependency.

This change updates the minimum Kubernetes version to 1.25 in advance of these upcoming changes.

[rules]: https://kubernetes.io/blog/2022/09/23/crd-validation-rules-beta/

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
