### PR TITLE
build: add image source label to all Dockerfiles

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -44,6 +44,7 @@ COPY proxy-identity proxy-identity
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/proxy-identity -mod=readonly -ldflags "-s -w" ./proxy-identity
 
 FROM $RUNTIME_IMAGE as runtime
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY --from=fetch /build/target/proxy/LICENSE /usr/lib/linkerd/LICENSE
 COPY --from=fetch /build/proxy-version /usr/lib/linkerd/linkerd2-proxy-version.txt
 COPY --from=fetch /build/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -76,6 +76,7 @@ RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd -tags prod -mod=readonly
 #
 
 FROM scratch as linux-amd64
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-amd64-full /out/linkerd /out/linkerd-linux-amd64
 # `ENTRYPOINT` prevents `docker build` from otherwise failing with "Error
@@ -83,31 +84,37 @@ COPY --from=linux-amd64-full /out/linkerd /out/linkerd-linux-amd64
 ENTRYPOINT ["/out/linkerd-linux-amd64"]
 
 FROM scratch as linux-arm64
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-arm64-full /out/linkerd /out/linkerd-linux-arm64
 ENTRYPOINT ["/out/linkerd-linux-arm64"]
 
 FROM scratch as linux-arm
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-arm64-full /out/linkerd /out/linkerd-linux-arm
 ENTRYPOINT ["/out/linkerd-linux-arm"]
 
 FROM scratch as darwin
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=darwin-full /out/linkerd /out/linkerd-darwin
 ENTRYPOINT ["/out/linkerd-darwin"]
 
 FROM scratch as darwin-arm64
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=darwin-arm64-full /out/linkerd /out/linkerd-darwin-arm64
 ENTRYPOINT ["/out/linkerd-darwin-arm64"]
 
 FROM scratch as windows
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=windows-full /out/linkerd /out/linkerd-windows
 ENTRYPOINT ["/out/linkerd-windows"]
 
 FROM scratch as multi-arch
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-amd64-full /out/linkerd /out/linkerd-linux-amd64
 COPY --from=linux-arm64-full /out/linkerd /out/linkerd-linux-arm64

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -27,6 +27,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/controller -tag
 
 ## package runtime
 FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/controller /controller
 # for heartbeat (https://versioncheck.linkerd.io/version.json)

--- a/jaeger/injector/Dockerfile
+++ b/jaeger/injector/Dockerfile
@@ -23,6 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/injector -tags 
 
 ## package runtime
 FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 ARG LINKERD_VERSION
 ENV LINKERD_CONTAINER_VERSION_OVERRIDE=${LINKERD_VERSION}
 COPY --from=golang /out/injector /injector

--- a/policy-controller/Dockerfile
+++ b/policy-controller/Dockerfile
@@ -22,5 +22,6 @@ RUN --mount=type=cache,target=target \
     mv "target/$target/$BUILD_TYPE/linkerd-policy-controller" /tmp/
 
 FROM scratch as runtime
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY --from=controller /tmp/linkerd-policy-controller /bin/
 ENTRYPOINT ["/bin/linkerd-policy-controller"]

--- a/viz/metrics-api/Dockerfile
+++ b/viz/metrics-api/Dockerfile
@@ -22,6 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/metrics-api -ta
 
 ## package runtime
 FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/metrics-api /metrics-api
 COPY --from=golang /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/viz/tap/Dockerfile
+++ b/viz/tap/Dockerfile
@@ -26,6 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/tap -tags prod 
 
 ## package runtime
 FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=golang /out/tap /tap
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -48,6 +48,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -mod=readonly -o web/we
 
 ## package it all up
 FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 WORKDIR /linkerd
 
 COPY LICENSE .


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->

Hello! 👋

This adds the [`org.opencontainers.image.source`](https://github.com/opencontainers/image-spec/blob/v1.1.0/annotations.md#pre-defined-annotation-keys) label to all Dockerfiles.

It allows tools to find the source repository for the produced images. In the case of [Renovate](https://docs.renovatebot.com/modules/datasource/docker/#description) and [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker), it allows them to enrich update PRs with the release notes.