### PR TITLE
Add timeout and failureThreshold to multicluster probe

### DIFF
--- a/multicluster/charts/linkerd-multicluster/README.md
+++ b/multicluster/charts/linkerd-multicluster/README.md
@@ -80,9 +80,11 @@ Kubernetes: `>=1.22.0-0`
 | gateway.nodeSelector | object | `{}` | Node selectors for the gateway pod |
 | gateway.pauseImage | string | `"gcr.io/google_containers/pause:3.2"` | The pause container to use |
 | gateway.port | int | `4143` | The port on which all the gateway will accept incoming traffic |
+| gateway.probe.failureThreshold | int | `3` | Minimum consecutive failures for the probe to be considered failed |
 | gateway.probe.path | string | `"/ready"` | The path that will be used by remote clusters for determining whether the gateway is alive |
 | gateway.probe.port | int | `4191` | The port used for liveliness probing |
 | gateway.probe.seconds | int | `3` | The interval (in seconds) between liveness probes |
+| gateway.probe.timeout | string | `"30s"` | Probe request timeout (in go's time.Duration format) |
 | gateway.replicas | int | `1` | Number of replicas for the gateway pod |
 | gateway.serviceAnnotations | object | `{}` | Annotations to add to the gateway service |
 | gateway.serviceExternalTrafficPolicy | string | `""` | Set externalTrafficPolicy on gateway service |

--- a/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/gateway.yaml
@@ -102,8 +102,10 @@ metadata:
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
   annotations:
     mirror.linkerd.io/gateway-identity: {{.Values.gateway.name}}.{{.Release.Namespace}}.serviceaccount.identity.{{.Values.linkerdNamespace}}.{{.Values.identityTrustDomain}}
+    mirror.linkerd.io/probe-failure-threshold: "{{.Values.gateway.probe.failureThreshold}}"
     mirror.linkerd.io/probe-period: "{{.Values.gateway.probe.seconds}}"
     mirror.linkerd.io/probe-path: {{.Values.gateway.probe.path}}
+    mirror.linkerd.io/probe-timeout: "{{.Values.gateway.probe.timeout}}"
     mirror.linkerd.io/multicluster-gateway: "true"
     component: gateway
     {{ include "partials.annotations.created-by" . }}

--- a/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
@@ -40,6 +40,10 @@ spec:
                 description: Spec for gateway health probe
                 type: object
                 properties:
+                  failureThreshold:
+                    default: "3"
+                    description: Minimum consecutive failures for the probe to be considered failed
+                    type: string
                   path:
                     description: Path of remote gateway health endpoint
                     type: string
@@ -48,6 +52,11 @@ spec:
                     type: string
                   port:
                     description: Port of remote gateway health endpoint
+                    type: string
+                  timeout:
+                    default: 30s
+                    description: Probe request timeout
+                    format: duration
                     type: string
               selector:
                 description: Kubernetes Label Selector

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -12,6 +12,8 @@ gateway:
   # nodePort -- Set the gateway nodePort (for LoadBalancer or NodePort) to a specific value
   # nodePort:
   probe:
+    # -- Minimum consecutive failures for the probe to be considered failed
+    failureThreshold: 3
     # -- The path that will be used by remote clusters for determining whether the
     # gateway is alive
     path: /ready
@@ -21,6 +23,8 @@ gateway:
     # nodePort:
     # -- The interval (in seconds) between liveness probes
     seconds: 3
+    # -- Probe request timeout (in go's time.Duration format)
+    timeout: 30s
   # -- Annotations to add to the gateway service
   serviceAnnotations: {}
   # -- Set externalTrafficPolicy on gateway service

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -68,8 +68,10 @@ metadata:
     linkerd.io/extension: multicluster
   annotations:
     mirror.linkerd.io/gateway-identity: linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.cluster.local
+    mirror.linkerd.io/probe-failure-threshold: "3"
     mirror.linkerd.io/probe-period: "3"
     mirror.linkerd.io/probe-path: /ready
+    mirror.linkerd.io/probe-timeout: "30s"
     mirror.linkerd.io/multicluster-gateway: "true"
     component: gateway
     linkerd.io/created-by: linkerd/helm linkerdVersionValue
@@ -277,6 +279,10 @@ spec:
                 description: Spec for gateway health probe
                 type: object
                 properties:
+                  failureThreshold:
+                    default: "3"
+                    description: Minimum consecutive failures for the probe to be considered failed
+                    type: string
                   path:
                     description: Path of remote gateway health endpoint
                     type: string
@@ -285,6 +291,11 @@ spec:
                     type: string
                   port:
                     description: Port of remote gateway health endpoint
+                    type: string
+                  timeout:
+                    default: 30s
+                    description: Probe request timeout
+                    format: duration
                     type: string
               selector:
                 description: Kubernetes Label Selector

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -106,8 +106,10 @@ metadata:
     linkerd.io/extension: multicluster
   annotations:
     mirror.linkerd.io/gateway-identity: linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.cluster.local
+    mirror.linkerd.io/probe-failure-threshold: "3"
     mirror.linkerd.io/probe-period: "3"
     mirror.linkerd.io/probe-path: /ready
+    mirror.linkerd.io/probe-timeout: "30s"
     mirror.linkerd.io/multicluster-gateway: "true"
     component: gateway
     linkerd.io/created-by: linkerd/helm linkerdVersionValue
@@ -349,6 +351,10 @@ spec:
                 description: Spec for gateway health probe
                 type: object
                 properties:
+                  failureThreshold:
+                    default: "3"
+                    description: Minimum consecutive failures for the probe to be considered failed
+                    type: string
                   path:
                     description: Path of remote gateway health endpoint
                     type: string
@@ -357,6 +363,11 @@ spec:
                     type: string
                   port:
                     description: Port of remote gateway health endpoint
+                    type: string
+                  timeout:
+                    default: 30s
+                    description: Probe request timeout
+                    format: duration
                     type: string
               selector:
                 description: Kubernetes Label Selector

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -68,8 +68,10 @@ metadata:
     linkerd.io/extension: multicluster
   annotations:
     mirror.linkerd.io/gateway-identity: linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.cluster.local
+    mirror.linkerd.io/probe-failure-threshold: "3"
     mirror.linkerd.io/probe-period: "3"
     mirror.linkerd.io/probe-path: /ready
+    mirror.linkerd.io/probe-timeout: "30s"
     mirror.linkerd.io/multicluster-gateway: "true"
     component: gateway
     linkerd.io/created-by: linkerd/helm linkerdVersionValue
@@ -311,6 +313,10 @@ spec:
                 description: Spec for gateway health probe
                 type: object
                 properties:
+                  failureThreshold:
+                    default: "3"
+                    description: Minimum consecutive failures for the probe to be considered failed
+                    type: string
                   path:
                     description: Path of remote gateway health endpoint
                     type: string
@@ -319,6 +325,11 @@ spec:
                     type: string
                   port:
                     description: Port of remote gateway health endpoint
+                    type: string
+                  timeout:
+                    default: 30s
+                    description: Probe request timeout
+                    format: duration
                     type: string
               selector:
                 description: Kubernetes Label Selector

--- a/multicluster/service-mirror/jittered_ticker.go
+++ b/multicluster/service-mirror/jittered_ticker.go
@@ -38,7 +38,7 @@ func NewTicker(minDuration time.Duration, maxJitter time.Duration) *Ticker {
 	if maxJitter < 0 {
 		log.WithField("jitter", minDuration).Panic("Negative jitter")
 	}
-	c := make(chan time.Time, 1)
+	c := make(chan time.Time)
 	ticker := &Ticker{
 		C:           c,
 		stop:        make(chan bool),

--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -62,10 +62,12 @@ type Gateway struct {
 
 // Probe contains all options for the Probe Service
 type Probe struct {
-	Path     string `json:"path"`
-	Port     uint32 `json:"port"`
-	NodePort uint32 `json:"nodePort"`
-	Seconds  uint32 `json:"seconds"`
+	FailureThreshold uint32 `json:"failureThreshold"`
+	Path             string `json:"path"`
+	Port             uint32 `json:"port"`
+	NodePort         uint32 `json:"nodePort"`
+	Seconds          uint32 `json:"seconds"`
+	Timeout          string `json:"timeout"`
 }
 
 // NewInstallValues returns a new instance of the Values type.

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -467,11 +467,17 @@ const (
 	// GatewayIdentity can be found on the remote gateway service
 	GatewayIdentity = SvcMirrorPrefix + "/gateway-identity"
 
+	// GatewayProbeFailureThreshold is the minimum consecutive failures for the probe to be considered failed
+	GatewayProbeFailureThreshold = SvcMirrorPrefix + "/probe-failure-threshold"
+
 	// GatewayProbePeriod the interval at which the health of the gateway should be probed
 	GatewayProbePeriod = SvcMirrorPrefix + "/probe-period"
 
 	// GatewayProbePath the path at which the health of the gateway should be probed
 	GatewayProbePath = SvcMirrorPrefix + "/probe-path"
+
+	// GatewayProbeTimeout is the probe request timeout
+	GatewayProbeTimeout = SvcMirrorPrefix + "/probe-timeout"
 
 	// ConfigKeyName is the key in the secret that stores the kubeconfig needed to connect
 	// to a remote cluster


### PR DESCRIPTION
This adds the `probeSpec.failureThreshold` and `probeSpec.timeout` fields to the Link CRD spec.

Likewise, the `gateway.probe.failureThreshold` and `gateway.probe.timeout` fields are added to the linkerd-multicluster chart, that are used to populate the new `mirror.linkerd.io/probe-failure-threshold` and `mirror.linkerd.io/probe-timeout` annotations in the gateway service (consumed by `linkerd mc link` to populate probe spec).

In the probe worker, we replace the hard-coded 50s timeout with the new timeout config (which now defaults to 30s). And the probe loop got refactored in order to not mark the gateway as unhealty until the consecutive failures threshold is reached.