### PR TITLE
New "audit" value for default inbound policy

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -237,7 +237,7 @@ Kubernetes: `>=1.22.0-0`
 | proxy.control.streams.initialTimeout | string | `"3s"` | The timeout for the first update from the control plane. |
 | proxy.control.streams.lifetime | string | `"1h"` | The maximum duration for a response stream (i.e. before it will be reinitialized). |
 | proxy.cores | int | `0` | The `cpu.limit` and `cores` should be kept in sync. The value of `cores` must be an integer and should typically be set by rounding up from the limit. E.g. if cpu.limit is '1500m', cores should be 2. |
-| proxy.defaultInboundPolicy | string | "all-unauthenticated" | The default allow policy to use when no `Server` selects a pod.  One of: "all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny" |
+| proxy.defaultInboundPolicy | string | "all-unauthenticated" | The default allow policy to use when no `Server` selects a pod.  One of: "all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny", "audit" |
 | proxy.disableInboundProtocolDetectTimeout | bool | `false` | When set to true, disables the protocol detection timeout on the inbound side of the proxy by setting it to a very high value |
 | proxy.disableOutboundProtocolDetectTimeout | bool | `false` | When set to true, disables the protocol detection timeout on the outbound side of the proxy by setting it to a very high value |
 | proxy.enableExternalProfiles | bool | `false` | Enable service profiles for non-Kubernetes services |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -217,7 +217,7 @@ proxy:
   # -- Grace period for graceful proxy shutdowns. If this timeout elapses before all open connections have completed, the proxy will terminate forcefully, closing any remaining connections.
   shutdownGracePeriod: ""
   # -- The default allow policy to use when no `Server` selects a pod.  One of: "all-authenticated",
-  # "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny"
+  # "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny", "audit"
   # @default -- "all-unauthenticated"
   defaultInboundPolicy: "all-unauthenticated"
   # -- Enable KEP-753 native sidecars

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -613,7 +613,7 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Unexpected error: %v\n", err)
 		}
 		values.Proxy.DefaultInboundPolicy = "everybody"
-		expected := "--default-inbound-policy must be one of: all-authenticated, all-unauthenticated, cluster-authenticated, cluster-unauthenticated, deny (got everybody)"
+		expected := "--default-inbound-policy must be one of: all-authenticated, all-unauthenticated, cluster-authenticated, cluster-unauthenticated, deny, audit (got everybody)"
 
 		err = validateValues(context.Background(), nil, values)
 		if err == nil {

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -646,7 +646,7 @@ func validateProxyValues(values *l5dcharts.Values) error {
 }
 
 func validatePolicy(policy string) error {
-	validPolicies := []string{"all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny"}
+	validPolicies := []string{"all-authenticated", "all-unauthenticated", "cluster-authenticated", "cluster-unauthenticated", "deny", "audit"}
 	for _, p := range validPolicies {
 		if p == policy {
 			return nil

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -493,7 +493,7 @@ func applyAnnotationOverrides(values *l5dcharts.Values, annotations map[string]s
 	}
 
 	if override, ok := annotations[k8s.ProxyDefaultInboundPolicyAnnotation]; ok {
-		if override != k8s.AllUnauthenticated && override != k8s.AllAuthenticated && override != k8s.ClusterUnauthenticated && override != k8s.ClusterAuthenticated && override != k8s.Deny {
+		if override != k8s.AllUnauthenticated && override != k8s.AllAuthenticated && override != k8s.ClusterUnauthenticated && override != k8s.ClusterAuthenticated && override != k8s.Deny && override != k8s.Audit {
 			log.Warnf("unrecognized value used for the %s annotation, valid values are: [%s, %s, %s, %s, %s]", k8s.ProxyDefaultInboundPolicyAnnotation, k8s.AllUnauthenticated, k8s.AllAuthenticated, k8s.ClusterUnauthenticated, k8s.ClusterAuthenticated, k8s.Deny)
 		} else {
 			values.Proxy.DefaultInboundPolicy = override

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -494,7 +494,7 @@ func applyAnnotationOverrides(values *l5dcharts.Values, annotations map[string]s
 
 	if override, ok := annotations[k8s.ProxyDefaultInboundPolicyAnnotation]; ok {
 		if override != k8s.AllUnauthenticated && override != k8s.AllAuthenticated && override != k8s.ClusterUnauthenticated && override != k8s.ClusterAuthenticated && override != k8s.Deny && override != k8s.Audit {
-			log.Warnf("unrecognized value used for the %s annotation, valid values are: [%s, %s, %s, %s, %s]", k8s.ProxyDefaultInboundPolicyAnnotation, k8s.AllUnauthenticated, k8s.AllAuthenticated, k8s.ClusterUnauthenticated, k8s.ClusterAuthenticated, k8s.Deny)
+			log.Warnf("unrecognized value used for the %s annotation, valid values are: [%s, %s, %s, %s, %s, %s]", k8s.ProxyDefaultInboundPolicyAnnotation, k8s.AllUnauthenticated, k8s.AllAuthenticated, k8s.ClusterUnauthenticated, k8s.ClusterAuthenticated, k8s.Deny, k8s.Audit)
 		} else {
 			values.Proxy.DefaultInboundPolicy = override
 		}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -307,6 +307,10 @@ const (
 	// Deny denies all connections.
 	Deny = "deny"
 
+	// Audit allows all connections, but logs and emits audit metrics whenever
+	// the default policy is enacted
+	Audit = "audit"
+
 	// ProxyShutdownGracePeriodAnnotation configures the grace period for
 	// graceful shutdowns in the proxy.
 	ProxyShutdownGracePeriodAnnotation = ProxyConfigAnnotationsPrefix + "/shutdown-grace-period"


### PR DESCRIPTION
As a preliminary for audit-mode support, this change just adds "audit" to the allowed values for the `proxy.defaultInboundPolicy` helm entry, and to the `--default-inbound-policy` flag for the install CLI. It also adds it to the allowed values for the `config.linkerd.io/default-inbound-policy` annotation.