### PR TITLE
Add configuration for proxy trace service name

### DIFF
--- a/jaeger/charts/linkerd-jaeger/README.md
+++ b/jaeger/charts/linkerd-jaeger/README.md
@@ -126,6 +126,7 @@ Kubernetes: `>=1.22.0-0`
 | webhook.collectorSvcAccount | string | `"collector"` | service account associated with the collector instance |
 | webhook.collectorSvcAddr | string | `"collector.linkerd-jaeger:55678"` | collector service address for the proxies to send trace data. Points by default to the linkerd-jaeger collector |
 | webhook.collectorTraceProtocol | string | `"opencensus"` | protocol proxies should use to send trace data. Can be `opencensus` (default) or `opentelemetry` |
+| webhook.collectorTraceSvcName | string | `"linkerd-proxy"` | name of the service proxies should use for exported traces |
 | webhook.crtPEM | string | `""` | Certificate for the webhook. If not provided and not using an external secret then Helm will generate one. |
 | webhook.externalSecret | bool | `false` | Do not create a secret resource for the webhook. If this is set to `true`, the value `webhook.caBundle` must be set or the ca bundle must injected with cert-manager ca injector using `webhook.injectCaFrom` or `webhook.injectCaFromSecret` (see below). |
 | webhook.failurePolicy | string | `"Ignore"` |  |

--- a/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/jaeger-injector.yaml
@@ -51,6 +51,7 @@ spec:
       - args:
         - -collector-svc-addr={{.Values.webhook.collectorSvcAddr}}
         - -collector-trace-protocol={{.Values.webhook.collectorTraceProtocol}}
+        - -collector-trace-svc-name={{.Values.webhook.collectorTraceSvcName}}
         - -collector-svc-account={{.Values.webhook.collectorSvcAccount}}
         - -log-level={{.Values.webhook.logLevel}}
         - -cluster-domain={{.Values.clusterDomain}}

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -296,6 +296,8 @@ webhook:
   # -- protocol proxies should use to send trace data.
   # Can be `opencensus` (default) or `opentelemetry`
   collectorTraceProtocol: opencensus
+  # -- name of the service proxies should use for exported traces
+  collectorTraceSvcName: linkerd-proxy
   # -- service account associated with the collector instance
   collectorSvcAccount: collector
 

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -47,6 +47,7 @@ spec:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
         - -collector-trace-protocol=opencensus
+        - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector
         - -log-level=info
         - -cluster-domain=cluster.local

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -47,6 +47,7 @@ spec:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
         - -collector-trace-protocol=opencensus
+        - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector
         - -log-level=info
         - -cluster-domain=cluster.local

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -47,6 +47,7 @@ spec:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
         - -collector-trace-protocol=opencensus
+        - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector
         - -log-level=info
         - -cluster-domain=cluster.local

--- a/jaeger/injector/cmd/main.go
+++ b/jaeger/injector/cmd/main.go
@@ -22,6 +22,8 @@ func main() {
 		"collector service address for the proxies to send trace data")
 	collectorTraceProtocol := cmd.String("collector-trace-protocol", "",
 		"protocol proxies should use to send trace data.")
+	collectorTraceSvcName := cmd.String("collector-trace-svc-name", "",
+		"name of the service proxies should use for exported traces.")
 	collectorSvcAccount := cmd.String("collector-svc-account", "",
 		"service account associated with the collector instance")
 	clusterDomain := cmd.String("cluster-domain", "cluster.local", "kubernetes cluster domain")
