### PR TITLE
policy: add `UnmeshedNetwork` resource

### DIFF
--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -226,6 +226,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list

--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -185,6 +185,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]

--- a/charts/linkerd-crds/templates/policy/unmeshed-network.yaml
+++ b/charts/linkerd-crds/templates/policy/unmeshed-network.yaml
@@ -60,4 +60,4 @@ spec:
                 default: ["0.0.0.0/0", "::/0"]
             type: object
             required:
-            - defaultPolicy
+            - trafficPolicy

--- a/charts/linkerd-crds/templates/policy/unmeshed-network.yaml
+++ b/charts/linkerd-crds/templates/policy/unmeshed-network.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: unmeshednetworks.policy.linkerd.io
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    linkerd.io/control-plane-ns: {{.Release.Namespace}}
+spec:
+  group: policy.linkerd.io
+  names:
+    categories:
+    - policy
+    kind: UnmeshedNetwork
+    listKind: UnmeshedNetworkList
+    plural: unmeshednetworks
+    singular: unmeshednetwork
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: >-
+          An UnmeshedNetwork captures traffic to destinations considered
+          to be external to the mesh.
+        type: object
+        required: [spec]
+        properties:
+          apiVerson:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaultPolicy:
+                type: string
+                enum:
+                - AllowAll
+                - DenyAll
+              networks:
+                type: array
+                items:
+                  type: string
+                default: ["0.0.0.0/0", "::/0"]
+            type: object
+            required:
+            - defaultPolicy

--- a/charts/linkerd-crds/templates/policy/unmeshed-network.yaml
+++ b/charts/linkerd-crds/templates/policy/unmeshed-network.yaml
@@ -38,11 +38,21 @@ spec:
             type: object
           spec:
             properties:
-              defaultPolicy:
+              trafficPolicy:
+                description: >-
+                  This field controls the traffic policy enforced upon traffic
+                  that does not match any explicit route resources associated
+                  with an instance of this object. The values that are allowed
+                  currently are:
+                   - AllowUnknown - permits all traffic, even if it has not been
+                                    explicitly described via attaching an xRoute
+                                    resources.
+                   - DenyUnknown - blocks all traffic that has not been described via
+                                   attaching an xRoute resource.
                 type: string
                 enum:
