### PR TITLE
Revert "Fix destination staleness issue when adding EndpointSlices (#12427)"

### DIFF
--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -795,18 +795,15 @@ func (pp *portPublisher) updateEndpoints(endpoints *corev1.Endpoints) {
 func (pp *portPublisher) addEndpointSlice(slice *discovery.EndpointSlice) {
 	newAddressSet := pp.endpointSliceToAddresses(slice)
 	for id, addr := range pp.addresses.Addresses {
-		if _, ok := newAddressSet.Addresses[id]; !ok {
-			newAddressSet.Addresses[id] = addr
-		}
+		newAddressSet.Addresses[id] = addr
+		newAddressSet.LocalTrafficPolicy = pp.localTrafficPolicy
 	}
 
 	add, _ := diffAddresses(pp.addresses, newAddressSet)
-	if len(add.Addresses) == 0 {
-		return
-	}
-
-	for _, listener := range pp.listeners {
-		listener.Add(add)
+	if len(add.Addresses) > 0 {
+		for _, listener := range pp.listeners {
+			listener.Add(add)
+		}
 	}
 
 	pp.addresses = newAddressSet


### PR DESCRIPTION
This reverts commit 4fccf3e9eccb8179b802725e816e423a3d3b824d.

The early return was causing `pp.addresses = newAddressSet` to not be run when the list of addresses is empty; but setting that is still necessary so that labels are tracked correctly.

This was caught by the tap (viz) integration test run in the release workflow.