### PR TITLE
Add json output to install and related commands

### DIFF
--- a/cli/cmd/check.go
+++ b/cli/cmd/check.go
@@ -143,7 +143,7 @@ func configureAndRunChecks(cmd *cobra.Command, wout io.Writer, werr io.Writer, o
 	}
 
 	crdManifest := bytes.Buffer{}
-	err = renderCRDs(&crdManifest, valuespkg.Options{})
+	err = renderCRDs(&crdManifest, valuespkg.Options{}, "yaml")
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func renderInstallManifest(ctx context.Context) (*charts.Values, string, error) 
 
 	// Use empty valuesOverrides because there are no option values to merge.
 	var b strings.Builder
-	err = renderControlPlane(&b, values, map[string]interface{}{})
+	err = renderControlPlane(&b, values, map[string]interface{}{}, "yaml")
 	if err != nil {
 		return nil, "", err
 	}

--- a/cli/cmd/inject_util.go
+++ b/cli/cmd/inject_util.go
@@ -87,12 +87,12 @@ func processYAML(in io.Reader, out io.Writer, report io.Writer, rt resourceTrans
 		reports = append(reports, irs...)
 
 		// If the format is set to json, we need to convert the yaml to json
-		if format == "json" {
+		if format == jsonOutput {
 			result, err = yaml.YAMLToJSON(result)
 			if err != nil {
 				errs = append(errs, err)
 			}
-		} else if format == "yaml" {
+		} else if format == yamlOutput {
 			// result is already in yaml format: noop.
 		} else {
 			errs = append(errs, fmt.Errorf("unsupported format %s", format))
@@ -100,10 +100,10 @@ func processYAML(in io.Reader, out io.Writer, report io.Writer, rt resourceTrans
 
 		if len(errs) == 0 {
 			out.Write(result)
-			if format == "yaml" {
+			if format == yamlOutput {
 				out.Write([]byte("---\n"))
 			}
-			if format == "json" {
+			if format == jsonOutput {
 				out.Write([]byte("\n"))
 			}
 		}

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -259,7 +259,7 @@ func TestRender(t *testing.T) {
 				t.Fatalf("Failed to get values overrides: %v", err)
 			}
 			var buf bytes.Buffer
-			if err := renderControlPlane(&buf, tc.values, valuesOverrides); err != nil {
+			if err := renderControlPlane(&buf, tc.values, valuesOverrides, "yaml"); err != nil {
 				t.Fatalf("Failed to render templates: %v", err)
 			}
 			if err := testDataDiffer.DiffTestYAML(tc.goldenFileName, buf.String()); err != nil {
@@ -277,7 +277,7 @@ func TestIgnoreCluster(t *testing.T) {
 	addFakeTLSSecrets(defaultValues)
 
 	var buf bytes.Buffer
-	if err := installControlPlane(context.Background(), nil, &buf, defaultValues, nil, values.Options{}); err != nil {
+	if err := installControlPlane(context.Background(), nil, &buf, defaultValues, nil, values.Options{}, "yaml"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -290,7 +290,7 @@ func TestRenderCRDs(t *testing.T) {
 	addFakeTLSSecrets(defaultValues)
 
 	var buf bytes.Buffer
-	if err := renderCRDs(&buf, values.Options{}); err != nil {
+	if err := renderCRDs(&buf, values.Options{}, "yaml"); err != nil {
 		t.Fatalf("Failed to render templates: %v", err)
 	}
 	if err := testDataDiffer.DiffTestYAML("install_crds.golden", buf.String()); err != nil {

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -148,9 +148,9 @@ func newCmdProfile() *cobra.Command {
 func writeProfile(profile *sp.ServiceProfile, w io.Writer, format string) error {
 	var output []byte
 	var err error
-	if format == "yaml" {
+	if format == yamlOutput {
 		output, err = yaml.Marshal(profile)
-	} else if format == "json" {
+	} else if format == jsonOutput {
 		output, err = json.Marshal(profile)
 	} else {
 		return fmt.Errorf("unknown output format: %s", format)

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -15,6 +15,8 @@ import (
 
 func newCmdPrune() *cobra.Command {
 
+	var output string
+
 	cmd := &cobra.Command{
 		Use:   "prune [flags]",
 		Args:  cobra.NoArgs,
@@ -49,16 +51,18 @@ Please note this command is only intended for instances of Linkerd that were ins
 
 			manifests := strings.Builder{}
 
-			if err = renderControlPlane(&manifests, values, make(map[string]interface{})); err != nil {
+			if err = renderControlPlane(&manifests, values, make(map[string]interface{}), "yaml"); err != nil {
 				return err
 			}
-			if err = renderCRDs(&manifests, valuespkg.Options{}); err != nil {
+			if err = renderCRDs(&manifests, valuespkg.Options{}, "yaml"); err != nil {
 				return err
 			}
 
-			return pkgCmd.Prune(cmd.Context(), k8sAPI, manifests.String(), k8s.ControllerNSLabel)
+			return pkgCmd.Prune(cmd.Context(), k8sAPI, manifests.String(), k8s.ControllerNSLabel, output)
 		},
 	}
+
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	return cmd
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -23,7 +23,8 @@ const (
 	defaultCNINamespace     = "linkerd-cni"
 	defaultClusterDomain    = "cluster.local"
 
-	jsonOutput  = healthcheck.JSONOutput
+	jsonOutput  = pkgcmd.JsonOutput
+	yamlOutput  = pkgcmd.YamlOutput
 	tableOutput = healthcheck.TableOutput
 	shortOutput = healthcheck.ShortOutput
 )

--- a/cli/cmd/uninstall.go
+++ b/cli/cmd/uninstall.go
@@ -17,6 +17,8 @@ const (
 
 func newCmdUninstall() *cobra.Command {
 	var force bool
+	var output string
+
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Args:  cobra.NoArgs,
@@ -87,7 +89,7 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 				return err
 			}
 
-			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, selector)
+			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, selector, output)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 			}
@@ -97,5 +99,6 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 	}
 
 	cmd.Flags().BoolVarP(&force, "force", "f", force, "Force uninstall even if there exist non-control-plane injected pods")
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml")
 	return cmd
 }

--- a/cli/cmd/upgrade_test.go
+++ b/cli/cmd/upgrade_test.go
@@ -577,11 +577,11 @@ func pathMatch(path []string, template []string) bool {
 func renderInstall(t *testing.T, values *charts.Values) *bytes.Buffer {
 	t.Helper()
 	var buf bytes.Buffer
-	if err := renderCRDs(&buf, valuespkg.Options{}); err != nil {
+	if err := renderCRDs(&buf, valuespkg.Options{}, "yaml"); err != nil {
 		t.Fatalf("could not render install manifests: %s", err)
 	}
 	buf.WriteString("---\n")
-	if err := renderControlPlane(&buf, values, nil); err != nil {
+	if err := renderControlPlane(&buf, values, nil, "yaml"); err != nil {
 		t.Fatalf("could not render install manifests: %s", err)
 	}
 	return &buf
@@ -592,9 +592,9 @@ func renderUpgrade(installManifest string, upgradeOpts []flag.Flag, templateOpts
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize fake API: %w\n\n%s", err, installManifest)
 	}
-	buf := upgradeCRDs(valuespkg.Options{})
+	buf := upgradeCRDs(valuespkg.Options{}, "yaml")
 	buf.WriteString("---\n")
-	cpbuf, err := upgradeControlPlane(context.Background(), k, upgradeOpts, templateOpts)
+	cpbuf, err := upgradeControlPlane(context.Background(), k, upgradeOpts, templateOpts, "yaml")
 	if err != nil {
 		return nil, err
 	}

--- a/jaeger/cmd/install.go
+++ b/jaeger/cmd/install.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -21,8 +19,6 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"helm.sh/helm/v3/pkg/engine"
-	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
-	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -196,29 +192,5 @@ func render(w io.Writer, valuesOverrides map[string]interface{}, registry string
 		}
 	}
 
-	if format == "json" {
-		reader := yamlDecoder.NewYAMLReader(bufio.NewReaderSize(&buf, 4096))
-		for {
-			manifest, err := reader.Read()
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				return err
-			}
-			bytes, err := yaml.YAMLToJSON(manifest)
-			if err != nil {
-				return err
-			}
-			_, err = w.Write(append(bytes, '\n'))
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	} else if format == "yaml" {
-		_, err = w.Write(buf.Bytes())
-		return err
-	}
-	return fmt.Errorf("unsupported format %s", format)
+	return pkgcmd.RenderYAMLAs(&buf, w, format)
 }

--- a/jaeger/cmd/install_test.go
+++ b/jaeger/cmd/install_test.go
@@ -45,7 +45,7 @@ func TestRender(t *testing.T) {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.goldenFileName), func(t *testing.T) {
 			var buf bytes.Buffer
 			// Merge overrides with default
-			if err := render(&buf, charts.MergeMaps(defaultValues, tc.values), ""); err != nil {
+			if err := render(&buf, charts.MergeMaps(defaultValues, tc.values), "", "yaml"); err != nil {
 				t.Fatalf("Failed to render templates: %v", err)
 			}
 			if err := testDataDiffer.DiffTestYAML(tc.goldenFileName, buf.String()); err != nil {

--- a/jaeger/cmd/prune.go
+++ b/jaeger/cmd/prune.go
@@ -17,6 +17,7 @@ func newCmdPrune() *cobra.Command {
 	var cniEnabled bool
 	var wait time.Duration
 	var options values.Options
+	var output string
 
 	cmd := &cobra.Command{
 		Use:   "prune [flags]",
@@ -47,11 +48,12 @@ func newCmdPrune() *cobra.Command {
 			}
 
 			label := fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, JaegerExtensionName)
-			return pkgCmd.Prune(cmd.Context(), hc.KubeAPIClient(), manifests.String(), label)
+			return pkgCmd.Prune(cmd.Context(), hc.KubeAPIClient(), manifests.String(), label, output)
 		},
 	}
 
 	cmd.Flags().DurationVar(&wait, "wait", 300*time.Second, "Wait for extension components to be available")
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	flags.AddValueOptionsFlags(cmd.Flags(), &options)
 

--- a/jaeger/cmd/prune.go
+++ b/jaeger/cmd/prune.go
@@ -42,7 +42,7 @@ func newCmdPrune() *cobra.Command {
 
 			manifests := strings.Builder{}
 
-			err := install(&manifests, options, "", cniEnabled)
+			err := install(&manifests, options, "", cniEnabled, "yaml")
 			if err != nil {
 				return err
 			}

--- a/jaeger/cmd/uninstall.go
+++ b/jaeger/cmd/uninstall.go
@@ -11,6 +11,8 @@ import (
 )
 
 func newCmdUninstall() *cobra.Command {
+	var output string
+
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Args:  cobra.NoArgs,
@@ -20,7 +22,7 @@ func newCmdUninstall() *cobra.Command {
 This command provides all Kubernetes namespace-scoped and cluster-scoped resources (e.g services, deployments, RBACs, etc.) necessary to uninstall the Linkerd-jaeger extension.`,
 		Example: `linkerd uninstall | kubectl delete -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := uninstallRunE(cmd.Context())
+			err := uninstallRunE(cmd.Context(), output)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
@@ -28,11 +30,12 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 			return nil
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	return cmd
 }
 
-func uninstallRunE(ctx context.Context) error {
+func uninstallRunE(ctx context.Context, format string) error {
 	k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 	if err != nil {
 		return err
@@ -43,5 +46,5 @@ func uninstallRunE(ctx context.Context) error {
 		return err
 	}
 
-	return pkgCmd.Uninstall(ctx, k8sAPI, selector)
+	return pkgCmd.Uninstall(ctx, k8sAPI, selector, format)
 }

--- a/multicluster/cmd/install_test.go
+++ b/multicluster/cmd/install_test.go
@@ -48,7 +48,7 @@ func TestRender(t *testing.T) {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.goldenFileName), func(t *testing.T) {
 			var buf bytes.Buffer
 			// Merge overrides with default
-			if err := render(&buf, tc.multiclusterValues, charts.MergeMaps(defaultValues, tc.values)); err != nil {
+			if err := render(&buf, tc.multiclusterValues, charts.MergeMaps(defaultValues, tc.values), "yaml"); err != nil {
 				t.Fatalf("Failed to render templates: %v", err)
 			}
 			if err := testDataDiffer.DiffTestYAML(tc.goldenFileName, buf.String()); err != nil {

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -392,4 +392,3 @@ spec:
     - kind: ServiceAccount
       name: prometheus
       namespace: linkerd-viz
----

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -464,4 +464,3 @@ spec:
     - kind: ServiceAccount
       name: prometheus
       namespace: linkerd-viz
----

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -426,4 +426,3 @@ spec:
     - kind: ServiceAccount
       name: prometheus
       namespace: linkerd-viz
----

--- a/multicluster/cmd/uninstall.go
+++ b/multicluster/cmd/uninstall.go
@@ -16,6 +16,7 @@ import (
 )
 
 func newMulticlusterUninstallCommand() *cobra.Command {
+	var output string
 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
@@ -58,7 +59,7 @@ func newMulticlusterUninstallCommand() *cobra.Command {
 				return err
 			}
 
-			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, selector)
+			err = pkgCmd.Uninstall(cmd.Context(), k8sAPI, selector, output)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
@@ -66,6 +67,7 @@ func newMulticlusterUninstallCommand() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	return cmd
 }

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -109,6 +110,22 @@ func (r Kubernetes) RenderResource(w io.Writer) error {
 	}
 
 	_, err = w.Write([]byte(yamlSep))
+	return err
+}
+
+// RenderResource renders a kubernetes object as a json object
+func (r Kubernetes) RenderResourceJSON(w io.Writer) error {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(b)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write([]byte("\n"))
 	return err
 }
 

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2" // TODO: pkg/profiles should not depend on controller/gen
+	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -223,7 +224,7 @@ func RenderProfileTemplate(namespace, service, clusterDomain string, w io.Writer
 		return err
 	}
 
-	if format == "json" {
+	if format == pkgcmd.JsonOutput {
 		bytes, err := yamlDecoder.ToJSON(buf.Bytes())
 		if err != nil {
 			return err
@@ -231,7 +232,7 @@ func RenderProfileTemplate(namespace, service, clusterDomain string, w io.Writer
 		_, err = w.Write(append(bytes, '\n'))
 		return err
 	}
-	if format == "yaml" {
+	if format == pkgcmd.YamlOutput {
 		_, err = w.Write(buf.Bytes())
 		return err
 	}

--- a/viz/cmd/install_test.go
+++ b/viz/cmd/install_test.go
@@ -93,7 +93,7 @@ func TestRender(t *testing.T) {
 		t.Run(fmt.Sprintf("%d: %s", i, tc.goldenFileName), func(t *testing.T) {
 			var buf bytes.Buffer
 			// Merge overrides with default
-			if err := render(&buf, charts.MergeMaps(defaultValues, tc.values)); err != nil {
+			if err := render(&buf, charts.MergeMaps(defaultValues, tc.values), "yaml"); err != nil {
 				t.Fatalf("Failed to render templates: %v", err)
 			}
 			if err := testDataDiffer.DiffTestYAML(tc.goldenFileName, buf.String()); err != nil {

--- a/viz/cmd/profile.go
+++ b/viz/cmd/profile.go
@@ -172,9 +172,9 @@ func renderTapOutputProfile(ctx context.Context, k8sAPI *k8s.KubernetesAPI, tapR
 		return err
 	}
 	var output []byte
-	if format == "yaml" {
+	if format == pkgcmd.YamlOutput {
 		output, err = yaml.Marshal(profile)
-	} else if format == "json" {
+	} else if format == pkgcmd.JsonOutput {
 		output, err = json.Marshal(profile)
 	} else {
 		return errors.New("output format must be one of yaml or json")

--- a/viz/cmd/prune.go
+++ b/viz/cmd/prune.go
@@ -44,7 +44,7 @@ func newCmdPrune() *cobra.Command {
 
 			manifests := strings.Builder{}
 
-			err := install(&manifests, options, ha, cniEnabled)
+			err := install(&manifests, options, ha, cniEnabled, "yaml")
 			if err != nil {
 				return err
 			}

--- a/viz/cmd/prune.go
+++ b/viz/cmd/prune.go
@@ -19,6 +19,7 @@ func newCmdPrune() *cobra.Command {
 	var cniEnabled bool
 	var wait time.Duration
 	var options values.Options
+	var output string
 
 	cmd := &cobra.Command{
 		Use:   "prune [flags]",
@@ -49,12 +50,13 @@ func newCmdPrune() *cobra.Command {
 			}
 
 			label := fmt.Sprintf("%s=%s", k8s.LinkerdExtensionLabel, vizHealthcheck.VizExtensionName)
-			return pkgCmd.Prune(cmd.Context(), hc.KubeAPIClient(), manifests.String(), label)
+			return pkgCmd.Prune(cmd.Context(), hc.KubeAPIClient(), manifests.String(), label, output)
 		},
 	}
 
 	cmd.Flags().BoolVar(&ha, "ha", false, `Set if Linkerd Viz Extension is installed in High Availability mode.`)
 	cmd.Flags().DurationVar(&wait, "wait", 300*time.Second, "Wait for extension components to be available")
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	flags.AddValueOptionsFlags(cmd.Flags(), &options)
 

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -99,13 +99,13 @@ func uninstallRunE(ctx context.Context, format string) error {
 
 func deleteResource(ty metav1.TypeMeta, meta metav1.ObjectMeta, format string) error {
 	r := resource.NewNamespaced(ty.APIVersion, ty.Kind, meta.Name, meta.Namespace)
-	if format == "json" {
+	if format == pkgCmd.JsonOutput {
 		if err := r.RenderResourceJSON(os.Stdout); err != nil {
 			return fmt.Errorf("error rendering Kubernetes resource: %w", err)
 		}
 		return nil
-	} else if format == "yaml" {
-		if err := r.RenderResourceJSON(os.Stdout); err != nil {
+	} else if format == pkgCmd.YamlOutput {
+		if err := r.RenderResource(os.Stdout); err != nil {
 			return fmt.Errorf("error rendering Kubernetes resource: %w", err)
 		}
 		return nil

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -67,7 +67,7 @@ func uninstallRunE(ctx context.Context, format string) error {
 	}
 
 	for _, authz := range authzs.Items {
-		if err := deleteResource(authz.TypeMeta, authz.ObjectMeta); err != nil {
+		if err := deleteResource(authz.TypeMeta, authz.ObjectMeta, format); err != nil {
 			return err
 		}
 	}
@@ -78,7 +78,7 @@ func uninstallRunE(ctx context.Context, format string) error {
 	}
 
 	for _, rt := range rts.Items {
-		if err := deleteResource(rt.TypeMeta, rt.ObjectMeta); err != nil {
+		if err := deleteResource(rt.TypeMeta, rt.ObjectMeta, format); err != nil {
 			return err
 		}
 	}
@@ -89,7 +89,7 @@ func uninstallRunE(ctx context.Context, format string) error {
 	}
 
 	for _, srv := range srvs.Items {
-		if err := deleteResource(srv.TypeMeta, srv.ObjectMeta); err != nil {
+		if err := deleteResource(srv.TypeMeta, srv.ObjectMeta, format); err != nil {
 			return err
 		}
 	}
@@ -97,10 +97,18 @@ func uninstallRunE(ctx context.Context, format string) error {
 	return nil
 }
 
-func deleteResource(ty metav1.TypeMeta, meta metav1.ObjectMeta) error {
+func deleteResource(ty metav1.TypeMeta, meta metav1.ObjectMeta, format string) error {
 	r := resource.NewNamespaced(ty.APIVersion, ty.Kind, meta.Name, meta.Namespace)
-	if err := r.RenderResource(os.Stdout); err != nil {
-		return fmt.Errorf("error rendering Kubernetes resource: %w", err)
+	if format == "json" {
+		if err := r.RenderResourceJSON(os.Stdout); err != nil {
+			return fmt.Errorf("error rendering Kubernetes resource: %w", err)
+		}
+		return nil
+	} else if format == "yaml" {
+		if err := r.RenderResourceJSON(os.Stdout); err != nil {
+			return fmt.Errorf("error rendering Kubernetes resource: %w", err)
+		}
+		return nil
 	}
-	return nil
+	return fmt.Errorf("unsupported output format: %s", format)
 }

--- a/viz/cmd/uninstall.go
+++ b/viz/cmd/uninstall.go
@@ -14,6 +14,8 @@ import (
 )
 
 func newCmdUninstall() *cobra.Command {
+	var output string
+
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Args:  cobra.NoArgs,
@@ -23,7 +25,7 @@ func newCmdUninstall() *cobra.Command {
 This command provides all Kubernetes namespace-scoped and cluster-scoped resources (e.g services, deployments, RBACs, etc.) necessary to uninstall the Linkerd-viz extension.`,
 		Example: `linkerd viz uninstall | kubectl delete -f -`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := uninstallRunE(cmd.Context())
+			err := uninstallRunE(cmd.Context(), output)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
@@ -31,11 +33,12 @@ This command provides all Kubernetes namespace-scoped and cluster-scoped resourc
 			return nil
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	return cmd
 }
 
-func uninstallRunE(ctx context.Context) error {
+func uninstallRunE(ctx context.Context, format string) error {
 	k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
 	if err != nil {
 		return err
@@ -48,7 +51,7 @@ func uninstallRunE(ctx context.Context) error {
 
 	// / `Uninstall` deletes cluster-scoped resources created by the extension
 	// (including the extension's namespace).
-	if err := pkgCmd.Uninstall(ctx, k8sAPI, selector); err != nil {
+	if err := pkgCmd.Uninstall(ctx, k8sAPI, selector, format); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We add support for the `--output/-o` flag in linkerd install and related commands. The supported output formats are yaml (default) and json. Kubectl is able to accept both of these formats which means that the output can be piped into kubectl regardless of which output format is used.

The full list of install related commands which we add json support to is:

* linkerd install
* linkerd prune
* linkerd upgrade
* linkerd uninstall
* linkerd viz install
* linkerd viz prune
* linkerd viz uninstall
* linkerd multicluster install
* linkerd multicluster prune
* linkerd multicluster uninstall
* linkerd jaeger install
* linkerd jaeger prune
* linkerd jaeger uninstall

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
