### PR TITLE
policy: Augment status controller to consider `UnmeshedNetwork`, `TCPRoute` and `TLSRoute`

### DIFF
--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -239,6 +239,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -254,6 +256,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1315,7 +1319,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1314,7 +1318,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1314,7 +1318,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1314,7 +1318,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1314,7 +1318,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1305,7 +1309,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1318,7 +1322,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1417,7 +1421,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f333dda9e649b289afc8802a35d7fdfd839ccaa7b2af8606e51a6086df67e810
+        checksum/config: d06304a25d23f4c6710de7c527a7951dadcc6a7c59abc4b6390954d287311535
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1417,7 +1421,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f333dda9e649b289afc8802a35d7fdfd839ccaa7b2af8606e51a6086df67e810
+        checksum/config: d06304a25d23f4c6710de7c527a7951dadcc6a7c59abc4b6390954d287311535
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1245,7 +1249,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -225,6 +225,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -240,6 +242,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1289,7 +1293,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4544d8ac904256c8122adfe9dd92960fa5370c1d34511aff183e5d074763ef78
+        checksum/config: 6e1411ea883e84adc4a1afcb9af1fcf9e263ca983d6c092b6f322e4b1089ea8a
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -225,6 +225,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -240,6 +242,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1392,7 +1396,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 80cce5b71b15f6fd2bfa74c658e1cdfcf35a506fee12b42399b3575d00cfde89
+        checksum/config: 262c9cd5315dbca985da47a177aace4c32382d91b4cdb763016801d4bbd053b1
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -225,6 +225,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -240,6 +242,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1396,7 +1400,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 80cce5b71b15f6fd2bfa74c658e1cdfcf35a506fee12b42399b3575d00cfde89
+        checksum/config: 262c9cd5315dbca985da47a177aace4c32382d91b4cdb763016801d4bbd053b1
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -225,6 +225,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -240,6 +242,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1400,7 +1404,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 80cce5b71b15f6fd2bfa74c658e1cdfcf35a506fee12b42399b3575d00cfde89
+        checksum/config: 262c9cd5315dbca985da47a177aace4c32382d91b4cdb763016801d4bbd053b1
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -225,6 +225,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -240,6 +242,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1382,7 +1386,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7957a04964ce3a235c322c8c4ab5d9cd1bd395fa8d81c640581f1309d54f1e50
+        checksum/config: 38859b43f0d9d8cd4d277a702a128c4cc238505a45f7961528f6213c17d57553
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1307,7 +1311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -231,6 +231,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -246,6 +248,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1253,7 +1257,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 475ebb4569888d2968a36dd541af21b5522aba2ba369d4a4bacd292e887181cb
+        checksum/config: 63f9e71709f09ccb38158e1cd7327b5f1bcb9d961289a248fe99be2cd77a86bb
         linkerd.io/created-by: CliVersion
         linkerd.io/proxy-version: ProxyVersion
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1314,7 +1318,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -234,6 +234,8 @@ rules:
     resources:
       - httproutes
       - grpcroutes
+      - tlsroutes
+      - tcproutes
     verbs:
       - get
       - list
@@ -249,6 +251,8 @@ rules:
     resources:
       - httproutes/status
       - grpcroutes/status
+      - tlsroutes/status
+      - tcproutes/status
     verbs:
       - patch
   - apiGroups:
