### PR TITLE
Add viz stat-inbound and viz stat-outbound commands

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -131,6 +131,8 @@ func init() {
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdEdges()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdRoutes()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdStat()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdStatInbound()))
+	RootCmd.AddCommand(deprecateCmd(viz.NewCmdStatOutbound()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdTap()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdTop()))
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -131,8 +131,6 @@ func init() {
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdEdges()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdRoutes()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdStat()))
-	RootCmd.AddCommand(deprecateCmd(viz.NewCmdStatInbound()))
-	RootCmd.AddCommand(deprecateCmd(viz.NewCmdStatOutbound()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdTap()))
 	RootCmd.AddCommand(deprecateCmd(viz.NewCmdTop()))
 

--- a/cli/table/table.go
+++ b/cli/table/table.go
@@ -115,7 +115,13 @@ func (t *Table) renderRow(w io.Writer, row Row, columnWidths []int) {
 		if strings.HasSuffix(value, "─") && c < len(t.Columns)-1 && strings.HasPrefix(row[c+1], "─") {
 			spacing = "──"
 		}
-		if col.LeftAlign {
+		if strings.HasPrefix(value, "─") {
+			padding = strings.Repeat("─", columnWidths[c]-utf8.RuneCountInString(value))
+			fmt.Fprintf(w, "%s%s%s", padding, value, spacing)
+		} else if strings.HasSuffix(value, "─") {
+			padding = strings.Repeat("─", columnWidths[c]-utf8.RuneCountInString(value))
+			fmt.Fprintf(w, "%s%s%s", value, padding, spacing)
+		} else if col.LeftAlign {
 			fmt.Fprintf(w, "%s%s%s", value, padding, spacing)
 		} else {
 			fmt.Fprintf(w, "%s%s%s", padding, value, spacing)

--- a/cli/table/table.go
+++ b/cli/table/table.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 type (
@@ -48,7 +49,7 @@ func NewColumn(header string) Column {
 	return Column{
 		Header:   header,
 		Flexible: true,
-		Width:    len(header),
+		Width:    utf8.RuneCountInString(header),
 	}
 }
 
@@ -74,8 +75,8 @@ func (t *Table) columnWidths() []int {
 		width := col.Width
 		if col.Flexible {
 			for _, row := range t.Data {
-				if len(row[c]) > width {
-					width = len(row[c])
+				if utf8.RuneCountInString(row[c]) > width {
+					width = utf8.RuneCountInString(row[c])
 				}
 			}
 		}
@@ -106,14 +107,18 @@ func (t *Table) renderRow(w io.Writer, row Row, columnWidths []int) {
 			continue
 		}
 		value := row[c]
-		if len(value) > columnWidths[c] {
+		if utf8.RuneCountInString(value) > columnWidths[c] {
 			value = value[:columnWidths[c]]
 		}
-		padding := strings.Repeat(" ", columnWidths[c]-len(value))
+		padding := strings.Repeat(" ", columnWidths[c]-utf8.RuneCountInString(value))
+		spacing := t.ColumnSpacing
+		if strings.HasSuffix(value, "─") && c < len(t.Columns)-1 && strings.HasPrefix(row[c+1], "─") {
+			spacing = "──"
+		}
 		if col.LeftAlign {
-			fmt.Fprintf(w, "%s%s%s", value, padding, t.ColumnSpacing)
+			fmt.Fprintf(w, "%s%s%s", value, padding, spacing)
 		} else {
-			fmt.Fprintf(w, "%s%s%s", padding, value, t.ColumnSpacing)
+			fmt.Fprintf(w, "%s%s%s", padding, value, spacing)
 		}
 	}
 	fmt.Fprint(w, "\n")

--- a/viz/cmd/root.go
+++ b/viz/cmd/root.go
@@ -89,6 +89,8 @@ func NewCmdViz() *cobra.Command {
 	vizCmd.AddCommand(newCmdProfile())
 	vizCmd.AddCommand(NewCmdRoutes())
 	vizCmd.AddCommand(NewCmdStat())
+	vizCmd.AddCommand(NewCmdStatInbound())
+	vizCmd.AddCommand(NewCmdStatOutbound())
 	vizCmd.AddCommand(NewCmdTap())
 	vizCmd.AddCommand(NewCmdTop())
 	vizCmd.AddCommand(newCmdUninstall())

--- a/viz/cmd/stat-inbound.go
+++ b/viz/cmd/stat-inbound.go
@@ -299,6 +299,7 @@ func inboundKeyForSample(sample *model.Sample, resource *pb.Resource) inboundRow
 	}
 	if labels["route_kind"] == "default" {
 		routeType = ""
+		route = "[default]"
 	}
 
 	return inboundRowKey{

--- a/viz/cmd/stat-inbound.go
+++ b/viz/cmd/stat-inbound.go
@@ -1,0 +1,348 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"github.com/linkerd/linkerd2/cli/table"
+	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
+	pkgUtil "github.com/linkerd/linkerd2/viz/pkg/util"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type statInboundOptions struct {
+	statOptionsBase
+	prometheusURL string
+}
+
+type inboundRowKey struct {
+	name      string
+	server    string
+	port      string
+	route     string
+	routeType string
+}
+
+type inboundRow struct {
+	successes  uint64
+	failures   uint64
+	latencyP50 string
+	latencyP95 string
+	latencyP99 string
+}
+
+func newStatInboundOptions() *statInboundOptions {
+	return &statInboundOptions{
+		statOptionsBase: *newStatOptionsBase(),
+	}
+}
+
+// NewCmdStatInbound creates a new cobra command `stat-inbound` for inbound stats functionality
+func NewCmdStatInbound() *cobra.Command {
+	options := newStatInboundOptions()
+
+	cmd := &cobra.Command{
+		Use:   "stat-inbound [flags] (RESOURCE)",
+		Short: "Display inbound traffic stats about a resource",
+		Long: `Display inbound traffic stats about a resource.
+
+  The RESOURCE argument specifies the target resource to display stats from:
+  TYPE/NAME
+
+  Examples:
+  * cronjob/my-cronjob
+  * deploy/my-deploy
+  * ds/my-daemonset
+  * job/my-job
+  * ns/my-ns
+  * rc/my-replication-controller
+  * rs/my-replicaset
+  * sts/my-statefulset
+
+  Valid resource types include:
+  * cronjobs
+  * daemonsets
+  * deployments
+  * namespaces
+  * jobs
+  * pods
+  * replicasets
+  * replicationcontrollers
+  * statefulsets`,
+		Args: cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			if options.namespace == "" {
+				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
+			}
+
+			cc := k8s.NewCommandCompletion(k8sAPI, options.namespace)
+
+			results, err := cc.Complete(args, toComplete)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			return results, cobra.ShellCompDirectiveDefault
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if options.namespace == "" {
+				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
+			}
+
+			promApi, err := api.NewPrometheusClient(cmd.Context(), hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
+			}, options.prometheusURL)
+			if err != nil {
+				return err
+			}
+
+			resource, err := pkgUtil.BuildResource(options.namespace, args[0])
+			if err != nil {
+				return err
+			}
+
+			// Issue Prometheus queries.
+
+			responseChan := queryRate(
+				cmd.Context(),
+				promApi,
+				"response_total",
+				options.timeWindow,
+				model.LabelSet{"direction": "inbound"},
+				model.LabelNames{"srv_name", "srv_kind", "route_name", "route_kind", "classification", "target_port"},
+				resource,
+			)
+
+			quantiles := queryQuantiles(
+				cmd.Context(),
+				promApi,
+				"response_latency_ms_bucket",
+				options.timeWindow,
+				model.LabelSet{"direction": "inbound"},
+				model.LabelNames{"srv_name", "srv_kind", "route_name", "route_kind", "target_port"},
+				resource,
+			)
+
+			// Collect Prometheus results.
+
+			results := make(map[inboundRowKey]inboundRow)
+
+			for sample := range responseChan {
+				labels := sample.Metric
+				key := inboundKeyForSample(sample, resource)
+				row := results[key]
+				if labels["classification"] == "success" {
+					row.successes += uint64(sample.Value)
+				} else {
+					row.failures += uint64(sample.Value)
+				}
+				results[key] = row
+			}
+
+			for quantile, resultsChan := range quantiles {
+				for sample := range resultsChan {
+					key := inboundKeyForSample(sample, resource)
+					row := results[key]
+					row.populateLatency(quantile, sample)
+					results[key] = row
+				}
+			}
+
+			// Render output.
+
+			rows := make([][]string, 0)
+
+			windowLength, err := time.ParseDuration(options.timeWindow)
+			if err != nil {
+				return err
+			}
+
+			for key, row := range results {
+				if row.failures+row.successes == 0 {
+					continue
+				}
+				rows = append(rows, []string{
+					key.name,
+					fmt.Sprintf("%s:%s", key.server, key.port),
+					key.route,
+					key.routeType,
+					fmt.Sprintf("%.2f%%", (float32)(row.successes)/(float32)(row.successes+row.failures)*100.0),
+					fmt.Sprintf("%.2f", (float32)(row.successes+row.failures)/float32(windowLength.Seconds())),
+					row.latencyP50,
+					row.latencyP95,
+					row.latencyP99,
+				})
+			}
+
+			columns := []table.Column{
+				table.NewColumn("NAME").WithLeftAlign(),
+				table.NewColumn("SERVER").WithLeftAlign(),
+				table.NewColumn("ROUTE").WithLeftAlign(),
+				table.NewColumn("TYPE").WithLeftAlign(),
+				table.NewColumn("SUCCESS"),
+				table.NewColumn("RPS"),
+				table.NewColumn("LATENCY_P50"),
+				table.NewColumn("LATENCY_P95"),
+				table.NewColumn("LATENCY_P99"),
+			}
+
+			table := table.NewTable(columns, rows)
+			table.Sort = []int{0, 1, 3} // Name, Server, Route
+			table.Render(os.Stdout)
+
+			return err
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\" or \"wide\"")
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace")
+	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"10s\", \"1m\", \"10m\", \"1h\")")
+	cmd.PersistentFlags().StringVar(&options.prometheusURL, "prometheusURL", options.prometheusURL, "Address of Prometheus instance to query")
+
+	return cmd
+}
+
+func queryRate(
+	ctx context.Context,
+	promAPI promv1.API,
+	metric string,
+	timeWindow string,
+	labels model.LabelSet,
+	groupBy model.LabelNames,
+	resource *pb.Resource,
+) <-chan *model.Sample {
+	results := make(chan *model.Sample)
+	go func() {
+		defer close(results)
+		query := fmt.Sprintf("sum(increase(%s%s[%s])) by (%s)",
+			metric,
+			labels.Merge(prometheus.PromQueryLabels(resource)),
+			timeWindow,
+			append(groupBy, prometheus.PromGroupByLabelNames(resource)...),
+		)
+		log.Debug(query)
+		val, warn, err := promAPI.Query(ctx, query, time.Time{})
+		if warn != nil {
+			log.Warnf("%v", warn)
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "failed to query Prometheus: ", err.Error())
+			os.Exit(1)
+		}
+		for _, sample := range val.(model.Vector) {
+			results <- sample
+		}
+	}()
+	return results
+}
+
+func queryQuantiles(
+	ctx context.Context,
+	promAPI promv1.API,
+	metric string,
+	timeWindow string,
+	labels model.LabelSet,
+	groupBy model.LabelNames,
+	resource *pb.Resource,
+) map[string]chan *model.Sample {
+	results := map[string]chan *model.Sample{
+		"0.5":  make(chan *model.Sample),
+		"0.95": make(chan *model.Sample),
+		"0.99": make(chan *model.Sample),
+	}
+	for quantile, resultsChan := range results {
+		go func(quantile string) {
+			defer close(resultsChan)
+			query := fmt.Sprintf("histogram_quantile(%s, sum(irate(%s%s[%s])) by (le, %s))",
+				quantile,
+				metric,
+				labels.Merge(prometheus.PromQueryLabels(resource)),
+				timeWindow,
+				append(groupBy, prometheus.PromGroupByLabelNames(resource)...),
+			)
+			log.Debug(query)
+			val, warn, err := promAPI.Query(ctx, query, time.Time{})
+			if warn != nil {
+				log.Warnf("%v", warn)
+			}
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "failed to query Prometheus: ", err.Error())
+				os.Exit(1)
+			}
+			for _, sample := range val.(model.Vector) {
+				resultsChan <- sample
+			}
+		}(quantile)
+	}
+	return results
+}
+
+func inboundKeyForSample(sample *model.Sample, resource *pb.Resource) inboundRowKey {
+	labels := sample.Metric
+	server := (string)(labels["srv_name"])
+	route := (string)(labels["route_name"])
+	routeType := (string)(labels["route_kind"])
+	if labels["srv_kind"] == "default" {
+		server = "[default]"
+	}
+	if labels["route_name"] == "default" {
+		route = "[default]"
+	}
+	if labels["route_kind"] == "default" {
+		routeType = ""
+	}
+
+	return inboundRowKey{
+		name:      (string)(labels[prometheus.PromResourceType(resource)]),
+		server:    server,
+		route:     route,
+		port:      (string)(labels["target_port"]),
+		routeType: routeType,
+	}
+}
+
+func formatLatencyMs(value float64) string {
+	latency := "-"
+	if !math.IsNaN(value) {
+		latency = fmt.Sprintf("%.0fms", value)
+	}
+	return latency
+}
+
+func (r *inboundRow) populateLatency(quantile string, sample *model.Sample) {
+	latency := formatLatencyMs(float64(sample.Value))
+	switch quantile {
+	case "0.5":
+		r.latencyP50 = latency
+	case "0.95":
+		r.latencyP95 = latency
+	case "0.99":
+		r.latencyP99 = latency
+	}
+}

--- a/viz/cmd/stat-inbound.go
+++ b/viz/cmd/stat-inbound.go
@@ -225,9 +225,9 @@ func queryRate(
 		defer close(results)
 		query := fmt.Sprintf("sum(increase(%s%s[%s])) by (%s)",
 			metric,
-			labels.Merge(prometheus.PromQueryLabels(resource)),
+			labels.Merge(prometheus.QueryLabels(resource)),
 			timeWindow,
-			append(groupBy, prometheus.PromGroupByLabelNames(resource)...),
+			append(groupBy, prometheus.GroupByLabelNames(resource)...),
 		)
 		log.Debug(query)
 		val, warn, err := promAPI.Query(ctx, query, time.Time{})
@@ -265,9 +265,9 @@ func queryQuantiles(
 			query := fmt.Sprintf("histogram_quantile(%s, sum(irate(%s%s[%s])) by (le, %s))",
 				quantile,
 				metric,
-				labels.Merge(prometheus.PromQueryLabels(resource)),
+				labels.Merge(prometheus.QueryLabels(resource)),
 				timeWindow,
-				append(groupBy, prometheus.PromGroupByLabelNames(resource)...),
+				append(groupBy, prometheus.GroupByLabelNames(resource)...),
 			)
 			log.Debug(query)
 			val, warn, err := promAPI.Query(ctx, query, time.Time{})
@@ -302,7 +302,7 @@ func inboundKeyForSample(sample *model.Sample, resource *pb.Resource) inboundRow
 	}
 
 	return inboundRowKey{
-		name:      (string)(labels[prometheus.PromResourceType(resource)]),
+		name:      (string)(labels[prometheus.ResourceType(resource)]),
 		server:    server,
 		route:     route,
 		port:      (string)(labels["target_port"]),

--- a/viz/cmd/stat-inbound.go
+++ b/viz/cmd/stat-inbound.go
@@ -203,7 +203,7 @@ func NewCmdStatInbound() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\" or \"wide\"")
+	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\"")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace")
 	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"10s\", \"1m\", \"10m\", \"1h\")")
 	cmd.PersistentFlags().StringVar(&options.prometheusURL, "prometheusURL", options.prometheusURL, "Address of Prometheus instance to query")

--- a/viz/cmd/stat-inbound.go
+++ b/viz/cmd/stat-inbound.go
@@ -299,7 +299,6 @@ func inboundKeyForSample(sample *model.Sample, resource *pb.Resource) inboundRow
 	}
 	if labels["route_kind"] == "default" {
 		routeType = ""
-		route = "[default]"
 	}
 
 	return inboundRowKey{

--- a/viz/cmd/stat-outbound.go
+++ b/viz/cmd/stat-outbound.go
@@ -345,7 +345,7 @@ func NewCmdStatOutbound() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\" or \"wide\"")
+	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\"")
 	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace")
 	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"10s\", \"1m\", \"10m\", \"1h\")")
 	cmd.PersistentFlags().StringVar(&options.prometheusURL, "prometheusURL", options.prometheusURL, "Address of Prometheus instance to query")

