### PR TITLE
Font fixes

### DIFF
--- a/web/app/css/styles.css
+++ b/web/app/css/styles.css
@@ -1,9 +1,6 @@
-/* material-ui uses Roboto */
-@import url("https://fonts.googleapis.com/css?family=Montserrat:400,700|Roboto:100,300,400|Roboto+Mono");
-
 :root {
   --linkblue: #2196f3;
-  --font-stack: 'Roboto', 'Lato', helvetica, arial, sans-serif;
+  --font-stack: 'Roboto', helvetica, arial, sans-serif;
 }
 
 body {

--- a/web/templates/includes/base.tmpl.html
+++ b/web/templates/includes/base.tmpl.html
@@ -8,7 +8,8 @@
     <meta name="description" content="Linkerd">
     <meta name="keywords" content="Linkerd">
     <link rel="icon" type="image/png" href="{{.Contents.PathPrefix}}dist/img/favicon.png">
-    <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,900" rel="stylesheet">
+    <!-- material-ui uses Roboto -->
+    <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400|Roboto+Mono" rel="stylesheet">
     {{ template "script-tags" . }}
   </head>
   <body>


### PR DESCRIPTION
Instead of loading Roboto from CSS (which, apparently, WAFs complain about), load it as a stylesheet in <HEAD> (which, apparently, WAFs don't complain about -- we were loading Lato that way before).

Also yank Lato and Montserrat since they were kind of pointless. Thanks to @travisbeckham for the suggestion here!

(I tested this with `bin/web dev`, then loading the Viz dashboard in Safari so I could use the inspector to see what font was getting rendered for the text elements, to make sure that Roboto really does get loaded and used after this change.)

Fixes #8179 (hopefully).

Signed-off-by: Flynn <flynn@buoyant.io>