@@ -33,7 +35,7 @@ func main() {
 	webhook.Launch(
 		context.Background(),
 		[]k8s.APIResource{k8s.NS},
-		mutator.Mutate(*collectorSvcAddr, *collectorTraceProtocol, *collectorSvcAccount, *clusterDomain, *linkerdNamespace),
+		mutator.Mutate(*collectorSvcAddr, *collectorTraceProtocol, *collectorTraceSvcName, *collectorSvcAccount, *clusterDomain, *linkerdNamespace),
 		"linkerd-jaeger-injector",
 		*metricsAddr,
 		*addr,

--- a/jaeger/injector/mutator/patch.go
+++ b/jaeger/injector/mutator/patch.go
@@ -34,6 +34,14 @@ const tpl = `[
     "op": "add",
     "path": "/spec/{{.ProxyPath}}/env/-",
     "value": {
+      "name": "LINKERD2_PROXY_TRACE_SERVICE_NAME",
+      "value": "{{.CollectorTraceSvcName}}"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/{{.ProxyPath}}/env/-",
+    "value": {
       "name": "LINKERD2_PROXY_TRACE_COLLECTOR_SVC_NAME",
       "value": "{{.CollectorSvcAccount}}.serviceaccount.identity.{{.LinkerdNamespace}}.{{.ClusterDomain}}"
     }

--- a/jaeger/injector/mutator/webhook.go
+++ b/jaeger/injector/mutator/webhook.go
@@ -22,6 +22,7 @@ import (
 const (
 	collectorSvcAddrAnnotation       = l5dLabels.ProxyConfigAnnotationsPrefix + "/trace-collector"
 	collectorTraceProtocolAnnotation = l5dLabels.ProxyConfigAnnotationsPrefix + "/trace-collector-protocol"
+	collectorTraceSvcNameAnnotation  = l5dLabels.ProxyConfigAnnotationsPrefix + "/trace-collector-name"
 	collectorSvcAccountAnnotation    = l5dLabels.ProxyConfigAnnotationsPrefixAlpha +
 		"/trace-collector-service-account"
 )
@@ -31,6 +32,7 @@ type Params struct {
 	ProxyPath              string
 	CollectorSvcAddr       string
 	CollectorTraceProtocol string
+	CollectorTraceSvcName  string
 	CollectorSvcAccount    string
 	ClusterDomain          string
 	LinkerdNamespace       string
@@ -38,7 +40,7 @@ type Params struct {
 
 // Mutate returns an AdmissionResponse containing the patch, if any, to apply
 // to the proxy
-func Mutate(collectorSvcAddr, collectorTraceProtocol, collectorSvcAccount, clusterDomain, linkerdNamespace string) webhook.Handler {
+func Mutate(collectorSvcAddr, collectorTraceProtocol, collectorTraceSvcName, collectorSvcAccount, clusterDomain, linkerdNamespace string) webhook.Handler {
 	return func(
 		_ context.Context,
 		api *k8s.MetadataAPI,
@@ -64,6 +66,7 @@ func Mutate(collectorSvcAddr, collectorTraceProtocol, collectorSvcAccount, clust
 			ProxyPath:              webhook.GetProxyContainerPath(pod.Spec),
 			CollectorSvcAddr:       collectorSvcAddr,
 			CollectorTraceProtocol: collectorTraceProtocol,
+			CollectorTraceSvcName:  collectorTraceSvcName,
 			CollectorSvcAccount:    collectorSvcAccount,
 			ClusterDomain:          clusterDomain,
 			LinkerdNamespace:       linkerdNamespace,
@@ -109,6 +112,9 @@ func applyOverrides(ns metav1.Object, pod *corev1.Pod, params *Params) {
 	}
 	if override, ok := ann[collectorTraceProtocolAnnotation]; ok {
 		params.CollectorTraceProtocol = override
+	}
+	if override, ok := ann[collectorTraceSvcNameAnnotation]; ok {
+		params.CollectorTraceSvcName = override
 	}
 	if override, ok := ann[collectorSvcAccountAnnotation]; ok {
 		params.CollectorSvcAccount = override


### PR DESCRIPTION
Companion to https://github.com/linkerd/linkerd2-proxy/pull/3245, exposes the configuration for the tracing service name in the proxy to the general linkerd config.

Similar in concept to https://github.com/linkerd/linkerd2/pull/12371, except the configuration lives entirely within the tracing injector config instead of going through the control plane.

Fixes #11157