### PR TITLE
Fix pod annotations propagating to namespace

### DIFF
--- a/jaeger/injector/mutator/webhook.go
+++ b/jaeger/injector/mutator/webhook.go
@@ -97,9 +97,9 @@ func Mutate(collectorSvcAddr, collectorTraceProtocol, collectorSvcAccount, clust
 }
 
 func applyOverrides(ns metav1.Object, pod *corev1.Pod, params *Params) {
-	ann := ns.GetAnnotations()
-	if ann == nil {
-		ann = map[string]string{}
+	ann := map[string]string{}
+	for k, v := range ns.GetAnnotations() {
+		ann[k] = v
 	}
 	for k, v := range pod.Annotations {
 		ann[k] = v


### PR DESCRIPTION
Currently, there's a bug with the jaeger injector where annotation overrides from a pod can propagate to any pod in the same namespace, provided they happen after the admission for the original pod occurs.

This fixes that by performing a deep copy of the namespace annotations, instead of editing the one in the local cache (which appears to have been unintentional).

Validated with a local deployment and checking that annotations are no longer propagated to unrelated pods.