### PR TITLE
Make `linkerd mc link`'s output compatible with pre-edge-24.9.3 clusters

### DIFF
--- a/pkg/multicluster/link.go
+++ b/pkg/multicluster/link.go
@@ -180,6 +180,22 @@ func NewLink(u unstructured.Unstructured) (Link, error) {
 // ToUnstructured converts a Link struct into an unstructured resource that can
 // be used by a kubernetes dynamic client.
 func (l Link) ToUnstructured() (unstructured.Unstructured, error) {
+
+	// only specify failureThreshold and timeout if they're not empty, to
+	// remain compatible with older Link CRDs
+	probeSpec := map[string]interface{}{
+		"path":   l.ProbeSpec.Path,
+		"port":   fmt.Sprintf("%d", l.ProbeSpec.Port),
+		"period": l.ProbeSpec.Period.String(),
+	}
+
+	if l.ProbeSpec.FailureThreshold > 0 {
+		probeSpec["failureThreshold"] = fmt.Sprintf("%d", l.ProbeSpec.FailureThreshold)
+	}
+	if l.ProbeSpec.Timeout > 0 {
+		probeSpec["timeout"] = l.ProbeSpec.Timeout.String()
+	}
+
 	spec := map[string]interface{}{
 		"targetClusterName":             l.TargetClusterName,
 		"targetClusterDomain":           l.TargetClusterDomain,
@@ -188,13 +204,7 @@ func (l Link) ToUnstructured() (unstructured.Unstructured, error) {
 		"gatewayAddress":                l.GatewayAddress,
 		"gatewayPort":                   fmt.Sprintf("%d", l.GatewayPort),
 		"gatewayIdentity":               l.GatewayIdentity,
-		"probeSpec": map[string]interface{}{
-			"failureThreshold": fmt.Sprintf("%d", l.ProbeSpec.FailureThreshold),
-			"path":             l.ProbeSpec.Path,
-			"port":             fmt.Sprintf("%d", l.ProbeSpec.Port),
-			"period":           l.ProbeSpec.Period.String(),
-			"timeout":          l.ProbeSpec.Timeout.String(),
-		},
+		"probeSpec":                     probeSpec,
 	}
 
 	data, err := json.Marshal(l.Selector)
@@ -235,7 +245,7 @@ func (l Link) ToUnstructured() (unstructured.Unstructured, error) {
 // ExtractProbeSpec parses the ProbSpec from a gateway service's annotations.
 func ExtractProbeSpec(gateway *corev1.Service) (ProbeSpec, error) {
 	// older gateways might not have this field
-	failureThreshold := uint64(DefaultFailureThreshold)
+	var failureThreshold uint64
 	failureThresholdStr := gateway.Annotations[k8s.GatewayProbeFailureThreshold]
 	if failureThresholdStr != "" {
 		var err error
@@ -260,14 +270,13 @@ func ExtractProbeSpec(gateway *corev1.Service) (ProbeSpec, error) {
 		return ProbeSpec{}, err
 	}
 
+	var timeout time.Duration
 	timeoutStr := gateway.Annotations[k8s.GatewayProbeTimeout]
-	if timeoutStr == "" {
-		timeoutStr = DefaultProbeTimeout
-	}
-
-	timeout, err := time.ParseDuration(timeoutStr)
-	if err != nil {
-		return ProbeSpec{}, err
+	if timeoutStr != "" {
+		timeout, err = time.ParseDuration(timeoutStr)
+		if err != nil {
+			return ProbeSpec{}, err
+		}
 	}
 
 	return ProbeSpec{


### PR DESCRIPTION
Followup to #1306

## Problem

if we run `linkerd mc link` using the latest CLI and attempted to apply the resulting manifests into a cluster with linkerd-multicluster on version edge-24.9.2 and earlier we would get the following error:

```
Error from server (BadRequest): error when creating "STDIN": Link in version "v1alpha1" cannot be handled as a Link: strict decoding error: unknown field "spec.probeSpec.failureThreshold", unknown field "spec.probeSpec.timeout"
```

## Solution

This changes the `linkerd mc link` command so that it doesn't generate default entries for the new (optional) fields `failureThreshold` and `timeout`, so that the output remains compatible with previous versions of the Link CRD.

`linkerd mc link` will however still generate those fields for clusters that have an up-to-date multicluster extension. Those fields values continue to be retrieved from the gateway service's `mirror.linkerd.io/probe-failure-threshold` and `mirror.linkerd.io/probe-timeout` annotations.

Note that once the linkerd-multicluster extension gets upgraded in the cluster to match the CLI version, the existing Link CRs will automatically receive the default values for these fields.