### PR TITLE
Fix flakey Handles_overflow test

### DIFF
--- a/controller/api/destination/endpoint_profile_translator_test.go
+++ b/controller/api/destination/endpoint_profile_translator_test.go
@@ -89,8 +89,9 @@ func TestEndpointProfileTranslator(t *testing.T) {
 			endStream,
 			log,
 		)
-		translator.Start()
-		defer translator.Stop()
+
+		// We avoid starting the translator so that it doesn't drain its update
+		// queue and we can test the overflow behavior.
 
 		for i := 0; i < updateQueueCapacity/2; i++ {
 			if err := translator.Update(podAddr); err != nil {


### PR DESCRIPTION
The `Handles overflow` test for the endpoint profile translator writes updates into the updates queue until it is full and then tests that no more updates can be enqueued.  However, since the test also starts the profile translator, it is concurrently draining updates off of the queue as well.  This leads to unpredictable results and test flakeyness.

We update the test to not start the translator so that updates are not drained off of the queue during the test.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
