### PR TITLE
feat(proxy): Disable all header and request logging

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -34,7 +34,7 @@ env:
 - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
   value: {{.Values.proxy.enableShutdownEndpoint | quote}}
 - name: LINKERD2_PROXY_LOG
-  value: "{{.Values.proxy.logLevel}}{{ if not (eq .Values.proxy.logHTTPHeaders "insecure") }},linkerd_proxy_http::client[{headers}]=off{{ end }}"
+  value: "{{.Values.proxy.logLevel}}{{ if not (eq .Values.proxy.logHTTPHeaders "insecure") }},[{headers}]=off,[{request}]=off{{ end }}"
 - name: LINKERD2_PROXY_LOG_FORMAT
   value: {{.Values.proxy.logFormat | quote}}
 - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -35,7 +35,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -35,7 +35,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -265,7 +265,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -35,7 +35,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -43,7 +43,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -278,7 +278,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -519,7 +519,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -760,7 +760,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -38,7 +38,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -38,7 +38,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -47,7 +47,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -278,7 +278,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -38,7 +38,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
@@ -85,7 +85,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -38,7 +38,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -38,7 +38,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -39,7 +39,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -37,7 +37,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -39,7 +39,7 @@ items:
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -279,7 +279,7 @@ items:
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -39,7 +39,7 @@ items:
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -279,7 +279,7 @@ items:
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG
-            value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+            value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
           - name: LINKERD2_PROXY_LOG_FORMAT
             value: plain
           - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -29,7 +29,7 @@ spec:
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -30,7 +30,7 @@ spec:
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -31,7 +31,7 @@ spec:
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -33,7 +33,7 @@ spec:
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG
-      value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+      value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
     - name: LINKERD2_PROXY_LOG_FORMAT
       value: plain
     - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -38,7 +38,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -33,7 +33,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -276,7 +276,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -54,7 +54,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off
+          value: warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: plain
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -986,7 +986,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1332,7 +1332,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1780,7 +1780,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1331,7 +1331,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1778,7 +1778,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1331,7 +1331,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1778,7 +1778,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1331,7 +1331,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1778,7 +1778,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1331,7 +1331,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1778,7 +1778,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1322,7 +1322,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1760,7 +1760,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -986,7 +986,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1335,7 +1335,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1789,7 +1789,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1062,7 +1062,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1453,7 +1453,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1941,7 +1941,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1062,7 +1062,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1453,7 +1453,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1941,7 +1941,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -916,7 +916,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1262,7 +1262,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1649,7 +1649,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -958,7 +958,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1306,7 +1306,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1757,7 +1757,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -1035,7 +1035,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1428,7 +1428,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1920,7 +1920,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -1036,7 +1036,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1432,7 +1432,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1931,7 +1931,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1043,7 +1043,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1440,7 +1440,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1940,7 +1940,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1025,7 +1025,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1418,7 +1418,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1910,7 +1910,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1324,7 +1324,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1764,7 +1764,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -935,7 +935,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1278,7 +1278,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1732,7 +1732,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1331,7 +1331,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1778,7 +1778,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -985,7 +985,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1331,7 +1331,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR
@@ -1778,7 +1778,7 @@ spec:
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
-          value: "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          value: "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         - name: LINKERD2_PROXY_LOG_FORMAT
           value: "plain"
         - name: LINKERD2_PROXY_DESTINATION_SVC_ADDR

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -176,7 +176,7 @@
         },
         {
           "name": "LINKERD2_PROXY_LOG",
-          "value": "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          "value": "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         },
         {
           "name": "LINKERD2_PROXY_LOG_FORMAT",

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -162,7 +162,7 @@
         },
         {
           "name": "LINKERD2_PROXY_LOG",
-          "value": "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          "value": "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         },
         {
           "name": "LINKERD2_PROXY_LOG_FORMAT",

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -152,7 +152,7 @@
         },
         {
           "name": "LINKERD2_PROXY_LOG",
-          "value": "warn,linkerd=info,hickory=error,linkerd_proxy_http::client[{headers}]=off"
+          "value": "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
         },
         {
           "name": "LINKERD2_PROXY_LOG_FORMAT",

--- a/testutil/inject_validator.go
+++ b/testutil/inject_validator.go
@@ -253,7 +253,7 @@ func (iv *InjectValidator) validateProxyContainer(pod *v1.PodSpec) error {
 	}
 
 	if iv.LogLevel != "" {
-		expectedLogLevel := fmt.Sprintf("%s,linkerd_proxy_http::client[{headers}]=off", iv.LogLevel)
+		expectedLogLevel := fmt.Sprintf("%s,[{headers}]=off,[{request}]=off", iv.LogLevel)
 		if err := iv.validateEnvVar(proxyContainer, "LINKERD2_PROXY_LOG", expectedLogLevel); err != nil {
 			return err
 		}


### PR DESCRIPTION
The Linkerd proxy suppresses all logging of HTTP headers at debug level or higher unless the `proxy.logHTTPHeaders` helm values is set to `insecure`.  However, even when this value is not set, HTTP headers can still be logged if the log level is set to trace.

We update the log string we use to disable logging of HTTP headers from `linkerd_proxy_http::client[{headers}]=off` to the more general `[{headers}]=off,[{request}]=off`.  This will disable any logging which includes a `headers` or `request` field.  This has the effect of disabling the logging of headers at trace level as well.  As before, these logs can be re-enabled by settings `proxy.logHTTPHeaders=insecure`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