--- a/viz/cmd/stat-outbound.go
+++ b/viz/cmd/stat-outbound.go
@@ -1,0 +1,485 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/linkerd/linkerd2/cli/table"
+	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
+	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/api"
+	hc "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
+	pkgUtil "github.com/linkerd/linkerd2/viz/pkg/util"
+	"github.com/prometheus/common/model"
+	"github.com/spf13/cobra"
+)
+
+type outboundRowKey struct {
+	name      string
+	service   string
+	port      string
+	route     string
+	routeType string
+}
+
+type outboundBackendRow struct {
+	successes  uint64
+	failures   uint64
+	latencyP50 string
+	latencyP95 string
+	latencyP99 string
+	timeouts   uint64
+}
+
+type backendKey struct {
+	name string
+	port string
+}
+
+type outboundRouteRow struct {
+	outboundBackendRow
+	retries  uint64
+	backends map[backendKey]outboundBackendRow
+}
+
+// NewCmdStatOutbound creates a new cobra command `stat-outbound` for outbound stat functionality
+func NewCmdStatOutbound() *cobra.Command {
+	options := newStatInboundOptions()
+
+	cmd := &cobra.Command{
+		Use:   "stat-outbound [flags] (RESOURCE)",
+		Short: "Display outbound traffic stats about a resource",
+		Long: `Display outbound traffic stats about a resource.
+
+  The RESOURCE argument specifies the target resource to aggregate stats over:
+  TYPE/NAME
+
+  Examples:
+  * cronjob/my-cronjob
+  * deploy/my-deploy
+  * ds/my-daemonset
+  * job/my-job
+  * ns/my-ns
+  * rc/my-replication-controller
+  * rs/my-replicaset
+  * sts/my-statefulset
+
+  Valid resource types include:
+  * cronjobs
+  * daemonsets
+  * deployments
+  * namespaces
+  * jobs
+  * pods
+  * replicasets
+  * replicationcontrollers
+  * statefulsets`,
+		Args: cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+
+			k8sAPI, err := k8s.NewAPI(kubeconfigPath, kubeContext, impersonate, impersonateGroup, 0)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			if options.namespace == "" {
+				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
+			}
+
+			cc := k8s.NewCommandCompletion(k8sAPI, options.namespace)
+
+			results, err := cc.Complete(args, toComplete)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			return results, cobra.ShellCompDirectiveDefault
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if options.namespace == "" {
+				options.namespace = pkgcmd.GetDefaultNamespace(kubeconfigPath, kubeContext)
+			}
+
+			promApi, err := api.NewPrometheusClient(cmd.Context(), hc.VizOptions{
+				Options: &healthcheck.Options{
+					ControlPlaneNamespace: controlPlaneNamespace,
+					KubeConfig:            kubeconfigPath,
+					Impersonate:           impersonate,
+					ImpersonateGroup:      impersonateGroup,
+					KubeContext:           kubeContext,
+					APIAddr:               apiAddr,
+				},
+				VizNamespaceOverride: vizNamespace,
+			}, options.prometheusURL)
+			if err != nil {
+				return err
+			}
+			resource, err := pkgUtil.BuildResource(options.namespace, args[0])
+			if err != nil {
+				return err
+			}
+
+			// Issue Prometheus queries for HTTP.
+
+			httpBackendChan := queryRate(
+				cmd.Context(),
+				promApi,
+				"outbound_http_route_backend_response_statuses_total",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "backend_name", "backend_port", "route_name", "route_kind", "http_status", "error"},
+				resource,
+			)
+
+			httpBackendQuantiles := queryQuantiles(
+				cmd.Context(),
+				promApi,
+				"outbound_http_route_backend_response_duration_seconds_bucket",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "backend_name", "backend_port", "route_name", "route_kind"},
+				resource,
+			)
+
+			httpRouteChan := queryRate(
+				cmd.Context(),
+				promApi,
+				"outbound_http_route_request_statuses_total",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "route_name", "route_kind", "http_status", "error"},
+				resource,
+			)
+
+			httpRetiesChan := queryRate(
+				cmd.Context(),
+				promApi,
+				"outbound_http_route_retry_requests_total",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "route_name", "route_kind"},
+				resource,
+			)
+
+			httpRouteQuantiles := queryQuantiles(
+				cmd.Context(),
+				promApi,
+				"outbound_http_route_request_duration_seconds_bucket",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "route_name", "route_kind"},
+				resource,
+			)
+
+			// Issue Prometheus queries for gRPC.
+
+			grpcBackendChan := queryRate(
+				cmd.Context(),
+				promApi,
+				"outbound_grpc_route_backend_response_statuses_total",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "backend_name", "backend_port", "route_name", "route_kind", "grpc_status", "error"},
+				resource,
+			)
+
+			grpcBackendQuantiles := queryQuantiles(
+				cmd.Context(),
+				promApi,
+				"outbound_grpc_route_backend_response_duration_seconds_bucket",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "backend_name", "backend_port", "route_name", "route_kind"},
+				resource,
+			)
+
+			grpcRouteChan := queryRate(
+				cmd.Context(),
+				promApi,
+				"outbound_grpc_route_request_statuses_total",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "route_name", "route_kind", "grpc_status", "error"},
+				resource,
+			)
+
+			grpcRetiesChan := queryRate(
+				cmd.Context(),
+				promApi,
+				"outbound_grpc_route_retry_requests_total",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "route_name", "route_kind"},
+				resource,
+			)
+
+			grpcRouteQuantiles := queryQuantiles(
+				cmd.Context(),
+				promApi,
+				"outbound_grpc_route_request_duration_seconds_bucket",
+				options.timeWindow,
+				model.LabelSet{},
+				model.LabelNames{"parent_name", "parent_port", "route_name", "route_kind"},
+				resource,
+			)
+
+			windowLength, err := time.ParseDuration(options.timeWindow)
+			if err != nil {
+				return err
+			}
+
+			// Collect Prometheus results for HTTP.
+
+			results := make(map[outboundRowKey]outboundRouteRow)
+
+			for sample := range httpBackendChan {
+				key := outboundKeyForSample(sample, resource)
+				row := results[key]
+				row.populateBackendHTTPCounts(sample)
+				results[key] = row
+			}
+
+			for quantile, resultsChan := range httpBackendQuantiles {
+				for sample := range resultsChan {
+					key := outboundKeyForSample(sample, resource)
+					row := results[key]
+					row.populateBackendLatency(quantile, sample)
+					results[key] = row
+				}
+			}
+
+			for sample := range httpRouteChan {
+				key := outboundKeyForSample(sample, resource)
+				row := results[key]
+				row.populateHTTPCounts(sample)
+				results[key] = row
+			}
+			for sample := range httpRetiesChan {
+				key := outboundKeyForSample(sample, resource)
+				row := results[key]
+				row.retries += uint64(sample.Value)
+				results[key] = row
+			}
+			for quantile, resultsChan := range httpRouteQuantiles {
+				for sample := range resultsChan {
+					key := outboundKeyForSample(sample, resource)
+					row := results[key]
+					row.populateLatency(quantile, sample)
+					results[key] = row
+				}
+			}
+
+			// Collect Prometheus results for gRPC.
+
+			for sample := range grpcBackendChan {
+				key := outboundKeyForSample(sample, resource)
+				row := results[key]
+				row.populateBackendGRPCCounts(sample)
+				results[key] = row
+			}
+
+			for quantile, resultsChan := range grpcBackendQuantiles {
+				for sample := range resultsChan {
+					key := outboundKeyForSample(sample, resource)
+					row := results[key]
+					row.populateBackendLatency(quantile, sample)
+					results[key] = row
+				}
+			}
+
+			for sample := range grpcRouteChan {
+				key := outboundKeyForSample(sample, resource)
+				row := results[key]
+				row.populateGRPCCounts(sample)
+				results[key] = row
+			}
+			for sample := range grpcRetiesChan {
+				key := outboundKeyForSample(sample, resource)
+				row := results[key]
+				row.retries += uint64(sample.Value)
+				results[key] = row
+			}
+			for quantile, resultsChan := range grpcRouteQuantiles {
+				for sample := range resultsChan {
+					key := outboundKeyForSample(sample, resource)
+					row := results[key]
+					row.populateLatency(quantile, sample)
+					results[key] = row
+				}
+			}
+
+			// Render output.
+
+			rows := make([][]string, 0)
+
+			for key, row := range results {
+				if row.failures+row.successes == 0 {
+					continue
+				}
+				rows = append(rows, []string{
+					key.name,
+					fmt.Sprintf("%s:%s", key.service, key.port),
+					key.route,
+					key.routeType,
+					"", // backend
+					fmt.Sprintf("%.2f%%", (float32)(row.successes)/(float32)(row.successes+row.failures)*100.0),
+					fmt.Sprintf("%.2f", (float32)(row.successes+row.failures)/float32(windowLength.Seconds())),
+					row.latencyP50,
+					row.latencyP95,
+					row.latencyP99,
+					fmt.Sprintf("%.2f%%", (float32)(row.timeouts)/(float32)(row.successes+row.failures)*100.0),
+					fmt.Sprintf("%.2f%%", (float32)(row.retries)/(float32)(row.successes+row.failures+row.retries)*100.0),
+				})
+				for backend, backendRow := range row.backends {
+					line := "├"
+					if len(key.route) > 0 {
+						line += strings.Repeat("─", len(key.route)-1)
+					}
+					rows = append(rows, []string{
+						"",
+						"",
+						line,
+						"────────►",
+						fmt.Sprintf("%s:%s", backend.name, backend.port),
+						fmt.Sprintf("%.2f%%", (float32)(backendRow.successes)/(float32)(backendRow.successes+backendRow.failures)*100.0),
+						fmt.Sprintf("%.2f", (float32)(backendRow.successes+backendRow.failures)/float32(windowLength.Seconds())),
+						backendRow.latencyP50,
+						backendRow.latencyP95,
+						backendRow.latencyP99,
+						fmt.Sprintf("%.2f%%", (float32)(backendRow.timeouts)/(float32)(backendRow.successes+backendRow.failures)*100.0),
+						"", // retries
+					})
+				}
+				lastBackendLine := rows[len(rows)-1][2]
+				rows[len(rows)-1][2] = strings.Replace(lastBackendLine, "├", "└", 1)
+			}
+
+			columns := []table.Column{
+				table.NewColumn("NAME").WithLeftAlign(),
+				table.NewColumn("SERVICE").WithLeftAlign(),
+				table.NewColumn("ROUTE").WithLeftAlign(),
+				table.NewColumn("TYPE").WithLeftAlign(),
+				table.NewColumn("BACKEND").WithLeftAlign(),
+				table.NewColumn("SUCCESS"),
+				table.NewColumn("RPS"),
+				table.NewColumn("LATENCY_P50"),
+				table.NewColumn("LATENCY_P95"),
+				table.NewColumn("LATENCY_P99"),
+				table.NewColumn("TIMEOUTS"),
+				table.NewColumn("RETRIES"),
+			}
+
+			table := table.NewTable(columns, rows)
+			table.Render(os.Stdout)
+
+			return err
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", options.outputFormat, "Output format; one of: \"table\" or \"json\" or \"wide\"")
+	cmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "n", options.namespace, "Namespace")
+	cmd.PersistentFlags().StringVarP(&options.timeWindow, "time-window", "t", options.timeWindow, "Stat window (for example: \"10s\", \"1m\", \"10m\", \"1h\")")
+	cmd.PersistentFlags().StringVar(&options.prometheusURL, "prometheusURL", options.prometheusURL, "Address of Prometheus instance to query")
+
+	return cmd
+}
+
+func outboundKeyForSample(sample *model.Sample, resource *pb.Resource) outboundRowKey {
+	labels := sample.Metric
+	route := (string)(labels["route_name"])
+	routeType := (string)(labels["route_kind"])
+	if labels["route_name"] == "default" {
+		route = "[default]"
+	}
+	if labels["route_kind"] == "default" {
+		routeType = ""
+	}
+
+	return outboundRowKey{
+		name:      (string)(labels[prometheus.PromResourceType(resource)]),
+		service:   (string)(labels["parent_name"]),
+		port:      (string)(labels["parent_port"]),
+		route:     route,
+		routeType: routeType,
+	}
+}
+
+func (r *outboundBackendRow) populateLatency(quantile string, sample *model.Sample) {
+	latency := formatLatencyMs(float64(sample.Value * 1000))
+	switch quantile {
+	case "0.5":
+		r.latencyP50 = latency
+	case "0.95":
+		r.latencyP95 = latency
+	case "0.99":
+		r.latencyP99 = latency
+	}
+}
+
+func (r *outboundRouteRow) populateBackendLatency(quantile string, sample *model.Sample) {
+	key := backendKey{
+		name: (string)(sample.Metric["backend_name"]),
+		port: (string)(sample.Metric["backend_port"]),
+	}
+	backend := r.backends[key]
+	backend.populateLatency(quantile, sample)
+	if r.backends == nil {
+		r.backends = make(map[backendKey]outboundBackendRow)
+	}
+	r.backends[key] = backend
+}
+
+func (r *outboundBackendRow) populateHTTPCounts(sample *model.Sample) {
+	labels := sample.Metric
+	if strings.HasPrefix((string)(labels["http_status"]), "5") || labels["error"] != "" {
+		r.failures += uint64(sample.Value)
+	} else {
+		r.successes += uint64(sample.Value)
+	}
+	if labels["error"] == "RESPONSE_HEADERS_TIMEOUT" || labels["error"] == "REQUEST_TIMEOUT" {
+		r.timeouts += uint64(sample.Value)
+	}
+}
+
+func (r *outboundRouteRow) populateBackendHTTPCounts(sample *model.Sample) {
+	key := backendKey{
+		name: (string)(sample.Metric["backend_name"]),
+		port: (string)(sample.Metric["backend_port"]),
+	}
+	backend := r.backends[key]
+	backend.populateHTTPCounts(sample)
+	if r.backends == nil {
+		r.backends = make(map[backendKey]outboundBackendRow)
+	}
+	r.backends[key] = backend
+}
+
+func (r *outboundBackendRow) populateGRPCCounts(sample *model.Sample) {
+	labels := sample.Metric
+	if labels["grpc_status"] != "OK" || labels["error"] != "" {
+		r.failures += uint64(sample.Value)
+	} else {
+		r.successes += uint64(sample.Value)
+	}
+	if labels["error"] == "RESPONSE_HEADERS_TIMEOUT" || labels["error"] == "REQUEST_TIMEOUT" {
+		r.timeouts += uint64(sample.Value)
+	}
+}
+
+func (r *outboundRouteRow) populateBackendGRPCCounts(sample *model.Sample) {
+	key := backendKey{
+		name: (string)(sample.Metric["backend_name"]),
+		port: (string)(sample.Metric["backend_port"]),
+	}
+	backend := r.backends[key]
+	backend.populateGRPCCounts(sample)
+	if r.backends == nil {
+		r.backends = make(map[backendKey]outboundBackendRow)
+	}
+	r.backends[key] = backend
+}

