### PR TITLE
chore(ci): Remove conditional integration testing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,60 +45,9 @@ jobs:
             .devcontainer/**
             **/Chart.yaml
             **/README*
-      - uses: tj-actions/changed-files@0874344d6ebbaa00a27da73276ae7162fadcaf69
-        id: policy
-        with:
-          files: |
-            .github/workflows/integration.yml
-            .proxy-version
-            Cargo.lock
-            charts/linkerd-control-plane/**
-            charts/linkerd-crds/templates/policy/**
-            justfile
-            policy-controller/**
-            policy-test/**
-            rust-toolchain.toml
-          files_ignore: |
-            **/Chart.yaml
-            **/README*
-      - uses: tj-actions/changed-files@0874344d6ebbaa00a27da73276ae7162fadcaf69
-        id: multicluster
-        with:
-          files: |
-            .github/workflows/integration.yml
-            .proxy-version
-            justfile
-            multicluster/**
-            test/integration/multicluster/**
-          files_ignore: |
-            **/Chart.yaml
-            **/README*
-      - uses: tj-actions/changed-files@0874344d6ebbaa00a27da73276ae7162fadcaf69
-        id: viz
-        with:
-          files: |
-            .github/workflows/integration.yml
-            .proxy-version
-            justfile
-            viz/**
-            test/integration/viz/**
-            bin/_test-helper.sh
-          files_ignore: |
-            **/Chart.yaml
-            **/README*
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      changed-core: ${{ steps.core.outputs.any_changed }}
-      changed-policy: ${{ steps.policy.outputs.any_changed }}
-      changed-multicluster: ${{ steps.multicluster.outputs.any_changed }}
-      changed-viz: ${{ steps.viz.outputs.any_changed }}
-      changed: >-
-        ${{
-          steps.core.outputs.any_changed == 'true' ||
-          steps.policy.outputs.any_changed == 'true' ||
-          steps.multicluster.outputs.any_changed == 'true' ||
-          steps.viz.outputs.any_changed == 'true'
-        }}
+      changed: ${{ steps.core.outputs.any_changed }}
 
   info:
     needs: meta
@@ -109,10 +58,6 @@ jobs:
         run: |
           echo "tag=${{ needs.meta.outputs.tag }}"
           echo "changed=${{ needs.meta.outputs.changed }}"
-          echo "changed-core=${{ needs.meta.outputs.changed-core }}"
-          echo "changed-policy=${{ needs.meta.outputs.changed-policy }}"
-          echo "changed-multicluster=${{ needs.meta.outputs.changed-multicluster }}"
-          echo "changed-viz=${{ needs.meta.outputs.changed-viz }}"
 
   build-cli:
     needs: meta
@@ -211,7 +156,7 @@ jobs:
 
   test-policy:
     needs: [meta, build-cli, build-core]
-    if: needs.meta.outputs.changed-policy == 'true'
+    if: needs.meta.outputs.changed == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
@@ -337,7 +282,7 @@ jobs:
 
   test-viz:
     needs: [meta, build-cli, build-core, build-ext]
-    if: needs.meta.outputs.changed-viz == 'true'
+    if: needs.meta.outputs.changed == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
@@ -363,7 +308,7 @@ jobs:
 
   test-multicluster:
     needs: [meta, build-cli, build-core, build-ext]
-    if: needs.meta.outputs.changed-multicluster == 'true'
+    if: needs.meta.outputs.changed == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
We instrumented conditional execution of some of our flakier integration test suites: viz, multicluster, and policy. Since then, we have introduced retries that ameliorate flakiness. The current state allows these tests to regress on main, to be discovered only at release time.

This commit removes the conditional execution of these tests, and instead runs all integration tests uniformly.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
