### PR TITLE
await endpoints ready in more e2e tests to combat flakyness

### DIFF
--- a/policy-test/tests/e2e_authorization_policy.rs
+++ b/policy-test/tests/e2e_authorization_policy.rs
@@ -36,6 +36,8 @@ async fn meshtls() {
             create_ready_pod(&client, web::pod(&ns))
         );
 
+        await_condition(&client, &ns, "web", endpoints_ready).await;
+
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
             curl.run("curl-injected", "http://web", LinkerdInject::Enabled),
@@ -88,6 +90,8 @@ async fn targets_route() {
             create(&client, web::service(&ns)),
             create_ready_pod(&client, web::pod(&ns))
         );
+
+        await_condition(&client, &ns, "web", endpoints_ready).await;
 
         let curl = curl::Runner::init(&client, &ns).await;
 
@@ -195,6 +199,8 @@ async fn targets_namespace() {
             create_ready_pod(&client, web::pod(&ns))
         );
 
+        await_condition(&client, &ns, "web", endpoints_ready).await;
+
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
             curl.run("curl-injected", "http://web", LinkerdInject::Enabled),
@@ -239,6 +245,8 @@ async fn meshtls_namespace() {
             create(&client, web::service(&ns)),
             create_ready_pod(&client, web::pod(&ns))
         );
+
+        await_condition(&client, &ns, "web", endpoints_ready).await;
 
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
@@ -540,6 +548,8 @@ async fn empty_authentications() {
             create(&client, web::service(&ns)),
             create_ready_pod(&client, web::pod(&ns))
         );
+
+        await_condition(&client, &ns, "web", endpoints_ready).await;
 
         // All requests should work.
         let curl = curl::Runner::init(&client, &ns).await;

--- a/policy-test/tests/e2e_http_routing.rs
+++ b/policy-test/tests/e2e_http_routing.rs
@@ -1,5 +1,8 @@
 use linkerd_policy_controller_k8s_api as k8s;
-use linkerd_policy_test::{create, create_ready_pod, curl, web, with_temp_ns, LinkerdInject};
+use linkerd_policy_test::{
+    await_condition, create, create_ready_pod, curl, endpoints_ready, web, with_temp_ns,
+    LinkerdInject,
+};
 
 #[tokio::test(flavor = "current_thread")]
 async fn path_based_routing() {
@@ -39,6 +42,8 @@ async fn path_based_routing() {
             create(&client, web::service(&ns)),
             create_ready_pod(&client, web::pod(&ns))
         );
+
+        await_condition(&client, &ns, "web", endpoints_ready).await;
 
         let curl = curl::Runner::init(&client, &ns).await;
         let (valid, invalid, notfound) = tokio::join!(

--- a/policy-test/tests/e2e_server_authorization.rs
+++ b/policy-test/tests/e2e_server_authorization.rs
@@ -34,6 +34,8 @@ async fn meshtls() {
             create_ready_pod(&client, web::pod(&ns))
         );
 
+        await_condition(&client, &ns, "web", endpoints_ready).await;
+
         let curl = curl::Runner::init(&client, &ns).await;
         let (injected, uninjected) = tokio::join!(
             curl.run("curl-injected", "http://web", LinkerdInject::Enabled),


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/pull/11368 added a step to certain e2e integration tests where we await the endpoints becoming ready before attempting to send traffic to them.  This was done to combat flakyness on those tests.

We have observed flakyness in other similar tests, `targets_route` in particular.  We add the same await step to that test and to all other tests in that form.

Given the nature of flaky tests, it's difficult to confirm that this fixes the flakyness.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
