### PR TITLE
Include extra attributes in SubjectAccessReview

### DIFF
--- a/pkg/k8s/authz.go
+++ b/pkg/k8s/authz.go
@@ -48,11 +48,13 @@ func ResourceAuthz(
 func ResourceAuthzForUser(
 	ctx context.Context,
 	client kubernetes.Interface,
-	namespace, verb, group, version, resource, subresource, name, user string, userGroups []string) error {
+	namespace, verb, group, version, resource, subresource, name, user string, userGroups []string, extra map[string]authV1.ExtraValue) error {
 	sar := &authV1.SubjectAccessReview{
 		Spec: authV1.SubjectAccessReviewSpec{
 			User:   user,
 			Groups: userGroups,
+			Extra: extra,
+
 			ResourceAttributes: &authV1.ResourceAttributes{
 				Namespace:   namespace,
 				Verb:        verb,

--- a/viz/tap/api/server.go
+++ b/viz/tap/api/server.go
@@ -50,7 +50,7 @@ func NewServer(
 		}
 	}()
 
-	clientCAPem, allowedNames, usernameHeader, groupHeader, err := serverAuth(ctx, k8sAPI)
+	clientCAPem, allowedNames, usernameHeader, groupHeader, extraHeaderPrefix, err := serverAuth(ctx, k8sAPI)
 	if err != nil {
 		return nil, err
 	}
@@ -80,11 +80,12 @@ func NewServer(
 
 	var emptyCert atomic.Value
 	h := &handler{
-		k8sAPI:         k8sAPI,
-		usernameHeader: usernameHeader,
-		groupHeader:    groupHeader,
-		grpcTapServer:  grpcTapServer,
-		log:            log,
+		k8sAPI:            k8sAPI,
+		usernameHeader:    usernameHeader,
+		groupHeader:       groupHeader,
+		extraHeaderPrefix: extraHeaderPrefix,
+		grpcTapServer:     grpcTapServer,
+		log:               log,
 	}
 
 	lis, err := net.Listen("tcp", addr)
@@ -164,28 +165,28 @@ func (a *Server) validate(req *http.Request) error {
 // authentication.
 // kubectl -n kube-system get cm/extension-apiserver-authentication
 // accessible via the extension-apiserver-authentication-reader role
-func serverAuth(ctx context.Context, k8sAPI *k8s.API) (string, []string, string, string, error) {
+func serverAuth(ctx context.Context, k8sAPI *k8s.API) (string, []string, string, string, string, error) {
 
 	cm, err := k8sAPI.Client.CoreV1().
 		ConfigMaps(metav1.NamespaceSystem).
 		Get(ctx, pkgk8s.ExtensionAPIServerAuthenticationConfigMapName, metav1.GetOptions{})
 	if err != nil {
-		return "", nil, "", "", fmt.Errorf("failed to load [%s] config: %w", pkgk8s.ExtensionAPIServerAuthenticationConfigMapName, err)
+		return "", nil, "", "", "", fmt.Errorf("failed to load [%s] config: %w", pkgk8s.ExtensionAPIServerAuthenticationConfigMapName, err)
 	}
 
 	clientCAPem, ok := cm.Data[pkgk8s.ExtensionAPIServerAuthenticationRequestHeaderClientCAFileKey]
 	if !ok {
-		return "", nil, "", "", fmt.Errorf("no client CA cert available for apiextension-server")
+		return "", nil, "", "", "", fmt.Errorf("no client CA cert available for apiextension-server")
 	}
 
 	allowedNames, err := deserializeStrings(cm.Data["requestheader-allowed-names"])
 	if err != nil {
-		return "", nil, "", "", err
+		return "", nil, "", "", "", err
 	}
 
 	usernameHeaders, err := deserializeStrings(cm.Data["requestheader-username-headers"])
 	if err != nil {
-		return "", nil, "", "", err
+		return "", nil, "", "", "", err
 	}
 	usernameHeader := ""
 	if len(usernameHeaders) > 0 {
@@ -194,14 +195,23 @@ func serverAuth(ctx context.Context, k8sAPI *k8s.API) (string, []string, string,
 
 	groupHeaders, err := deserializeStrings(cm.Data["requestheader-group-headers"])
 	if err != nil {
-		return "", nil, "", "", err
+		return "", nil, "", "", "", err
 	}
 	groupHeader := ""
 	if len(groupHeaders) > 0 {
 		groupHeader = groupHeaders[0]
 	}
 
-	return clientCAPem, allowedNames, usernameHeader, groupHeader, nil
+	extraHeaderPrefixes, err := deserializeStrings(cm.Data["requestheader-group-headers"])
+	if err != nil {
+		return "", nil, "", "", "", err
+	}
+	extraHeaderPrefix := ""
+	if len(extraHeaderPrefixes) > 0 {
+		extraHeaderPrefix = extraHeaderPrefixes[0]
+	}
+
+	return clientCAPem, allowedNames, usernameHeader, groupHeader, extraHeaderPrefix, nil
 }
 
 // copied from https://github.com/kubernetes/apiserver/blob/781c3cd1b3dc5b6f79c68ab0d16fe544600421ef/pkg/server/options/authentication.go#L360

--- a/viz/tap/api/server_test.go
+++ b/viz/tap/api/server_test.go
@@ -18,12 +18,13 @@ import (
 
 func TestAPIServerAuth(t *testing.T) {
 	expectations := []struct {
-		k8sRes         []string
-		clientCAPem    string
-		allowedNames   []string
-		usernameHeader string
-		groupHeader    string
-		err            error
+		k8sRes            []string
+		clientCAPem       string
+		allowedNames      []string
+		usernameHeader    string
+		groupHeader       string
+		extraHeaderPrefix string
+		err               error
 	}{
 		{
 			err: fmt.Errorf("failed to load [%s] config: configmaps %q not found", k8sutils.ExtensionAPIServerAuthenticationConfigMapName, k8sutils.ExtensionAPIServerAuthenticationConfigMapName),
@@ -44,11 +45,12 @@ data:
   requestheader-username-headers: '["X-Remote-User"]'
 `,
 			},
-			clientCAPem:    "requestheader-client-ca-file",
-			allowedNames:   []string{"name1", "name2"},
-			usernameHeader: "X-Remote-User",
-			groupHeader:    "X-Remote-Group",
-			err:            nil,
+			clientCAPem:       "requestheader-client-ca-file",
+			allowedNames:      []string{"name1", "name2"},
+			usernameHeader:    "X-Remote-User",
+			groupHeader:       "X-Remote-Group",
+			extraHeaderPrefix: "X-Remote-Extra-",
+			err:               nil,
 		},
 	}
 
@@ -62,7 +64,7 @@ data:
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			clientCAPem, allowedNames, usernameHeader, groupHeader, err := serverAuth(ctx, k8sAPI)
+			clientCAPem, allowedNames, usernameHeader, groupHeader, extraHeaderPrefix, err := serverAuth(ctx, k8sAPI)
 
 			if err != nil && exp.err != nil {
 				if err.Error() != exp.err.Error() {
@@ -85,6 +87,9 @@ data:
 			}
 			if groupHeader != exp.groupHeader {
 				t.Errorf("apiServerAuth returned unexpected groupHeader: %q, expected: %q", groupHeader, exp.groupHeader)
+			}
+			if extraHeaderPrefix != exp.extraHeaderPrefix {
+				t.Errorf("apiServerAuth returned unexpected extraHeaderPrefix: %q, expected: %q", extraHeaderPrefix, exp.extraHeaderPrefix)
 			}
 		})
 	}


### PR DESCRIPTION
Kubernetes authorization plugins can rely on extra attributes on a user, and these are provided via `X-Remote-Extra-` headers. Currently the Linkerd Viz `tap` API doesn't include these attributes when making the `SubjectAccessReview` request which means the Tap API cannot be used by end-users who's clusters use such authz plugins.

This change updates the `tap` controller to parse the `X-Remote-Extra-` headers and include them in the SubjectAccessReview request.

Fixed #13169