### PR TITLE
Export zone locality in outbound destination metrics

### DIFF
--- a/controller/api/destination/endpoint_translator_test.go
+++ b/controller/api/destination/endpoint_translator_test.go
@@ -485,6 +485,7 @@ func TestEndpointTranslatorForPods(t *testing.T) {
 			"serviceaccount":        "serviceaccount-name",
 			"control_plane_ns":      "linkerd",
 			"zone":                  "",
+			"zone_locality":         "unknown",
 		}
 		if diff := deep.Equal(actualAddedAddress1MetricLabels, expectedAddedAddress1MetricLabels); diff != nil {
 			t.Fatalf("Expected global metric labels sent to be [%v] but was [%v]", expectedAddedAddress1MetricLabels, actualAddedAddress1MetricLabels)
@@ -658,6 +659,7 @@ func TestEndpointTranslatorExternalWorkloads(t *testing.T) {
 		expectedAddedAddress1MetricLabels := map[string]string{
 			"external_workload": "ew-1",
 			"zone":              "",
+			"zone_locality":     "unknown",
 			"workloadgroup":     "wg-name",
 		}
 		if diff := deep.Equal(actualAddedAddress1MetricLabels, expectedAddedAddress1MetricLabels); diff != nil {


### PR DESCRIPTION
Currently, we don't have a simple way of checking if the endpoint a proxy is discovering is in the same zone or not.

This adds a "zone_locality" metric label to the outbound destination address metrics. Note that this does not increase the cardinality of the related metrics, as this label doesn't vary within an endpoint.

Validated by checking the prometheus metrics on a local cluster and verifying this label appears in the outbound transport metrics.