@@ -1314,7 +1318,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b7905a5e0ffecb432c01c7be03bed6a976b262c7020f209461875f433d08381c
+        checksum/config: f5dcc8dd49587e611c938da8debcb81964d7ef93e72c6e1f0384e7294fb7d5c6
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/policy-controller/k8s/status/src/resource_id.rs
+++ b/policy-controller/k8s/status/src/resource_id.rs
@@ -29,6 +29,8 @@ impl NamespaceGroupKindName {
             (POLICY_API_GROUP, "HTTPRoute") => Ok(linkerd_k8s_api::HttpRoute::api_version(&())),
             (GATEWAY_API_GROUP, "HTTPRoute") => Ok(k8s_gateway_api::HttpRoute::api_version(&())),
             (GATEWAY_API_GROUP, "GRPCRoute") => Ok(k8s_gateway_api::GrpcRoute::api_version(&())),
+            (GATEWAY_API_GROUP, "TCPRoute") => Ok(k8s_gateway_api::TcpRoute::api_version(&())),
+            (GATEWAY_API_GROUP, "TLSRoute") => Ok(k8s_gateway_api::TlsRoute::api_version(&())),
             (group, kind) => {
                 anyhow::bail!("unknown group + kind combination: ({}, {})", group, kind)
             }

--- a/policy-controller/k8s/status/src/routes/grpc.rs
+++ b/policy-controller/k8s/status/src/routes/grpc.rs
@@ -134,6 +134,13 @@ mod test {
                         },
                         k8s_gateway_api::BackendObjectReference {
                             group: Some(POLICY_API_GROUP.to_string()),
+                            kind: Some("UnmeshedNetwork".to_string()),
+                            name: "ref-3".to_string(),
+                            namespace: None,
+                            port: Some(555),
+                        },
+                        k8s_gateway_api::BackendObjectReference {
+                            group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("Server".to_string()),
                             name: "ref-2".to_string(),
                             namespace: None,
@@ -160,13 +167,15 @@ mod test {
                 .flatten(),
         );
         assert_eq!(
-            2,
+            3,
             result.len(),
             "expected only two BackendReferences from route"
         );
         let mut iter = result.into_iter();
-        let known = iter.next().unwrap();
-        assert!(matches!(known, BackendReference::Service(_)));
+        let service = iter.next().unwrap();
+        assert!(matches!(service, BackendReference::Service(_)));
+        let unmeshed_net = iter.next().unwrap();
+        assert!(matches!(unmeshed_net, BackendReference::UnmeshedNetwork(_)));
         let unknown = iter.next().unwrap();
         assert!(matches!(unknown, BackendReference::Unknown))
     }

--- a/policy-controller/k8s/status/src/routes/http.rs
+++ b/policy-controller/k8s/status/src/routes/http.rs
@@ -1,17 +1,5 @@
-use super::{BackendReference, ParentReference};
+use super::BackendReference;
 use linkerd_policy_controller_k8s_api::gateway as k8s_gateway_api;
-
-pub(crate) fn make_parents(
-    namespace: &str,
-    route: &k8s_gateway_api::CommonRouteSpec,
-) -> Vec<ParentReference> {
-    route
-        .parent_refs
-        .iter()
-        .flatten()
-        .map(|pr| ParentReference::from_parent_ref(pr, namespace))
-        .collect()
-}
 
 pub(crate) fn make_backends(
     namespace: &str,
@@ -152,6 +140,13 @@ mod test {
                         },
                         k8s_gateway_api::BackendObjectReference {
                             group: Some(POLICY_API_GROUP.to_string()),
+                            kind: Some("UnmeshedNetwork".to_string()),
+                            name: "ref-3".to_string(),
+                            namespace: None,
+                            port: Some(555),
+                        },
+                        k8s_gateway_api::BackendObjectReference {
+                            group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("Server".to_string()),
                             name: "ref-2".to_string(),
                             namespace: None,
@@ -179,13 +174,15 @@ mod test {
                 .flatten(),
         );
         assert_eq!(
-            2,
+            3,
             result.len(),
             "expected only two BackendReferences from route"
         );
         let mut iter = result.into_iter();
-        let known = iter.next().unwrap();
-        assert!(matches!(known, BackendReference::Service(_)));
+        let service = iter.next().unwrap();
+        assert!(matches!(service, BackendReference::Service(_)));
+        let unmeshed_net = iter.next().unwrap();
+        assert!(matches!(unmeshed_net, BackendReference::UnmeshedNetwork(_)));
         let unknown = iter.next().unwrap();
         assert!(matches!(unknown, BackendReference::Unknown))
     }

--- a/policy-controller/k8s/status/src/routes/tcp.rs
+++ b/policy-controller/k8s/status/src/routes/tcp.rs
@@ -1,0 +1,146 @@
+#[cfg(test)]
+mod test {
+    use crate::index::POLICY_API_GROUP;
+    use crate::routes::BackendReference;
+    use linkerd_policy_controller_k8s_api::{self as k8s_core_api, gateway as k8s_gateway_api};
+
+    #[test]
+    fn backendrefs_from_route() {
+        let route = k8s_gateway_api::TcpRoute {
+            metadata: k8s_core_api::ObjectMeta {
+                namespace: Some("foo".to_string()),
+                name: Some("foo".to_string()),
+                ..Default::default()
+            },
+            spec: k8s_gateway_api::TcpRouteSpec {
+                inner: k8s_gateway_api::CommonRouteSpec { parent_refs: None },
+                rules: vec![
+                    k8s_gateway_api::TcpRouteRule {
+                        backend_refs: vec![
+                            k8s_gateway_api::BackendRef {
+                                weight: None,
+                                inner: k8s_gateway_api::BackendObjectReference {
+                                    group: None,
+                                    kind: None,
+                                    name: "ref-1".to_string(),
+                                    namespace: Some("default".to_string()),
+                                    port: None,
+                                },
+                            },
+                            k8s_gateway_api::BackendRef {
+                                weight: None,
+                                inner: k8s_gateway_api::BackendObjectReference {
+                                    group: None,
+                                    kind: None,
+                                    name: "ref-2".to_string(),
+                                    namespace: None,
+                                    port: None,
+                                },
+                            },
+                        ],
+                    },
+                    k8s_gateway_api::TcpRouteRule {
+                        backend_refs: vec![k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: Some("Core".to_string()),
+                                kind: Some("Service".to_string()),
+                                name: "ref-3".to_string(),
+                                namespace: Some("default".to_string()),
+                                port: None,
+                            },
+                        }],
+                    },
+                ],
+            },
+            status: None,
+        };
+
+        let result: Vec<_> = route
+            .spec
+            .rules
+            .into_iter()
+            .flat_map(|rule| rule.backend_refs)
+            .map(|br| BackendReference::from_backend_ref(&br.inner, "default"))
+            .collect();
+
+        assert_eq!(
+            3,
+            result.len(),
+            "expected only three BackendReferences from route"
+        );
+        result.into_iter().for_each(|backend_ref| {
+            assert!(matches!(backend_ref, BackendReference::Service(_)));
+        })
+    }
+
+    #[test]
+    fn backendrefs_from_multiple_types() {
+        let route = k8s_gateway_api::TcpRoute {
+            metadata: k8s_core_api::ObjectMeta {
+                namespace: Some("default".to_string()),
+                name: Some("foo".to_string()),
+                ..Default::default()
+            },
+            spec: k8s_gateway_api::TcpRouteSpec {
+                inner: k8s_gateway_api::CommonRouteSpec { parent_refs: None },
+                rules: vec![k8s_gateway_api::TcpRouteRule {
+                    backend_refs: vec![
+                        k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: None,
+                                kind: None,
+                                name: "ref-1".to_string(),
+                                namespace: None,
+                                port: None,
+                            },
+                        },
+                        k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: Some(POLICY_API_GROUP.to_string()),
+                                kind: Some("UnmeshedNetwork".to_string()),
+                                name: "ref-3".to_string(),
+                                namespace: None,
+                                port: Some(555),
+                            },
+                        },
+                        k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: Some(POLICY_API_GROUP.to_string()),
+                                kind: Some("Server".to_string()),
+                                name: "ref-2".to_string(),
+                                namespace: None,
+                                port: None,
+                            },
+                        },
+                    ],
+                }],
+            },
+            status: None,
+        };
+
+        let result: Vec<_> = route
+            .spec
+            .rules
+            .into_iter()
+            .flat_map(|rule| rule.backend_refs)
+            .map(|br| BackendReference::from_backend_ref(&br.inner, "default"))
+            .collect();
+
+        assert_eq!(
+            3,
+            result.len(),
+            "expected only two BackendReferences from route"
+        );
+        let mut iter = result.into_iter();
+        let service = iter.next().unwrap();
+        assert!(matches!(service, BackendReference::Service(_)));
+        let unmeshed_net = iter.next().unwrap();
+        assert!(matches!(unmeshed_net, BackendReference::UnmeshedNetwork(_)));
+        let unknown = iter.next().unwrap();
+        assert!(matches!(unknown, BackendReference::Unknown))
+    }
+}

