### PR TITLE
Trigger policy tests on Rust files changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,6 +36,7 @@ jobs:
             .proxy-version
             go.sum
             **/*.go
+            **/*.rs
             **/Dockerfile*
             charts/**
             justfile


### PR DESCRIPTION
The filter for the changed-files job in the integration.yml workflow wasn't taking into account Rust files. So changes that touched only the policy controller weren't triggering the policy controller integration tests, as seen in #12847