### PR TITLE
add nil check when reading endpoint hostname

### DIFF
--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -358,6 +358,8 @@ metadata:
 addressType: IPv4
 endpoints:
 - addresses:
+  - 172.17.13.14 # Endpoint without a targetRef or hostname
+- addresses:
   - 172.17.13.15
   hostname: pod-0
   targetRef:

--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -580,7 +580,7 @@ func (ww *WorkloadWatcher) getEndpointByHostname(hostname string, svcID *Service
 		}
 		for _, slice := range sliceList {
 			for _, ep := range slice.Endpoints {
-				if hostname == *ep.Hostname {
+				if ep.Hostname != nil && hostname == *ep.Hostname {
 					if ep.TargetRef != nil && ep.TargetRef.Kind == "Pod" {
 						podName := ep.TargetRef.Name
 						podNamespace := ep.TargetRef.Namespace


### PR DESCRIPTION
Fixes #12686

When an endpoint in an EndpointSlice resource does not contain a hostname field, the destination controller can panic while looking for an endpoint with a certain hostname.  This happens when doing a lookup with a pod dns name.

We add a nil check to avoid the panic.

We add such an endpoint to our test fixture to exercise this case.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
