### PR TITLE
Allow configuring externalTrafficPolicy

### DIFF
--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -85,6 +85,7 @@ Kubernetes: `>=1.22.0-0`
 | gateway.probe.seconds | int | `3` | The interval (in seconds) between liveness probes |
 | gateway.replicas | int | `1` | Number of replicas for the gateway pod |
 | gateway.serviceAnnotations | object | `{}` | Annotations to add to the gateway service |
+| gateway.serviceExternalTrafficPolicy | string | `""` | Set externalTrafficPolicy on gateway service |
 | gateway.serviceType | string | `"LoadBalancer"` | Service Type of gateway Service |
 | gateway.terminationGracePeriodSeconds | string | `""` | Set terminationGracePeriodSeconds on gateway deployment |
 | gateway.tolerations | list | `[]` | Tolerations for the gateway pod |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -126,6 +126,9 @@ spec:
   selector:
     app: {{.Values.gateway.name}}
   type: {{ .Values.gateway.serviceType }}
+{{- with .Values.gateway.serviceExternalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+{{- end }}
 {{- if .Values.gateway.loadBalancerClass }}
   loadBalancerClass: {{ .Values.gateway.loadBalancerClass }}
 {{- end }}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -23,6 +23,8 @@ gateway:
     seconds: 3
   # -- Annotations to add to the gateway service
   serviceAnnotations: {}
+  # -- Set externalTrafficPolicy on gateway service
+  serviceExternalTrafficPolicy: ""
   # -- Annotations to add to the gateway deployment
   deploymentAnnotations: {}
   # -- Set loadBalancerClass on gateway service


### PR DESCRIPTION
The linkerd-multicluster helm chart does not allow changing the `externalTrafficPolicy` of the `linkerd-gateway` Service

Add `serviceExternalTrafficPolicy` to allow changing the value in the deployed service if needed.

Deploying the linkerd-multicluster chart with `serviceExternalTrafficPolicy: Local` will make the Service to be deployed with `externalTrafficPolicy: Local`

Fixes #13015

Signed-off-by: Lauri Kuittinen <lauriku@gmail.com>

