### PR TITLE
Add json output format support to linkerd profile command

### DIFF
--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -120,10 +120,7 @@ func newCmdProfile() *cobra.Command {
 
 			var profile *sp.ServiceProfile
 			if options.template {
-				if options.output != "yaml" {
-					return errors.New("the --template flag is only compatible with yaml output")
-				}
-				return profiles.RenderProfileTemplate(options.namespace, options.name, clusterDomain, os.Stdout)
+				return profiles.RenderProfileTemplate(options.namespace, options.name, clusterDomain, os.Stdout, options.output)
 			} else if options.openAPI != "" {
 				profile, err = profiles.RenderOpenAPI(options.openAPI, options.namespace, options.name, clusterDomain)
 			} else if options.proto != "" {

--- a/cli/cmd/profile_test.go
+++ b/cli/cmd/profile_test.go
@@ -14,7 +14,7 @@ import (
 func TestParseProfile(t *testing.T) {
 	var buf bytes.Buffer
 
-	err := profiles.RenderProfileTemplate("myns", "mysvc", "mycluster.local", &buf)
+	err := profiles.RenderProfileTemplate("myns", "mysvc", "mycluster.local", &buf, "yaml")
 	if err != nil {
 		t.Fatalf("Error rendering service profile template: %v", err)
 	}

--- a/pkg/profiles/openapi.go
+++ b/pkg/profiles/openapi.go
@@ -21,31 +21,31 @@ const (
 // RenderOpenAPI reads an OpenAPI spec file and renders the corresponding
 // ServiceProfile to a buffer, given a namespace, service, and control plane
 // namespace.
-func RenderOpenAPI(fileName, namespace, name, clusterDomain string, w io.Writer) error {
+func RenderOpenAPI(fileName, namespace, name, clusterDomain string) (*sp.ServiceProfile, error) {
 
 	input, err := readFile(fileName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	bytes, err := io.ReadAll(input)
 	if err != nil {
-		return fmt.Errorf("Error reading file: %w", err)
+		return nil, fmt.Errorf("Error reading file: %w", err)
 	}
 	json, err := yaml.YAMLToJSON(bytes)
 	if err != nil {
-		return fmt.Errorf("Error parsing yaml: %w", err)
+		return nil, fmt.Errorf("Error parsing yaml: %w", err)
 	}
 
 	swagger := spec.Swagger{}
 	err = swagger.UnmarshalJSON(json)
 	if err != nil {
-		return fmt.Errorf("Error parsing OpenAPI spec: %w", err)
+		return nil, fmt.Errorf("Error parsing OpenAPI spec: %w", err)
 	}
 
 	profile := swaggerToServiceProfile(swagger, namespace, name, clusterDomain)
 
-	return writeProfile(profile, w)
+	return &profile, nil
 }
 
 func swaggerToServiceProfile(swagger spec.Swagger, namespace, name, clusterDomain string) sp.ServiceProfile {

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -233,15 +233,6 @@ func readFile(fileName string) (io.Reader, error) {
 	return os.Open(filepath.Clean(fileName))
 }
 
-func writeProfile(profile sp.ServiceProfile, w io.Writer) error {
-	output, err := yaml.Marshal(profile)
-	if err != nil {
-		return fmt.Errorf("Error writing Service Profile: %w", err)
-	}
-	_, err = w.Write(output)
-	return err
-}
-
 // PathToRegex converts a path into a regex.
 func PathToRegex(path string) string {
 	escaped := regexp.QuoteMeta(path)

--- a/pkg/profiles/profiles_fuzzer.go
+++ b/pkg/profiles/profiles_fuzzer.go
@@ -42,11 +42,9 @@ func FuzzRenderProto(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	w, err := os.OpenFile("/dev/null", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	_, err = RenderProto(protofile.Name(), namespace, name, clusterDomain)
 	if err != nil {
 		return 0
 	}
-	defer w.Close()
-	_ = RenderProto(protofile.Name(), namespace, name, clusterDomain, w)
 	return 1
 }

--- a/pkg/profiles/proto.go
+++ b/pkg/profiles/proto.go
@@ -2,7 +2,6 @@ package profiles
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -15,20 +14,15 @@ import (
 // RenderProto reads a protobuf definition file and renders the corresponding
 // ServiceProfile to a buffer, given a namespace, service, and control plane
 // namespace.
-func RenderProto(fileName, namespace, name, clusterDomain string, w io.Writer) error {
+func RenderProto(fileName, namespace, name, clusterDomain string) (*sp.ServiceProfile, error) {
 	input, err := readFile(fileName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	parser := proto.NewParser(input)
 
-	profile, err := protoToServiceProfile(parser, namespace, name, clusterDomain)
-	if err != nil {
-		return err
-	}
-
-	return writeProfile(*profile, w)
+	return protoToServiceProfile(parser, namespace, name, clusterDomain)
 }
 
 func protoToServiceProfile(parser *proto.Parser, namespace, name, clusterDomain string) (*sp.ServiceProfile, error) {

--- a/web/srv/handlers.go
+++ b/web/srv/handlers.go
@@ -74,7 +74,7 @@ func (h *handler) handleProfileDownload(w http.ResponseWriter, req *http.Request
 	}
 
 	profileYaml := &bytes.Buffer{}
-	err := profiles.RenderProfileTemplate(namespace, service, h.clusterDomain, profileYaml)
+	err := profiles.RenderProfileTemplate(namespace, service, h.clusterDomain, profileYaml, "yaml")
 
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
Add an`-o/--output` flag to the `linkerd profile` command which outputs ServiceProfile manifests.  The supported output formats are yaml (default) and json.  Both of these formats are supported by kubectl and either one can be piped into `kubectl apply`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
