### PR TITLE
Update deprecation warning text for v1beta1 Server

### DIFF
--- a/charts/linkerd-crds/templates/policy/server.yaml
+++ b/charts/linkerd-crds/templates/policy/server.yaml
@@ -74,7 +74,7 @@ spec:
       served: true
       storage: false
       deprecated: true
-      deprecationWarning: "policy.linkerd.io/v1alpha1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
+      deprecationWarning: "policy.linkerd.io/v1beta1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
       schema:
         openAPIV3Schema:
           type: object

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -5907,7 +5907,7 @@ spec:
       served: true
       storage: false
       deprecated: true
-      deprecationWarning: "policy.linkerd.io/v1alpha1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
+      deprecationWarning: "policy.linkerd.io/v1beta1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
       schema:
         openAPIV3Schema:
           type: object

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -5919,7 +5919,7 @@ spec:
       served: true
       storage: false
       deprecated: true
-      deprecationWarning: "policy.linkerd.io/v1alpha1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
+      deprecationWarning: "policy.linkerd.io/v1beta1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
       schema:
         openAPIV3Schema:
           type: object

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -5919,7 +5919,7 @@ spec:
       served: true
       storage: false
       deprecated: true
-      deprecationWarning: "policy.linkerd.io/v1alpha1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
+      deprecationWarning: "policy.linkerd.io/v1beta1 Server is deprecated; use policy.linkerd.io/v1beta3 Server"
       schema:
         openAPIV3Schema:
           type: object


### PR DESCRIPTION
Subject
Update deprecation warning text for v1beta1 Server resource

Problem
The deprecation warning for v1beta1 Server reads v1alpha1

Solution
Update warning text

Validation
Warning text when deploying a v1beta1 Server resource reads v1beta1

Fixes #13187

DCO Sign off: Trivial change