-                - AllowAll
-                - DenyAll
+                - AllowUnknown
+                - DenyUnknown
               networks:
                 type: array
                 items:

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -50,6 +50,7 @@ You can use the --ignore-cluster flag if you just want to generate the installat
 var (
 	TemplatesCrdFiles = []string{
 		"templates/policy/authorization-policy.yaml",
+		"templates/policy/unmeshed-network.yaml",
 		"templates/policy/httproute.yaml",
 		"templates/policy/meshtls-authentication.yaml",
 		"templates/policy/network-authentication.yaml",

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1312,7 +1313,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1311,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -101,6 +101,59 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: unmeshednetworks.policy.linkerd.io
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    helm.sh/chart: linkerd-crds-0.0.0-undefined
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: policy.linkerd.io
+  names:
+    categories:
+    - policy
+    kind: UnmeshedNetwork
+    listKind: UnmeshedNetworkList
+    plural: unmeshednetworks
+    singular: unmeshednetwork
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: >-
+          An UnmeshedNetwork captures traffic to destinations considered
+          to be external to the mesh.
+        type: object
+        required: [spec]
+        properties:
+          apiVerson:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaultPolicy:
+                type: string
+                enum:
+                - AllowAll
+                - DenyAll
+              networks:
+                type: array
+                items:
+                  type: string
+                default: ["0.0.0.0/0", "::/0"]
+            type: object
+            required:
+            - defaultPolicy
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: httproutes.policy.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -159,7 +159,7 @@ spec:
                 default: ["0.0.0.0/0", "::/0"]
             type: object
             required:
-            - defaultPolicy
+            - trafficPolicy
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -137,11 +137,21 @@ spec:
             type: object
           spec:
             properties:
-              defaultPolicy:
+              trafficPolicy:
+                description: >-
+                  This field controls the traffic policy enforced upon traffic
+                  that does not match any explicit route resources associated
+                  with an instance of this object. The values that are allowed
+                  currently are:
+                   - AllowUnknown - permits all traffic, even if it has not been
+                                    explicitly described via attaching an xRoute
+                                    resources.
+                   - DenyUnknown - blocks all traffic that has not been described via
+                                   attaching an xRoute resource.
                 type: string
                 enum:
-                - AllowAll
-                - DenyAll
+                - AllowUnknown
+                - DenyUnknown
               networks:
                 type: array
                 items:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1311,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1310,7 +1311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1311,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1310,7 +1311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1311,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1310,7 +1311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1311,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1310,7 +1311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1301,7 +1302,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1302,7 +1303,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1314,7 +1315,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1315,7 +1316,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1414,7 +1415,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7245d5614cda8877ca536f3859d2734377d1939b3414186d02aff5e657cdbb36
+        checksum/config: f9322e4f6bb1dd4ea4a5bb03bce6d3feadf6089ef044c115396a26254a1a82f3
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1413,7 +1414,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 92d3d7185abd241437f7889dabe15a840b3b91f8910f9491ab10de3a1074ed6d
+        checksum/config: 7245d5614cda8877ca536f3859d2734377d1939b3414186d02aff5e657cdbb36
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1414,7 +1415,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7245d5614cda8877ca536f3859d2734377d1939b3414186d02aff5e657cdbb36
+        checksum/config: f9322e4f6bb1dd4ea4a5bb03bce6d3feadf6089ef044c115396a26254a1a82f3
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1413,7 +1414,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 92d3d7185abd241437f7889dabe15a840b3b91f8910f9491ab10de3a1074ed6d
+        checksum/config: 7245d5614cda8877ca536f3859d2734377d1939b3414186d02aff5e657cdbb36
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1242,7 +1243,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1241,7 +1242,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -172,6 +172,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1286,7 +1287,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: afe4a43b744d6ce7ae13a6a74ab72730871299b205071e6c96f8c5e19b6a37e3
+        checksum/config: 074af221fb5bbd6b3bc96c6aee168d6911786e90851551ad2beb20be8985684d
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -212,6 +212,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1285,7 +1286,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: aae2f97af199e93464b02da923a0732b603488c822241c14b2d86ba2bf6da03d
+        checksum/config: afe4a43b744d6ce7ae13a6a74ab72730871299b205071e6c96f8c5e19b6a37e3
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -172,6 +172,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1389,7 +1390,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47aa83bd3122b81ec49d7db1d0ac78ee879b7453fd94c18808f2d320ef1c9f04
+        checksum/config: ea41a9a611486495cbb5e088455e1e81e25ea2aa1574f63e3c9229ccb798be84
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -212,6 +212,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1388,7 +1389,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b4f4db151be1b48cf7ccff4b16df4d7eb45dee57b998d50cfe13eec8efbaac7
+        checksum/config: 47aa83bd3122b81ec49d7db1d0ac78ee879b7453fd94c18808f2d320ef1c9f04
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -212,6 +212,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1392,7 +1393,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b4f4db151be1b48cf7ccff4b16df4d7eb45dee57b998d50cfe13eec8efbaac7
+        checksum/config: 47aa83bd3122b81ec49d7db1d0ac78ee879b7453fd94c18808f2d320ef1c9f04
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -172,6 +172,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1393,7 +1394,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47aa83bd3122b81ec49d7db1d0ac78ee879b7453fd94c18808f2d320ef1c9f04
+        checksum/config: ea41a9a611486495cbb5e088455e1e81e25ea2aa1574f63e3c9229ccb798be84
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -163,7 +163,7 @@ spec:
                 default: ["0.0.0.0/0", "::/0"]
             type: object
             required:
-            - defaultPolicy
+            - trafficPolicy
 ---
 # Source: linkerd-crds/templates/policy/httproute.yaml
 ---

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -141,11 +141,21 @@ spec:
             type: object
           spec:
             properties:
-              defaultPolicy:
+              trafficPolicy:
+                description: >-
+                  This field controls the traffic policy enforced upon traffic
+                  that does not match any explicit route resources associated
+                  with an instance of this object. The values that are allowed
+                  currently are:
+                   - AllowUnknown - permits all traffic, even if it has not been
+                                    explicitly described via attaching an xRoute
+                                    resources.
+                   - DenyUnknown - blocks all traffic that has not been described via
+                                   attaching an xRoute resource.
                 type: string
                 enum:
-                - AllowAll
-                - DenyAll
+                - AllowUnknown
+                - DenyUnknown
               networks:
                 type: array
                 items:

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -100,6 +100,61 @@ spec:
                         maxLength: 253
                         type: string
 ---
+# Source: linkerd-crds/templates/policy/unmeshed-network.yaml
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: unmeshednetworks.policy.linkerd.io
+  annotations:
+    linkerd.io/created-by: linkerd/helm linkerd-version
+  labels:
+    helm.sh/chart: linkerd-crds-
+    linkerd.io/control-plane-ns: linkerd-dev
+spec:
+  group: policy.linkerd.io
+  names:
+    categories:
+    - policy
+    kind: UnmeshedNetwork
+    listKind: UnmeshedNetworkList
+    plural: unmeshednetworks
+    singular: unmeshednetwork
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: >-
+          An UnmeshedNetwork captures traffic to destinations considered
+          to be external to the mesh.
+        type: object
+        required: [spec]
+        properties:
+          apiVerson:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaultPolicy:
+                type: string
+                enum:
+                - AllowAll
+                - DenyAll
+              networks:
+                type: array
+                items:
+                  type: string
+                default: ["0.0.0.0/0", "::/0"]
+            type: object
+            required:
+            - defaultPolicy
+---
 # Source: linkerd-crds/templates/policy/httproute.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -163,7 +163,7 @@ spec:
                 default: ["0.0.0.0/0", "::/0"]
             type: object
             required:
-            - defaultPolicy
+            - trafficPolicy
 ---
 # Source: linkerd-crds/templates/policy/httproute.yaml
 ---

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -141,11 +141,21 @@ spec:
             type: object
           spec:
             properties:
-              defaultPolicy:
+              trafficPolicy:
+                description: >-
+                  This field controls the traffic policy enforced upon traffic
+                  that does not match any explicit route resources associated
+                  with an instance of this object. The values that are allowed
+                  currently are:
+                   - AllowUnknown - permits all traffic, even if it has not been
+                                    explicitly described via attaching an xRoute
+                                    resources.
+                   - DenyUnknown - blocks all traffic that has not been described via
+                                   attaching an xRoute resource.
                 type: string
                 enum:
-                - AllowAll
-                - DenyAll
+                - AllowUnknown
+                - DenyUnknown
               networks:
                 type: array
                 items:

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -100,6 +100,61 @@ spec:
                         maxLength: 253
                         type: string
 ---
+# Source: linkerd-crds/templates/policy/unmeshed-network.yaml
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: unmeshednetworks.policy.linkerd.io
+  annotations:
+    linkerd.io/created-by: linkerd/helm linkerd-version
+  labels:
+    helm.sh/chart: linkerd-crds-
+    linkerd.io/control-plane-ns: linkerd-dev
+spec:
+  group: policy.linkerd.io
+  names:
+    categories:
+    - policy
+    kind: UnmeshedNetwork
+    listKind: UnmeshedNetworkList
+    plural: unmeshednetworks
+    singular: unmeshednetwork
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        description: >-
+          An UnmeshedNetwork captures traffic to destinations considered
+          to be external to the mesh.
+        type: object
+        required: [spec]
+        properties:
+          apiVerson:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              defaultPolicy:
+                type: string
+                enum:
+                - AllowAll
+                - DenyAll
+              networks:
+                type: array
+                items:
+                  type: string
+                default: ["0.0.0.0/0", "::/0"]
+            type: object
+            required:
+            - defaultPolicy
+---
 # Source: linkerd-crds/templates/policy/httproute.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -212,6 +212,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1396,7 +1397,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2b4f4db151be1b48cf7ccff4b16df4d7eb45dee57b998d50cfe13eec8efbaac7
+        checksum/config: 47aa83bd3122b81ec49d7db1d0ac78ee879b7453fd94c18808f2d320ef1c9f04
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -172,6 +172,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1397,7 +1398,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 47aa83bd3122b81ec49d7db1d0ac78ee879b7453fd94c18808f2d320ef1c9f04
+        checksum/config: ea41a9a611486495cbb5e088455e1e81e25ea2aa1574f63e3c9229ccb798be84
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -172,6 +172,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1379,7 +1380,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: af805c45b4c393e060c115dd10f20ec50332cc63a533e006ba10c7f6eafdd407
+        checksum/config: 44655e7f43eca233af69a2dd3b972a76f826f43c5af3b16035ef4c0fed21e8b1
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -212,6 +212,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1378,7 +1379,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 92e9069580ccc3e2e6a5a23fe9d4586ae8f0f3b48b906119e6f884ff66ea7395
+        checksum/config: af805c45b4c393e060c115dd10f20ec50332cc63a533e006ba10c7f6eafdd407
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1304,7 +1305,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1303,7 +1304,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -218,6 +218,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1249,7 +1250,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7523675f365af90bf6840b8b1eb0b12bbb4c819738cc9353608cbd16a9bf4196
+        checksum/config: 75aefe4ed043b3174f5ed97ea39d6166cfedf1a81eee5ab0e8f22018c82b1de4
         linkerd.io/created-by: CliVersion
         linkerd.io/proxy-version: ProxyVersion
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -178,6 +178,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1250,7 +1251,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 75aefe4ed043b3174f5ed97ea39d6166cfedf1a81eee5ab0e8f22018c82b1de4
+        checksum/config: 57c861889553506b3301f7b5e72d6040ec8470b502a0a4d57c2c20f9b47956ae
         linkerd.io/created-by: CliVersion
         linkerd.io/proxy-version: ProxyVersion
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1311,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1310,7 +1311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -181,6 +181,7 @@ webhooks:
     - meshtlsauthentications
     - serverauthorizations
     - servers
+    - unmeshednetworks
   - operations: ["CREATE", "UPDATE"]
     apiGroups: ["gateway.networking.k8s.io"]
     apiVersions: ["*"]
@@ -1311,7 +1312,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
+        checksum/config: 78df803900a4ba0cfd97d4bdfdf6acfdbb1514d3b9ec9351aa56f4fcb5fa1544
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -221,6 +221,7 @@ rules:
       - networkauthentications
       - servers
       - serverauthorizations
+      - unmeshednetworks
     verbs:
       - get
       - list
@@ -1310,7 +1311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ed64a2dea184e1e880a33bb5577b3f6c2a3fdf72492321683bbdaef30a1f365
+        checksum/config: ca3013f634e783f05e7c060cf1b6ee9849b3a856817712cd5394d22a0662a40d
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -24,10 +24,16 @@ pub type HttpRoute = OutboundRoute<HttpRouteMatch, HttpRetryCondition>;
 pub type GrpcRoute = OutboundRoute<GrpcRouteMatch, GrpcRetryCondition>;
 pub type RouteSet<T> = HashMap<GroupKindNamespaceName, T>;
 
+pub enum TargetKind {
+    UnmeshedNetwork,
+    Service,
+}
+
 pub struct OutboundDiscoverTarget {
-    pub service_name: String,
-    pub service_namespace: String,
-    pub service_port: NonZeroU16,
+    pub kind: TargetKind,
+    pub name: String,
+    pub namespace: String,
+    pub port: NonZeroU16,
     pub source_namespace: String,
 }
 

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -14,7 +14,7 @@ use linkerd2_proxy_api::{
 use linkerd_policy_controller_core::{
     outbound::{
         DiscoverOutboundPolicy, OutboundDiscoverTarget, OutboundPolicy, OutboundPolicyStream,
-        OutboundRoute,
+        OutboundRoute, TargetKind,
     },
     routes::GroupKindNamespaceName,
 };
@@ -62,14 +62,15 @@ where
         let target = match target {
             outbound::traffic_spec::Target::Addr(target) => target,
             outbound::traffic_spec::Target::Authority(auth) => {
-                return self.lookup_authority(&auth).map(
-                    |(service_namespace, service_name, service_port)| OutboundDiscoverTarget {
-                        service_name,
-                        service_namespace,
-                        service_port,
+                return self.lookup_authority(&auth).map(|(namespace, name, port)| {
+                    OutboundDiscoverTarget {
+                        kind: TargetKind::Service,
+                        name,
+                        namespace,
+                        port,
                         source_namespace,
-                    },
-                )
+                    }
+                })
             }
         };
 

--- a/policy-controller/k8s/api/src/policy.rs
+++ b/policy-controller/k8s/api/src/policy.rs
@@ -6,16 +6,18 @@ pub mod network_authentication;
 pub mod server;
 pub mod server_authorization;
 pub mod target_ref;
+pub mod unmeshed_network;
 
 pub use self::{
     authorization_policy::{AuthorizationPolicy, AuthorizationPolicySpec},
     httproute::{HttpRoute, HttpRouteSpec},
     meshtls_authentication::{MeshTLSAuthentication, MeshTLSAuthenticationSpec},
-    network::Network,
+    network::{Cidr, Network},
     network_authentication::{NetworkAuthentication, NetworkAuthenticationSpec},
     server::{Server, ServerSpec},
     server_authorization::{ServerAuthorization, ServerAuthorizationSpec},
     target_ref::{ClusterTargetRef, LocalTargetRef, NamespacedTargetRef},
+    unmeshed_network::{UnmeshedNetwork, UnmeshedNetworkSpec},
 };
 
 fn targets_kind<T>(group: Option<&str>, kind: &str) -> bool

--- a/policy-controller/k8s/api/src/policy/network.rs
+++ b/policy-controller/k8s/api/src/policy/network.rs
@@ -33,7 +33,10 @@ impl Cidr {
         }
     }
 
-    pub fn size(&self) -> usize {
+    /// Returns the size of this CIDR block.
+    ///
+    /// Returns `1` if this represents a single address.
+    pub fn block_size(&self) -> usize {
         match self {
             Cidr::Net(net) => net.hosts().count(),
             Cidr::Addr(_) => 1,

--- a/policy-controller/k8s/api/src/policy/network.rs
+++ b/policy-controller/k8s/api/src/policy/network.rs
@@ -32,6 +32,13 @@ impl Cidr {
             (Self::Addr(this), Self::Addr(other)) => this == other,
         }
     }
+
+    pub fn size(&self) -> usize {
+        match self {
+            Cidr::Net(net) => net.hosts().count(),
+            Cidr::Addr(_) => 1,
+        }
+    }
 }
 
 impl std::str::FromStr for Cidr {

--- a/policy-controller/k8s/api/src/policy/unmeshed_network.rs
+++ b/policy-controller/k8s/api/src/policy/unmeshed_network.rs
@@ -1,0 +1,29 @@
+use super::network::Cidr;
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, CustomResource, Deserialize, Serialize, JsonSchema)]
+#[kube(
+    group = "policy.linkerd.io",
+    version = "v1alpha1",
+    kind = "UnmeshedNetwork",
+    namespaced
+)]
+#[serde(rename_all = "camelCase")]
+pub struct UnmeshedNetworkSpec {
+    pub networks: Vec<Cidr>,
+    pub default_policy: DefaultPolicy,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+pub enum DefaultPolicy {
+    AllowAll,
+    DenyAll,
+}
+
+impl Default for DefaultPolicy {
+    fn default() -> Self {
+        Self::AllowAll
+    }
+}

--- a/policy-controller/k8s/api/src/policy/unmeshed_network.rs
+++ b/policy-controller/k8s/api/src/policy/unmeshed_network.rs
@@ -13,17 +13,11 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct UnmeshedNetworkSpec {
     pub networks: Vec<Cidr>,
-    pub traffic_policy: DefaultPolicy,
+    pub traffic_policy: TrafficPolicy,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
-pub enum DefaultPolicy {
+pub enum TrafficPolicy {
     AllowUnknown,
     DenyUnknown,
-}
-
-impl Default for DefaultPolicy {
-    fn default() -> Self {
-        Self::AllowUnknown
-    }
 }

--- a/policy-controller/k8s/api/src/policy/unmeshed_network.rs
+++ b/policy-controller/k8s/api/src/policy/unmeshed_network.rs
@@ -18,12 +18,12 @@ pub struct UnmeshedNetworkSpec {
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 pub enum DefaultPolicy {
-    AllowAll,
-    DenyAll,
+    AllowUnknown,
+    DenyUnknown,
 }
 
 impl Default for DefaultPolicy {
     fn default() -> Self {
-        Self::AllowAll
+        Self::AllowUnknown
     }
 }

--- a/policy-controller/k8s/api/src/policy/unmeshed_network.rs
+++ b/policy-controller/k8s/api/src/policy/unmeshed_network.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub struct UnmeshedNetworkSpec {
     pub networks: Vec<Cidr>,
-    pub default_policy: DefaultPolicy,
+    pub traffic_policy: DefaultPolicy,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -6,9 +6,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-chrono = { version = "0.4.38", default_features = false }
 ahash = "0.8"
 anyhow = "1"
+chrono = { version = "0.4.38", default_features = false }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 kube = { version = "0.87.1", default-features = false, features = [

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+chrono = { version = "0.4.38", default_features = false }
 ahash = "0.8"
 anyhow = "1"
 futures = { version = "0.3", default-features = false }

--- a/policy-controller/k8s/index/src/outbound.rs
+++ b/policy-controller/k8s/index/src/outbound.rs
@@ -1,6 +1,6 @@
 pub mod index;
 
-pub use index::{metrics, Index, ServiceRef, SharedIndex};
+pub use index::{metrics, Index, ResourceRef, SharedIndex};
 
 #[cfg(test)]
 mod tests;

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -275,7 +275,7 @@ impl kubert::index::IndexNamespacedResource<Pod> for Index {
                         Ok(addr) => addr,
                         Err(error) => {
                             tracing::error!(%error, "malformed pod IP: {ip}");
-                            return;
+                            continue;
                         }
                     };
 

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -1,3 +1,4 @@
+use self::unmeshed_network::UnmeshedNetwork;
 use crate::{
     ports::{ports_annotation, PortSet},
     routes::{ExplicitGKN, HttpRouteResource, ImpliedGKN},
@@ -24,8 +25,6 @@ pub mod grpc;
 pub mod http;
 pub mod metrics;
 mod unmeshed_network;
-
-use unmeshed_network::UnmeshedNetwork;
 
 #[derive(Debug)]
 pub struct Index {
@@ -261,7 +260,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::UnmeshedNetwork> fo
 
 impl kubert::index::IndexNamespacedResource<Pod> for Index {
     fn apply(&mut self, pod: Pod) {
-        let ns = pod.namespace().unwrap();
+        let ns = pod.namespace().expect("Pod must have a namespace");
         let name = pod.name_unchecked();
         tracing::debug!(name, ns, "indexing pod");
 
@@ -275,7 +274,7 @@ impl kubert::index::IndexNamespacedResource<Pod> for Index {
                     let pod_ip_addr = match IpAddr::from_str(ip) {
                         Ok(addr) => addr,
                         Err(error) => {
-                            tracing::error!(%error, "malformed PodIp");
+                            tracing::error!(%error, "malformed pod IP: {ip}");
                             return;
                         }
                     };

--- a/policy-controller/k8s/index/src/outbound/index/grpc.rs
+++ b/policy-controller/k8s/index/src/outbound/index/grpc.rs
@@ -1,7 +1,7 @@
 use std::time;
 
 use super::http::{convert_backend, convert_gateway_filter};
-use super::{parse_duration, parse_timeouts, ServiceInfo, ServiceRef};
+use super::{parse_duration, parse_timeouts, ResourceRef, ServiceInfo};
 use crate::{routes, ClusterInfo};
 use ahash::AHashMap as HashMap;
 use anyhow::{bail, Result};
@@ -16,7 +16,7 @@ pub(super) fn convert_route(
     ns: &str,
     route: gateway::GrpcRoute,
     cluster: &ClusterInfo,
-    service_info: &HashMap<ServiceRef, ServiceInfo>,
+    service_info: &HashMap<ResourceRef, ServiceInfo>,
 ) -> Result<GrpcRoute> {
     let timeouts = parse_timeouts(route.annotations())?;
     let retry = parse_grpc_retry(route.annotations())?;
@@ -59,7 +59,7 @@ fn convert_rule(
     ns: &str,
     rule: gateway::GrpcRouteRule,
     cluster: &ClusterInfo,
-    service_info: &HashMap<ServiceRef, ServiceInfo>,
+    service_info: &HashMap<ResourceRef, ServiceInfo>,
     timeouts: RouteTimeouts,
     retry: Option<RouteRetry<GrpcRetryCondition>>,
 ) -> Result<OutboundRouteRule<GrpcRouteMatch, GrpcRetryCondition>> {

--- a/policy-controller/k8s/index/src/outbound/index/http.rs
+++ b/policy-controller/k8s/index/src/outbound/index/http.rs
@@ -1,6 +1,6 @@
 use std::{num::NonZeroU16, time};
 
-use super::{is_service, parse_duration, parse_timeouts, ServiceInfo, ServiceRef};
+use super::{is_service, parse_duration, parse_timeouts, ResourceRef, ServiceInfo};
 use crate::{
     routes::{self, HttpRouteResource},
     ClusterInfo,
@@ -21,7 +21,7 @@ pub(super) fn convert_route(
     ns: &str,
     route: HttpRouteResource,
     cluster: &ClusterInfo,
-    service_info: &HashMap<ServiceRef, ServiceInfo>,
+    service_info: &HashMap<ResourceRef, ServiceInfo>,
 ) -> Result<OutboundRoute<HttpRouteMatch, HttpRetryCondition>> {
     match route {
         HttpRouteResource::LinkerdHttp(route) => {
@@ -105,7 +105,7 @@ fn convert_linkerd_rule(
     ns: &str,
     rule: policy::httproute::HttpRouteRule,
     cluster: &ClusterInfo,
-    service_info: &HashMap<ServiceRef, ServiceInfo>,
+    service_info: &HashMap<ResourceRef, ServiceInfo>,
     mut timeouts: RouteTimeouts,
     retry: Option<RouteRetry<HttpRetryCondition>>,
 ) -> Result<OutboundRouteRule<HttpRouteMatch, HttpRetryCondition>> {
@@ -156,7 +156,7 @@ fn convert_gateway_rule(
     ns: &str,
     rule: gateway::HttpRouteRule,
     cluster: &ClusterInfo,
-    service_info: &HashMap<ServiceRef, ServiceInfo>,
+    service_info: &HashMap<ResourceRef, ServiceInfo>,
     timeouts: RouteTimeouts,
     retry: Option<RouteRetry<HttpRetryCondition>>,
 ) -> Result<OutboundRouteRule<HttpRouteMatch, HttpRetryCondition>> {
@@ -194,7 +194,7 @@ pub(super) fn convert_backend<BackendRef: Into<gateway::HttpBackendRef>>(
     ns: &str,
     backend: BackendRef,
     cluster: &ClusterInfo,
-    services: &HashMap<ServiceRef, ServiceInfo>,
+    services: &HashMap<ResourceRef, ServiceInfo>,
 ) -> Option<Backend> {
     let backend = backend.into();
     let filters = backend.filters;
@@ -229,7 +229,7 @@ pub(super) fn convert_backend<BackendRef: Into<gateway::HttpBackendRef>>(
             })
         }
     };
-    let service_ref = ServiceRef {
+    let service_ref = ResourceRef {
         name: name.clone(),
         namespace: backend.inner.namespace.unwrap_or_else(|| ns.to_string()),
     };

--- a/policy-controller/k8s/index/src/outbound/index/unmeshed_network.rs
+++ b/policy-controller/k8s/index/src/outbound/index/unmeshed_network.rs
@@ -1,0 +1,230 @@
+use chrono::{offset::Utc, DateTime};
+use linkerd_policy_controller_k8s_api::policy::Cidr;
+use linkerd_policy_controller_k8s_api::{policy as linkerd_k8s_api, ResourceExt};
+use std::net::IpAddr;
+
+#[derive(Debug, Default)]
+pub(crate) struct Networks(pub Vec<Cidr>);
+
+#[derive(Debug, Default)]
+pub(crate) struct UnmeshedNetwork {
+    pub networks: Networks,
+    pub name: String,
+    pub namespace: String,
+    pub creation_timestamp: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MatchedUnmeshedNetwork {
+    matched_cidr: MatchedCidr,
+    name: String,
+    namespace: String,
+    creation_timestamp: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MatchedCidr(Cidr);
+
+// === impl MatchedUnmeshedNetwork ===
+
+impl Networks {
+    pub fn find_match(&self, ip: IpAddr) -> Option<Cidr> {
+        let ip: Cidr = ip.into();
+        self.0
+            .iter()
+            .filter(|c| c.contains(&ip))
+            .min_by(|a, b| a.size().cmp(&b.size()))
+            .cloned()
+    }
+}
+
+// === impl UnmeshedNetwork ===
+
+impl From<linkerd_k8s_api::UnmeshedNetwork> for UnmeshedNetwork {
+    fn from(u: linkerd_k8s_api::UnmeshedNetwork) -> Self {
+        let name = u.name_unchecked();
+        let namespace = u
+            .namespace()
+            .expect("UnmeshedNetwork must have a namespace");
+
+        UnmeshedNetwork {
+            name,
+            namespace,
+            networks: Networks(u.spec.networks.clone()),
+            creation_timestamp: u.creation_timestamp().map(|d| d.0),
+        }
+    }
+}
+
+// === impl MatchedUnmeshedNetwork ===
+
+impl From<(Cidr, &UnmeshedNetwork)> for MatchedUnmeshedNetwork {
+    fn from((cidr, unet): (Cidr, &UnmeshedNetwork)) -> Self {
+        Self {
+            name: unet.name.clone(),
+            namespace: unet.namespace.clone(),
+            matched_cidr: MatchedCidr(cidr),
+            creation_timestamp: unet.creation_timestamp,
+        }
+    }
+}
+
+impl std::cmp::PartialOrd for MatchedUnmeshedNetwork {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for MatchedUnmeshedNetwork {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.matched_cidr
+            .cmp(&other.matched_cidr)
+            .then_with(|| self.creation_timestamp.cmp(&other.creation_timestamp))
+            .then_with(|| self.namespace.cmp(&other.namespace))
+            .then_with(|| self.name.cmp(&other.name))
+    }
+}
+
+// === impl MatchedCidr ===
+
+impl std::cmp::PartialOrd for MatchedCidr {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for MatchedCidr {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let cidr_size_self = self.0.size();
+        let cidr_size_other = other.0.size();
+
+        match cidr_size_self.cmp(&cidr_size_other) {
+            std::cmp::Ordering::Less => std::cmp::Ordering::Greater,
+            std::cmp::Ordering::Greater => std::cmp::Ordering::Less,
+            std::cmp::Ordering::Equal => std::cmp::Ordering::Equal,
+        }
+    }
+}
+
+// Attempts to find the best matching network for a certain discovery look-up.
+// Logic is:
+// 1. if there are Unmeshed networks in the source_namespace, only these are considered
+// 2. the target IP is matches against the cidrs of the UnmeshedNetwork
+// 3. ambiguity is resolved as:
+//    - prefer the more specific cidr match
+//    - prefer older resource
+//    - if all fails, rely on alphabetical sort of namespace/name
+pub(crate) fn resolve_unmeshed_network<'n>(
+    addr: IpAddr,
+    source_namespace: String,
+    nets: impl Iterator<Item = &'n UnmeshedNetwork>,
+) -> Option<super::ResourceRef> {
+    let (same_ns, rest): (Vec<_>, Vec<_>) = nets.partition(|un| un.namespace == source_namespace);
+    let to_pick_from = if !same_ns.is_empty() { same_ns } else { rest };
+
+    to_pick_from
+        .iter()
+        .filter_map(|un| {
+            un.networks
+                .find_match(addr)
+                .map(|cidr| MatchedUnmeshedNetwork::from((cidr, *un)))
+        })
+        .max()
+        .map(|m| super::ResourceRef {
+            name: m.name,
+            namespace: m.namespace,
+        })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_picks_smallest_cidr() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/16".parse().unwrap()]),
+                name: "net-1".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: None,
+            },
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/24".parse().unwrap()]),
+                name: "net-2".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: None,
+            },
+        ];
+
+        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.into_iter());
+        assert_eq!(resolved.unwrap().name, "net-2".to_string())
+    }
+
+    #[test]
+    fn test_picks_local_ns() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/16".parse().unwrap()]),
+                name: "net-1".to_string(),
+                namespace: "ns-1".to_string(),
+                creation_timestamp: None,
+            },
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/24".parse().unwrap()]),
+                name: "net-2".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: None,
+            },
+        ];
+
+        let resolved = resolve_unmeshed_network(ip_addr, "ns-1".into(), networks.into_iter());
+        assert_eq!(resolved.unwrap().name, "net-1".to_string())
+    }
+
+    #[test]
+    fn test_picks_older_resource() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/16".parse().unwrap()]),
+                name: "net-1".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: Some(DateTime::<Utc>::MAX_UTC),
+            },
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/16".parse().unwrap()]),
+                name: "net-2".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: Some(DateTime::<Utc>::MIN_UTC),
+            },
+        ];
+
+        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.into_iter());
+        assert_eq!(resolved.unwrap().name, "net-1".to_string())
+    }
+
+    #[test]
+    fn test_picks_alphabetical_order() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/16".parse().unwrap()]),
+                name: "b".to_string(),
+                namespace: "a".to_string(),
+                creation_timestamp: None,
+            },
+            UnmeshedNetwork {
+                networks: Networks(vec!["192.168.0.1/16".parse().unwrap()]),
+                name: "d".to_string(),
+                namespace: "c".to_string(),
+                creation_timestamp: None,
+            },
+        ];
+
+        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.into_iter());
+        assert_eq!(resolved.unwrap().name, "b".to_string())
+    }
+}

--- a/policy-controller/k8s/index/src/outbound/index/unmeshed_network.rs
+++ b/policy-controller/k8s/index/src/outbound/index/unmeshed_network.rs
@@ -80,8 +80,8 @@ impl std::cmp::Ord for MatchedUnmeshedNetwork {
         self.matched_cidr
             .cmp(&other.matched_cidr)
             .then_with(|| self.creation_timestamp.cmp(&other.creation_timestamp))
-            .then_with(|| self.namespace.cmp(&other.namespace))
-            .then_with(|| self.name.cmp(&other.name))
+            .then_with(|| self.namespace.cmp(&other.namespace).reverse())
+            .then_with(|| self.name.cmp(&other.name).reverse())
     }
 }
 
@@ -158,7 +158,7 @@ mod test {
             },
         ];
 
