### PR TITLE
Remove empty `shortnames` from ExternalWorkload

### DIFF
--- a/charts/linkerd-crds/templates/workload/external-workload.yaml
+++ b/charts/linkerd-crds/templates/workload/external-workload.yaml
@@ -17,7 +17,6 @@ spec:
     listKind: ExternalWorkloadList
     plural: externalworkloads
     singular: externalworkload
-    shortNames: []
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -11732,7 +11732,6 @@ spec:
     listKind: ExternalWorkloadList
     plural: externalworkloads
     singular: externalworkload
-    shortNames: []
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -11752,7 +11752,6 @@ spec:
     listKind: ExternalWorkloadList
     plural: externalworkloads
     singular: externalworkload
-    shortNames: []
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -11752,7 +11752,6 @@ spec:
     listKind: ExternalWorkloadList
     plural: externalworkloads
     singular: externalworkload
-    shortNames: []
   scope: Namespaced
   versions:
   - name: v1alpha1


### PR DESCRIPTION
The `shortnames: []` field on the `ExternalWorkload` CRD causes tools like ArgoCD to report applications out of sync.

Remove the empty field completely from the CRD manifest.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
