### PR TITLE
fix(ci): Disable arm64 install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,49 +146,6 @@ jobs:
           [[ "$TAG" == "$($CMD version --short --client)" ]]
           bin/tests --images preload --name ${{ matrix.integration_test }} "$CMD"
 
-  arm64_integration_tests:
-    needs: [tag, docker_build]
-    runs-on: [self-hosted, Linux, ARM64]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
-        with:
-          go-version: "1.22"
-      - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb
-      - name: Pull linkerd binary
-        run: |
-          TAG='${{ needs.tag.outputs.tag }}'
-          bin/docker-pull-binaries "$TAG"
-          CMD="$PWD/target/release/linkerd2-cli-$TAG-linux-arm64"
-          echo "CMD=$CMD" >> "$GITHUB_ENV"
-          "$CMD" version --client
-      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
-      - name: Setup k3d
-        shell: bash
-        run: |
-          mkdir -p "$PWD/target/bin"
-          PATH=$PATH:"$PWD/target/bin"
-          echo "PATH=$PATH" >> "$GITHUB_ENV"
-          bin/scurl "https://raw.githubusercontent.com/k3d-io/k3d/${{ env.K3D_VERSION }}/install.sh" \
-            | USE_SUDO=false K3D_INSTALL_DIR=$PWD/target/bin bash
-      - name: Cluster setup
-        run: |
-          CLUSTER_NAME=$(printf "${{ github.ref_name }}" | tr -c '[:alnum:]' -)
-          echo "CLUSTER_NAME=$CLUSTER_NAME" >> "$GITHUB_ENV"
-          just k3d-name="$CLUSTER_NAME" k3d-create
-          just k3d-name="$CLUSTER_NAME" k3d-use
-      - env:
-          RUN_ARM_TEST: 1
-          LINKERD_DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-        run: go test ./test/integration/deep/... --integration-tests --linkerd "$CMD"
-      - name: Delete cluster
-        if: always()
-        run: just k3d-name="$CLUSTER_NAME" k3d-delete
-
   choco_pack:
     # only runs for stable tags. The conditionals are at each step level instead of the job level
     # otherwise the jobs below that depend on this one won't run


### PR DESCRIPTION
Our release workflow exercises an install on a manually managed ARM host. This is fragile, and has fallen into disrepair. Practically speaking, we have never found an issue in the ARM test -- if it builds, it works.

This commit removes the arm install from the release workflow.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
