### PR TITLE
Allow configuring proxy trace export protocol

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -125,6 +125,7 @@ Kubernetes: `>=1.22.0-0`
 | webhook.caBundle | string | `""` | Bundle of CA certificates for webhook. If not provided nor injected with cert-manager, then Helm will use the certificate generated for `webhook.crtPEM`. If `webhook.externalSecret` is set to true, this value, injectCaFrom, or injectCaFromSecret must be set, as no certificate will be generated. See the cert-manager [CA Injector Docs](https://cert-manager.io/docs/concepts/ca-injector) for more information. |
 | webhook.collectorSvcAccount | string | `"collector"` | service account associated with the collector instance |
 | webhook.collectorSvcAddr | string | `"collector.linkerd-jaeger:55678"` | collector service address for the proxies to send trace data. Points by default to the linkerd-jaeger collector |
+| webhook.collectorTraceProtocol | string | `"opencensus"` | protocol proxies should use to send trace data. Can be `opencensus` (default) or `opentelemetry` |
 | webhook.crtPEM | string | `""` | Certificate for the webhook. If not provided and not using an external secret then Helm will generate one. |
 | webhook.externalSecret | bool | `false` | Do not create a secret resource for the webhook. If this is set to `true`, the value `webhook.caBundle` must be set or the ca bundle must injected with cert-manager ca injector using `webhook.injectCaFrom` or `webhook.injectCaFromSecret` (see below). |
 | webhook.failurePolicy | string | `"Ignore"` |  |

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -50,6 +50,7 @@ spec:
       containers:
       - args:
         - -collector-svc-addr={{.Values.webhook.collectorSvcAddr}}
+        - -collector-trace-protocol={{.Values.webhook.collectorTraceProtocol}}
         - -collector-svc-account={{.Values.webhook.collectorSvcAccount}}
         - -log-level={{.Values.webhook.logLevel}}
         - -cluster-domain={{.Values.clusterDomain}}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -102,6 +102,9 @@ collector:
   config:
     receivers:
       opencensus:
+      otlp:
+        protocols:
+          grpc:
     processors:
       batch:
       resource:
@@ -177,7 +180,7 @@ collector:
       extensions: [health_check]
       pipelines:
         traces:
-          receivers: [opencensus]
+          receivers: [opencensus, otlp]
           processors: [resource, k8sattributes, batch]
           exporters: [jaeger]
 
@@ -290,6 +293,9 @@ webhook:
   # -- collector service address for the proxies to send trace data.
   # Points by default to the linkerd-jaeger collector
   collectorSvcAddr: collector.linkerd-jaeger:55678
+  # -- protocol proxies should use to send trace data.
+  # Can be `opencensus` (default) or `opentelemetry`
+  collectorTraceProtocol: opencensus
   # -- service account associated with the collector instance
   collectorSvcAccount: collector
 

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -46,6 +46,7 @@ spec:
       containers:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
+        - -collector-trace-protocol=opencensus
         - -collector-svc-account=collector
         - -log-level=info
         - -cluster-domain=cluster.local

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -46,6 +46,7 @@ spec:
       containers:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
+        - -collector-trace-protocol=opencensus
         - -collector-svc-account=collector
         - -log-level=info
         - -cluster-domain=cluster.local
@@ -371,6 +372,9 @@ data:
           key: k8s.namespace.name
     receivers:
       opencensus: null
+      otlp:
+        protocols:
+          grpc: null
     service:
       extensions:
       - health_check
@@ -384,6 +388,7 @@ data:
           - batch
           receivers:
           - opencensus
+          - otlp
 ---
 apiVersion: v1
 kind: Service
@@ -444,7 +449,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 319d95c61f89ff68538c097cca12358ac58383e2c1d93fe3d92e35c501b0541a
+        checksum/config: a5b9a0f939a556548f732f80a6cfe7b27a55f1c309ad2decacd1ce63d469d4a3
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
         config.linkerd.io/proxy-await: "enabled"

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -46,6 +46,7 @@ spec:
       containers:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
+        - -collector-trace-protocol=opencensus
         - -collector-svc-account=collector
         - -log-level=info
         - -cluster-domain=cluster.local
@@ -360,6 +361,9 @@ data:
           key: k8s.namespace.name
     receivers:
       opencensus: null
+      otlp:
+        protocols:
+          grpc: null
     service:
       extensions:
       - health_check
@@ -373,6 +377,7 @@ data:
           - batch
           receivers:
           - opencensus
+          - otlp
 ---
 apiVersion: v1
 kind: Service
@@ -433,7 +438,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 319d95c61f89ff68538c097cca12358ac58383e2c1d93fe3d92e35c501b0541a
+        checksum/config: a5b9a0f939a556548f732f80a6cfe7b27a55f1c309ad2decacd1ce63d469d4a3
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
         config.linkerd.io/proxy-await: "enabled"

--- a/jaeger/injector/cmd/main.go
+++ b/jaeger/injector/cmd/main.go
@@ -20,6 +20,8 @@ func main() {
 	kubeconfig := cmd.String("kubeconfig", "", "path to kubeconfig")
 	collectorSvcAddr := cmd.String("collector-svc-addr", "",
 		"collector service address for the proxies to send trace data")
+	collectorTraceProtocol := cmd.String("collector-trace-protocol", "",
+		"protocol proxies should use to send trace data.")
 	collectorSvcAccount := cmd.String("collector-svc-account", "",
 		"service account associated with the collector instance")
 	clusterDomain := cmd.String("cluster-domain", "cluster.local", "kubernetes cluster domain")
@@ -31,7 +33,7 @@ func main() {
 	webhook.Launch(
 		context.Background(),
 		[]k8s.APIResource{k8s.NS},
-		mutator.Mutate(*collectorSvcAddr, *collectorSvcAccount, *clusterDomain, *linkerdNamespace),
+		mutator.Mutate(*collectorSvcAddr, *collectorTraceProtocol, *collectorSvcAccount, *clusterDomain, *linkerdNamespace),
 		"linkerd-jaeger-injector",
 		*metricsAddr,
 		*addr,

--- a/jaeger/injector/mutator/patch.go
+++ b/jaeger/injector/mutator/patch.go
@@ -26,6 +26,14 @@ const tpl = `[
     "op": "add",
     "path": "/spec/{{.ProxyPath}}/env/-",
     "value": {
+      "name": "LINKERD2_PROXY_TRACE_PROTOCOL",
+      "value": "{{.CollectorTraceProtocol}}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/{{.ProxyPath}}/env/-",
+    "value": {
       "name": "LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME",
       "value": "{{.CollectorSvcAccount}}.serviceaccount.identity.{{.LinkerdNamespace}}.{{.ClusterDomain}}"
     }


### PR DESCRIPTION
Allows setting the trace export protocol env var (`LINKERD2_PROXY_TRACE_PROTOCOL`) on instances of the proxy using the existing mechanisms we have today for setting the trace collector endpoint (helm values, annotations, etc.).

Currently defaults the protocol to `opencensus` to match the behavior we have today.

#10111