### PR TITLE
Allow control plane components to specify concurrency

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -177,6 +177,8 @@ spec:
       {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       {{- if not (empty .Values.destinationProxyResources) }}
+      {{- $c := dig "cores" .Values.proxy.cores .Values.destinationProxyResources }}
+      {{- $_ := set $tree.Values.proxy "cores" $c }}
       {{- $r := merge .Values.destinationProxyResources .Values.proxy.resources }}
       {{- $_ := set $tree.Values.proxy "resources" $r }}
       {{- end }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -209,6 +209,8 @@ spec:
         - mountPath: /var/run/linkerd/identity/trust-roots/
           name: trust-roots
       {{- if not (empty .Values.identityProxyResources) }}
+      {{- $c := dig "cores" .Values.proxy.cores .Values.identityProxyResources }}
+      {{- $_ := set $tree.Values.proxy "cores" $c }}
       {{- $r := merge .Values.identityProxyResources .Values.proxy.resources }}
       {{- $_ := set $tree.Values.proxy "resources" $r }}
       {{- end }}

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -57,6 +57,8 @@ spec:
       {{- include "linkerd.affinity" $tree | nindent 6 }}
       containers:
       {{- if not (empty .Values.proxyInjectorProxyResources) }}
+      {{- $c := dig "cores" .Values.proxy.cores .Values.proxyInjectorProxyResources }}
+      {{- $_ := set $tree.Values.proxy "cores" $c }}
       {{- $r := merge .Values.proxyInjectorProxyResources .Values.proxy.resources }}
       {{- $_ := set $tree.Values.proxy "resources" $r }}
       {{- end }}


### PR DESCRIPTION
Concurrency in Linkerd is configured globally through a `proxy.cores` value or it can be configured through the injector. Control plane components cannot be configured through the injector since they come with the proxy pre-configured. In certain cases, it is necessary for proxies to specify their concurrency. Even though a global value exists, that directly influences all workloads in the cluster which can have other implications.

Each control plane component has a `<component>ProxyResources` field that is used to configure limits and requests. We overload this field and allow `cores` to be specified. We do not expect this value to be used often since directly specifying the number of cores might not make a lot of sense -- this does offer an escape hatch when the control plane components can't scale up to meet bursty workloads.


### Note for reviewers

[Click me for `dig` function docs](https://helm.sh/docs/chart_template_guide/function_list/#dig)

Overloading the operator with an additional field does not lead to failures. I have a couple of scenarios I tested and instructions on how to test locally. 

To test:
1. `bin/docker-build`
2. Create a k3d cluster and import the images, `bin/image-import --k3d --cluster <name>`
3. Install through Helm (or CLI)

```
$ helm install linkerd \
       --namespace linkerd \
       --set destinationProxyResources.cores="2" \
       --set destinationProxyResources.memory.request="250Mi" \
       --set-file identityTrustAnchorsPEM=ca.crt \
       --set-file identity.issuer.tls.crtPEM=issuer.crt \
       --set-file identity.issuer.tls.keyPEM=issuer.key \
       --set linkerdVersion=(bin/root-tag) \
       charts/linkerd-control-plane/
```

I tested the following scenarios:

(1) Per-component default is applied

```
 $ helm install linkerd \
          --namespace linkerd \
          --set destinationProxyResources.cores="2" \
          --set destinationProxyResources.cpu.limit="3" \
          --set destinationProxyResources.memory.request="250Mi" \
          --set-file identityTrustAnchorsPEM=ca.crt \
          --set-file identity.issuer.tls.crtPEM=issuer.crt \
          --set-file identity.issuer.tls.keyPEM=issuer.key \
          --set linkerdVersion=(bin/root-tag) \
          charts/linkerd-control-plane/

$ k get po -n linkerd linkerd-destination-fc4bcdfb7-g7hfg -o yaml | yq '.spec.containers[] | select ( .name == "linkerd-proxy")' | rg 'CORES' -A 1
  - name: LINKERD2_PROXY_CORES
    value: "2"

$ k get po -n linkerd linkerd-destination-fc4bcdfb7-g7hfg -o yaml | yq '.spec.containers[] | select ( .name == "linkerd-proxy").resources'
limits:
  cpu: "3"
requests:
  cpu: "3"
  memory: 250Mi
```

(2) When nothing is specified (globally or per-component) we roll with the default.

```
$ helm install linkerd \
       --namespace linkerd \
       --set-file identityTrustAnchorsPEM=ca.crt \
       --set-file identity.issuer.tls.crtPEM=issuer.crt \
       --set-file identity.issuer.tls.keyPEM=issuer.key \
       --set linkerdVersion=(bin/root-tag) \
       charts/linkerd-control-plane/

$ k get po -n linkerd linkerd-destination-7bb9687899-8k7gf -o yaml |  yq '.spec.containers[] | select ( .name == "linkerd-proxy")' | rg 'CORES' -A 1
<nothing>
```

(3) When choosing between global and per-component, per-component is the override

```
$ helm install linkerd \
       --namespace linkerd \
       --set destinationProxyResources.cores="2" \
       --set proxy.cores="3" \
       --set destinationProxyResources.memory.request="250Mi" \
       --set-file identityTrustAnchorsPEM=ca.crt \
       --set-file identity.issuer.tls.crtPEM=issuer.crt \
       --set-file identity.issuer.tls.keyPEM=issuer.key \
       --set linkerdVersion=(bin/root-tag) \
       charts/linkerd-control-plane/

$  k get po -n linkerd linkerd-destination-6d7f86fd48-v7zkz -o yaml | yq '.spec.containers[] | select ( .name == "linkerd-proxy")' | rg 'CORES' -A 1
  - name: LINKERD2_PROXY_CORES
    value: "2"
```

(4) Specifying only a global means components respect the global

```
$ helm install linkerd \
       --namespace linkerd \
       --set proxy.cores="3" \
       --set destinationProxyResources.memory.request="250Mi" \
       --set-file identityTrustAnchorsPEM=ca.crt \
       --set-file identity.issuer.tls.crtPEM=issuer.crt \
       --set-file identity.issuer.tls.keyPEM=issuer.key \
       --set linkerdVersion=(bin/root-tag) \
       charts/linkerd-control-plane/

$ k get po -n linkerd linkerd-destination-56c786ff49-kl6r7 -o yaml | yq '.spec.containers[] | select ( .name == "linkerd-proxy")' | rg 'CORES' -A 1
  - name: LINKERD2_PROXY_CORES
    value: "3"
```

(5) We can upgrade and specify a per-component value to override the global

```
 $ helm upgrade linkerd \
       --namespace linkerd \
       --set destinationProxyResources.cores="1" \
       --set destinationProxyResources.memory.request="250Mi" \
       --set-file identityTrustAnchorsPEM=ca.crt \
       --set-file identity.issuer.tls.crtPEM=issuer.crt \
       --set-file identity.issuer.tls.keyPEM=issuer.key \
       --set linkerdVersion=(bin/root-tag) \
       charts/linkerd-control-plane/

$ k get po -n linkerd linkerd-destination-74968c6999-q6kwn -o yaml |  yq '.spec.containers[] | select ( .name == "linkerd-proxy")' | rg 'CORES' -A 1
  - name: LINKERD2_PROXY_CORES
    value: "1"
```

The tests show some of the basic install / upgrade flows that people would follow. Since the value will override only when specified (and is not documented) it should not affect existing installations _unless users explicitly opt-in_.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
