### PR TITLE
handle httproute grpcroute conflicts

### DIFF
--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -18,7 +18,7 @@ use linkerd_policy_controller_core::{
     },
     routes::GroupKindNamespaceName,
 };
-use std::{iter, num::NonZeroU16, str::FromStr, sync::Arc, time};
+use std::{num::NonZeroU16, str::FromStr, sync::Arc, time};
 
 mod grpc;
 mod http;
@@ -231,25 +231,14 @@ fn to_service(outbound: OutboundPolicy) -> outbound::OutboundPolicy {
         });
 
         let mut http_routes = outbound.http_routes.into_iter().collect::<Vec<_>>();
-        http_routes.sort_by(timestamp_then_name);
-        let mut http_routes = http_routes.into_iter().peekable();
-
         let mut grpc_routes = outbound.grpc_routes.into_iter().collect::<Vec<_>>();
-        grpc_routes.sort_by(timestamp_then_name);
-        let mut grpc_routes = grpc_routes.into_iter().peekable();
 
-        // If both HTTP and gRPC routes are present, we choose the route kind by which has the oldest timestamp.
-        match (http_routes.peek(), grpc_routes.peek()) {
-            (Some(http), Some(grpc)) => {
-                if timestamp_then_name(http, grpc).is_gt() {
-                    grpc::protocol(backend, grpc_routes, accrual)
-                } else {
-                    http::protocol(backend, http_routes, accrual)
-                }
-            }
-            (Some((_, _http)), None) => http::protocol(backend, http_routes, accrual),
-            (None, Some((_, _grpc))) => grpc::protocol(backend, grpc_routes, accrual),
-            (None, None) => http::protocol(backend, iter::empty(), accrual),
+        if !grpc_routes.is_empty() {
+            grpc_routes.sort_by(timestamp_then_name);
+            grpc::protocol(backend, grpc_routes.into_iter(), accrual)
+        } else {
+            http_routes.sort_by(timestamp_then_name);
+            http::protocol(backend, http_routes.into_iter(), accrual)
         }
     };
 

--- a/policy-controller/k8s/status/src/tests/routes/grpc.rs
+++ b/policy-controller/k8s/status/src/tests/routes/grpc.rs
@@ -457,6 +457,139 @@ fn route_rejected_after_server_delete() {
     assert!(updates_rx.try_recv().is_err());
 }
 
