### PR TITLE
Switch debug container to alpine base image

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,19 +1,15 @@
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
+FROM alpine:3.20.1
+RUN apk add \
+    bind-tools \
     curl \
-    dnsutils \
     iptables \
+    iptables-legacy \
     jq \
     nghttp2 \
     tcpdump \
     iproute2 \
     lsof \
-    conntrack \
-    tshark && \
-    rm -rf /var/lib/apt/lists/*
-
-# We still rely on old iptables-legacy syntax.
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
-    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    conntrack-tools \
+    tshark
 
 ENTRYPOINT [ "tshark", "-i", "any" ]


### PR DESCRIPTION
The debug container was previously built using Debian 12 (bookworm) as its base image, but `snyk` reports this vulnerability for that image:

https://security.snyk.io/vuln/SNYK-DEBIAN12-ZLIB-6008963

By switching to the latest version of Alpine as a base image, the debug container scans cleanly with `snyk` and has access to new versions of installed utilities.

Here's a rundown of some of the debug utilities included in the `edge-24.7.3` debug container:

```sh
# curl --version
curl 7.88.1
# dig -v
DiG 9.18.24-1-Debian
# iptables --version
iptables v1.8.9 (legacy)
# iptables-nft --version
iptables v1.8.9 (nf_tables)
# jq --version
jq-1.6
# nghttp --version
nghttp nghttp2/1.52.0
# tcpdump --version
tcpdump version 4.99.3
libpcap version 1.10.3 (with TPACKET_V3)
OpenSSL 3.0.13 30 Jan 2024
# nstat --version
nstat utility, iproute2-6.1.0
# lsof -v
revision: 4.95.0
# conntrack --version
conntrack v1.4.7 (conntrack-tools)
# tshark --version
TShark (Wireshark) 4.0.11 (Git v4.0.11 packaged as 4.0.11-1~deb12u1).
```

Compare that to the debug container build from this branch:

```sh
# curl --version
curl 8.8.0
# dig -v
DiG 9.18.27
# iptables-legacy --version
iptables v1.8.10 (legacy)
# iptables --version
iptables v1.8.10 (nf_tables)
# jq --version
jq-1.7.1
# nghttp --version
nghttp nghttp2/1.62.1
# tcpdump --version
tcpdump version 4.99.4
libpcap version 1.10.4 (with TPACKET_V3)
OpenSSL 3.3.1 4 Jun 2024
# nstat --version
nstat utility, iproute2-6.9.0
# lsof -v
revision: 4.99.3
# conntrack --version
conntrack v1.4.8 (conntrack-tools)
# tshark --version
TShark (Wireshark) 4.2.5 (Git commit 798e06a0f7be).
```

It's also the case that the debug container built from this branch is about half the size of the `edge-24.7.3` version:

```
cr.l5d.io/linkerd/debug         git-b4aa3532            7817231cb383   22 minutes ago   159MB
cr.l5d.io/linkerd/debug         edge-24.7.3             429fb197e718   25 hours ago     314MB
```