### PR TITLE
Reindex outbound policy backends when a service changes

### DIFF
--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -78,6 +78,7 @@ pub struct WeightedService {
     pub namespace: String,
     pub port: NonZeroU16,
     pub filters: Vec<Filter>,
+    pub exists: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -398,37 +398,37 @@ fn convert_http_backend(
             if svc.exists {
                 let filters = svc.filters.into_iter().map(convert_filter).collect();
                 outbound::http_route::WeightedRouteBackend {
-                weight: svc.weight,
-                backend: Some(outbound::http_route::RouteBackend {
-                    backend: Some(outbound::Backend {
-                        metadata: Some(Metadata {
-                            kind: Some(metadata::Kind::Resource(api::meta::Resource {
-                                group: "core".to_string(),
-                                kind: "Service".to_string(),
-                                name: svc.name,
-                                namespace: svc.namespace,
-                                section: Default::default(),
-                                port: u16::from(svc.port).into(),
-                            })),
+                    weight: svc.weight,
+                    backend: Some(outbound::http_route::RouteBackend {
+                        backend: Some(outbound::Backend {
+                            metadata: Some(Metadata {
+                                kind: Some(metadata::Kind::Resource(api::meta::Resource {
+                                    group: "core".to_string(),
+                                    kind: "Service".to_string(),
+                                    name: svc.name,
+                                    namespace: svc.namespace,
+                                    section: Default::default(),
+                                    port: u16::from(svc.port).into(),
+                                })),
+                            }),
+                            queue: Some(default_queue_config()),
+                            kind: Some(outbound::backend::Kind::Balancer(
+                                outbound::backend::BalanceP2c {
+                                    discovery: Some(outbound::backend::EndpointDiscovery {
+                                        kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
+                                            outbound::backend::endpoint_discovery::DestinationGet {
+                                                path: svc.authority,
+                                            },
+                                        )),
+                                    }),
+                                    load: Some(default_balancer_config()),
+                                },
+                            )),
                         }),
-                        queue: Some(default_queue_config()),
-                        kind: Some(outbound::backend::Kind::Balancer(
-                            outbound::backend::BalanceP2c {
-                                discovery: Some(outbound::backend::EndpointDiscovery {
-                                    kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
-                                        outbound::backend::endpoint_discovery::DestinationGet {
-                                            path: svc.authority,
-                                        },
-                                    )),
-                                }),
-                                load: Some(default_balancer_config()),
-                            },
-                        )),
+                        filters,
+                        request_timeout,
                     }),
-                    filters,
-                    request_timeout,
-                }),
-            }
+                }
             } else {
                 outbound::http_route::WeightedRouteBackend {
                     weight: svc.weight,

--- a/policy-controller/k8s/index/src/outbound.rs
+++ b/policy-controller/k8s/index/src/outbound.rs
@@ -1,3 +1,6 @@
 pub mod index;
 
 pub use index::{metrics, Index, ServiceRef, SharedIndex};
+
+#[cfg(test)]
+mod tests;

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -92,6 +92,7 @@ impl kubert::index::IndexNamespacedResource<api::HttpRoute> for Index {
 
     fn delete(&mut self, namespace: String, name: String) {
         let gknn = gkn_for_linkerd_http_route(name).namespaced(namespace);
+        tracing::debug!(?gknn, "deleting route");
         for ns_index in self.namespaces.by_ns.values_mut() {
             ns_index.delete(&gknn);
         }
@@ -105,6 +106,7 @@ impl kubert::index::IndexNamespacedResource<k8s_gateway_api::HttpRoute> for Inde
 
     fn delete(&mut self, namespace: String, name: String) {
         let gknn = gkn_for_gateway_http_route(name).namespaced(namespace);
+        tracing::debug!(?gknn, "deleting route");
         for ns_index in self.namespaces.by_ns.values_mut() {
             ns_index.delete(&gknn);
         }
@@ -115,6 +117,7 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
     fn apply(&mut self, service: Service) {
         let name = service.name_unchecked();
         let ns = service.namespace().expect("Service must have a namespace");
+        tracing::debug!(name, ns, "indexing service");
         let accrual = parse_accrual_config(service.annotations())
             .map_err(|error| tracing::error!(%error, service=name, namespace=ns, "failed to parse accrual config"))
             .unwrap_or_default();
@@ -168,12 +171,17 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
             },
             service_info,
         );
+
+        self.reindex_services()
     }
 
     fn delete(&mut self, namespace: String, name: String) {
+        tracing::debug!(name, namespace, "deleting service");
         let service_ref = ServiceRef { name, namespace };
         self.service_info.remove(&service_ref);
         self.services_by_ip.retain(|_, v| *v != service_ref);
+
+        self.reindex_services()
     }
 }
 
@@ -250,6 +258,12 @@ impl Index {
                 );
         }
     }
+
+    fn reindex_services(&mut self) {
+        for ns in self.namespaces.by_ns.values_mut() {
+            ns.reindex_services(&self.service_info);
+        }
+    }
 }
 
 impl Namespace {
@@ -300,6 +314,27 @@ impl Namespace {
                 .entry(parent_ref.name.clone())
                 .or_default()
                 .insert(route.gknn(), outbound_route);
+        }
+    }
+
+    fn reindex_services(&mut self, service_info: &HashMap<ServiceRef, ServiceInfo>) {
+        for routes in self.service_port_routes.values_mut() {
+            for routes in routes.watches_by_ns.values_mut() {
+                for route in routes.routes.values_mut() {
+                    for rule in route.rules.iter_mut() {
+                        for backend in rule.backends.iter_mut() {
+                            if let Backend::Service(svc) = backend {
+                                let service_ref = ServiceRef {
+                                    name: svc.name.clone(),
+                                    namespace: svc.namespace.clone(),
+                                };
+                                svc.exists = service_info.contains_key(&service_ref);
+                            }
+                        }
+                    }
+                }
+                routes.send_if_modified();
+            }
         }
     }
 