-        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.into_iter());
+        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.iter());
         assert_eq!(resolved.unwrap().name, "net-2".to_string())
     }
 
@@ -180,7 +180,7 @@ mod test {
             },
         ];
 
-        let resolved = resolve_unmeshed_network(ip_addr, "ns-1".into(), networks.into_iter());
+        let resolved = resolve_unmeshed_network(ip_addr, "ns-1".into(), networks.iter());
         assert_eq!(resolved.unwrap().name, "net-1".to_string())
     }
 
@@ -202,7 +202,7 @@ mod test {
             },
         ];
 
-        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.into_iter());
+        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.iter());
         assert_eq!(resolved.unwrap().name, "net-1".to_string())
     }
 
@@ -224,7 +224,7 @@ mod test {
             },
         ];
 
-        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.into_iter());
+        let resolved = resolve_unmeshed_network(ip_addr, "ns".into(), networks.iter());
         assert_eq!(resolved.unwrap().name, "b".to_string())
     }
 }

--- a/policy-controller/k8s/index/src/outbound/index/unmeshed_network.rs
+++ b/policy-controller/k8s/index/src/outbound/index/unmeshed_network.rs
@@ -25,7 +25,7 @@ struct MatchedUnmeshedNetwork {
 #[derive(Debug, PartialEq, Eq)]
 struct MatchedCidr(Cidr);
 
-// === impl MatchedUnmeshedNetwork ===
+// === impl Networks ===
 
 impl Networks {
     pub fn find_match(&self, ip: IpAddr) -> Option<Cidr> {
@@ -33,7 +33,7 @@ impl Networks {
         self.0
             .iter()
             .filter(|c| c.contains(&ip))
-            .min_by(|a, b| a.size().cmp(&b.size()))
+            .min_by(|a, b| a.block_size().cmp(&b.block_size()))
             .cloned()
     }
 }
@@ -95,8 +95,8 @@ impl std::cmp::PartialOrd for MatchedCidr {
 
 impl std::cmp::Ord for MatchedCidr {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let cidr_size_self = self.0.size();
-        let cidr_size_other = other.0.size();
+        let cidr_size_self = self.0.block_size();
+        let cidr_size_other = other.0.block_size();
 
         match cidr_size_self.cmp(&cidr_size_other) {
             std::cmp::Ordering::Less => std::cmp::Ordering::Greater,

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -127,7 +127,7 @@ impl DiscoverOutboundPolicy<OutboundDiscoverTarget> for OutboundDiscover {
         }: OutboundDiscoverTarget,
     ) -> Result<Option<OutboundPolicyStream>> {
         if let TargetKind::UnmeshedNetwork = kind {
-            tracing::debug!("UnmeshedNetwork network is not supported yet");
+            tracing::debug!("UnmeshedNetwork is not supported yet");
             return Ok(None);
         }
 

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -307,7 +307,7 @@ async fn main() -> Result<()> {
     let all_pods = runtime.watch_all::<k8s::Pod>(watcher::Config::default());
     let all_pods_indexes = IndexList::new(outbound_index.clone()).shared();
     tokio::spawn(
-        kubert::index::namespaced(all_pods_indexes, all_pods).instrument(info_span!("all pods")),
+        kubert::index::namespaced(all_pods_indexes, all_pods).instrument(info_span!("pods")),
     );
 
     let unmeshed_networks =
@@ -315,7 +315,7 @@ async fn main() -> Result<()> {
     let unmeshed_networks_indexes = IndexList::new(outbound_index.clone()).shared();
     tokio::spawn(
         kubert::index::namespaced(unmeshed_networks_indexes, unmeshed_networks)
-            .instrument(info_span!("unmeshed networks")),
+            .instrument(info_span!("unmeshednetworks")),
     );
 
     // Spawn the status Controller reconciliation.

--- a/policy-test/tests/admit_unmeshed_networks.rs
+++ b/policy-test/tests/admit_unmeshed_networks.rs
@@ -1,6 +1,6 @@
 use linkerd_policy_controller_k8s_api::{
     self as api,
-    policy::unmeshed_network::{DefaultPolicy, UnmeshedNetwork, UnmeshedNetworkSpec},
+    policy::unmeshed_network::{TrafficPolicy, UnmeshedNetwork, UnmeshedNetworkSpec},
 };
 use linkerd_policy_test::admission;
 
@@ -13,7 +13,7 @@ async fn accepts_valid() {
             ..Default::default()
         },
         spec: UnmeshedNetworkSpec {
-            traffic_policy: DefaultPolicy::AllowUnknown,
+            traffic_policy: TrafficPolicy::AllowUnknown,
             networks: vec![
                 "10.1.0.0/24".parse().unwrap(),
                 "10.1.1.0/24".parse().unwrap(),
@@ -32,7 +32,7 @@ async fn rejects_empty_networks() {
             ..Default::default()
         },
         spec: UnmeshedNetworkSpec {
-            traffic_policy: DefaultPolicy::AllowUnknown,
+            traffic_policy: TrafficPolicy::AllowUnknown,
             networks: Default::default(),
         },
     })

--- a/policy-test/tests/admit_unmeshed_networks.rs
+++ b/policy-test/tests/admit_unmeshed_networks.rs
@@ -13,7 +13,7 @@ async fn accepts_valid() {
             ..Default::default()
         },
         spec: UnmeshedNetworkSpec {
-            default_policy: DefaultPolicy::AllowUnknown,
+            traffic_policy: DefaultPolicy::AllowUnknown,
             networks: vec![
                 "10.1.0.0/24".parse().unwrap(),
                 "10.1.1.0/24".parse().unwrap(),
@@ -32,7 +32,7 @@ async fn rejects_empty_networks() {
             ..Default::default()
         },
         spec: UnmeshedNetworkSpec {
-            default_policy: DefaultPolicy::AllowUnknown,
+            traffic_policy: DefaultPolicy::AllowUnknown,
             networks: Default::default(),
         },
     })

--- a/policy-test/tests/admit_unmeshed_networks.rs
+++ b/policy-test/tests/admit_unmeshed_networks.rs
@@ -1,0 +1,43 @@
+use linkerd_policy_controller_k8s_api::{
+    self as api,
+    policy::{
+        network_authentication::{Network, NetworkAuthentication, NetworkAuthenticationSpec},
+        unmeshed_network::{DefaultPolicy, UnmeshedNetwork, UnmeshedNetworkSpec},
+    },
+};
+use linkerd_policy_test::admission;
+
+#[tokio::test(flavor = "current_thread")]
+async fn accepts_valid() {
+    admission::accepts(|ns| UnmeshedNetwork {
+        metadata: api::ObjectMeta {
+            namespace: Some(ns),
+            name: Some("test".to_string()),
+            ..Default::default()
+        },
+        spec: UnmeshedNetworkSpec {
+            default_policy: DefaultPolicy::AllowAll,
+            networks: vec![
+                "10.1.0.0/24".parse().unwrap(),
+                "10.1.1.0/24".parse().unwrap(),
+            ],
+        },
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejects_empty_networks() {
+    admission::rejects(|ns| UnmeshedNetwork {
+        metadata: api::ObjectMeta {
+            namespace: Some(ns),
+            name: Some("test".to_string()),
+            ..Default::default()
+        },
+        spec: UnmeshedNetworkSpec {
+            default_policy: DefaultPolicy::AllowAll,
+            networks: Default::default(),
+        },
+    })
+    .await;
+}

--- a/policy-test/tests/admit_unmeshed_networks.rs
+++ b/policy-test/tests/admit_unmeshed_networks.rs
@@ -1,9 +1,6 @@
 use linkerd_policy_controller_k8s_api::{
     self as api,
-    policy::{
-        network_authentication::{Network, NetworkAuthentication, NetworkAuthenticationSpec},
-        unmeshed_network::{DefaultPolicy, UnmeshedNetwork, UnmeshedNetworkSpec},
-    },
+    policy::unmeshed_network::{DefaultPolicy, UnmeshedNetwork, UnmeshedNetworkSpec},
 };
 use linkerd_policy_test::admission;
 

--- a/policy-test/tests/admit_unmeshed_networks.rs
+++ b/policy-test/tests/admit_unmeshed_networks.rs
@@ -13,7 +13,7 @@ async fn accepts_valid() {
             ..Default::default()
         },
         spec: UnmeshedNetworkSpec {
-            default_policy: DefaultPolicy::AllowAll,
+            default_policy: DefaultPolicy::AllowUnknown,
             networks: vec![
                 "10.1.0.0/24".parse().unwrap(),
                 "10.1.1.0/24".parse().unwrap(),
@@ -32,7 +32,7 @@ async fn rejects_empty_networks() {
             ..Default::default()
         },
         spec: UnmeshedNetworkSpec {
-            default_policy: DefaultPolicy::AllowAll,
+            default_policy: DefaultPolicy::AllowUnknown,
             networks: Default::default(),
         },
     })


### PR DESCRIPTION
At the moment, we do not have a clear way of representing traffic that leaves the mesh. This PR adds
an UnmeshedNetwork resource, which purpose is to do that. The change is non-functional as it should not
change existing behavior. The most notable change so far is that we index these resources in the outbound
index of the policy controller and execute the following resolution logic on outbound discovery requests:

1. We check whether there is a service with the IP address that is being looked up. If so, we return a response as usual
2. If not, we check whether there is a pod with this IP address that we have observed. If yes, we return a NotFound status in order to let the destinations controller fulfill the discovery request as usual.
3. If the request has not been served by now, we try to attribute the request to an `UnmeshedNetwork` parent.

Since no default or explicit route attachments have been implemented for `UnmeshedNetwork`, we currently return NotFound even if we manage to resolve such a parent.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