--- a/policy-controller/k8s/status/src/routes/tls.rs
+++ b/policy-controller/k8s/status/src/routes/tls.rs
@@ -1,0 +1,148 @@
+#[cfg(test)]
+mod test {
+    use crate::index::POLICY_API_GROUP;
+    use crate::routes::BackendReference;
+    use linkerd_policy_controller_k8s_api::{self as k8s_core_api, gateway as k8s_gateway_api};
+
+    #[test]
+    fn backendrefs_from_route() {
+        let route = k8s_gateway_api::TlsRoute {
+            metadata: k8s_core_api::ObjectMeta {
+                namespace: Some("foo".to_string()),
+                name: Some("foo".to_string()),
+                ..Default::default()
+            },
+            spec: k8s_gateway_api::TlsRouteSpec {
+                inner: k8s_gateway_api::CommonRouteSpec { parent_refs: None },
+                hostnames: None,
+                rules: vec![
+                    k8s_gateway_api::TlsRouteRule {
+                        backend_refs: vec![
+                            k8s_gateway_api::BackendRef {
+                                weight: None,
+                                inner: k8s_gateway_api::BackendObjectReference {
+                                    group: None,
+                                    kind: None,
+                                    name: "ref-1".to_string(),
+                                    namespace: Some("default".to_string()),
+                                    port: None,
+                                },
+                            },
+                            k8s_gateway_api::BackendRef {
+                                weight: None,
+                                inner: k8s_gateway_api::BackendObjectReference {
+                                    group: None,
+                                    kind: None,
+                                    name: "ref-2".to_string(),
+                                    namespace: None,
+                                    port: None,
+                                },
+                            },
+                        ],
+                    },
+                    k8s_gateway_api::TlsRouteRule {
+                        backend_refs: vec![k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: Some("Core".to_string()),
+                                kind: Some("Service".to_string()),
+                                name: "ref-3".to_string(),
+                                namespace: Some("default".to_string()),
+                                port: None,
+                            },
+                        }],
+                    },
+                ],
+            },
+            status: None,
+        };
+
+        let result: Vec<_> = route
+            .spec
+            .rules
+            .into_iter()
+            .flat_map(|rule| rule.backend_refs)
+            .map(|br| BackendReference::from_backend_ref(&br.inner, "default"))
+            .collect();
+
+        assert_eq!(
+            3,
+            result.len(),
+            "expected only three BackendReferences from route"
+        );
+        result.into_iter().for_each(|backend_ref| {
+            assert!(matches!(backend_ref, BackendReference::Service(_)));
+        })
+    }
+
+    #[test]
+    fn backendrefs_from_multiple_types() {
+        let route = k8s_gateway_api::TlsRoute {
+            metadata: k8s_core_api::ObjectMeta {
+                namespace: Some("default".to_string()),
+                name: Some("foo".to_string()),
+                ..Default::default()
+            },
+            spec: k8s_gateway_api::TlsRouteSpec {
+                inner: k8s_gateway_api::CommonRouteSpec { parent_refs: None },
+                hostnames: None,
+                rules: vec![k8s_gateway_api::TlsRouteRule {
+                    backend_refs: vec![
+                        k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: None,
+                                kind: None,
+                                name: "ref-1".to_string(),
+                                namespace: None,
+                                port: None,
+                            },
+                        },
+                        k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: Some(POLICY_API_GROUP.to_string()),
+                                kind: Some("UnmeshedNetwork".to_string()),
+                                name: "ref-3".to_string(),
+                                namespace: None,
+                                port: Some(555),
+                            },
+                        },
+                        k8s_gateway_api::BackendRef {
+                            weight: None,
+                            inner: k8s_gateway_api::BackendObjectReference {
+                                group: Some(POLICY_API_GROUP.to_string()),
+                                kind: Some("Server".to_string()),
+                                name: "ref-2".to_string(),
+                                namespace: None,
+                                port: None,
+                            },
+                        },
+                    ],
+                }],
+            },
+            status: None,
+        };
+
+        let result: Vec<_> = route
+            .spec
+            .rules
+            .into_iter()
+            .flat_map(|rule| rule.backend_refs)
+            .map(|br| BackendReference::from_backend_ref(&br.inner, "default"))
+            .collect();
+
+        assert_eq!(
+            3,
+            result.len(),
+            "expected only two BackendReferences from route"
+        );
+        let mut iter = result.into_iter();
+        let service = iter.next().unwrap();
+        assert!(matches!(service, BackendReference::Service(_)));
+        let unmeshed_net = iter.next().unwrap();
+        assert!(matches!(unmeshed_net, BackendReference::UnmeshedNetwork(_)));
+        let unknown = iter.next().unwrap();
+        assert!(matches!(unknown, BackendReference::Unknown))
+    }
+}

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -76,7 +76,7 @@ async fn accepted_parent_unmeshed_network() {
             },
             spec: policy::UnmeshedNetworkSpec {
                 networks: vec!["192.168.0.1/16".parse().unwrap()],
-                traffic_policy: policy::unmeshed_network::DefaultPolicy::AllowUnknown,
+                traffic_policy: policy::unmeshed_network::TrafficPolicy::AllowUnknown,
             },
         };
         let unet = create(&client, unet).await;
