### PR TITLE
Properly set log level for hickory_resolver in proxy

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -252,7 +252,7 @@ Kubernetes: `>=1.22.0-0`
 | proxy.livenessProbe | object | `{"initialDelaySeconds":10,"timeoutSeconds":1}` | LivenessProbe timeout and delay configuration |
 | proxy.logFormat | string | `"plain"` | Log format (`plain` or `json`) for the proxy |
 | proxy.logHTTPHeaders | `off` or `insecure` | `"off"` | If set to `off`, will prevent the proxy from logging HTTP headers. If set to `insecure`, HTTP headers may be logged verbatim. Note that setting this to `insecure` is not alone sufficient to log HTTP headers; the proxy logLevel must also be set to debug. |
-| proxy.logLevel | string | `"warn,linkerd=info,trust_dns=error"` | Log level for the proxy |
+| proxy.logLevel | string | `"warn,linkerd=info,hickory=error"` | Log level for the proxy |
 | proxy.nativeSidecar | bool | `false` | Enable KEP-753 native sidecars This is an experimental feature. It requires Kubernetes >= 1.29. If enabled, .proxy.waitBeforeExitSeconds should not be used. |
 | proxy.opaquePorts | string | `"25,587,3306,4444,5432,6379,9300,11211"` | Default set of opaque ports - SMTP (25,587) server-first - MYSQL (3306) server-first - Galera (4444) server-first - PostgreSQL (5432) server-first - Redis (6379) server-first - ElasticSearch (9300) server-first - Memcached (11211) clients do not issue any preamble, which breaks detection |
 | proxy.outbound.server.http2.keepAliveInterval | string | `"10s"` | The interval at which PINGs are issued to local application HTTP/2 clients. |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -150,7 +150,7 @@ proxy:
     # @default -- linkerdVersion
     version: ""
   # -- Log level for the proxy
-  logLevel: warn,linkerd=info,trust_dns=error
+  logLevel: warn,linkerd=info,hickory=error
   # -- Log format (`plain` or `json`) for the proxy
   logFormat: plain
   # -- (`off` or `insecure`) If set to `off`, will prevent the proxy from

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -33,7 +33,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -33,7 +33,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -268,7 +268,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -33,7 +33,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -41,7 +41,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -281,7 +281,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -527,7 +527,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -773,7 +773,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -45,7 +45,7 @@ spec:
         - name: LINKERD2_PROXY_CORES
           value: "1"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -281,7 +281,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
@@ -90,7 +90,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -37,7 +37,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -35,7 +35,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -37,7 +37,7 @@ items:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -282,7 +282,7 @@ items:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -37,7 +37,7 @@ items:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -282,7 +282,7 @@ items:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -27,7 +27,7 @@ spec:
         fieldRef:
           fieldPath: spec.nodeName
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -28,7 +28,7 @@ spec:
         fieldRef:
           fieldPath: spec.nodeName
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -29,7 +29,7 @@ spec:
         fieldRef:
           fieldPath: spec.nodeName
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -31,7 +31,7 @@ spec:
         fieldRef:
           fieldPath: spec.nodeName
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -31,7 +31,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -279,7 +279,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -52,7 +52,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -986,7 +986,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1335,7 +1335,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1786,7 +1786,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1334,7 +1334,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1784,7 +1784,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1334,7 +1334,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1784,7 +1784,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1334,7 +1334,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1784,7 +1784,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1334,7 +1334,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1784,7 +1784,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1325,7 +1325,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1766,7 +1766,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -986,7 +986,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1338,7 +1338,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1795,7 +1795,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -713,7 +713,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -1062,7 +1062,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1451,7 +1451,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1937,7 +1937,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -713,7 +713,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -1062,7 +1062,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1451,7 +1451,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1937,7 +1937,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -617,7 +617,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -916,7 +916,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1265,7 +1265,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1655,7 +1655,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -663,7 +663,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -958,7 +958,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1309,7 +1309,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1763,7 +1763,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -690,7 +690,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -1035,7 +1035,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1426,7 +1426,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1916,7 +1916,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -690,7 +690,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -1036,7 +1036,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1430,7 +1430,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1927,7 +1927,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -694,7 +694,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -1043,7 +1043,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1438,7 +1438,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1936,7 +1936,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -685,7 +685,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -1025,7 +1025,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1416,7 +1416,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1906,7 +1906,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1327,7 +1327,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1770,7 +1770,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1334,7 +1334,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1784,7 +1784,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -686,7 +686,7 @@ data:
         timeoutSeconds: 1
       logFormat: plain
       logHTTPHeaders: "off"
-      logLevel: warn,linkerd=info,trust_dns=error
+      logLevel: warn,linkerd=info,hickory=error
       nativeSidecar: false
       opaquePorts: 25,587,3306,4444,5432,6379,9300,11211
       outbound:
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1334,7 +1334,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1784,7 +1784,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -181,7 +181,7 @@
         },
         {
           "name": "LINKERD2_PROXY_LOG",
-          "value": "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          "value": "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         },
         {
           "name": "LINKERD2_PROXY_LOG_FORMAT",

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -167,7 +167,7 @@
         },
         {
           "name": "LINKERD2_PROXY_LOG",
-          "value": "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          "value": "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         },
         {
           "name": "LINKERD2_PROXY_LOG_FORMAT",

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -157,7 +157,7 @@
         },
         {
           "name": "LINKERD2_PROXY_LOG",
-          "value": "warn,linkerd=info,trust_dns=error,linkerd_proxy_http::client[{headers}]=off"
+          "value": "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
         },
         {
           "name": "LINKERD2_PROXY_LOG_FORMAT",

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -122,7 +122,7 @@ func TestNewValues(t *testing.T) {
 				Name:    "cr.l5d.io/linkerd/proxy",
 				Version: "",
 			},
-			LogLevel:       "warn,linkerd=info,trust_dns=error",
+			LogLevel:       "warn,linkerd=info,hickory=error",
 			LogFormat:      "plain",
 			LogHTTPHeaders: "off",
 			Ports: &Ports{


### PR DESCRIPTION
Followup to linkerd/linkerd2-proxy#2872 , where we swapped the trust-dns-resolver with the hickory-resolver dependency. This change updates the default log level setting for the proxy to account for that.