### PR TITLE
fix: use correct key to set GID in charts

### DIFF
--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -49,7 +49,7 @@ spec:
           runAsNonRoot: true
           readOnlyRootFilesystem: true
           runAsUser: {{.Values.defaultUID}}
-          runAsUser: {{.Values.defaultGID}}
+          runAsGroup: {{.Values.defaultGID}}
           seccompProfile:
             type: RuntimeDefault
         args:


### PR DESCRIPTION
Duplicate Key and not setting of GroupID in `namespace-metadata` job

```
..
runAsUser: {{.Values.defaultUID}}
runAsUser: {{.Values.defaultGID}}
..
```
This does not fulfill the goal to make the group configurable. Further the built yaml will be invalid as map keys must be unique.

use the correct `runAsGroup` key to match the `defaultGID` value