@@ -318,7 +318,7 @@ async fn multiple_statuses_unmeshed_network() {
             },
             spec: policy::UnmeshedNetworkSpec {
                 networks: vec!["192.168.0.1/16".parse().unwrap()],
-                traffic_policy: policy::unmeshed_network::DefaultPolicy::AllowUnknown,
+                traffic_policy: policy::unmeshed_network::TrafficPolicy::AllowUnknown,
             },
         };
         let unet = create(&client, unet).await;

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -3,13 +3,13 @@ use k8s_gateway_api::{ParentReference, RouteParentStatus, RouteStatus};
 use k8s_openapi::chrono::Utc;
 use kube::ResourceExt;
 use linkerd_policy_controller_core::POLICY_CONTROLLER_NAME;
-use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_controller_k8s_api::{self as k8s, policy};
 use linkerd_policy_test::{
     await_condition, await_route_status, create, find_route_condition, mk_route, with_temp_ns,
 };
 
 #[tokio::test(flavor = "current_thread")]
-async fn accepted_parent() {
+async fn accepted_parent_service() {
     with_temp_ns(|client, ns| async move {
         // Create a parent Service
         let svc_name = "test-service";
@@ -56,6 +56,62 @@ async fn accepted_parent() {
 
         // Check status is accepted with a status of 'True'
         let cond = find_route_condition(&statuses, svc_name)
+            .expect("must have at least one 'Accepted' condition for accepted servuce");
+        assert_eq!(cond.status, "True");
+        assert_eq!(cond.reason, "Accepted")
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn accepted_parent_unmeshed_network() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent UnmeshedNetwork
+        let unet_name = "test-unmeshednetwork";
+        let unet = policy::UnmeshedNetwork {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some(unet_name.to_string()),
+                ..Default::default()
+            },
+            spec: policy::UnmeshedNetworkSpec {
+                networks: vec!["192.168.0.1/16".parse().unwrap()],
+                traffic_policy: policy::unmeshed_network::DefaultPolicy::AllowUnknown,
+            },
+        };
+        let unet = create(&client, unet).await;
+        let unet_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("policy.linkerd.io".to_string()),
+            kind: Some("UnmeshedNetwork".to_string()),
+            namespace: unet.namespace(),
+            name: unet.name_unchecked(),
+            section_name: None,
+            port: Some(80),
+        }];
+
+        // Create a route that references the UnmeshedNetwork resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(unet_ref))).await;
+        // Wait until route is updated with a status
+        let statuses = await_route_status(&client, &ns, "test-route").await.parents;
+
+        let route_status = statuses
+            .clone()
+            .into_iter()
+            .find(|route_status| route_status.parent_ref.name == unet_name)
+            .expect("must have at least one parent status");
+
+        // Check status references to parent we have created
+        assert_eq!(
+            route_status.parent_ref.group.as_deref(),
+            Some("policy.linkerd.io")
+        );
+        assert_eq!(
+            route_status.parent_ref.kind.as_deref(),
+            Some("UnmeshedNetwork")
+        );
+
+        // Check status is accepted with a status of 'True'
+        let cond = find_route_condition(&statuses, unet_name)
             .expect("must have at least one 'Accepted' condition for accepted servuce");
         assert_eq!(cond.status, "True");
         assert_eq!(cond.reason, "Accepted")
@@ -152,7 +208,7 @@ async fn external_name() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn multiple_statuses() {
+async fn multiple_statuses_service() {
     with_temp_ns(|client, ns| async move {
         // Create a parent Service
         let svc_name = "test-service";
@@ -184,6 +240,99 @@ async fn multiple_statuses() {
 
         // Create a route that references the Service resource.
         let _route = create(&client, mk_route(&ns, "test-route", Some(svc_ref))).await;
+
+        // Patch a status onto the HttpRoute.
+        let value = serde_json::json!({
+            "apiVersion": "policy.linkerd.io",
+                "kind": "HTTPRoute",
+                "name": "test-route",
+                "status": k8s::policy::httproute::HttpRouteStatus {
+                    inner: RouteStatus {
+                        parents: vec![RouteParentStatus {
+                            conditions: vec![Condition {
+                                last_transition_time: k8s::Time(Utc::now()),
+                                message: "".to_string(),
+                                observed_generation: None,
+                                reason: "Accepted".to_string(),
+                                status: "True".to_string(),
+                                type_: "Accepted".to_string(),
+                            }],
+                            controller_name: "someone/else".to_string(),
+                            parent_ref: ParentReference {
+                                group: Some("gateway.networking.k8s.io".to_string()),
+                                name: "foo".to_string(),
+                                kind: Some("Gateway".to_string()),
+                                namespace: Some("bar".to_string()),
+                                port: None,
+                                section_name: None,
+                            },
+                        }],
+                    },
+                },
+        });
+        let patch = k8s::Patch::Merge(value);
+        let patch_params = k8s::PatchParams::apply("someone/else");
+        let api = k8s::Api::<k8s::policy::HttpRoute>::namespaced(client.clone(), &ns);
+        api.patch_status("test-route", &patch_params, &patch)
+            .await
+            .expect("failed to patch status");
+
+        await_condition(
+            &client,
+            &ns,
+            "test-route",
+            |obj: Option<&k8s::policy::HttpRoute>| -> bool {
+                obj.and_then(|route| route.status.as_ref())
+                    .map(|status| {
+                        let statuses = &status.inner.parents;
+
+                        let other_status_found = statuses
+                            .iter()
+                            .any(|route_status| route_status.controller_name == "someone/else");
+
+                        let linkerd_status_found = statuses.iter().any(|route_status| {
+                            route_status.controller_name == POLICY_CONTROLLER_NAME
+                        });
+
+                        other_status_found && linkerd_status_found
+                    })
+                    .unwrap_or(false)
+            },
+        )
+        .await
+        .expect("must have both statuses");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multiple_statuses_unmeshed_network() {
+    with_temp_ns(|client, ns| async move {
+        // Create a parent UnmeshedNetwork
+        let unet_name = "test-unmeshednetwork";
+        let unet = policy::UnmeshedNetwork {
+            metadata: k8s::ObjectMeta {
+                namespace: Some(ns.clone()),
+                name: Some(unet_name.to_string()),
+                ..Default::default()
+            },
+            spec: policy::UnmeshedNetworkSpec {
+                networks: vec!["192.168.0.1/16".parse().unwrap()],
+                traffic_policy: policy::unmeshed_network::DefaultPolicy::AllowUnknown,
+            },
+        };
+        let unet = create(&client, unet).await;
+        let unet_ref = vec![k8s::policy::httproute::ParentReference {
+            group: Some("policy.linkerd.io".to_string()),
+            kind: Some("UnmeshedNetwork".to_string()),
+            namespace: unet.namespace(),
+            name: unet.name_unchecked(),
+            section_name: None,
+            port: Some(80),
+        }];
+
+        // Create a route that references the Service resource.
+        let _route = create(&client, mk_route(&ns, "test-route", Some(unet_ref))).await;
 
         // Patch a status onto the HttpRoute.
         let value = serde_json::json!({


### PR DESCRIPTION
This PR adds a couple of changes to the status controller: 

- make status setting on `TLSRoute` work
- make status setting on `TCPRoute` work
- enables the attachment of all routes to `UnmeshedNetwork` targets
- expands the logic for determining if routes are conflicted based on the rules outlined in [the gateway API GEP=1426](https://gateway-api.sigs.k8s.io/geps/gep-1426/#route-types)


Unit tests were added where possible. Some integration tests were added, but the do not cover all route types. More extensive integration tests will be added as a follow-up.

This PR depends on: #13156

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>