### PR TITLE
Make logHTTPHeaders optional

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -2,7 +2,7 @@
 {{ if and .Values.proxy.nativeSidecar .Values.proxy.waitBeforeExitSeconds }}
 {{ fail "proxy.nativeSidecar and waitBeforeExitSeconds cannot be used simultaneously" }}
 {{- end }}
-{{- if not (has .Values.proxy.logHTTPHeaders (list "insecure" "off")) }}
+{{- if not (has .Values.proxy.logHTTPHeaders (list "insecure" "off" "")) }}
 {{- fail "logHTTPHeaders must be one of: insecure | off" }}
 {{- end }}
 {{- $trustDomain := (.Values.identityTrustDomain | default .Values.clusterDomain) -}}


### PR DESCRIPTION
The `proxy.logHTTPHeaders` Helm variable supports two values: "insecure" and "off".  However, if this value is absent entirely, validation will fail because it it not one of the supported values.  This can cause issues with backwards compatibility.

We make this value optional by adding "" as a legal value during validation.  Leaving this value unset is equivalent to "off" which is the default value.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