@@ -591,12 +626,6 @@ fn convert_backend(
         name: name.clone(),
         namespace: backend.inner.namespace.unwrap_or_else(|| ns.to_string()),
     };
-    if !services.contains_key(&service_ref) {
-        return Some(Backend::Invalid {
-            weight: weight.into(),
-            message: format!("Service not found {name}"),
-        });
-    }
 
     let filters = match filters
         .into_iter()
@@ -620,6 +649,7 @@ fn convert_backend(
         namespace: service_ref.namespace.to_string(),
         port,
         filters,
+        exists: services.contains_key(&service_ref),
     }))
 }
 

--- a/policy-controller/k8s/index/src/outbound/tests.rs
+++ b/policy-controller/k8s/index/src/outbound/tests.rs
@@ -55,7 +55,7 @@ impl TestConfig {
             default_opaque_ports: Default::default(),
             probe_networks,
         };
-        let index = Index::shared(Arc::new(cluster.clone()));
+        let index = Index::shared(Arc::new(cluster));
         Self { index }
     }
 }

--- a/policy-controller/k8s/index/src/outbound/tests.rs
+++ b/policy-controller/k8s/index/src/outbound/tests.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use crate::{
+    defaults::DefaultPolicy,
+    outbound::index::{Index, SharedIndex},
+    ClusterInfo,
+};
+use kubert::index::IndexNamespacedResource;
+use linkerd_policy_controller_core::IpNet;
+use linkerd_policy_controller_k8s_api::{self as k8s};
+use tokio::time;
+
+mod http_routes;
+
+struct TestConfig {
+    index: SharedIndex,
+}
+
+pub fn mk_service(ns: impl ToString, name: impl ToString, port: i32) -> k8s::Service {
+    k8s::Service {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        spec: Some(k8s::api::core::v1::ServiceSpec {
+            ports: Some(vec![k8s::api::core::v1::ServicePort {
+                port,
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+impl TestConfig {
+    fn from_default_policy(default_policy: DefaultPolicy) -> Self {
+        Self::from_default_policy_with_probes(default_policy, vec![])
+    }
+
+    fn from_default_policy_with_probes(
+        default_policy: DefaultPolicy,
+        probe_networks: Vec<IpNet>,
+    ) -> Self {
+        let cluster_net = "192.0.2.0/24".parse().unwrap();
+        let detect_timeout = time::Duration::from_secs(1);
+        let cluster = ClusterInfo {
+            networks: vec![cluster_net],
+            control_plane_ns: "linkerd".to_string(),
+            identity_domain: "cluster.example.com".into(),
+            dns_domain: "cluster.example.com".into(),
+            default_policy,
+            default_detect_timeout: detect_timeout,
+            default_opaque_ports: Default::default(),
+            probe_networks,
+        };
+        let index = Index::shared(Arc::new(cluster.clone()));
+        Self { index }
+    }
+}
+
+impl Default for TestConfig {
+    fn default() -> TestConfig {
+        Self::from_default_policy(DefaultPolicy::Allow {
+            authenticated_only: false,
+            cluster_only: true,
+        })
+    }
+}

--- a/policy-controller/k8s/index/src/outbound/tests/http_routes.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/http_routes.rs
@@ -1,0 +1,173 @@
+use k8s_gateway_api::BackendRef;
+use kube::Resource;
+use linkerd_policy_controller_core::{
+    http_route::GroupKindNamespaceName,
+    outbound::{Backend, WeightedService},
+    POLICY_CONTROLLER_NAME,
+};
+use tracing::Level;
+
+use super::*;
+
+#[test]
+fn backend_service() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .init();
+
+    let test = TestConfig::default();
+    // Create apex service.
+    let apex = mk_service("ns", "apex", 8080);
+    test.index.write().apply(apex);
+
+    // Create httproute.
+    let route = mk_route("ns", "route", 8080, "apex", "backend");
+    test.index.write().apply(route);
+
+    let mut rx = test
+        .index
+        .write()
+        .outbound_policy_rx(
+            "apex".to_string(),
+            "ns".to_string(),
+            8080.try_into().unwrap(),
+            "ns".to_string(),
+        )
+        .expect("apex.ns should exist");
+
+    {
+        let policy = rx.borrow_and_update();
+        let backend = policy
+            .http_routes
+            .get(&GroupKindNamespaceName {
+                group: k8s::policy::HttpRoute::group(&()),
+                kind: k8s::policy::HttpRoute::kind(&()),
+                namespace: "ns".into(),
+                name: "route".into(),
+            })
+            .expect("route should exist")
+            .rules
+            .first()
+            .expect("rule should exist")
+            .backends
+            .first()
+            .expect("backend should exist");
+        let exists = match backend {
+            Backend::Service(WeightedService { exists, .. }) => exists,
+            _ => panic!("backend should be a service"),
+        };
+        // Backend should not exist.
+        assert!(!exists);
+    }
+
+    // Create backend service.
+    let backend = mk_service("ns", "backend", 8080);
+    test.index.write().apply(backend);
+    assert!(rx.has_changed().unwrap());
+
+    {
+        let policy = rx.borrow_and_update();
+        let backend = policy
+            .http_routes
+            .get(&GroupKindNamespaceName {
+                group: k8s::policy::HttpRoute::group(&()),
+                kind: k8s::policy::HttpRoute::kind(&()),
+                namespace: "ns".into(),
+                name: "route".into(),
+            })
+            .expect("route should exist")
+            .rules
+            .first()
+            .expect("rule should exist")
+            .backends
+            .first()
+            .expect("backend should exist");
+        let exists = match backend {
+            Backend::Service(WeightedService { exists, .. }) => exists,
+            _ => panic!("backend should be a service"),
+        };
+        // Backend should exist.
+        assert!(exists);
+    }
+}
+
+fn mk_route(
+    ns: impl ToString,
+    name: impl ToString,
+    port: u16,
+    parent: impl ToString,
+    backend: impl ToString,
+) -> k8s::policy::HttpRoute {
+    use chrono::Utc;
+    use k8s::{policy::httproute::*, Time};
+
+    HttpRoute {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            creation_timestamp: Some(Time(Utc::now())),
+            ..Default::default()
+        },
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![ParentReference {
+                    group: Some("core".to_string()),
+                    kind: Some("Service".to_string()),
+                    namespace: Some(ns.to_string()),
+                    name: parent.to_string(),
+                    section_name: None,
+                    port: Some(port),
+                }]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::PathPrefix {
+                        value: "/foo/bar".to_string(),
+                    }),
+                    headers: None,
+                    query_params: None,
+                    method: Some("GET".to_string()),
+                }]),
+                filters: None,
+                backend_refs: Some(vec![HttpBackendRef {
+                    backend_ref: Some(BackendRef {
+                        weight: None,
+                        inner: BackendObjectReference {
+                            group: Some("core".to_string()),
+                            kind: Some("Service".to_string()),
+                            namespace: Some(ns.to_string()),
+                            name: backend.to_string(),
+                            port: Some(port),
+                        },
+                    }),
+                    filters: None,
+                }]),
+                timeouts: None,
+            }]),
+        },
+        status: Some(k8s::policy::httproute::HttpRouteStatus {
+            inner: k8s::gateway::RouteStatus {
+                parents: vec![k8s::gateway::RouteParentStatus {
+                    parent_ref: ParentReference {
+                        group: Some("core".to_string()),
+                        kind: Some("Service".to_string()),
+                        namespace: Some(ns.to_string()),
+                        name: parent.to_string(),
+                        section_name: None,
+                        port: Some(port),
+                    },
+                    controller_name: POLICY_CONTROLLER_NAME.to_string(),
+                    conditions: vec![k8s::Condition {
+                        last_transition_time: k8s::Time(chrono::DateTime::<chrono::Utc>::MIN_UTC),
+                        message: "".to_string(),
+                        observed_generation: None,
+                        reason: "Accepted".to_string(),
+                        status: "True".to_string(),
+                        type_: "Accepted".to_string(),
+                    }],
+                }],
+            },
+        }),
+    }
+}


### PR DESCRIPTION
If an HTTPRoute references a backend service that does not exist, the policy controller synthesizes a FailureInjector in the outbound policy so that requests to that backend will fail with a 500 status code.  However, we do not update the policy when backend services are created or deleted, which can result in an outbound policy that synthesizes 500s for backends, even if the backend currently exists (or vice versa).

This is often papered over because when a backend service is created or deleted, this will trigger the HTTPRoute's ResolvedRef status condition to change which will cause a reindex of the HTTPRotue and a recomputation of the backends.  However, depending on the specific order that these updates are processed, the outbound policy can still be left with the incorrect backend state.

In order to be able to update the backend of an outbound policy when backend services are created or deleted, we change the way these backends are represented in the index.  Previously, we had represented backends which were services that did not exist as `Backend::Invalid`.  However, this discards the necessary backend information necessary to recreate the backend if the service is created.  Instead, we update this to represent these backends as a `Backend::Service` but with a new field `exists` set to false.  This allows us to update this field as backend services are created or deleted.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