--- a/viz/cmd/stat-outbound.go
+++ b/viz/cmd/stat-outbound.go
@@ -365,7 +365,7 @@ func outboundKeyForSample(sample *model.Sample, resource *pb.Resource) outboundR
 	}
 
 	return outboundRowKey{
-		name:      (string)(labels[prometheus.PromResourceType(resource)]),
+		name:      (string)(labels[prometheus.ResourceType(resource)]),
 		service:   (string)(labels["parent_name"]),
 		port:      (string)(labels["parent_port"]),
 		route:     route,

--- a/viz/cmd/stat-outbound.go
+++ b/viz/cmd/stat-outbound.go
@@ -362,6 +362,7 @@ func outboundKeyForSample(sample *model.Sample, resource *pb.Resource) outboundR
 	}
 	if labels["route_kind"] == "default" {
 		routeType = ""
+		route = "[default]"
 	}
 
 	return outboundRowKey{
@@ -469,15 +470,11 @@ func renderStatOutboundTable(results map[outboundRowKey]outboundRouteRow, window
 			fmt.Sprintf("%.2f%%", (float32)(row.retries)/(float32)(row.successes+row.failures+row.retries)*100.0),
 		})
 		for backend, backendRow := range row.backends {
-			line := "├"
-			if len(key.route) > 0 {
-				line += strings.Repeat("─", len(key.route)-1)
-			}
 			rows = append(rows, []string{
 				"",
 				"",
-				line,
-				"────────►",
+				"├─",
+				"─►",
 				fmt.Sprintf("%s:%s", backend.name, backend.port),
 				fmt.Sprintf("%.2f%%", (float32)(backendRow.successes)/(float32)(backendRow.successes+backendRow.failures)*100.0),
 				fmt.Sprintf("%.2f", (float32)(backendRow.successes+backendRow.failures)/float32(windowLength.Seconds())),

--- a/viz/metrics-api/authz.go
+++ b/viz/metrics-api/authz.go
@@ -23,7 +23,7 @@ func (s *grpcServer) Authz(ctx context.Context, req *pb.AuthzRequest) (*pb.Authz
 		}, nil
 	}
 
-	labels := prometheus.PromQueryLabels(req.GetResource())
+	labels := prometheus.QueryLabels(req.GetResource())
 	reqLabels := labels.Merge(model.LabelSet{
 		"direction": model.LabelValue("inbound"),
 	})

--- a/viz/metrics-api/authz.go
+++ b/viz/metrics-api/authz.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,13 +23,13 @@ func (s *grpcServer) Authz(ctx context.Context, req *pb.AuthzRequest) (*pb.Authz
 		}, nil
 	}
 
-	labels := promQueryLabels(req.GetResource())
+	labels := prometheus.PromQueryLabels(req.GetResource())
 	reqLabels := labels.Merge(model.LabelSet{
 		"direction": model.LabelValue("inbound"),
 	})
 
 	groupBy := model.LabelNames{
-		routeKindLabel, routeNameLabel, authorizationKindLabel, authorizationNameLabel, serverKindLabel, serverNameLabel,
+		prometheus.RouteKindLabel, prometheus.RouteNameLabel, prometheus.AuthorizationKindLabel, prometheus.AuthorizationNameLabel, prometheus.ServerKindLabel, prometheus.ServerNameLabel,
 	}
 	promQueries := make(map[promType]string)
 	promQueries[promRequests] = fmt.Sprintf(reqQuery, reqLabels, req.TimeWindow, groupBy.String())
@@ -60,12 +61,12 @@ func (s *grpcServer) Authz(ctx context.Context, req *pb.AuthzRequest) (*pb.Authz
 	for _, result := range results {
 		for _, sample := range result.vec {
 			key := rowKey{
-				routeName:  string(sample.Metric[routeNameLabel]),
-				routeKind:  string(sample.Metric[routeKindLabel]),
-				serverName: string(sample.Metric[serverNameLabel]),
-				serverKind: string(sample.Metric[serverKindLabel]),
-				authzName:  string(sample.Metric[authorizationNameLabel]),
-				authzKind:  string(sample.Metric[authorizationKindLabel]),
+				routeName:  string(sample.Metric[prometheus.RouteNameLabel]),
+				routeKind:  string(sample.Metric[prometheus.RouteKindLabel]),
+				serverName: string(sample.Metric[prometheus.ServerNameLabel]),
+				serverKind: string(sample.Metric[prometheus.ServerKindLabel]),
+				authzName:  string(sample.Metric[prometheus.AuthorizationNameLabel]),
+				authzKind:  string(sample.Metric[prometheus.AuthorizationKindLabel]),
 			}
 			// Get the row if it exists or initialize an empty one
 			row := rows[key]
@@ -75,17 +76,17 @@ func (s *grpcServer) Authz(ctx context.Context, req *pb.AuthzRequest) (*pb.Authz
 					Stats:    &pb.BasicStats{},
 					SrvStats: &pb.ServerStats{
 						Srv: &pb.Resource{
-							Namespace: string(sample.Metric[namespaceLabel]),
+							Namespace: string(sample.Metric[prometheus.NamespaceLabel]),
 							Type:      key.serverKind,
 							Name:      key.serverName,
 						},
 						Route: &pb.Resource{
-							Namespace: string(sample.Metric[namespaceLabel]),
+							Namespace: string(sample.Metric[prometheus.NamespaceLabel]),
 							Type:      key.routeKind,
 							Name:      key.routeName,
 						},
 						Authz: &pb.Resource{
-							Namespace: string(sample.Metric[namespaceLabel]),
+							Namespace: string(sample.Metric[prometheus.NamespaceLabel]),
 							Type:      key.authzKind,
 							Name:      key.authzName,
 						},

--- a/viz/metrics-api/edges.go
+++ b/viz/metrics-api/edges.go
@@ -39,7 +39,7 @@ func (s *grpcServer) Edges(ctx context.Context, req *pb.EdgesRequest) (*pb.Edges
 		return edgesError(req, "Edges request missing Selector Resource"), nil
 	}
 
-	resourceType := prometheus.PromResourceType(req.GetSelector().GetResource())
+	resourceType := prometheus.ResourceType(req.GetSelector().GetResource())
 	dstResourceType := "dst_" + resourceType
 	labelsOutbound := promDirectionLabels("outbound")
 	labelsOutboundStr := generateLabelStringWithExclusion(labelsOutbound, string(resourceType), string(dstResourceType))

--- a/viz/metrics-api/edges.go
+++ b/viz/metrics-api/edges.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -38,7 +39,7 @@ func (s *grpcServer) Edges(ctx context.Context, req *pb.EdgesRequest) (*pb.Edges
 		return edgesError(req, "Edges request missing Selector Resource"), nil
 	}
 
-	resourceType := promResourceType(req.GetSelector().GetResource())
+	resourceType := prometheus.PromResourceType(req.GetSelector().GetResource())
 	dstResourceType := "dst_" + resourceType
 	labelsOutbound := promDirectionLabels("outbound")
 	labelsOutboundStr := generateLabelStringWithExclusion(labelsOutbound, string(resourceType), string(dstResourceType))

--- a/viz/metrics-api/edges_test.go
+++ b/viz/metrics-api/edges_test.go
@@ -8,6 +8,7 @@ import (
 
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
 	"github.com/prometheus/common/model"
 	"google.golang.org/protobuf/proto"
 )
@@ -29,12 +30,12 @@ func genOutboundPromSample(resourceNamespace, resourceName, resourceNameDst, res
 
 	return &model.Sample{
 		Metric: model.Metric{
-			resourceLabel:     model.LabelValue(resourceName),
-			namespaceLabel:    model.LabelValue(resourceNamespace),
-			dstNamespaceLabel: model.LabelValue(resourceNamespaceDst),
-			dstResourceLabel:  model.LabelValue(resourceNameDst),
-			serverIDLabel:     model.LabelValue(serverID),
-			podLabel:          model.LabelValue(resourceName + "-0"),
+			resourceLabel:                model.LabelValue(resourceName),
+			prometheus.NamespaceLabel:    model.LabelValue(resourceNamespace),
+			prometheus.DstNamespaceLabel: model.LabelValue(resourceNamespaceDst),
+			dstResourceLabel:             model.LabelValue(resourceNameDst),
+			serverIDLabel:                model.LabelValue(serverID),
+			podLabel:                     model.LabelValue(resourceName + "-0"),
 		},
 		Value:     123,
 		Timestamp: 456,

--- a/viz/metrics-api/gateways.go
+++ b/viz/metrics-api/gateways.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,14 +43,14 @@ func buildGatewaysRequestLabels(req *pb.GatewaysRequest) (labels model.LabelSet,
 	labels = model.LabelSet{}
 
 	if req.GatewayNamespace != "" {
-		labels[gatewayNamespaceLabel] = model.LabelValue(req.GatewayNamespace)
+		labels[prometheus.GatewayNamespaceLabel] = model.LabelValue(req.GatewayNamespace)
 	}
 
 	if req.RemoteClusterName != "" {
-		labels[remoteClusterNameLabel] = model.LabelValue(req.RemoteClusterName)
+		labels[prometheus.RemoteClusterNameLabel] = model.LabelValue(req.RemoteClusterName)
 	}
 
-	groupBy := model.LabelNames{gatewayNamespaceLabel, remoteClusterNameLabel, gatewayNameLabel}
+	groupBy := model.LabelNames{prometheus.GatewayNamespaceLabel, prometheus.RemoteClusterNameLabel, prometheus.GatewayNameLabel}
 
 	return labels, groupBy
 }
@@ -80,7 +81,7 @@ func processPrometheusResult(results []promResult, numSvcMap map[string]uint64) 
 	for _, result := range results {
 		for _, sample := range result.vec {
 
-			clusterName := string(sample.Metric[remoteClusterNameLabel])
+			clusterName := string(sample.Metric[prometheus.RemoteClusterNameLabel])
 			numPairedSvc := numSvcMap[clusterName]
 
 			addRow := func() {

--- a/viz/metrics-api/policy.go
+++ b/viz/metrics-api/policy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
 	"github.com/prometheus/common/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -168,49 +169,49 @@ func (s *grpcServer) getPolicyMetrics(
 func buildServerRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet, labelNames model.LabelNames) {
 	if req.GetSelector().GetResource().GetNamespace() != "" {
 		labels = labels.Merge(model.LabelSet{
-			namespaceLabel: model.LabelValue(req.GetSelector().GetResource().GetNamespace()),
+			prometheus.NamespaceLabel: model.LabelValue(req.GetSelector().GetResource().GetNamespace()),
 		})
 	}
 	var groupBy model.LabelNames
 	if req.GetSelector().GetResource().GetType() == k8s.Server {
 		// note that metricToKey assumes the label ordering (..., namespace, name)
-		groupBy = model.LabelNames{serverKindLabel, namespaceLabel, serverNameLabel}
+		groupBy = model.LabelNames{prometheus.ServerKindLabel, prometheus.NamespaceLabel, prometheus.ServerNameLabel}
 		labels = labels.Merge(model.LabelSet{
-			serverKindLabel: model.LabelValue("server"),
+			prometheus.ServerKindLabel: model.LabelValue("server"),
 		})
 		if req.GetSelector().GetResource().GetName() != "" {
 			labels = labels.Merge(model.LabelSet{
-				serverNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
+				prometheus.ServerNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
 			})
 		}
 	} else if req.GetSelector().GetResource().GetType() == k8s.ServerAuthorization {
 		// note that metricToKey assumes the label ordering (..., namespace, name)
-		groupBy = model.LabelNames{namespaceLabel, authorizationNameLabel}
+		groupBy = model.LabelNames{prometheus.NamespaceLabel, prometheus.AuthorizationNameLabel}
 		labels = labels.Merge(model.LabelSet{
-			authorizationKindLabel: model.LabelValue("serverauthorization"),
+			prometheus.AuthorizationKindLabel: model.LabelValue("serverauthorization"),
 		})
 		if req.GetSelector().GetResource().GetName() != "" {
 			labels = labels.Merge(model.LabelSet{
-				authorizationNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
+				prometheus.AuthorizationNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
 			})
 		}
 	} else if req.GetSelector().GetResource().GetType() == k8s.AuthorizationPolicy {
 		// note that metricToKey assumes the label ordering (..., namespace, name)
-		groupBy = model.LabelNames{namespaceLabel, authorizationNameLabel}
+		groupBy = model.LabelNames{prometheus.NamespaceLabel, prometheus.AuthorizationNameLabel}
 		labels = labels.Merge(model.LabelSet{
-			authorizationKindLabel: model.LabelValue("authorizationpolicy"),
+			prometheus.AuthorizationKindLabel: model.LabelValue("authorizationpolicy"),
 		})
 		if req.GetSelector().GetResource().GetName() != "" {
 			labels = labels.Merge(model.LabelSet{
-				authorizationNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
+				prometheus.AuthorizationNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
 			})
 		}
 	} else if req.GetSelector().GetResource().GetType() == k8s.HTTPRoute {
 		// note that metricToKey assumes the label ordering (..., namespace, name)
-		groupBy = model.LabelNames{serverNameLabel, serverKindLabel, routeNameLabel, routeKindLabel, namespaceLabel, routeNameLabel}
+		groupBy = model.LabelNames{prometheus.ServerNameLabel, prometheus.ServerKindLabel, prometheus.RouteNameLabel, prometheus.RouteKindLabel, prometheus.NamespaceLabel, prometheus.RouteNameLabel}
 		if req.GetSelector().GetResource().GetName() != "" {
 			labels = labels.Merge(model.LabelSet{
-				routeNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
+				prometheus.RouteNameLabel: model.LabelValue(req.GetSelector().GetResource().GetName()),
 			})
 		}
 	}
@@ -220,7 +221,7 @@ func buildServerRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet
 		// if --to flag is passed, Calculate traffic sent to the policy resource
 		// with additional filtering narrowing down to the workload
 		// it is sent to.
-		labels = labels.Merge(promQueryLabels(out.ToResource))
+		labels = labels.Merge(prometheus.PromQueryLabels(out.ToResource))
 
 	// No FromResource case as policy metrics are all inbound
 	default:

--- a/viz/metrics-api/policy.go
+++ b/viz/metrics-api/policy.go
@@ -221,7 +221,7 @@ func buildServerRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet
 		// if --to flag is passed, Calculate traffic sent to the policy resource
 		// with additional filtering narrowing down to the workload
 		// it is sent to.
-		labels = labels.Merge(prometheus.PromQueryLabels(out.ToResource))
+		labels = labels.Merge(prometheus.QueryLabels(out.ToResource))
 
 	// No FromResource case as policy metrics are all inbound
 	default:

--- a/viz/metrics-api/prometheus.go
+++ b/viz/metrics-api/prometheus.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/linkerd/linkerd2/pkg/k8s"
-	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -35,19 +33,6 @@ const (
 	promLatencyP50      = promType("0.5")
 	promLatencyP95      = promType("0.95")
 	promLatencyP99      = promType("0.99")
-
-	namespaceLabel         = model.LabelName("namespace")
-	dstNamespaceLabel      = model.LabelName("dst_namespace")
-	gatewayNameLabel       = model.LabelName("gateway_name")
-	gatewayNamespaceLabel  = model.LabelName("gateway_namespace")
-	remoteClusterNameLabel = model.LabelName("target_cluster_name")
-	authorityLabel         = model.LabelName("authority")
-	serverKindLabel        = model.LabelName("srv_kind")
-	serverNameLabel        = model.LabelName("srv_name")
-	authorizationKindLabel = model.LabelName("authz_kind")
-	authorizationNameLabel = model.LabelName("authz_name")
-	routeKindLabel         = model.LabelName("route_kind")
-	routeNameLabel         = model.LabelName("route_name")
 )
 
 var (
@@ -91,74 +76,6 @@ func (s *grpcServer) queryProm(ctx context.Context, query string) (model.Vector,
 	return res.(model.Vector), nil
 }
 
-// add filtering by resource type
-// note that metricToKey assumes the label ordering (namespace, name)
-func promGroupByLabelNames(resource *pb.Resource) model.LabelNames {
-	names := model.LabelNames{namespaceLabel}
-
-	if resource.Type != k8s.Namespace {
-		names = append(names, promResourceType(resource))
-	}
-	return names
-}
-
-// add filtering by resource type
-// note that metricToKey assumes the label ordering (namespace, name)
-func promDstGroupByLabelNames(resource *pb.Resource) model.LabelNames {
-	names := model.LabelNames{dstNamespaceLabel}
-
-	if isNonK8sResourceQuery(resource.GetType()) {
-		names = append(names, promResourceType(resource))
-	} else if resource.Type != k8s.Namespace {
-		names = append(names, "dst_"+promResourceType(resource))
-	}
-	return names
-}
-
-// query a named resource
-func promQueryLabels(resource *pb.Resource) model.LabelSet {
-	set := model.LabelSet{}
-	if resource != nil {
-		if resource.Name != "" {
-			if resource.GetType() == k8s.Server {
-				set[serverKindLabel] = model.LabelValue("server")
-				set[serverNameLabel] = model.LabelValue(resource.GetName())
-			} else if resource.GetType() == k8s.ServerAuthorization {
-				set[authorizationKindLabel] = model.LabelValue("serverauthorization")
-				set[authorizationNameLabel] = model.LabelValue(resource.GetName())
-			} else if resource.GetType() == k8s.AuthorizationPolicy {
-				set[authorizationKindLabel] = model.LabelValue("authorizationpolicy")
-				set[authorizationNameLabel] = model.LabelValue(resource.GetName())
-			} else if resource.GetType() == k8s.HTTPRoute {
-				set[routeNameLabel] = model.LabelValue(resource.GetName())
-			} else if resource.GetType() != k8s.Service {
-				set[promResourceType(resource)] = model.LabelValue(resource.Name)
-			}
-		}
-		if shouldAddNamespaceLabel(resource) {
-			set[namespaceLabel] = model.LabelValue(resource.Namespace)
-		}
-	}
-	return set
-}
-
-// query a named resource
-func promDstQueryLabels(resource *pb.Resource) model.LabelSet {
-	set := model.LabelSet{}
-	if resource.Name != "" {
-		if isNonK8sResourceQuery(resource.GetType()) {
-			set[promResourceType(resource)] = model.LabelValue(resource.Name)
-		} else {
-			set["dst_"+promResourceType(resource)] = model.LabelValue(resource.Name)
-			if shouldAddNamespaceLabel(resource) {
-				set[dstNamespaceLabel] = model.LabelValue(resource.Namespace)
-			}
-		}
-	}
-
-	return set
-}
-
 // insert a not-nil check into a LabelSet to verify that data for a specified
 // label name exists. due to the `!=` this must be inserted as a string. the
 // structure of this code is taken from the Prometheus labelset.go library.
@@ -198,11 +115,6 @@ func generateQuantileQueries(quantileQuery, labels, timeWindow, groupBy string) 
 	}
 }
 
-// determine if we should add "namespace=<namespace>" to a named query
-func shouldAddNamespaceLabel(resource *pb.Resource) bool {
-	return resource.Type != k8s.Namespace && resource.Namespace != ""
-}
-
 // query for inbound or outbound requests
 func promDirectionLabels(direction string) model.LabelSet {
 	return model.LabelSet{
@@ -214,11 +126,6 @@ func promPeerLabel(peer string) model.LabelSet {
 	return model.LabelSet{
 		model.LabelName("peer"): model.LabelValue(peer),
 	}
-}
-
-func promResourceType(resource *pb.Resource) model.LabelName {
-	l5dLabel := k8s.KindToL5DLabel(resource.Type)
-	return model.LabelName(l5dLabel)
 }
 
 func (s *grpcServer) getPrometheusMetrics(ctx context.Context, requestQueries map[promType]string, latencyQueries map[promType]string) ([]promResult, error) {

--- a/viz/metrics-api/stat_summary.go
+++ b/viz/metrics-api/stat_summary.go
@@ -427,23 +427,23 @@ func buildRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet, labe
 
 	switch out := req.Outbound.(type) {
 	case *pb.StatSummaryRequest_ToResource:
-		labelNames = prometheus.PromGroupByLabelNames(req.Selector.Resource)
+		labelNames = prometheus.GroupByLabelNames(req.Selector.Resource)
 
-		labels = labels.Merge(prometheus.PromDstQueryLabels(out.ToResource))
-		labels = labels.Merge(prometheus.PromQueryLabels(req.Selector.Resource))
+		labels = labels.Merge(prometheus.DstQueryLabels(out.ToResource))
+		labels = labels.Merge(prometheus.QueryLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 
 	case *pb.StatSummaryRequest_FromResource:
-		labelNames = prometheus.PromDstGroupByLabelNames(req.Selector.Resource)
+		labelNames = prometheus.DstGroupByLabelNames(req.Selector.Resource)
 
-		labels = labels.Merge(prometheus.PromQueryLabels(out.FromResource))
-		labels = labels.Merge(prometheus.PromDstQueryLabels(req.Selector.Resource))
+		labels = labels.Merge(prometheus.QueryLabels(out.FromResource))
+		labels = labels.Merge(prometheus.DstQueryLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 
 	default:
-		labelNames = prometheus.PromGroupByLabelNames(req.Selector.Resource)
+		labelNames = prometheus.GroupByLabelNames(req.Selector.Resource)
 
-		labels = labels.Merge(prometheus.PromQueryLabels(req.Selector.Resource))
+		labels = labels.Merge(prometheus.QueryLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("inbound"))
 	}
 
@@ -463,11 +463,11 @@ func buildServiceRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSe
 		// if --to flag is passed, Calculate traffic sent to the service
 		// with additional filtering narrowing down to the workload
 		// it is sent to.
-		labels = labels.Merge(prometheus.PromDstQueryLabels(out.ToResource))
+		labels = labels.Merge(prometheus.DstQueryLabels(out.ToResource))
 
 	case *pb.StatSummaryRequest_FromResource:
 		// if --from flag is passed, FromResource is never a service here
-		labels = labels.Merge(prometheus.PromQueryLabels(out.FromResource))
+		labels = labels.Merge(prometheus.QueryLabels(out.FromResource))
 
 	default:
 		// no extra labels needed

--- a/viz/metrics-api/stat_summary.go
+++ b/viz/metrics-api/stat_summary.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
 	vizutil "github.com/linkerd/linkerd2/viz/pkg/util"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
@@ -124,7 +125,7 @@ func (s *grpcServer) StatSummary(ctx context.Context, req *pb.StatSummaryRequest
 		statReq.Selector.Resource.Type = resource
 
 		go func() {
-			if isNonK8sResourceQuery(statReq.GetSelector().GetResource().GetType()) {
+			if prometheus.IsNonK8sResourceQuery(statReq.GetSelector().GetResource().GetType()) {
 				resultChan <- s.nonK8sResourceQuery(ctx, statReq)
 			} else if statReq.GetSelector().GetResource().GetType() == k8s.Service {
 				resultChan <- s.serviceResourceQuery(ctx, statReq)
@@ -397,10 +398,6 @@ func (s *grpcServer) nonK8sResourceQuery(ctx context.Context, req *pb.StatSummar
 	return resourceResult{res: &rsp, err: nil}
 }
 
-func isNonK8sResourceQuery(resourceType string) bool {
-	return resourceType == k8s.Authority
-}
-
 // get the list of objects for which we want to return results
 func getResultKeys(
 	req *pb.StatSummaryRequest,
@@ -430,23 +427,23 @@ func buildRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSet, labe
 
 	switch out := req.Outbound.(type) {
 	case *pb.StatSummaryRequest_ToResource:
-		labelNames = promGroupByLabelNames(req.Selector.Resource)
+		labelNames = prometheus.PromGroupByLabelNames(req.Selector.Resource)
 
-		labels = labels.Merge(promDstQueryLabels(out.ToResource))
-		labels = labels.Merge(promQueryLabels(req.Selector.Resource))
+		labels = labels.Merge(prometheus.PromDstQueryLabels(out.ToResource))
+		labels = labels.Merge(prometheus.PromQueryLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 
 	case *pb.StatSummaryRequest_FromResource:
-		labelNames = promDstGroupByLabelNames(req.Selector.Resource)
+		labelNames = prometheus.PromDstGroupByLabelNames(req.Selector.Resource)
 
-		labels = labels.Merge(promQueryLabels(out.FromResource))
-		labels = labels.Merge(promDstQueryLabels(req.Selector.Resource))
+		labels = labels.Merge(prometheus.PromQueryLabels(out.FromResource))
+		labels = labels.Merge(prometheus.PromDstQueryLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 
 	default:
-		labelNames = promGroupByLabelNames(req.Selector.Resource)
+		labelNames = prometheus.PromGroupByLabelNames(req.Selector.Resource)
 
-		labels = labels.Merge(promQueryLabels(req.Selector.Resource))
+		labels = labels.Merge(prometheus.PromQueryLabels(req.Selector.Resource))
 		labels = labels.Merge(promDirectionLabels("inbound"))
 	}
 
@@ -466,11 +463,11 @@ func buildServiceRequestLabels(req *pb.StatSummaryRequest) (labels model.LabelSe
 		// if --to flag is passed, Calculate traffic sent to the service
 		// with additional filtering narrowing down to the workload
 		// it is sent to.
-		labels = labels.Merge(promDstQueryLabels(out.ToResource))
+		labels = labels.Merge(prometheus.PromDstQueryLabels(out.ToResource))
 
 	case *pb.StatSummaryRequest_FromResource:
 		// if --from flag is passed, FromResource is never a service here
-		labels = labels.Merge(promQueryLabels(out.FromResource))
+		labels = labels.Merge(prometheus.PromQueryLabels(out.FromResource))
 
 	default:
 		// no extra labels needed
@@ -532,7 +529,7 @@ func (s *grpcServer) getServiceMetrics(ctx context.Context, req *pb.StatSummaryR
 	}
 	authority := fmt.Sprintf("%s.%s.svc.%s", service, namespace, s.clusterDomain)
 
-	reqLabels := generateLabelStringWithRegex(labels, string(authorityLabel), authority)
+	reqLabels := generateLabelStringWithRegex(labels, string(prometheus.AuthorityLabel), authority)
 
 	promQueries := map[promType]string{
 		promRequests: fmt.Sprintf(reqQuery, reqLabels, timeWindow, groupBy.String()),
@@ -541,7 +538,7 @@ func (s *grpcServer) getServiceMetrics(ctx context.Context, req *pb.StatSummaryR
 	if req.TcpStats {
 		// Service stats always need to have `peer=dst`, cuz there is no `src` with `authority` label
 		tcpLabels := labels.Merge(promPeerLabel("dst"))
-		tcpLabelString := generateLabelStringWithRegex(tcpLabels, string(authorityLabel), authority)
+		tcpLabelString := generateLabelStringWithRegex(tcpLabels, string(prometheus.AuthorityLabel), authority)
 		promQueries[promTCPConnections] = fmt.Sprintf(tcpConnectionsQuery, tcpLabelString, groupBy.String())
 		promQueries[promTCPReadBytes] = fmt.Sprintf(tcpReadBytesQuery, tcpLabelString, timeWindow, groupBy.String())
 		promQueries[promTCPWriteBytes] = fmt.Sprintf(tcpWriteBytesQuery, tcpLabelString, timeWindow, groupBy.String())
@@ -610,16 +607,16 @@ func processPrometheusMetrics(req *pb.StatSummaryRequest, results []promResult, 
 
 			if authzStats[resource] == nil {
 				srv := pb.Resource{
-					Type: string(sample.Metric[serverKindLabel]),
-					Name: string(sample.Metric[serverNameLabel]),
+					Type: string(sample.Metric[prometheus.ServerKindLabel]),
+					Name: string(sample.Metric[prometheus.ServerNameLabel]),
 				}
 				route := pb.Resource{
-					Type: string(sample.Metric[routeKindLabel]),
-					Name: string(sample.Metric[routeNameLabel]),
+					Type: string(sample.Metric[prometheus.RouteKindLabel]),
+					Name: string(sample.Metric[prometheus.RouteNameLabel]),
 				}
 				authz := pb.Resource{
-					Type: string(sample.Metric[authorizationKindLabel]),
-					Name: string(sample.Metric[authorizationNameLabel]),
+					Type: string(sample.Metric[prometheus.AuthorizationKindLabel]),
+					Name: string(sample.Metric[prometheus.AuthorizationNameLabel]),
 				}
 				authzStats[resource] = &pb.ServerStats{
 					Srv:   &srv,

--- a/viz/metrics-api/top_routes.go
+++ b/viz/metrics-api/top_routes.go
@@ -11,6 +11,7 @@ import (
 	api "github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/linkerd/linkerd2/viz/pkg/prometheus"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
@@ -295,13 +296,13 @@ func (s *grpcServer) buildRouteLabels(req *pb.TopRoutesRequest, dsts []string, r
 	switch req.Outbound.(type) {
 
 	case *pb.TopRoutesRequest_ToResource:
-		labels = labels.Merge(promQueryLabels(resource))
+		labels = labels.Merge(prometheus.PromQueryLabels(resource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 		return renderLabels(labels, dsts)
 
 	default:
 		labels = labels.Merge(promDirectionLabels("inbound"))
-		labels = labels.Merge(promQueryLabels(resource))
+		labels = labels.Merge(prometheus.PromQueryLabels(resource))
 		return renderLabels(labels, dsts)
 	}
 }

--- a/viz/metrics-api/top_routes.go
+++ b/viz/metrics-api/top_routes.go
@@ -296,13 +296,13 @@ func (s *grpcServer) buildRouteLabels(req *pb.TopRoutesRequest, dsts []string, r
 	switch req.Outbound.(type) {
 
 	case *pb.TopRoutesRequest_ToResource:
-		labels = labels.Merge(prometheus.PromQueryLabels(resource))
+		labels = labels.Merge(prometheus.QueryLabels(resource))
 		labels = labels.Merge(promDirectionLabels("outbound"))
 		return renderLabels(labels, dsts)
 
 	default:
 		labels = labels.Merge(promDirectionLabels("inbound"))
-		labels = labels.Merge(prometheus.PromQueryLabels(resource))
+		labels = labels.Merge(prometheus.QueryLabels(resource))
 		return renderLabels(labels, dsts)
 	}
 }

--- a/viz/pkg/api/api.go
+++ b/viz/pkg/api/api.go
@@ -67,14 +67,14 @@ func exitOnError(result *healthcheck.CheckResult) {
 }
 
 func NewPrometheusClient(ctx context.Context, hcOptions vizHealthCheck.VizOptions, addr string) (promv1.API, error) {
-	checks := []healthcheck.CategoryID{
-		healthcheck.KubernetesAPIChecks,
-	}
-	hc := vizHealthCheck.NewHealthChecker(checks, &hcOptions)
-	hc.AppendCategories(hc.VizCategory(false))
-	hc.RunChecks(exitOnError)
-
 	if addr == "" {
+		checks := []healthcheck.CategoryID{
+			healthcheck.KubernetesAPIChecks,
+		}
+		hc := vizHealthCheck.NewHealthChecker(checks, &hcOptions)
+		hc.AppendCategories(hc.VizCategory(false))
+		hc.RunChecks(exitOnError)
+
 		if hc.ExternalPrometheusURL() == "" {
 			portforward, err := k8s.NewPortForward(
 				ctx,

--- a/viz/pkg/api/api.go
+++ b/viz/pkg/api/api.go
@@ -1,13 +1,17 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/k8s"
 	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	vizHealthCheck "github.com/linkerd/linkerd2/viz/pkg/healthcheck"
+	promApi "github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 // CheckClientOrExit builds a new Viz API client and executes default status
@@ -60,4 +64,46 @@ func exitOnError(result *healthcheck.CheckResult) {
 
 		os.Exit(1)
 	}
+}
+
+func NewPrometheusClient(ctx context.Context, hcOptions vizHealthCheck.VizOptions, addr string) (promv1.API, error) {
+	checks := []healthcheck.CategoryID{
+		healthcheck.KubernetesAPIChecks,
+	}
+	hc := vizHealthCheck.NewHealthChecker(checks, &hcOptions)
+	hc.AppendCategories(hc.VizCategory(false))
+	hc.RunChecks(exitOnError)
+
+	if addr == "" {
+		if hc.ExternalPrometheusURL() == "" {
+			portforward, err := k8s.NewPortForward(
+				ctx,
+				hc.KubeAPIClient(),
+				hc.VizNamespace(),
+				"prometheus",
+				"localhost",
+				0,
+				9090,
+				false,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			addr = fmt.Sprintf("http://%s", portforward.AddressAndPort())
+
+			if err = portforward.Init(); err != nil {
+				return nil, err
+			}
+		} else {
+			addr = hc.ExternalPrometheusURL()
+		}
+	}
+
+	promClient, err := promApi.NewClient(promApi.Config{Address: addr})
+	if err != nil {
+		return nil, err
+	}
+
+	return promv1.NewAPI(promClient), nil
 }

--- a/viz/pkg/healthcheck/healthcheck.go
+++ b/viz/pkg/healthcheck/healthcheck.go
@@ -71,6 +71,17 @@ func (hc *HealthChecker) VizAPIClient() pb.ApiClient {
 	return hc.vizAPIClient
 }
 
+// ExternalPrometheusURL returns URL of the external prometheus if one is
+// configured. Otherwise, it returns an empty string.
+func (hc *HealthChecker) ExternalPrometheusURL() string {
+	return hc.externalPrometheusURL
+}
+
+// VizNamespace returns the namespace where the viz extension is installed.
+func (hc *HealthChecker) VizNamespace() string {
+	return hc.vizNamespace
+}
+
 // RunChecks implements the healthcheck.Runner interface
 func (hc *HealthChecker) RunChecks(observer healthcheck.CheckObserver) (bool, bool) {
 	return hc.HealthChecker.RunChecks(observer)

--- a/viz/pkg/prometheus/prometheus.go
+++ b/viz/pkg/prometheus/prometheus.go
@@ -1,0 +1,104 @@
+package prometheus
+
+import (
+	"github.com/linkerd/linkerd2/pkg/k8s"
+	pb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	NamespaceLabel         = model.LabelName("namespace")
+	DstNamespaceLabel      = model.LabelName("dst_namespace")
+	GatewayNameLabel       = model.LabelName("gateway_name")
+	GatewayNamespaceLabel  = model.LabelName("gateway_namespace")
+	RemoteClusterNameLabel = model.LabelName("target_cluster_name")
+	AuthorityLabel         = model.LabelName("authority")
+	ServerKindLabel        = model.LabelName("srv_kind")
+	ServerNameLabel        = model.LabelName("srv_name")
+	AuthorizationKindLabel = model.LabelName("authz_kind")
+	AuthorizationNameLabel = model.LabelName("authz_name")
+	RouteKindLabel         = model.LabelName("route_kind")
+	RouteNameLabel         = model.LabelName("route_name")
+)
+
+// add filtering by resource type
+// note that metricToKey assumes the label ordering (namespace, name)
+func PromGroupByLabelNames(resource *pb.Resource) model.LabelNames {
+	names := model.LabelNames{NamespaceLabel}
+
+	if resource.Type != k8s.Namespace {
+		names = append(names, PromResourceType(resource))
+	}
+	return names
+}
+
+// query a named resource
+func PromQueryLabels(resource *pb.Resource) model.LabelSet {
+	set := model.LabelSet{}
+	if resource != nil {
+		if resource.Name != "" {
+			if resource.GetType() == k8s.Server {
+				set[ServerKindLabel] = model.LabelValue("server")
+				set[ServerNameLabel] = model.LabelValue(resource.GetName())
+			} else if resource.GetType() == k8s.ServerAuthorization {
+				set[AuthorizationKindLabel] = model.LabelValue("serverauthorization")
+				set[AuthorizationNameLabel] = model.LabelValue(resource.GetName())
+			} else if resource.GetType() == k8s.AuthorizationPolicy {
+				set[AuthorizationKindLabel] = model.LabelValue("authorizationpolicy")
+				set[AuthorizationNameLabel] = model.LabelValue(resource.GetName())
+			} else if resource.GetType() == k8s.HTTPRoute {
+				set[RouteNameLabel] = model.LabelValue(resource.GetName())
+			} else if resource.GetType() != k8s.Service {
+				set[PromResourceType(resource)] = model.LabelValue(resource.Name)
+			}
+		}
+		if shouldAddNamespaceLabel(resource) {
+			set[NamespaceLabel] = model.LabelValue(resource.Namespace)
+		}
+	}
+	return set
+}
+
+// add filtering by resource type
+// note that metricToKey assumes the label ordering (namespace, name)
+func PromDstGroupByLabelNames(resource *pb.Resource) model.LabelNames {
+	names := model.LabelNames{DstNamespaceLabel}
+
+	if IsNonK8sResourceQuery(resource.GetType()) {
+		names = append(names, PromResourceType(resource))
+	} else if resource.Type != k8s.Namespace {
+		names = append(names, "dst_"+PromResourceType(resource))
+	}
+	return names
+}
+
+// query a named resource
+func PromDstQueryLabels(resource *pb.Resource) model.LabelSet {
+	set := model.LabelSet{}
+	if resource.Name != "" {
+		if IsNonK8sResourceQuery(resource.GetType()) {
+			set[PromResourceType(resource)] = model.LabelValue(resource.Name)
+		} else {
+			set["dst_"+PromResourceType(resource)] = model.LabelValue(resource.Name)
+			if shouldAddNamespaceLabel(resource) {
+				set[DstNamespaceLabel] = model.LabelValue(resource.Namespace)
+			}
+		}
+	}
+
+	return set
+}
+
+func PromResourceType(resource *pb.Resource) model.LabelName {
+	l5dLabel := k8s.KindToL5DLabel(resource.Type)
+	return model.LabelName(l5dLabel)
+}
+
+// determine if we should add "namespace=<namespace>" to a named query
+func shouldAddNamespaceLabel(resource *pb.Resource) bool {
+	return resource.Type != k8s.Namespace && resource.Namespace != ""
+}
+
+func IsNonK8sResourceQuery(resourceType string) bool {
+	return resourceType == k8s.Authority
+}

--- a/viz/pkg/prometheus/prometheus.go
+++ b/viz/pkg/prometheus/prometheus.go
@@ -23,17 +23,17 @@ const (
 
 // add filtering by resource type
 // note that metricToKey assumes the label ordering (namespace, name)
-func PromGroupByLabelNames(resource *pb.Resource) model.LabelNames {
+func GroupByLabelNames(resource *pb.Resource) model.LabelNames {
 	names := model.LabelNames{NamespaceLabel}
 
 	if resource.Type != k8s.Namespace {
-		names = append(names, PromResourceType(resource))
+		names = append(names, ResourceType(resource))
 	}
 	return names
 }
 
 // query a named resource
-func PromQueryLabels(resource *pb.Resource) model.LabelSet {
+func QueryLabels(resource *pb.Resource) model.LabelSet {
 	set := model.LabelSet{}
 	if resource != nil {
 		if resource.Name != "" {
@@ -49,7 +49,7 @@ func PromQueryLabels(resource *pb.Resource) model.LabelSet {
 			} else if resource.GetType() == k8s.HTTPRoute {
 				set[RouteNameLabel] = model.LabelValue(resource.GetName())
 			} else if resource.GetType() != k8s.Service {
-				set[PromResourceType(resource)] = model.LabelValue(resource.Name)
+				set[ResourceType(resource)] = model.LabelValue(resource.Name)
 			}
 		}
 		if shouldAddNamespaceLabel(resource) {
@@ -61,25 +61,25 @@ func PromQueryLabels(resource *pb.Resource) model.LabelSet {
 
 // add filtering by resource type
 // note that metricToKey assumes the label ordering (namespace, name)
-func PromDstGroupByLabelNames(resource *pb.Resource) model.LabelNames {
+func DstGroupByLabelNames(resource *pb.Resource) model.LabelNames {
 	names := model.LabelNames{DstNamespaceLabel}
 
 	if IsNonK8sResourceQuery(resource.GetType()) {
-		names = append(names, PromResourceType(resource))
+		names = append(names, ResourceType(resource))
 	} else if resource.Type != k8s.Namespace {
-		names = append(names, "dst_"+PromResourceType(resource))
+		names = append(names, "dst_"+ResourceType(resource))
 	}
 	return names
 }
 
 // query a named resource
-func PromDstQueryLabels(resource *pb.Resource) model.LabelSet {
+func DstQueryLabels(resource *pb.Resource) model.LabelSet {
 	set := model.LabelSet{}
 	if resource.Name != "" {
 		if IsNonK8sResourceQuery(resource.GetType()) {
-			set[PromResourceType(resource)] = model.LabelValue(resource.Name)
+			set[ResourceType(resource)] = model.LabelValue(resource.Name)
 		} else {
-			set["dst_"+PromResourceType(resource)] = model.LabelValue(resource.Name)
+			set["dst_"+ResourceType(resource)] = model.LabelValue(resource.Name)
 			if shouldAddNamespaceLabel(resource) {
 				set[DstNamespaceLabel] = model.LabelValue(resource.Namespace)
 			}
@@ -89,7 +89,7 @@ func PromDstQueryLabels(resource *pb.Resource) model.LabelSet {
 	return set
 }
 
-func PromResourceType(resource *pb.Resource) model.LabelName {
+func ResourceType(resource *pb.Resource) model.LabelName {
 	l5dLabel := k8s.KindToL5DLabel(resource.Type)
 	return model.LabelName(l5dLabel)
 }


### PR DESCRIPTION
We add two new commands to the linkerd viz extension: `linkerd viz stat-inbound` and `linkerd viz stat-outbound`.  These commands are meant as replacements for the `linkerd viz stat`.  The `linkerd viz stat` command provides stats when ServiceProfiles are used whereas the new commands provide stats when xRoute resources are used.  Either command can be used when no xRoute or ServiceProfile is used but the new commands include several improvements:

* Inbound and outbound stats are clearly separated into different commands rather than being contextual based on flag combinations
* Route level and backend level stats are displayed together in a tree-view in `linkerd viz stat-outbound` to easily see the effects of retries, timeouts, and traffic splitting

```
> linkerd viz stat-outbound -n schlep deploy                  
NAME         SERVICE      ROUTE           TYPE       BACKEND    SUCCESS   RPS  LATENCY_P50  LATENCY_P95  LATENCY_P99  TIMEOUTS  RETRIES  
client-http  schlep:80    schlep-default  HTTPRoute             100.00%  1.00         31ms        387ms        478ms     0.00%    6.25%  
                          └───────────────────────►  schlep:80   93.75%  1.07         16ms         88ms         98ms     1.56%           
client-grpc  schlep:8080  schlep-default  GRPCRoute              98.31%  0.98         36ms        425ms        485ms     0.00%    0.00%  
                          ├───────────────────────►  fail:8080   96.88%  0.53         12ms         24ms         25ms     0.00%           
                          └───────────────────────►  good:8080  100.00%  0.45         25ms         95ms         99ms     0.00%
```

```
> linkerd viz stat-inbound -n schlep deploy
NAME         SERVER          ROUTE      TYPE  SUCCESS   RPS  LATENCY_P50  LATENCY_P95  LATENCY_P99  
client-grpc  [default]:4191  [default]        100.00%  0.10          2ms          3ms          3ms  
client-grpc  [default]:4191  probe            100.00%  0.20          0ms          1ms          1ms  
client-http  [default]:4191  [default]        100.00%  0.10          2ms          2ms          2ms  
client-http  [default]:4191  probe            100.00%  0.20          0ms          1ms          1ms  
server-fail  [default]:4191  probe            100.00%  0.20          0ms          1ms          1ms  
server-fail  [default]:4191  [default]        100.00%  0.10          2ms          2ms          2ms  
server-fail  [default]:8080  [default]         94.87%  1.30          0ms          1ms          1ms  
server-good  [default]:4191  [default]        100.00%  0.10          0ms          1ms          1ms  
server-good  [default]:4191  probe            100.00%  0.20          0ms          1ms          1ms  
server-good  [default]:8080  [default]        100.00%  0.73          8ms         92ms         98ms  
server-slow  [default]:4191  [default]        100.00%  0.10          0ms          1ms          1ms  
server-slow  [default]:4191  probe            100.00%  0.20          0ms          1ms          1ms
```

Unlike the `linkerd viz stat` command, these commands query prometheus directly rather than going through the intermediary of the metrics-api.  If prometheus is enabled in linkerd-viz, these commands will use a port-forward to connect to that prometheus instance.  If an external prometheus is configured, these commands will attempt to use that prometheus URL; however note that the prometheus URL must be reachable from where the CLI is executed for this to work.  This can be overridden by a `--prometheusURL` flag.

Json and table output are both supported.