### PR TITLE
Fix dual-stack integration test

### DIFF
--- a/test/integration/deep/dualstack/testdata/ipfamilies-server-client.yml
+++ b/test/integration/deep/dualstack/testdata/ipfamilies-server-client.yml
@@ -25,6 +25,10 @@ spec:
         args:
         - -c
         - 'go run /go/src/app/main.go'
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
         volumeMounts:
         - name: go-app
           mountPath: /go/src/app


### PR DESCRIPTION
The test was sporadically failing with
```
=== RUN   TestDualStack/Hit_IPv4_addr_directly
    dualstack_test.go:129: expected 'IPv4', received ''
--- FAIL: TestDualStack (18.09s)
```
The problem was the ipfamilies-server pod was taking longer to become ready than the client pod, and so the request was failing. I added a readiness probe to the server manifest so `checkPods()` blocks until all is ready.