### PR TITLE
Make IPv6 support opt-in in linkerd-cni

### DIFF
--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -31,7 +31,7 @@ useWaitFlag:      false
 # -- Variant of iptables that will be used to configure routing
 iptablesMode: "legacy"
 # -- Disables adding IPv6 rules on top of IPv4 rules
-disableIPv6: false
+disableIPv6: true
 # -- Kubernetes priorityClassName for the CNI plugin's Pods
 priorityClassName: ""
 # -- Specifies the number of old ReplicaSets to retain to allow rollback.

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -76,7 +76,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "legacy",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -77,7 +77,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "legacy",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -77,7 +77,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "legacy",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -77,7 +77,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "legacy",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -77,7 +77,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "legacy",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -69,7 +69,7 @@ data:
         "simulate": false,
         "use-wait-flag": false,
         "iptables-mode": "legacy",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -70,7 +70,7 @@ data:
         "simulate": false,
         "use-wait-flag": true,
         "iptables-mode": "legacy",
-        "ipv6": true
+        "ipv6": false
       }
     }
 ---


### PR DESCRIPTION
Followup to 7dbafb26c8f3ff0a5823849198d0767da18c6aa9 where we made IPv6 support opt-in for the control plane and proxy init. This follows suit doing the same for linkerd-cni.