+#[test]
+fn service_route_type_conflict() {
+    let hostname = "test";
+    let claim = kubert::lease::Claim {
+        holder: "test".to_string(),
+        expiry: DateTime::<Utc>::MAX_UTC,
+    };
+    let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
+    let (updates_tx, mut updates_rx) = mpsc::channel(10000);
+    let index = Index::shared(
+        hostname,
+        claims_rx,
+        updates_tx,
+        IndexMetrics::register(&mut Default::default()),
+    );
+
+    // Apply the parent service
+    let parent = super::make_service("ns-0", "svc");
+    index.write().apply(parent.clone());
+
+    let parent = k8s_gateway_api::ParentReference {
+        group: Some("core".to_string()),
+        kind: Some("Service".to_string()),
+        namespace: parent.namespace(),
+        name: parent.name_unchecked(),
+        section_name: None,
+        port: Some(8080),
+    };
+
+    // Apply the HTTP route.
+    let http_id = NamespaceGroupKindName {
+        namespace: parent.namespace.as_deref().unwrap().to_string(),
+        gkn: GroupKindName {
+            group: k8s_gateway_api::HttpRoute::group(&()),
+            kind: k8s_gateway_api::HttpRoute::kind(&()),
+            name: "httproute-foo".into(),
+        },
+    };
+    let http_route = k8s_gateway_api::HttpRoute {
+        status: None,
+        metadata: k8s_core_api::ObjectMeta {
+            name: Some(http_id.gkn.name.to_string()),
+            namespace: Some(http_id.namespace.clone()),
+            creation_timestamp: Some(k8s_core_api::Time(Utc::now())),
+            ..Default::default()
+        },
+        spec: k8s_gateway_api::HttpRouteSpec {
+            inner: k8s_gateway_api::CommonRouteSpec {
+                parent_refs: Some(vec![parent.clone()]),
+            },
+            hostnames: None,
+            rules: Some(vec![]),
+        },
+    };
+    index.write().apply(http_route);
+
+    // Create the expected update -- HTTPRoute should be accepted
+    let accepted_condition = k8s_core_api::Condition {
+        last_transition_time: k8s_core_api::Time(DateTime::<Utc>::MIN_UTC),
+        message: "".to_string(),
+        observed_generation: None,
+        reason: "Accepted".to_string(),
+        status: "True".to_string(),
+        type_: "Accepted".to_string(),
+    };
+    // No backends were specified, so we have vacuously resolved them all.
+    let backend_condition = k8s_core_api::Condition {
+        last_transition_time: k8s_core_api::Time(DateTime::<Utc>::MIN_UTC),
+        message: "".to_string(),
+        observed_generation: None,
+        reason: "ResolvedRefs".to_string(),
+        status: "True".to_string(),
+        type_: "ResolvedRefs".to_string(),
+    };
+    let parent_status = k8s_gateway_api::RouteParentStatus {
+        parent_ref: parent.clone(),
+        controller_name: POLICY_CONTROLLER_NAME.to_string(),
+        conditions: vec![accepted_condition.clone(), backend_condition.clone()],
+    };
+    let status = make_status(vec![parent_status]);
+    let patch = crate::index::make_patch(&http_id, status).unwrap();
+    let update = updates_rx.try_recv().unwrap();
+    assert_eq!(http_id, update.id);
+    assert_eq!(patch, update.patch);
+
+    // Apply the GRPC route.
+    let grpc_id = NamespaceGroupKindName {
+        namespace: parent.namespace.as_deref().unwrap().to_string(),
+        gkn: GroupKindName {
+            group: k8s_gateway_api::GrpcRoute::group(&()),
+            kind: k8s_gateway_api::GrpcRoute::kind(&()),
+            name: "grpcroute-foo".into(),
+        },
+    };
+    let route = make_route(&grpc_id, parent.clone(), None);
+    index.write().apply(route);
+
+    // Two expected updates: HTTPRoute should be rejected and GRPCRoute should be accepted
+    for _ in 0..2 {
+        let update = updates_rx.try_recv().unwrap();
+        if update.id.gkn.kind == k8s_gateway_api::HttpRoute::kind(&()) {
+            let conflict_condition = k8s_core_api::Condition {
+                last_transition_time: k8s_core_api::Time(DateTime::<Utc>::MIN_UTC),
+                message: "".to_string(),
+                observed_generation: None,
+                reason: "RouteReasonConflicted".to_string(),
+                status: "False".to_string(),
+                type_: "Accepted".to_string(),
+            };
+            let parent_status = k8s_gateway_api::RouteParentStatus {
+                parent_ref: parent.clone(),
+                controller_name: POLICY_CONTROLLER_NAME.to_string(),
+                conditions: vec![conflict_condition, backend_condition.clone()],
+            };
+            let status = make_status(vec![parent_status]);
+            let patch = crate::index::make_patch(&http_id, status).unwrap();
+            assert_eq!(patch, update.patch);
+        } else {
+            let parent_status = k8s_gateway_api::RouteParentStatus {
+                parent_ref: parent.clone(),
+                controller_name: POLICY_CONTROLLER_NAME.to_string(),
+                conditions: vec![accepted_condition.clone(), backend_condition.clone()],
+            };
+            let status = make_status(vec![parent_status]);
+            let patch = crate::index::make_patch(&grpc_id, status).unwrap();
+            assert_eq!(patch, update.patch);
+        }
+    }
+
+    // No more updates.
+    assert!(updates_rx.try_recv().is_err())
+}
+
 fn make_route(
     id: &NamespaceGroupKindName,
     parent: k8s_gateway_api::ParentReference,


### PR DESCRIPTION
GEP-1426 specifies that if a GrpcRoute and an HttpRoute both attempt to attach to the same parent, the HttpRoute should be ignored and have the Accepted condition set to false with the reason `RouteReasonConflicted`. 
https://gateway-api.sigs.k8s.io/geps/gep-1426/#route-types 

We update the status controller and outbound policy index to implement this behavior.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
