### PR TITLE
policy: Serve EgressNetwork responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/add-error-type-to-tls-and-tcp-route#d7385b43d087da05ef4356e51d81be0a1a736a14"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/make-route-error-optional#5493beff7e0713e048c845fbb92777cfe1a58274"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,8 +1325,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c72fb98d969e1e94e95d52a6fcdf4693764702c369e577934256e72fb5bc61"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/add-error-type-to-tls-and-tcp-route#d7385b43d087da05ef4356e51d81be0a1a736a14"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/make-route-error-optional#5493beff7e0713e048c845fbb92777cfe1a58274"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=c5648ae2a1e405cc6b8aca20522356ebdf20f1ea#c5648ae2a1e405cc6b8aca20522356ebdf20f1ea"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ members = [
 
 [profile.release]
 lto = "thin"
+
+[patch.crates-io]
+linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/add-error-type-to-tls-and-tcp-route' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ members = [
 lto = "thin"
 
 [patch.crates-io]
-linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/make-route-error-optional' }
+# TODO(Zahari): switch released version once TLS protocol support is out.
+linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', rev = 'c5648ae2a1e405cc6b8aca20522356ebdf20f1ea' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ members = [
 lto = "thin"
 
 [patch.crates-io]
-linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/add-error-type-to-tls-and-tcp-route' }
+linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/make-route-error-optional' }

--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,7 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/linkerd/linkerd2-proxy-api"]
 
 [sources.allow-org]
 github = []

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -29,13 +29,13 @@ pub trait DiscoverOutboundPolicy<R, T> {
 
     async fn watch_outbound_policy(&self, target: R) -> Result<Option<OutboundPolicyStream>>;
 
-    async fn watch_fallback_policy(&self) -> FallbackPolicyStream;
+    async fn watch_external_policy(&self) -> ExternalPolicyStream;
 
     fn lookup_ip(&self, addr: IpAddr, port: NonZeroU16, source_namespace: String) -> Option<T>;
 }
 
 pub type OutboundPolicyStream = Pin<Box<dyn Stream<Item = OutboundPolicy> + Send + Sync + 'static>>;
-pub type FallbackPolicyStream = Pin<Box<dyn Stream<Item = FallbackPolicy> + Send + Sync + 'static>>;
+pub type ExternalPolicyStream = Pin<Box<dyn Stream<Item = FallbackPolicy> + Send + Sync + 'static>>;
 
 pub type HttpRoute = OutboundRoute<HttpRouteMatch, HttpRetryCondition>;
 pub type GrpcRoute = OutboundRoute<GrpcRouteMatch, GrpcRetryCondition>;

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -6,11 +6,14 @@ use ahash::AHashMap as HashMap;
 use anyhow::Result;
 use chrono::{offset::Utc, DateTime};
 use futures::prelude::*;
-use std::{
-    net::{IpAddr, SocketAddr},
-    num::NonZeroU16,
-    pin::Pin,
-    time,
+use std::{net::IpAddr, num::NonZeroU16, pin::Pin, time};
+
+mod policy;
+mod target;
+
+pub use self::{
+    policy::{OutboundPolicy, OutboundPolicyKind, ParentMeta, ResourceOutboundPolicy},
+    target::{Kind, OutboundDiscoverTarget, ResourceTarget},
 };
 
 pub trait Route {
@@ -20,14 +23,15 @@ pub trait Route {
 /// Models outbound policy discovery.
 #[async_trait::async_trait]
 pub trait DiscoverOutboundPolicy<T> {
-    async fn get_outbound_policy(&self, target: T) -> Result<Option<OutboundPolicy>>;
+    async fn get_outbound_policy(&self, target: T) -> Result<Option<OutboundPolicyKind>>;
 
     async fn watch_outbound_policy(&self, target: T) -> Result<Option<OutboundPolicyStream>>;
 
     fn lookup_ip(&self, addr: IpAddr, port: NonZeroU16, source_namespace: String) -> Option<T>;
 }
 
-pub type OutboundPolicyStream = Pin<Box<dyn Stream<Item = OutboundPolicy> + Send + Sync + 'static>>;
+pub type OutboundPolicyStream =
+    Pin<Box<dyn Stream<Item = OutboundPolicyKind> + Send + Sync + 'static>>;
 
 pub type HttpRoute = OutboundRoute<HttpRouteMatch, HttpRetryCondition>;
 pub type GrpcRoute = OutboundRoute<GrpcRouteMatch, GrpcRetryCondition>;
@@ -38,41 +42,6 @@ pub type RouteSet<T> = HashMap<GroupKindNamespaceName, T>;
 pub enum TrafficPolicy {
     Allow,
     Deny,
-}
-
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Kind {
-    EgressNetwork {
-        original_dst: SocketAddr,
-        traffic_policy: TrafficPolicy,
-    },
-    Service,
-}
-
-#[derive(Clone, Debug)]
-pub struct OutboundDiscoverTarget {
-    pub name: String,
-    pub namespace: String,
-    pub port: NonZeroU16,
-    pub source_namespace: String,
-    pub kind: Kind,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct OutboundPolicy {
-    pub http_routes: RouteSet<HttpRoute>,
-    pub grpc_routes: RouteSet<GrpcRoute>,
-    pub tls_routes: RouteSet<TlsRoute>,
-    pub tcp_routes: RouteSet<TcpRoute>,
-    pub service_authority: String,
-    pub name: String,
-    pub namespace: String,
-    pub port: NonZeroU16,
-    pub opaque: bool,
-    pub accrual: Option<FailureAccrual>,
-    pub http_retry: Option<RouteRetry<HttpRetryCondition>>,
-    pub grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
-    pub timeouts: RouteTimeouts,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -14,7 +14,7 @@ mod target;
 type FallbackPolicy = ();
 
 pub use self::{
-    policy::{OutboundPolicy, ParentInfo, ResourceOutboundPolicy},
+    policy::{OutboundPolicy, ParentInfo},
     target::{Kind, OutboundDiscoverTarget, ResourceTarget},
 };
 

--- a/policy-controller/core/src/outbound/policy.rs
+++ b/policy-controller/core/src/outbound/policy.rs
@@ -3,7 +3,7 @@ use super::{
     RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
 };
 
-use std::{net::SocketAddr, num::NonZeroU16};
+use std::num::NonZeroU16;
 
 // ParentInfo carries resource-specific information about
 // the parent to which outbound policy is associated.
@@ -59,14 +59,5 @@ impl OutboundPolicy {
 
     pub fn parent_namespace(&self) -> &str {
         self.parent_info.namespace()
-    }
-}
-
-impl ResourceOutboundPolicy {
-    pub fn policy(&self) -> &OutboundPolicy {
-        match self {
-            Self::Egress { policy, .. } => policy,
-            Self::Service { policy, .. } => policy,
-        }
     }
 }

--- a/policy-controller/core/src/outbound/policy.rs
+++ b/policy-controller/core/src/outbound/policy.rs
@@ -1,0 +1,67 @@
+use super::{
+    FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute, RouteRetry,
+    RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+};
+
+use std::{net::SocketAddr, num::NonZeroU16};
+
+/// OutboundPolicyKind describes a resolved outbound policy that is
+/// either attributed to a resource or is a fallback one.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum OutboundPolicyKind {
+    Fallback(SocketAddr),
+    Resource(ResourceOutboundPolicy),
+}
+
+/// ResourceOutboundPolicy expresses the known resource types
+/// that can be parents for outbound policy. They each come with
+/// specific metadata that is used when putting together the final
+/// policy response.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ResourceOutboundPolicy {
+    Service {
+        authority: String,
+        policy: OutboundPolicy,
+    },
+    Egress {
+        traffic_policy: TrafficPolicy,
+        original_dst: SocketAddr,
+        policy: OutboundPolicy,
+    },
+}
+
+// ParentMeta carries information resource-specific
+// information about the parent to which outbound policy
+// is associated.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ParentMeta {
+    Service { authority: String },
+    EgressNetwork(TrafficPolicy),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct OutboundPolicy {
+    pub parent_meta: ParentMeta,
+    pub http_routes: RouteSet<HttpRoute>,
+    pub grpc_routes: RouteSet<GrpcRoute>,
+    pub tls_routes: RouteSet<TlsRoute>,
+    pub tcp_routes: RouteSet<TcpRoute>,
+    pub name: String,
+    pub namespace: String,
+    pub port: NonZeroU16,
+    pub opaque: bool,
+    pub accrual: Option<FailureAccrual>,
+    pub http_retry: Option<RouteRetry<HttpRetryCondition>>,
+    pub grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
+    pub timeouts: RouteTimeouts,
+}
+
+impl ResourceOutboundPolicy {
+    pub fn policy(&self) -> &OutboundPolicy {
+        match self {
+            Self::Egress { policy, .. } => policy,
+            Self::Service { policy, .. } => policy,
+        }
+    }
+}

--- a/policy-controller/core/src/outbound/policy.rs
+++ b/policy-controller/core/src/outbound/policy.rs
@@ -5,23 +5,6 @@ use super::{
 
 use std::{net::SocketAddr, num::NonZeroU16};
 
-/// ResourceOutboundPolicy expresses the known resource types
-/// that can be parents for outbound policy. They each come with
-/// specific metadata that is used when putting together the final
-/// policy response.
-#[derive(Clone, Debug, PartialEq)]
-pub enum ResourceOutboundPolicy {
-    Service {
-        authority: String,
-        policy: OutboundPolicy,
-    },
-    Egress {
-        traffic_policy: TrafficPolicy,
-        original_dst: SocketAddr,
-        policy: OutboundPolicy,
-    },
-}
-
 // ParentInfo carries resource-specific information about
 // the parent to which outbound policy is associated.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/policy-controller/core/src/outbound/target.rs
+++ b/policy-controller/core/src/outbound/target.rs
@@ -1,0 +1,26 @@
+use std::{net::SocketAddr, num::NonZeroU16};
+
+/// OutboundDiscoverTarget allows us to express the fact that
+/// a policy resolution can be fulfilled by either a resource
+/// we know about (a specific EgressNetwork or a Service) or
+/// by our fallback mechanism.
+#[derive(Clone, Debug)]
+pub enum OutboundDiscoverTarget {
+    Resource(ResourceTarget),
+    Fallback(SocketAddr),
+}
+
+#[derive(Clone, Debug)]
+pub struct ResourceTarget {
+    pub name: String,
+    pub namespace: String,
+    pub port: NonZeroU16,
+    pub source_namespace: String,
+    pub kind: Kind,
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Kind {
+    EgressNetwork(SocketAddr),
+    Service,
+}

--- a/policy-controller/core/src/outbound/target.rs
+++ b/policy-controller/core/src/outbound/target.rs
@@ -7,7 +7,7 @@ use std::{net::SocketAddr, num::NonZeroU16};
 #[derive(Clone, Debug)]
 pub enum OutboundDiscoverTarget {
     Resource(ResourceTarget),
-    Fallback(SocketAddr),
+    External(SocketAddr),
 }
 
 #[derive(Clone, Debug)]

--- a/policy-controller/core/src/outbound/target.rs
+++ b/policy-controller/core/src/outbound/target.rs
@@ -24,3 +24,12 @@ pub enum Kind {
     EgressNetwork(SocketAddr),
     Service,
 }
+
+impl ResourceTarget {
+    pub fn original_dst(&self) -> Option<SocketAddr> {
+        match self.kind {
+            Kind::EgressNetwork(original_dst) => Some(original_dst),
+            Kind::Service => None,
+        }
+    }
+}

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -383,8 +383,8 @@ fn to_proto(
     }
 }
 
-fn timestamp_then_name<L: Route, R: Route>(
-    (left_id, left_route): &(GroupKindNamespaceName, L),
+fn timestamp_then_name<R: Route>(
+    (left_id, left_route): &(GroupKindNamespaceName, R),
     (right_id, right_route): &(GroupKindNamespaceName, R),
 ) -> std::cmp::Ordering {
     let by_ts = match (

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -13,7 +13,7 @@ use linkerd2_proxy_api::{
 };
 use linkerd_policy_controller_core::{
     outbound::{
-        DiscoverOutboundPolicy, FallbackPolicyStream, Kind, OutboundDiscoverTarget, OutboundPolicy,
+        DiscoverOutboundPolicy, ExternalPolicyStream, Kind, OutboundDiscoverTarget, OutboundPolicy,
         OutboundPolicyStream, ParentInfo, ResourceTarget, Route, WeightedEgressNetwork,
         WeightedService,
     },
@@ -173,7 +173,7 @@ where
                 }
             }
 
-            OutboundDiscoverTarget::Fallback(original_dst) => {
+            OutboundDiscoverTarget::External(original_dst) => {
                 Ok(tonic::Response::new(fallback(original_dst)))
             }
         }
@@ -205,9 +205,9 @@ where
                 )))
             }
 
-            OutboundDiscoverTarget::Fallback(original_dst) => {
-                let rx = self.index.watch_fallback_policy().await;
-                Ok(tonic::Response::new(fallback_stream(
+            OutboundDiscoverTarget::External(original_dst) => {
+                let rx = self.index.watch_external_policy().await;
+                Ok(tonic::Response::new(external_stream(
                     drain,
                     rx,
                     original_dst,
@@ -252,9 +252,9 @@ fn response_stream(
     })
 }
 
-fn fallback_stream(
+fn external_stream(
     drain: drain::Watch,
-    mut rx: FallbackPolicyStream,
+    mut rx: ExternalPolicyStream,
     original_dst: SocketAddr,
 ) -> BoxWatchStream {
     Box::pin(async_stream::try_stream! {

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -283,8 +283,6 @@ fn external_stream(
 
 fn fallback(original_dst: SocketAddr) -> outbound::OutboundPolicy {
     // This encoder sets deprecated timeouts for older proxies.
-    #![allow(deprecated)]
-
     let metadata = Some(Metadata {
         kind: Some(metadata::Kind::Default("egress-fallback".to_string())),
     });
@@ -331,18 +329,14 @@ fn fallback(original_dst: SocketAddr) -> outbound::OutboundPolicy {
                     outbound::http_route::distribution::FirstAvailable {
                         backends: vec![outbound::http_route::RouteBackend {
                             backend: Some(backend),
-                            filters: Vec::default(),
-                            request_timeout: None,
+                            ..Default::default()
                         }],
                     },
                 )),
             }),
             matches: vec![api::http_route::HttpRouteMatch::default()],
             filters: Vec::default(),
-            request_timeout: None,
-            timeouts: None,
-            retry: None,
-            allow_l5d_request_headers: false,
+            ..Default::default()
         }],
     }];
 

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -4,8 +4,8 @@ use crate::workload;
 use futures::prelude::*;
 use http_crate::uri::Authority;
 use linkerd2_proxy_api::{
-    self as api,
-    meta::{metadata, Metadata},
+    self as api, destination,
+    meta::{metadata, Metadata, Resource},
     outbound::{
         self,
         outbound_policies_server::{OutboundPolicies, OutboundPoliciesServer},
@@ -13,8 +13,8 @@ use linkerd2_proxy_api::{
 };
 use linkerd_policy_controller_core::{
     outbound::{
-        DiscoverOutboundPolicy, OutboundDiscoverTarget, OutboundPolicy, OutboundPolicyStream,
-        OutboundRoute,
+        DiscoverOutboundPolicy, Kind, OutboundDiscoverTarget, OutboundPolicy, OutboundPolicyStream,
+        Route, WeightedEgressNetwork, WeightedService,
     },
     routes::GroupKindNamespaceName,
 };
@@ -22,6 +22,8 @@ use std::{num::NonZeroU16, str::FromStr, sync::Arc, time};
 
 mod grpc;
 mod http;
+mod tcp;
+mod tls;
 
 #[derive(Clone, Debug)]
 pub struct OutboundPolicyServer<T> {
@@ -62,14 +64,15 @@ where
         let target = match target {
             outbound::traffic_spec::Target::Addr(target) => target,
             outbound::traffic_spec::Target::Authority(auth) => {
-                return self.lookup_authority(&auth).map(
-                    |(service_namespace, service_name, service_port)| OutboundDiscoverTarget {
-                        service_name,
-                        service_namespace,
-                        service_port,
+                return self.lookup_authority(&auth).map(|(namespace, name, port)| {
+                    OutboundDiscoverTarget {
+                        kind: Kind::Service,
+                        name,
+                        namespace,
+                        port,
                         source_namespace,
-                    },
-                )
+                    }
+                })
             }
         };
 
@@ -146,19 +149,19 @@ where
         req: tonic::Request<outbound::TrafficSpec>,
     ) -> Result<tonic::Response<outbound::OutboundPolicy>, tonic::Status> {
         let service = self.lookup(req.into_inner())?;
-
         let policy = self
             .index
-            .get_outbound_policy(service)
+            .get_outbound_policy(service.clone())
             .await
             .map_err(|error| {
                 tonic::Status::internal(format!("failed to get outbound policy: {error}"))
             })?;
 
         if let Some(policy) = policy {
-            Ok(tonic::Response::new(to_service(
+            Ok(tonic::Response::new(to_proto(
                 policy,
                 self.allow_l5d_request_headers,
+                service,
             )))
         } else {
             Err(tonic::Status::not_found("No such policy"))
@@ -172,11 +175,12 @@ where
         req: tonic::Request<outbound::TrafficSpec>,
     ) -> Result<tonic::Response<BoxWatchStream>, tonic::Status> {
         let service = self.lookup(req.into_inner())?;
+
         let drain = self.drain.clone();
 
         let rx = self
             .index
-            .watch_outbound_policy(service)
+            .watch_outbound_policy(service.clone())
             .await
             .map_err(|e| tonic::Status::internal(format!("lookup failed: {e}")))?
             .ok_or_else(|| tonic::Status::not_found("unknown server"))?;
@@ -184,6 +188,7 @@ where
             drain,
             rx,
             self.allow_l5d_request_headers,
+            service,
         )))
     }
 }
@@ -196,6 +201,7 @@ fn response_stream(
     drain: drain::Watch,
     mut rx: OutboundPolicyStream,
     allow_l5d_request_headers: bool,
+    target: OutboundDiscoverTarget,
 ) -> BoxWatchStream {
     Box::pin(async_stream::try_stream! {
         tokio::pin! {
@@ -207,7 +213,7 @@ fn response_stream(
                 // When the port is updated with a new server, update the server watch.
                 res = rx.next() => match res {
                     Some(policy) => {
-                        yield to_service(policy, allow_l5d_request_headers);
+                        yield to_proto(policy, allow_l5d_request_headers, target.clone());
                     }
                     None => return,
                 },
@@ -222,15 +228,23 @@ fn response_stream(
     })
 }
 
-fn to_service(
+fn no_explicit_routes(outbound: &OutboundPolicy) -> bool {
+    outbound.http_routes.is_empty()
+        && outbound.grpc_routes.is_empty()
+        && outbound.tls_routes.is_empty()
+        && outbound.tcp_routes.is_empty()
+}
+
+fn to_proto(
     outbound: OutboundPolicy,
     allow_l5d_request_headers: bool,
+    target: OutboundDiscoverTarget,
 ) -> outbound::OutboundPolicy {
-    let backend: outbound::Backend = default_backend(&outbound);
+    let backend: outbound::Backend = default_backend(&outbound, target.kind);
 
     let kind = if outbound.opaque {
         outbound::proxy_protocol::Kind::Opaque(outbound::proxy_protocol::Opaque {
-            routes: vec![default_outbound_opaq_route(backend)],
+            routes: vec![default_outbound_opaq_route(backend, target.kind)],
         })
     } else {
         let accrual = outbound.accrual.map(|accrual| outbound::FailureAccrual {
@@ -251,20 +265,9 @@ fn to_service(
             }),
         });
 
-        let mut http_routes = outbound.http_routes.into_iter().collect::<Vec<_>>();
-        let mut grpc_routes = outbound.grpc_routes.into_iter().collect::<Vec<_>>();
-
-        if !grpc_routes.is_empty() {
-            grpc_routes.sort_by(timestamp_then_name);
-            grpc::protocol(
-                backend,
-                grpc_routes.into_iter(),
-                accrual,
-                outbound.grpc_retry,
-                outbound.timeouts,
-                allow_l5d_request_headers,
-            )
-        } else {
+        // if we have no explicit routes attached to the parent, always attempt protocol detection
+        if no_explicit_routes(&outbound) {
+            let mut http_routes = outbound.http_routes.into_iter().collect::<Vec<_>>();
             http_routes.sort_by(timestamp_then_name);
             http::protocol(
                 backend,
@@ -273,14 +276,55 @@ fn to_service(
                 outbound.http_retry,
                 outbound.timeouts,
                 allow_l5d_request_headers,
+                target.clone(),
             )
+        } else {
+            let mut grpc_routes = outbound.grpc_routes.into_iter().collect::<Vec<_>>();
+            let mut http_routes = outbound.http_routes.into_iter().collect::<Vec<_>>();
+            let mut tls_routes = outbound.tls_routes.into_iter().collect::<Vec<_>>();
+            let mut tcp_routes = outbound.tcp_routes.into_iter().collect::<Vec<_>>();
+
+            if !grpc_routes.is_empty() {
+                grpc_routes.sort_by(timestamp_then_name);
+                grpc::protocol(
+                    backend,
+                    grpc_routes.into_iter(),
+                    accrual,
+                    outbound.grpc_retry,
+                    outbound.timeouts,
+                    allow_l5d_request_headers,
+                    target.clone(),
+                )
+            } else if !http_routes.is_empty() {
+                http_routes.sort_by(timestamp_then_name);
+                http::protocol(
+                    backend,
+                    http_routes.into_iter(),
+                    accrual,
+                    outbound.http_retry,
+                    outbound.timeouts,
+                    allow_l5d_request_headers,
+                    target.clone(),
+                )
+            } else if !tls_routes.is_empty() {
+                tls_routes.sort_by(timestamp_then_name);
+                tls::protocol(backend, tls_routes.into_iter(), target.clone())
+            } else {
+                tcp_routes.sort_by(timestamp_then_name);
+                tcp::protocol(backend, tcp_routes.into_iter(), target.clone())
+            }
         }
+    };
+
+    let (parent_group, parent_kind) = match target.kind {
+        Kind::EgressNetwork { .. } => ("policy.linkerd.io", "EgressNetwork"),
+        Kind::Service => ("core", "Service"),
     };
 
     let metadata = Metadata {
         kind: Some(metadata::Kind::Resource(api::meta::Resource {
-            group: "core".to_string(),
-            kind: "Service".to_string(),
+            group: parent_group.into(),
+            kind: parent_kind.into(),
             namespace: outbound.namespace,
             name: outbound.name,
             port: u16::from(outbound.port).into(),
@@ -294,13 +338,13 @@ fn to_service(
     }
 }
 
-fn timestamp_then_name<LM, LR, RM, RR>(
-    (left_id, left_route): &(GroupKindNamespaceName, OutboundRoute<LM, LR>),
-    (right_id, right_route): &(GroupKindNamespaceName, OutboundRoute<RM, RR>),
+fn timestamp_then_name<L: Route, R: Route>(
+    (left_id, left_route): &(GroupKindNamespaceName, L),
+    (right_id, right_route): &(GroupKindNamespaceName, R),
 ) -> std::cmp::Ordering {
     let by_ts = match (
-        &left_route.creation_timestamp,
-        &right_route.creation_timestamp,
+        &left_route.creation_timestamp(),
+        &right_route.creation_timestamp(),
     ) {
         (Some(left_ts), Some(right_ts)) => left_ts.cmp(right_ts),
         (None, None) => std::cmp::Ordering::Equal,
@@ -312,50 +356,87 @@ fn timestamp_then_name<LM, LR, RM, RR>(
     by_ts.then_with(|| left_id.name.cmp(&right_id.name))
 }
 
-fn default_backend(outbound: &OutboundPolicy) -> outbound::Backend {
-    outbound::Backend {
-        metadata: Some(Metadata {
-            kind: Some(metadata::Kind::Resource(api::meta::Resource {
-                group: "core".to_string(),
-                kind: "Service".to_string(),
-                name: outbound.name.clone(),
-                namespace: outbound.namespace.clone(),
-                section: Default::default(),
-                port: u16::from(outbound.port).into(),
-            })),
-        }),
-        queue: Some(default_queue_config()),
-        kind: Some(outbound::backend::Kind::Balancer(
-            outbound::backend::BalanceP2c {
-                discovery: Some(outbound::backend::EndpointDiscovery {
-                    kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
-                        outbound::backend::endpoint_discovery::DestinationGet {
-                            path: outbound.authority.clone(),
-                        },
-                    )),
-                }),
-                load: Some(default_balancer_config()),
-            },
-        )),
+fn default_backend(outbound: &OutboundPolicy, parent_kind: Kind) -> outbound::Backend {
+    match parent_kind {
+        Kind::Service => outbound::Backend {
+            metadata: Some(Metadata {
+                kind: Some(metadata::Kind::Resource(api::meta::Resource {
+                    group: "core".to_string(),
+                    kind: "Service".to_string(),
+                    name: outbound.name.clone(),
+                    namespace: outbound.namespace.clone(),
+                    section: Default::default(),
+                    port: u16::from(outbound.port).into(),
+                })),
+            }),
+            queue: Some(default_queue_config()),
+            kind: Some(outbound::backend::Kind::Balancer(
+                outbound::backend::BalanceP2c {
+                    discovery: Some(outbound::backend::EndpointDiscovery {
+                        kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
+                            outbound::backend::endpoint_discovery::DestinationGet {
+                                path: outbound.service_authority.clone(),
+                            },
+                        )),
+                    }),
+                    load: Some(default_balancer_config()),
+                },
+            )),
+        },
+        Kind::EgressNetwork { original_dst, .. } => outbound::Backend {
+            metadata: Some(Metadata {
+                kind: Some(metadata::Kind::Resource(api::meta::Resource {
+                    group: "policy.linkerd.io".to_string(),
+                    kind: "EgressNetwork".to_string(),
+                    name: outbound.name.clone(),
+                    namespace: outbound.namespace.clone(),
+                    section: Default::default(),
+                    port: u16::from(outbound.port).into(),
+                })),
+            }),
+            queue: Some(default_queue_config()),
+            kind: Some(outbound::backend::Kind::Forward(
+                destination::WeightedAddr {
+                    addr: Some(original_dst.into()),
+                    weight: 1,
+                    ..Default::default()
+                },
+            )),
+        },
     }
 }
 
-fn default_outbound_opaq_route(backend: outbound::Backend) -> outbound::OpaqueRoute {
-    let metadata = Some(Metadata {
-        kind: Some(metadata::Kind::Default("opaq".to_string())),
-    });
-    let rules = vec![outbound::opaque_route::Rule {
-        backends: Some(outbound::opaque_route::Distribution {
-            kind: Some(outbound::opaque_route::distribution::Kind::FirstAvailable(
-                outbound::opaque_route::distribution::FirstAvailable {
-                    backends: vec![outbound::opaque_route::RouteBackend {
-                        backend: Some(backend),
-                    }],
-                },
-            )),
-        }),
-    }];
-    outbound::OpaqueRoute { metadata, rules }
+fn default_outbound_opaq_route(
+    backend: outbound::Backend,
+    parent_kind: Kind,
+) -> outbound::OpaqueRoute {
+    match parent_kind {
+        Kind::EgressNetwork { traffic_policy, .. } => {
+            tcp::default_outbound_egress_route(backend, traffic_policy)
+        }
+        Kind::Service => {
+            let metadata = Some(Metadata {
+                kind: Some(metadata::Kind::Default("opaq".to_string())),
+            });
+            let rules = vec![outbound::opaque_route::Rule {
+                backends: Some(outbound::opaque_route::Distribution {
+                    kind: Some(outbound::opaque_route::distribution::Kind::FirstAvailable(
+                        outbound::opaque_route::distribution::FirstAvailable {
+                            backends: vec![outbound::opaque_route::RouteBackend {
+                                backend: Some(backend),
+                            }],
+                        },
+                    )),
+                }),
+            }];
+
+            outbound::OpaqueRoute {
+                metadata,
+                rules,
+                error: None,
+            }
+        }
+    }
 }
 
 fn default_balancer_config() -> outbound::backend::balance_p2c::Load {
@@ -394,4 +475,39 @@ pub(crate) fn convert_duration(
             tracing::error!(%error, "Invalid {name} duration");
         })
         .ok()
+}
+
+pub(crate) fn service_meta(svc: WeightedService) -> Metadata {
+    Metadata {
+        kind: Some(metadata::Kind::Resource(Resource {
+            group: "core".to_string(),
+            kind: "Service".to_string(),
+            name: svc.name,
+            namespace: svc.namespace,
+            section: Default::default(),
+            port: u16::from(svc.port).into(),
+        })),
+    }
+}
+
+pub(crate) fn egress_net_meta(
+    egress_net: WeightedEgressNetwork,
+    original_dst_port: Option<u16>,
+) -> Metadata {
+    let port = egress_net
+        .port
+        .map(NonZeroU16::get)
+        .or(original_dst_port)
+        .unwrap_or_default();
+
+    Metadata {
+        kind: Some(metadata::Kind::Resource(Resource {
+            group: "policy.linkerd.io".to_string(),
+            kind: "EgressNetwork".to_string(),
+            name: egress_net.name,
+            namespace: egress_net.namespace,
+            section: Default::default(),
+            port: port.into(),
+        })),
+    }
 }

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -312,6 +312,7 @@ fn fallback(original_dst: SocketAddr) -> outbound::OutboundPolicy {
                         outbound::opaque_route::distribution::FirstAvailable {
                             backends: vec![outbound::opaque_route::RouteBackend {
                                 backend: Some(backend.clone()),
+                                invalid: None,
                             }],
                         },
                     )),
@@ -591,6 +592,7 @@ fn default_outbound_opaq_route(
                         outbound::opaque_route::distribution::FirstAvailable {
                             backends: vec![outbound::opaque_route::RouteBackend {
                                 backend: Some(backend),
+                                invalid: None,
                             }],
                         },
                     )),

--- a/policy-controller/grpc/src/outbound/grpc.rs
+++ b/policy-controller/grpc/src/outbound/grpc.rs
@@ -5,8 +5,8 @@ use crate::routes::{
 use linkerd2_proxy_api::{destination, grpc_route, http_route, meta, outbound};
 use linkerd_policy_controller_core::{
     outbound::{
-        Backend, Filter, GrpcRetryCondition, GrpcRoute, OutboundRoute, OutboundRouteRule,
-        RouteRetry, RouteTimeouts,
+        Backend, Filter, GrpcRetryCondition, GrpcRoute, Kind, OutboundDiscoverTarget,
+        OutboundRoute, OutboundRouteRule, RouteRetry, RouteTimeouts, TrafficPolicy,
     },
     routes::{FailureInjectorFilter, GroupKindNamespaceName},
 };
@@ -19,8 +19,9 @@ pub(crate) fn protocol(
     service_retry: Option<RouteRetry<GrpcRetryCondition>>,
     service_timeouts: RouteTimeouts,
     allow_l5d_request_headers: bool,
+    target: OutboundDiscoverTarget,
 ) -> outbound::proxy_protocol::Kind {
-    let routes = routes
+    let mut routes = routes
         .map(|(gknn, route)| {
             convert_outbound_route(
                 gknn,
@@ -29,9 +30,20 @@ pub(crate) fn protocol(
                 service_retry.clone(),
                 service_timeouts.clone(),
                 allow_l5d_request_headers,
+                target.clone(),
             )
         })
         .collect::<Vec<_>>();
+
+    if let Kind::EgressNetwork { traffic_policy, .. } = target.kind {
+        routes.push(default_outbound_egress_route(
+            default_backend,
+            service_retry,
+            service_timeouts,
+            traffic_policy,
+        ));
+    }
+
     outbound::proxy_protocol::Kind::Grpc(outbound::proxy_protocol::Grpc {
         routes,
         failure_accrual,
@@ -49,6 +61,7 @@ fn convert_outbound_route(
     service_retry: Option<RouteRetry<GrpcRetryCondition>>,
     service_timeouts: RouteTimeouts,
     allow_l5d_request_headers: bool,
+    target: OutboundDiscoverTarget,
 ) -> outbound::GrpcRoute {
     // This encoder sets deprecated timeouts for older proxies.
     #![allow(deprecated)]
@@ -77,7 +90,7 @@ fn convert_outbound_route(
              }| {
                 let backends = backends
                     .into_iter()
-                    .map(convert_backend)
+                    .map(|b| convert_backend(b, target.clone()))
                     .collect::<Vec<_>>();
                 let dist = if backends.is_empty() {
                     outbound::grpc_route::distribution::Kind::FirstAvailable(
@@ -158,7 +171,15 @@ fn convert_outbound_route(
     }
 }
 
-fn convert_backend(backend: Backend) -> outbound::grpc_route::WeightedRouteBackend {
+fn convert_backend(
+    backend: Backend,
+    target: OutboundDiscoverTarget,
+) -> outbound::grpc_route::WeightedRouteBackend {
+    let original_dst_port = match target.kind {
+        Kind::EgressNetwork { original_dst, .. } => Some(original_dst.port()),
+        Kind::Service => None,
+    };
+
     match backend {
         Backend::Addr(addr) => {
             let socket_addr = SocketAddr::new(addr.addr, addr.port.get());
@@ -181,88 +202,214 @@ fn convert_backend(backend: Backend) -> outbound::grpc_route::WeightedRouteBacke
                 }),
             }
         }
-        Backend::Service(svc) => {
-            if svc.exists {
-                let filters = svc.filters.into_iter().map(convert_to_filter).collect();
-                outbound::grpc_route::WeightedRouteBackend {
-                    weight: svc.weight,
-                    backend: Some(outbound::grpc_route::RouteBackend {
-                        backend: Some(outbound::Backend {
-                            metadata: Some(meta::Metadata {
-                                kind: Some(meta::metadata::Kind::Resource(meta::Resource {
-                                    group: "core".to_string(),
-                                    kind: "Service".to_string(),
-                                    name: svc.name,
-                                    namespace: svc.namespace,
-                                    section: Default::default(),
-                                    port: u16::from(svc.port).into(),
-                                })),
-                            }),
-                            queue: Some(default_queue_config()),
-                            kind: Some(outbound::backend::Kind::Balancer(
-                                outbound::backend::BalanceP2c {
-                                    discovery: Some(outbound::backend::EndpointDiscovery {
-                                        kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
-                                            outbound::backend::endpoint_discovery::DestinationGet {
-                                                path: svc.authority,
-                                            },
-                                        )),
-                                    }),
-                                    load: Some(default_balancer_config()),
-                                },
-                            )),
-                        }),
-                        filters,
-                        ..Default::default()
+        Backend::Service(svc) if svc.exists => {
+            let filters = svc
+                .filters
+                .clone()
+                .into_iter()
+                .map(convert_to_filter)
+                .collect();
+            outbound::grpc_route::WeightedRouteBackend {
+                weight: svc.weight,
+                backend: Some(outbound::grpc_route::RouteBackend {
+                    backend: Some(outbound::Backend {
+                        metadata: Some(super::service_meta(svc.clone())),
+                        queue: Some(default_queue_config()),
+                        kind: Some(outbound::backend::Kind::Balancer(
+                            outbound::backend::BalanceP2c {
+                                discovery: Some(outbound::backend::EndpointDiscovery {
+                                    kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
+                                        outbound::backend::endpoint_discovery::DestinationGet {
+                                            path: svc.authority,
+                                        },
+                                    )),
+                                }),
+                                load: Some(default_balancer_config()),
+                            },
+                        )),
                     }),
-                }
-            } else {
-                outbound::grpc_route::WeightedRouteBackend {
-                    weight: svc.weight,
-                    backend: Some(outbound::grpc_route::RouteBackend {
-                        backend: Some(outbound::Backend {
-                            metadata: Some(meta::Metadata {
-                                kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
-                            }),
-                            queue: Some(default_queue_config()),
-                            kind: None,
-                        }),
-                        filters: vec![outbound::grpc_route::Filter {
-                            kind: Some(outbound::grpc_route::filter::Kind::FailureInjector(
-                                grpc_route::GrpcFailureInjector {
-                                    code: 500,
-                                    message: format!("Service not found {}", svc.name),
-                                    ratio: None,
-                                },
-                            )),
-                        }],
-                        ..Default::default()
-                    }),
-                }
+                    filters,
+                    ..Default::default()
+                }),
             }
         }
-        Backend::Invalid { weight, message } => outbound::grpc_route::WeightedRouteBackend {
-            weight,
-            backend: Some(outbound::grpc_route::RouteBackend {
-                backend: Some(outbound::Backend {
-                    metadata: Some(meta::Metadata {
-                        kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
-                    }),
-                    queue: Some(default_queue_config()),
-                    kind: None,
-                }),
-                filters: vec![outbound::grpc_route::Filter {
-                    kind: Some(outbound::grpc_route::filter::Kind::FailureInjector(
-                        grpc_route::GrpcFailureInjector {
-                            code: 500,
-                            message,
-                            ratio: None,
-                        },
-                    )),
-                }],
-                ..Default::default()
-            }),
+        Backend::Service(svc) => invalid_backend(
+            svc.weight,
+            format!("Service not found {}", svc.name),
+            super::service_meta(svc),
+        ),
+        Backend::EgressNetwork(egress_net) if egress_net.exists => match target.kind {
+            Kind::EgressNetwork { original_dst, .. } => {
+                if target.name == egress_net.name && target.namespace == egress_net.namespace {
+                    let filters = egress_net
+                        .filters
+                        .clone()
+                        .into_iter()
+                        .map(convert_to_filter)
+                        .collect();
+
+                    outbound::grpc_route::WeightedRouteBackend {
+                        weight: egress_net.weight,
+                        backend: Some(outbound::grpc_route::RouteBackend {
+                            backend: Some(outbound::Backend {
+                                metadata: Some(super::egress_net_meta(
+                                    egress_net.clone(),
+                                    original_dst_port,
+                                )),
+                                queue: Some(default_queue_config()),
+                                kind: Some(outbound::backend::Kind::Forward(
+                                    destination::WeightedAddr {
+                                        addr: Some(original_dst.into()),
+                                        weight: egress_net.weight,
+                                        ..Default::default()
+                                    },
+                                )),
+                            }),
+                            filters,
+                            ..Default::default()
+                        }),
+                    }
+                } else {
+                    let weight = egress_net.weight;
+                    let message =  "Route with EgressNetwork backend needs to have the same EgressNetwork as a parent".to_string();
+                    invalid_backend(
+                        weight,
+                        message,
+                        super::egress_net_meta(egress_net, original_dst_port),
+                    )
+                }
+            }
+            Kind::Service => invalid_backend(
+                egress_net.weight,
+                "EgressNetwork backends attach to EgressNetwork parents only".to_string(),
+                super::egress_net_meta(egress_net, original_dst_port),
+            ),
         },
+        Backend::EgressNetwork(egress_net) => invalid_backend(
+            egress_net.weight,
+            format!("EgressNetwork not found {}", egress_net.name),
+            super::egress_net_meta(egress_net, original_dst_port),
+        ),
+        Backend::Invalid { weight, message } => invalid_backend(
+            weight,
+            message,
+            meta::Metadata {
+                kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
+            },
+        ),
+    }
+}
+
+fn invalid_backend(
+    weight: u32,
+    message: String,
+    meta: meta::Metadata,
+) -> outbound::grpc_route::WeightedRouteBackend {
+    outbound::grpc_route::WeightedRouteBackend {
+        weight,
+        backend: Some(outbound::grpc_route::RouteBackend {
+            backend: Some(outbound::Backend {
+                metadata: Some(meta),
+                queue: Some(default_queue_config()),
+                kind: None,
+            }),
+            filters: vec![outbound::grpc_route::Filter {
+                kind: Some(outbound::grpc_route::filter::Kind::FailureInjector(
+                    grpc_route::GrpcFailureInjector {
+                        code: 500,
+                        message,
+                        ratio: None,
+                    },
+                )),
+            }],
+            ..Default::default()
+        }),
+    }
+}
+
+pub(crate) fn default_outbound_egress_route(
+    backend: outbound::Backend,
+    service_retry: Option<RouteRetry<GrpcRetryCondition>>,
+    service_timeouts: RouteTimeouts,
+    traffic_policy: TrafficPolicy,
+) -> outbound::GrpcRoute {
+    #![allow(deprecated)]
+    let (filters, name) = match traffic_policy {
+        TrafficPolicy::Allow => (Vec::default(), "grpc-egress-allow"),
+        TrafficPolicy::Deny => (
+            vec![outbound::grpc_route::Filter {
+                kind: Some(outbound::grpc_route::filter::Kind::FailureInjector(
+                    grpc_route::GrpcFailureInjector {
+                        code: 7,
+                        message: "traffic not allowed".to_string(),
+                        ratio: None,
+                    },
+                )),
+            }],
+            "grpc-egress-deny",
+        ),
+    };
+
+    // This encoder sets deprecated timeouts for older proxies.
+    let metadata = Some(meta::Metadata {
+        kind: Some(meta::metadata::Kind::Default(name.to_string())),
+    });
+    let rules = vec![outbound::grpc_route::Rule {
+        matches: vec![grpc_route::GrpcRouteMatch::default()],
+        backends: Some(outbound::grpc_route::Distribution {
+            kind: Some(outbound::grpc_route::distribution::Kind::FirstAvailable(
+                outbound::grpc_route::distribution::FirstAvailable {
+                    backends: vec![outbound::grpc_route::RouteBackend {
+                        backend: Some(backend),
+                        ..Default::default()
+                    }],
+                },
+            )),
+        }),
+        request_timeout: service_timeouts
+            .request
+            .and_then(|d| convert_duration("request timeout", d)),
+        timeouts: Some(http_route::Timeouts {
+            request: service_timeouts
+                .request
+                .and_then(|d| convert_duration("stream timeout", d)),
+            idle: service_timeouts
+                .idle
+                .and_then(|d| convert_duration("idle timeout", d)),
+            response: service_timeouts
+                .response
+                .and_then(|d| convert_duration("response timeout", d)),
+        }),
+        retry: service_retry.map(|r| outbound::grpc_route::Retry {
+            max_retries: r.limit.into(),
+            max_request_bytes: 64 * 1024,
+            backoff: Some(outbound::ExponentialBackoff {
+                min_backoff: Some(time::Duration::from_millis(25).try_into().unwrap()),
+                max_backoff: Some(time::Duration::from_millis(250).try_into().unwrap()),
+                jitter_ratio: 1.0,
+            }),
+            conditions: Some(r.conditions.iter().flatten().fold(
+                outbound::grpc_route::retry::Conditions::default(),
+                |mut cond, c| {
+                    match c {
+                        GrpcRetryCondition::Cancelled => cond.cancelled = true,
+                        GrpcRetryCondition::DeadlineExceeded => cond.deadine_exceeded = true,
+                        GrpcRetryCondition::Internal => cond.internal = true,
+                        GrpcRetryCondition::ResourceExhausted => cond.resource_exhausted = true,
+                        GrpcRetryCondition::Unavailable => cond.unavailable = true,
+                    };
+                    cond
+                },
+            )),
+            timeout: r.timeout.and_then(|d| convert_duration("retry timeout", d)),
+        }),
+        filters,
+        ..Default::default()
+    }];
+    outbound::GrpcRoute {
+        metadata,
+        rules,
+        ..Default::default()
     }
 }
 

--- a/policy-controller/grpc/src/outbound/http.rs
+++ b/policy-controller/grpc/src/outbound/http.rs
@@ -9,8 +9,8 @@ use crate::routes::{
 use linkerd2_proxy_api::{destination, http_route, meta, outbound};
 use linkerd_policy_controller_core::{
     outbound::{
-        Backend, Filter, HttpRetryCondition, HttpRoute, OutboundRouteRule, RouteRetry,
-        RouteTimeouts,
+        Backend, Filter, HttpRetryCondition, HttpRoute, Kind, OutboundDiscoverTarget,
+        OutboundRouteRule, RouteRetry, RouteTimeouts, TrafficPolicy,
     },
     routes::GroupKindNamespaceName,
 };
@@ -23,8 +23,9 @@ pub(crate) fn protocol(
     service_retry: Option<RouteRetry<HttpRetryCondition>>,
     service_timeouts: RouteTimeouts,
     allow_l5d_request_headers: bool,
+    target: OutboundDiscoverTarget,
 ) -> outbound::proxy_protocol::Kind {
-    let opaque_route = default_outbound_opaq_route(default_backend.clone());
+    let opaque_route = default_outbound_opaq_route(default_backend.clone(), target.kind);
     let mut routes = routes
         .map(|(gknn, route)| {
             convert_outbound_route(
@@ -34,16 +35,31 @@ pub(crate) fn protocol(
                 service_retry.clone(),
                 service_timeouts.clone(),
                 allow_l5d_request_headers,
+                target.clone(),
             )
         })
         .collect::<Vec<_>>();
-    if routes.is_empty() {
-        routes.push(default_outbound_route(
-            default_backend,
-            service_retry.clone(),
-            service_timeouts.clone(),
-        ));
+
+    match target.kind {
+        Kind::Service => {
+            if routes.is_empty() {
+                routes.push(default_outbound_service_route(
+                    default_backend,
+                    service_retry.clone(),
+                    service_timeouts.clone(),
+                ));
+            }
+        }
+        Kind::EgressNetwork { traffic_policy, .. } => {
+            routes.push(default_outbound_egress_route(
+                default_backend,
+                service_retry.clone(),
+                service_timeouts.clone(),
+                traffic_policy,
+            ));
+        }
     }
+
     outbound::proxy_protocol::Kind::Detect(outbound::proxy_protocol::Detect {
         timeout: Some(
             time::Duration::from_secs(10)
@@ -76,10 +92,10 @@ fn convert_outbound_route(
     service_retry: Option<RouteRetry<HttpRetryCondition>>,
     service_timeouts: RouteTimeouts,
     allow_l5d_request_headers: bool,
+    target: OutboundDiscoverTarget,
 ) -> outbound::HttpRoute {
     // This encoder sets deprecated timeouts for older proxies.
     #![allow(deprecated)]
-
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Resource(meta::Resource {
             group: gknn.group.to_string(),
@@ -104,7 +120,7 @@ fn convert_outbound_route(
              }| {
                 let backends = backends
                     .into_iter()
-                    .map(convert_backend)
+                    .map(|b| convert_backend(b, target.clone()))
                     .collect::<Vec<_>>();
                 let dist = if backends.is_empty() {
                     outbound::http_route::distribution::Kind::FirstAvailable(
@@ -149,7 +165,15 @@ fn convert_outbound_route(
     }
 }
 
-fn convert_backend(backend: Backend) -> outbound::http_route::WeightedRouteBackend {
+fn convert_backend(
+    backend: Backend,
+    target: OutboundDiscoverTarget,
+) -> outbound::http_route::WeightedRouteBackend {
+    let original_dst_port = match target.kind {
+        Kind::EgressNetwork { original_dst, .. } => Some(original_dst.port()),
+        Kind::Service => None,
+    };
+
     match backend {
         Backend::Addr(addr) => {
             let socket_addr = SocketAddr::new(addr.addr, addr.port.get());
@@ -172,92 +196,132 @@ fn convert_backend(backend: Backend) -> outbound::http_route::WeightedRouteBacke
                 }),
             }
         }
-        Backend::Service(svc) => {
-            if svc.exists {
-                let filters = svc.filters.into_iter().map(convert_to_filter).collect();
-                outbound::http_route::WeightedRouteBackend {
-                    weight: svc.weight,
-                    backend: Some(outbound::http_route::RouteBackend {
-                        backend: Some(outbound::Backend {
-                            metadata: Some(meta::Metadata {
-                                kind: Some(meta::metadata::Kind::Resource(meta::Resource {
-                                    group: "core".to_string(),
-                                    kind: "Service".to_string(),
-                                    name: svc.name,
-                                    namespace: svc.namespace,
-                                    section: Default::default(),
-                                    port: u16::from(svc.port).into(),
-                                })),
-                            }),
-                            queue: Some(default_queue_config()),
-                            kind: Some(outbound::backend::Kind::Balancer(
-                                outbound::backend::BalanceP2c {
-                                    discovery: Some(outbound::backend::EndpointDiscovery {
-                                        kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
-                                            outbound::backend::endpoint_discovery::DestinationGet {
-                                                path: svc.authority,
-                                            },
-                                        )),
-                                    }),
-                                    load: Some(default_balancer_config()),
-                                },
-                            )),
-                        }),
-                        filters,
-                        ..Default::default()
+        Backend::Service(svc) if svc.exists => {
+            let filters = svc
+                .filters
+                .clone()
+                .into_iter()
+                .map(convert_to_filter)
+                .collect();
+            outbound::http_route::WeightedRouteBackend {
+                weight: svc.weight,
+                backend: Some(outbound::http_route::RouteBackend {
+                    backend: Some(outbound::Backend {
+                        metadata: Some(super::service_meta(svc.clone())),
+                        queue: Some(default_queue_config()),
+                        kind: Some(outbound::backend::Kind::Balancer(
+                            outbound::backend::BalanceP2c {
+                                discovery: Some(outbound::backend::EndpointDiscovery {
+                                    kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
+                                        outbound::backend::endpoint_discovery::DestinationGet {
+                                            path: svc.authority,
+                                        },
+                                    )),
+                                }),
+                                load: Some(default_balancer_config()),
+                            },
+                        )),
                     }),
-                }
-            } else {
-                outbound::http_route::WeightedRouteBackend {
-                    weight: svc.weight,
-                    backend: Some(outbound::http_route::RouteBackend {
-                        backend: Some(outbound::Backend {
-                            metadata: Some(meta::Metadata {
-                                kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
-                            }),
-                            queue: Some(default_queue_config()),
-                            kind: None,
-                        }),
-                        filters: vec![outbound::http_route::Filter {
-                            kind: Some(outbound::http_route::filter::Kind::FailureInjector(
-                                http_route::HttpFailureInjector {
-                                    status: 500,
-                                    message: format!("Service not found {}", svc.name),
-                                    ratio: None,
-                                },
-                            )),
-                        }],
-                        ..Default::default()
-                    }),
-                }
+                    filters,
+                    ..Default::default()
+                }),
             }
         }
-        Backend::Invalid { weight, message } => outbound::http_route::WeightedRouteBackend {
-            weight,
-            backend: Some(outbound::http_route::RouteBackend {
-                backend: Some(outbound::Backend {
-                    metadata: Some(meta::Metadata {
-                        kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
-                    }),
-                    queue: Some(default_queue_config()),
-                    kind: None,
-                }),
-                filters: vec![outbound::http_route::Filter {
-                    kind: Some(outbound::http_route::filter::Kind::FailureInjector(
-                        http_route::HttpFailureInjector {
-                            status: 500,
-                            message,
-                            ratio: None,
-                        },
-                    )),
-                }],
-                ..Default::default()
-            }),
+        Backend::Service(svc) => invalid_backend(
+            svc.weight,
+            format!("Service not found {}", svc.name),
+            super::service_meta(svc),
+        ),
+        Backend::EgressNetwork(egress_net) if egress_net.exists => match target.kind {
+            Kind::EgressNetwork { original_dst, .. } => {
+                if target.name == egress_net.name && target.namespace == egress_net.namespace {
+                    let filters = egress_net
+                        .filters
+                        .clone()
+                        .into_iter()
+                        .map(convert_to_filter)
+                        .collect();
+
+                    outbound::http_route::WeightedRouteBackend {
+                        weight: egress_net.weight,
+                        backend: Some(outbound::http_route::RouteBackend {
+                            backend: Some(outbound::Backend {
+                                metadata: Some(super::egress_net_meta(
+                                    egress_net.clone(),
+                                    original_dst_port,
+                                )),
+                                queue: Some(default_queue_config()),
+                                kind: Some(outbound::backend::Kind::Forward(
+                                    destination::WeightedAddr {
+                                        addr: Some(original_dst.into()),
+                                        weight: egress_net.weight,
+                                        ..Default::default()
+                                    },
+                                )),
+                            }),
+                            filters,
+                            ..Default::default()
+                        }),
+                    }
+                } else {
+                    let weight = egress_net.weight;
+                    let message =  "Route with EgressNetwork backend needs to have the same EgressNetwork as a parent".to_string();
+                    invalid_backend(
+                        weight,
+                        message,
+                        super::egress_net_meta(egress_net, original_dst_port),
+                    )
+                }
+            }
+            Kind::Service => invalid_backend(
+                egress_net.weight,
+                "EgressNetwork backends attach to EgressNetwork parents only".to_string(),
+                super::egress_net_meta(egress_net, original_dst_port),
+            ),
         },
+        Backend::EgressNetwork(egress_net) => invalid_backend(
+            egress_net.weight,
+            format!("EgressNetwork not found {}", egress_net.name),
+            super::egress_net_meta(egress_net, original_dst_port),
+        ),
+        Backend::Invalid { weight, message } => invalid_backend(
+            weight,
+            message,
+            meta::Metadata {
+                kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
+            },
+        ),
     }
 }
 
-pub(crate) fn default_outbound_route(
+fn invalid_backend(
+    weight: u32,
+    message: String,
+    meta: meta::Metadata,
+) -> outbound::http_route::WeightedRouteBackend {
+    outbound::http_route::WeightedRouteBackend {
+        weight,
+        backend: Some(outbound::http_route::RouteBackend {
+            backend: Some(outbound::Backend {
+                metadata: Some(meta),
+                queue: Some(default_queue_config()),
+                kind: None,
+            }),
+            filters: vec![outbound::http_route::Filter {
+                kind: Some(outbound::http_route::filter::Kind::FailureInjector(
+                    http_route::HttpFailureInjector {
+                        status: 500,
+                        message,
+                        ratio: None,
+                    },
+                )),
+            }],
+            ..Default::default()
+        }),
+    }
+}
+
+pub(crate) fn default_outbound_service_route(
     backend: outbound::Backend,
     service_retry: Option<RouteRetry<HttpRetryCondition>>,
     service_timeouts: RouteTimeouts,
@@ -290,6 +354,65 @@ pub(crate) fn default_outbound_route(
             .request
             .and_then(|d| convert_duration("request timeout", d)),
         timeouts: Some(convert_timeouts(service_timeouts)),
+        ..Default::default()
+    }];
+    outbound::HttpRoute {
+        metadata,
+        rules,
+        ..Default::default()
+    }
+}
+
+pub(crate) fn default_outbound_egress_route(
+    backend: outbound::Backend,
+    service_retry: Option<RouteRetry<HttpRetryCondition>>,
+    service_timeouts: RouteTimeouts,
+    traffic_policy: TrafficPolicy,
+) -> outbound::HttpRoute {
+    #![allow(deprecated)]
+    let (filters, name) = match traffic_policy {
+        TrafficPolicy::Allow => (Vec::default(), "http-egress-allow"),
+        TrafficPolicy::Deny => (
+            vec![outbound::http_route::Filter {
+                kind: Some(outbound::http_route::filter::Kind::FailureInjector(
+                    http_route::HttpFailureInjector {
+                        status: 403,
+                        message: "traffic not allowed".to_string(),
+                        ratio: None,
+                    },
+                )),
+            }],
+            "http-egress-deny",
+        ),
+    };
+
+    // This encoder sets deprecated timeouts for older proxies.
+    let metadata = Some(meta::Metadata {
+        kind: Some(meta::metadata::Kind::Default(name.to_string())),
+    });
+    let rules = vec![outbound::http_route::Rule {
+        matches: vec![http_route::HttpRouteMatch {
+            path: Some(http_route::PathMatch {
+                kind: Some(http_route::path_match::Kind::Prefix("/".to_string())),
+            }),
+            ..Default::default()
+        }],
+        backends: Some(outbound::http_route::Distribution {
+            kind: Some(outbound::http_route::distribution::Kind::FirstAvailable(
+                outbound::http_route::distribution::FirstAvailable {
+                    backends: vec![outbound::http_route::RouteBackend {
+                        backend: Some(backend),
+                        ..Default::default()
+                    }],
+                },
+            )),
+        }),
+        retry: service_retry.map(convert_retry),
+        request_timeout: service_timeouts
+            .request
+            .and_then(|d| convert_duration("request timeout", d)),
+        timeouts: Some(convert_timeouts(service_timeouts)),
+        filters,
         ..Default::default()
     }];
     outbound::HttpRoute {

--- a/policy-controller/grpc/src/outbound/tcp.rs
+++ b/policy-controller/grpc/src/outbound/tcp.rs
@@ -65,6 +65,7 @@ fn convert_outbound_route(
             outbound::opaque_route::distribution::FirstAvailable {
                 backends: vec![outbound::opaque_route::RouteBackend {
                     backend: Some(backend.clone()),
+                    invalid: None,
                 }],
             },
         )
@@ -109,8 +110,8 @@ fn convert_backend(
                             },
                         )),
                     }),
+                    invalid: None,
                 }),
-                error: None,
             }
         }
         Backend::Service(svc) if svc.exists => outbound::opaque_route::WeightedRouteBackend {
@@ -132,8 +133,8 @@ fn convert_backend(
                         },
                     )),
                 }),
+                invalid: None,
             }),
-            error: None,
         },
         Backend::Service(svc) => invalid_backend(
             svc.weight,
@@ -166,8 +167,8 @@ fn convert_backend(
                                         },
                                     )),
                                 }),
+                                invalid: None,
                             }),
-                            error: None,
                         }
                     } else {
                         let weight = egress_net.weight;
@@ -219,8 +220,8 @@ fn invalid_backend(
                 queue: Some(default_queue_config()),
                 kind: None,
             }),
+            invalid: Some(outbound::opaque_route::route_backend::Invalid { message }),
         }),
-        error: Some(outbound::BackendError { message }),
     }
 }
 
@@ -231,8 +232,8 @@ pub(crate) fn default_outbound_egress_route(
     let (error, name) = match traffic_policy {
         TrafficPolicy::Allow => (None, "tcp-egress-allow"),
         TrafficPolicy::Deny => (
-            Some(outbound::RouteError {
-                message: "traffic not allowed".to_string(),
+            Some(outbound::opaque_route::RouteError {
+                kind: outbound::opaque_route::route_error::Kind::Forbidden as i32,
             }),
             "tcp-egress-deny",
         ),
@@ -247,6 +248,7 @@ pub(crate) fn default_outbound_egress_route(
                 outbound::opaque_route::distribution::FirstAvailable {
                     backends: vec![outbound::opaque_route::RouteBackend {
                         backend: Some(backend),
+                        invalid: None,
                     }],
                 },
             )),

--- a/policy-controller/grpc/src/outbound/tcp.rs
+++ b/policy-controller/grpc/src/outbound/tcp.rs
@@ -34,9 +34,6 @@ fn convert_outbound_route(
     backend: outbound::Backend,
     policy: &ResourceOutboundPolicy,
 ) -> outbound::OpaqueRoute {
-    // This encoder sets deprecated timeouts for older proxies.
-    #![allow(deprecated)]
-
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Resource(meta::Resource {
             group: gknn.group.to_string(),
@@ -215,7 +212,6 @@ pub(crate) fn default_outbound_egress_route(
     backend: outbound::Backend,
     traffic_policy: &TrafficPolicy,
 ) -> outbound::OpaqueRoute {
-    #![allow(deprecated)]
     let (error, name) = match traffic_policy {
         TrafficPolicy::Allow => (None, "tcp-egress-allow"),
         TrafficPolicy::Deny => (
@@ -226,7 +222,6 @@ pub(crate) fn default_outbound_egress_route(
         ),
     };
 
-    // This encoder sets deprecated timeouts for older proxies.
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Default(name.to_string())),
     });

--- a/policy-controller/grpc/src/outbound/tcp.rs
+++ b/policy-controller/grpc/src/outbound/tcp.rs
@@ -1,0 +1,247 @@
+use super::{default_balancer_config, default_queue_config};
+use linkerd2_proxy_api::{destination, meta, outbound};
+use linkerd_policy_controller_core::{
+    outbound::{Backend, Kind, OutboundDiscoverTarget, TcpRoute, TrafficPolicy},
+    routes::GroupKindNamespaceName,
+};
+use std::net::SocketAddr;
+
+pub(crate) fn protocol(
+    default_backend: outbound::Backend,
+    routes: impl Iterator<Item = (GroupKindNamespaceName, TcpRoute)>,
+    target: OutboundDiscoverTarget,
+) -> outbound::proxy_protocol::Kind {
+    let mut routes = routes
+        .map(|(gknn, route)| {
+            convert_outbound_route(gknn, route, default_backend.clone(), target.clone())
+        })
+        .collect::<Vec<_>>();
+
+    if let Kind::EgressNetwork { traffic_policy, .. } = target.kind {
+        routes.push(default_outbound_egress_route(
+            default_backend,
+            traffic_policy,
+        ));
+    }
+
+    outbound::proxy_protocol::Kind::Opaque(outbound::proxy_protocol::Opaque { routes })
+}
+
+fn convert_outbound_route(
+    gknn: GroupKindNamespaceName,
+    TcpRoute {
+        rule,
+        creation_timestamp: _,
+    }: TcpRoute,
+    backend: outbound::Backend,
+    target: OutboundDiscoverTarget,
+) -> outbound::OpaqueRoute {
+    // This encoder sets deprecated timeouts for older proxies.
+    #![allow(deprecated)]
+
+    let metadata = Some(meta::Metadata {
+        kind: Some(meta::metadata::Kind::Resource(meta::Resource {
+            group: gknn.group.to_string(),
+            kind: gknn.kind.to_string(),
+            namespace: gknn.namespace.to_string(),
+            name: gknn.name.to_string(),
+            ..Default::default()
+        })),
+    });
+
+    let backends = rule
+        .backends
+        .into_iter()
+        .map(|b| convert_backend(b, target.clone()))
+        .collect::<Vec<_>>();
+
+    let dist = if backends.is_empty() {
+        outbound::opaque_route::distribution::Kind::FirstAvailable(
+            outbound::opaque_route::distribution::FirstAvailable {
+                backends: vec![outbound::opaque_route::RouteBackend {
+                    backend: Some(backend.clone()),
+                }],
+            },
+        )
+    } else {
+        outbound::opaque_route::distribution::Kind::RandomAvailable(
+            outbound::opaque_route::distribution::RandomAvailable { backends },
+        )
+    };
+
+    let rules = vec![outbound::opaque_route::Rule {
+        backends: Some(outbound::opaque_route::Distribution { kind: Some(dist) }),
+    }];
+
+    outbound::OpaqueRoute {
+        metadata,
+        rules,
+        error: None,
+    }
+}
+
+fn convert_backend(
+    backend: Backend,
+    target: OutboundDiscoverTarget,
+) -> outbound::opaque_route::WeightedRouteBackend {
+    let original_dst_port = match target.kind {
+        Kind::EgressNetwork { original_dst, .. } => Some(original_dst.port()),
+        Kind::Service => None,
+    };
+
+    match backend {
+        Backend::Addr(addr) => {
+            let socket_addr = SocketAddr::new(addr.addr, addr.port.get());
+            outbound::opaque_route::WeightedRouteBackend {
+                weight: addr.weight,
+                backend: Some(outbound::opaque_route::RouteBackend {
+                    backend: Some(outbound::Backend {
+                        metadata: None,
+                        queue: Some(default_queue_config()),
+                        kind: Some(outbound::backend::Kind::Forward(
+                            destination::WeightedAddr {
+                                addr: Some(socket_addr.into()),
+                                weight: addr.weight,
+                                ..Default::default()
+                            },
+                        )),
+                    }),
+                }),
+                error: None,
+            }
+        }
+        Backend::Service(svc) if svc.exists => outbound::opaque_route::WeightedRouteBackend {
+            weight: svc.weight,
+            backend: Some(outbound::opaque_route::RouteBackend {
+                backend: Some(outbound::Backend {
+                    metadata: Some(super::service_meta(svc.clone())),
+                    queue: Some(default_queue_config()),
+                    kind: Some(outbound::backend::Kind::Balancer(
+                        outbound::backend::BalanceP2c {
+                            discovery: Some(outbound::backend::EndpointDiscovery {
+                                kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
+                                    outbound::backend::endpoint_discovery::DestinationGet {
+                                        path: svc.authority,
+                                    },
+                                )),
+                            }),
+                            load: Some(default_balancer_config()),
+                        },
+                    )),
+                }),
+            }),
+            error: None,
+        },
+        Backend::Service(svc) => invalid_backend(
+            svc.weight,
+            format!("Service not found {}", svc.name),
+            super::service_meta(svc),
+        ),
+        Backend::EgressNetwork(egress_net) if egress_net.exists => match target.kind {
+            Kind::EgressNetwork { original_dst, .. } => {
+                if target.name == egress_net.name && target.namespace == egress_net.namespace {
+                    outbound::opaque_route::WeightedRouteBackend {
+                        weight: egress_net.weight,
+                        backend: Some(outbound::opaque_route::RouteBackend {
+                            backend: Some(outbound::Backend {
+                                metadata: Some(super::egress_net_meta(
+                                    egress_net.clone(),
+                                    original_dst_port,
+                                )),
+                                queue: Some(default_queue_config()),
+                                kind: Some(outbound::backend::Kind::Forward(
+                                    destination::WeightedAddr {
+                                        addr: Some(original_dst.into()),
+                                        weight: egress_net.weight,
+                                        ..Default::default()
+                                    },
+                                )),
+                            }),
+                        }),
+                        error: None,
+                    }
+                } else {
+                    let weight = egress_net.weight;
+                    let message =  "Route with EgressNetwork backend needs to have the same EgressNetwork as a parent".to_string();
+                    invalid_backend(
+                        weight,
+                        message,
+                        super::egress_net_meta(egress_net, original_dst_port),
+                    )
+                }
+            }
+            Kind::Service { .. } => invalid_backend(
+                egress_net.weight,
+                "EgressNetwork backends attach to EgressNetwork parents only".to_string(),
+                super::egress_net_meta(egress_net, original_dst_port),
+            ),
+        },
+        Backend::EgressNetwork(egress_net) => invalid_backend(
+            egress_net.weight,
+            format!("EgressNetwork not found {}", egress_net.name),
+            super::egress_net_meta(egress_net, original_dst_port),
+        ),
+        Backend::Invalid { weight, message } => invalid_backend(
+            weight,
+            message,
+            meta::Metadata {
+                kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
+            },
+        ),
+    }
+}
+
+fn invalid_backend(
+    weight: u32,
+    message: String,
+    meta: meta::Metadata,
+) -> outbound::opaque_route::WeightedRouteBackend {
+    outbound::opaque_route::WeightedRouteBackend {
+        weight,
+        backend: Some(outbound::opaque_route::RouteBackend {
+            backend: Some(outbound::Backend {
+                metadata: Some(meta),
+                queue: Some(default_queue_config()),
+                kind: None,
+            }),
+        }),
+        error: Some(outbound::BackendError { message }),
+    }
+}
+
+pub(crate) fn default_outbound_egress_route(
+    backend: outbound::Backend,
+    traffic_policy: TrafficPolicy,
+) -> outbound::OpaqueRoute {
+    #![allow(deprecated)]
+    let (error, name) = match traffic_policy {
+        TrafficPolicy::Allow => (None, "tcp-egress-allow"),
+        TrafficPolicy::Deny => (
+            Some(outbound::RouteError {
+                message: "traffic not allowed".to_string(),
+            }),
+            "tcp-egress-deny",
+        ),
+    };
+
+    // This encoder sets deprecated timeouts for older proxies.
+    let metadata = Some(meta::Metadata {
+        kind: Some(meta::metadata::Kind::Default(name.to_string())),
+    });
+    let rules = vec![outbound::opaque_route::Rule {
+        backends: Some(outbound::opaque_route::Distribution {
+            kind: Some(outbound::opaque_route::distribution::Kind::FirstAvailable(
+                outbound::opaque_route::distribution::FirstAvailable {
+                    backends: vec![outbound::opaque_route::RouteBackend {
+                        backend: Some(backend),
+                    }],
+                },
+            )),
+        }),
+    }];
+    outbound::OpaqueRoute {
+        metadata,
+        rules,
+        error,
+    }
+}

--- a/policy-controller/grpc/src/outbound/tls.rs
+++ b/policy-controller/grpc/src/outbound/tls.rs
@@ -69,6 +69,7 @@ fn convert_outbound_route(
             outbound::tls_route::distribution::FirstAvailable {
                 backends: vec![outbound::tls_route::RouteBackend {
                     backend: Some(backend.clone()),
+                    invalid: None,
                 }],
             },
         )
@@ -114,8 +115,8 @@ fn convert_backend(
                             },
                         )),
                     }),
+                    invalid: None,
                 }),
-                error: None,
             }
         }
         Backend::Service(svc) if svc.exists => outbound::tls_route::WeightedRouteBackend {
@@ -137,8 +138,8 @@ fn convert_backend(
                         },
                     )),
                 }),
+                invalid: None,
             }),
-            error: None,
         },
         Backend::Service(svc) => invalid_backend(
             svc.weight,
@@ -171,8 +172,8 @@ fn convert_backend(
                                         },
                                     )),
                                 }),
+                                invalid: None,
                             }),
-                            error: None,
                         }
                     } else {
                         let weight = egress_net.weight;
@@ -224,8 +225,8 @@ fn invalid_backend(
                 queue: Some(default_queue_config()),
                 kind: None,
             }),
+            invalid: Some(outbound::tls_route::route_backend::Invalid { message }),
         }),
-        error: Some(outbound::BackendError { message }),
     }
 }
 
@@ -236,8 +237,8 @@ pub(crate) fn default_outbound_egress_route(
     let (error, name) = match traffic_policy {
         TrafficPolicy::Allow => (None, "tls-egress-allow"),
         TrafficPolicy::Deny => (
-            Some(outbound::RouteError {
-                message: "traffic not allowed".to_string(),
+            Some(outbound::tls_route::RouteError {
+                kind: outbound::tls_route::route_error::Kind::Forbidden as i32,
             }),
             "tls-egress-deny",
         ),
@@ -252,6 +253,7 @@ pub(crate) fn default_outbound_egress_route(
                 outbound::tls_route::distribution::FirstAvailable {
                     backends: vec![outbound::tls_route::RouteBackend {
                         backend: Some(backend),
+                        invalid: None,
                     }],
                 },
             )),

--- a/policy-controller/grpc/src/outbound/tls.rs
+++ b/policy-controller/grpc/src/outbound/tls.rs
@@ -36,9 +36,6 @@ fn convert_outbound_route(
     backend: outbound::Backend,
     policy: &ResourceOutboundPolicy,
 ) -> outbound::TlsRoute {
-    // This encoder sets deprecated timeouts for older proxies.
-    #![allow(deprecated)]
-
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Resource(meta::Resource {
             group: gknn.group.to_string(),
@@ -220,7 +217,6 @@ pub(crate) fn default_outbound_egress_route(
     backend: outbound::Backend,
     traffic_policy: &TrafficPolicy,
 ) -> outbound::TlsRoute {
-    #![allow(deprecated)]
     let (error, name) = match traffic_policy {
         TrafficPolicy::Allow => (None, "tls-egress-allow"),
         TrafficPolicy::Deny => (
@@ -231,7 +227,6 @@ pub(crate) fn default_outbound_egress_route(
         ),
     };
 
-    // This encoder sets deprecated timeouts for older proxies.
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Default(name.to_string())),
     });

--- a/policy-controller/grpc/src/outbound/tls.rs
+++ b/policy-controller/grpc/src/outbound/tls.rs
@@ -2,7 +2,7 @@ use super::{default_balancer_config, default_queue_config};
 use crate::routes::convert_sni_match;
 use linkerd2_proxy_api::{destination, meta, outbound};
 use linkerd_policy_controller_core::{
-    outbound::{Backend, ResourceOutboundPolicy, TlsRoute, TrafficPolicy},
+    outbound::{Backend, ParentInfo, TlsRoute, TrafficPolicy},
     routes::GroupKindNamespaceName,
 };
 use std::net::SocketAddr;
@@ -10,13 +10,22 @@ use std::net::SocketAddr;
 pub(crate) fn protocol(
     default_backend: outbound::Backend,
     routes: impl Iterator<Item = (GroupKindNamespaceName, TlsRoute)>,
-    policy: &ResourceOutboundPolicy,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
 ) -> outbound::proxy_protocol::Kind {
     let mut routes = routes
-        .map(|(gknn, route)| convert_outbound_route(gknn, route, default_backend.clone(), policy))
+        .map(|(gknn, route)| {
+            convert_outbound_route(
+                gknn,
+                route,
+                default_backend.clone(),
+                parent_info,
+                original_dst,
+            )
+        })
         .collect::<Vec<_>>();
 
-    if let ResourceOutboundPolicy::Egress { traffic_policy, .. } = policy {
+    if let ParentInfo::EgressNetwork { traffic_policy, .. } = parent_info {
         routes.push(default_outbound_egress_route(
             default_backend,
             traffic_policy,
@@ -34,7 +43,8 @@ fn convert_outbound_route(
         creation_timestamp: _,
     }: TlsRoute,
     backend: outbound::Backend,
-    policy: &ResourceOutboundPolicy,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
 ) -> outbound::TlsRoute {
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Resource(meta::Resource {
@@ -51,7 +61,7 @@ fn convert_outbound_route(
     let backends = rule
         .backends
         .into_iter()
-        .map(|b| convert_backend(b, policy))
+        .map(|b| convert_backend(b, parent_info, original_dst))
         .collect::<Vec<_>>();
 
     let dist = if backends.is_empty() {
@@ -82,12 +92,10 @@ fn convert_outbound_route(
 
 fn convert_backend(
     backend: Backend,
-    policy: &ResourceOutboundPolicy,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
 ) -> outbound::tls_route::WeightedRouteBackend {
-    let original_dst_port = match policy {
-        ResourceOutboundPolicy::Egress { original_dst, .. } => Some(original_dst.port()),
-        ResourceOutboundPolicy::Service { .. } => None,
-    };
+    let original_dst_port = original_dst.map(|o| o.port());
 
     match backend {
         Backend::Addr(addr) => {
@@ -137,49 +145,57 @@ fn convert_backend(
             format!("Service not found {}", svc.name),
             super::service_meta(svc),
         ),
-        Backend::EgressNetwork(egress_net) if egress_net.exists => match policy {
-            ResourceOutboundPolicy::Egress {
-                original_dst,
-                policy,
-                ..
-            } => {
-                if policy.name == egress_net.name && policy.namespace == egress_net.namespace {
-                    outbound::tls_route::WeightedRouteBackend {
-                        weight: egress_net.weight,
-                        backend: Some(outbound::tls_route::RouteBackend {
-                            backend: Some(outbound::Backend {
-                                metadata: Some(super::egress_net_meta(
-                                    egress_net.clone(),
-                                    original_dst_port,
-                                )),
-                                queue: Some(default_queue_config()),
-                                kind: Some(outbound::backend::Kind::Forward(
-                                    destination::WeightedAddr {
-                                        addr: Some((*original_dst).into()),
-                                        weight: egress_net.weight,
-                                        ..Default::default()
-                                    },
-                                )),
+        Backend::EgressNetwork(egress_net) if egress_net.exists => {
+            match (parent_info, original_dst) {
+                (
+                    ParentInfo::EgressNetwork {
+                        name, namespace, ..
+                    },
+                    Some(original_dst),
+                ) => {
+                    if *name == egress_net.name && *namespace == egress_net.namespace {
+                        outbound::tls_route::WeightedRouteBackend {
+                            weight: egress_net.weight,
+                            backend: Some(outbound::tls_route::RouteBackend {
+                                backend: Some(outbound::Backend {
+                                    metadata: Some(super::egress_net_meta(
+                                        egress_net.clone(),
+                                        original_dst_port,
+                                    )),
+                                    queue: Some(default_queue_config()),
+                                    kind: Some(outbound::backend::Kind::Forward(
+                                        destination::WeightedAddr {
+                                            addr: Some(original_dst.into()),
+                                            weight: egress_net.weight,
+                                            ..Default::default()
+                                        },
+                                    )),
+                                }),
                             }),
-                        }),
-                        error: None,
+                            error: None,
+                        }
+                    } else {
+                        let weight = egress_net.weight;
+                        let message =  "Route with EgressNetwork backend needs to have the same EgressNetwork as a parent".to_string();
+                        invalid_backend(
+                            weight,
+                            message,
+                            super::egress_net_meta(egress_net, original_dst_port),
+                        )
                     }
-                } else {
-                    let weight = egress_net.weight;
-                    let message =  "Route with EgressNetwork backend needs to have the same EgressNetwork as a parent".to_string();
-                    invalid_backend(
-                        weight,
-                        message,
-                        super::egress_net_meta(egress_net, original_dst_port),
-                    )
                 }
+                (ParentInfo::EgressNetwork { .. }, None) => invalid_backend(
+                    egress_net.weight,
+                    "EgressNetwork can be resolved from an ip:port combo only".to_string(),
+                    super::egress_net_meta(egress_net, original_dst_port),
+                ),
+                (ParentInfo::Service { .. }, _) => invalid_backend(
+                    egress_net.weight,
+                    "EgressNetwork backends attach to EgressNetwork parents only".to_string(),
+                    super::egress_net_meta(egress_net, original_dst_port),
+                ),
             }
-            ResourceOutboundPolicy::Service { .. } => invalid_backend(
-                egress_net.weight,
-                "EgressNetwork backends attach to EgressNetwork parents only".to_string(),
-                super::egress_net_meta(egress_net, original_dst_port),
-            ),
-        },
+        }
         Backend::EgressNetwork(egress_net) => invalid_backend(
             egress_net.weight,
             format!("EgressNetwork not found {}", egress_net.name),

--- a/policy-controller/grpc/src/outbound/tls.rs
+++ b/policy-controller/grpc/src/outbound/tls.rs
@@ -2,7 +2,7 @@ use super::{default_balancer_config, default_queue_config};
 use crate::routes::convert_sni_match;
 use linkerd2_proxy_api::{destination, meta, outbound};
 use linkerd_policy_controller_core::{
-    outbound::{Backend, Kind, OutboundDiscoverTarget, TlsRoute, TrafficPolicy},
+    outbound::{Backend, ResourceOutboundPolicy, TlsRoute, TrafficPolicy},
     routes::GroupKindNamespaceName,
 };
 use std::net::SocketAddr;
@@ -10,15 +10,13 @@ use std::net::SocketAddr;
 pub(crate) fn protocol(
     default_backend: outbound::Backend,
     routes: impl Iterator<Item = (GroupKindNamespaceName, TlsRoute)>,
-    target: OutboundDiscoverTarget,
+    policy: &ResourceOutboundPolicy,
 ) -> outbound::proxy_protocol::Kind {
     let mut routes = routes
-        .map(|(gknn, route)| {
-            convert_outbound_route(gknn, route, default_backend.clone(), target.clone())
-        })
+        .map(|(gknn, route)| convert_outbound_route(gknn, route, default_backend.clone(), policy))
         .collect::<Vec<_>>();
 
-    if let Kind::EgressNetwork { traffic_policy, .. } = target.kind {
+    if let ResourceOutboundPolicy::Egress { traffic_policy, .. } = policy {
         routes.push(default_outbound_egress_route(
             default_backend,
             traffic_policy,
@@ -36,7 +34,7 @@ fn convert_outbound_route(
         creation_timestamp: _,
     }: TlsRoute,
     backend: outbound::Backend,
-    target: OutboundDiscoverTarget,
+    policy: &ResourceOutboundPolicy,
 ) -> outbound::TlsRoute {
     // This encoder sets deprecated timeouts for older proxies.
     #![allow(deprecated)]
@@ -56,7 +54,7 @@ fn convert_outbound_route(
     let backends = rule
         .backends
         .into_iter()
-        .map(|b| convert_backend(b, target.clone()))
+        .map(|b| convert_backend(b, policy))
         .collect::<Vec<_>>();
 
     let dist = if backends.is_empty() {
@@ -87,11 +85,11 @@ fn convert_outbound_route(
 
 fn convert_backend(
     backend: Backend,
-    target: OutboundDiscoverTarget,
+    policy: &ResourceOutboundPolicy,
 ) -> outbound::tls_route::WeightedRouteBackend {
-    let original_dst_port = match target.kind {
-        Kind::EgressNetwork { original_dst, .. } => Some(original_dst.port()),
-        Kind::Service => None,
+    let original_dst_port = match policy {
+        ResourceOutboundPolicy::Egress { original_dst, .. } => Some(original_dst.port()),
+        ResourceOutboundPolicy::Service { .. } => None,
     };
 
     match backend {
@@ -142,9 +140,13 @@ fn convert_backend(
             format!("Service not found {}", svc.name),
             super::service_meta(svc),
         ),
-        Backend::EgressNetwork(egress_net) if egress_net.exists => match target.kind {
-            Kind::EgressNetwork { original_dst, .. } => {
-                if target.name == egress_net.name && target.namespace == egress_net.namespace {
+        Backend::EgressNetwork(egress_net) if egress_net.exists => match policy {
+            ResourceOutboundPolicy::Egress {
+                original_dst,
+                policy,
+                ..
+            } => {
+                if policy.name == egress_net.name && policy.namespace == egress_net.namespace {
                     outbound::tls_route::WeightedRouteBackend {
                         weight: egress_net.weight,
                         backend: Some(outbound::tls_route::RouteBackend {
@@ -156,7 +158,7 @@ fn convert_backend(
                                 queue: Some(default_queue_config()),
                                 kind: Some(outbound::backend::Kind::Forward(
                                     destination::WeightedAddr {
-                                        addr: Some(original_dst.into()),
+                                        addr: Some((*original_dst).into()),
                                         weight: egress_net.weight,
                                         ..Default::default()
                                     },
@@ -175,7 +177,7 @@ fn convert_backend(
                     )
                 }
             }
-            Kind::Service { .. } => invalid_backend(
+            ResourceOutboundPolicy::Service { .. } => invalid_backend(
                 egress_net.weight,
                 "EgressNetwork backends attach to EgressNetwork parents only".to_string(),
                 super::egress_net_meta(egress_net, original_dst_port),
@@ -216,7 +218,7 @@ fn invalid_backend(
 
 pub(crate) fn default_outbound_egress_route(
     backend: outbound::Backend,
-    traffic_policy: TrafficPolicy,
+    traffic_policy: &TrafficPolicy,
 ) -> outbound::TlsRoute {
     #![allow(deprecated)]
     let (error, name) = match traffic_policy {

--- a/policy-controller/grpc/src/outbound/tls.rs
+++ b/policy-controller/grpc/src/outbound/tls.rs
@@ -1,0 +1,253 @@
+use super::{default_balancer_config, default_queue_config};
+use crate::routes::convert_sni_match;
+use linkerd2_proxy_api::{destination, meta, outbound};
+use linkerd_policy_controller_core::{
+    outbound::{Backend, Kind, OutboundDiscoverTarget, TlsRoute, TrafficPolicy},
+    routes::GroupKindNamespaceName,
+};
+use std::net::SocketAddr;
+
+pub(crate) fn protocol(
+    default_backend: outbound::Backend,
+    routes: impl Iterator<Item = (GroupKindNamespaceName, TlsRoute)>,
+    target: OutboundDiscoverTarget,
+) -> outbound::proxy_protocol::Kind {
+    let mut routes = routes
+        .map(|(gknn, route)| {
+            convert_outbound_route(gknn, route, default_backend.clone(), target.clone())
+        })
+        .collect::<Vec<_>>();
+
+    if let Kind::EgressNetwork { traffic_policy, .. } = target.kind {
+        routes.push(default_outbound_egress_route(
+            default_backend,
+            traffic_policy,
+        ));
+    }
+
+    outbound::proxy_protocol::Kind::Tls(outbound::proxy_protocol::Tls { routes })
+}
+
+fn convert_outbound_route(
+    gknn: GroupKindNamespaceName,
+    TlsRoute {
+        hostnames,
+        rule,
+        creation_timestamp: _,
+    }: TlsRoute,
+    backend: outbound::Backend,
+    target: OutboundDiscoverTarget,
+) -> outbound::TlsRoute {
+    // This encoder sets deprecated timeouts for older proxies.
+    #![allow(deprecated)]
+
+    let metadata = Some(meta::Metadata {
+        kind: Some(meta::metadata::Kind::Resource(meta::Resource {
+            group: gknn.group.to_string(),
+            kind: gknn.kind.to_string(),
+            namespace: gknn.namespace.to_string(),
+            name: gknn.name.to_string(),
+            ..Default::default()
+        })),
+    });
+
+    let snis = hostnames.into_iter().map(convert_sni_match).collect();
+
+    let backends = rule
+        .backends
+        .into_iter()
+        .map(|b| convert_backend(b, target.clone()))
+        .collect::<Vec<_>>();
+
+    let dist = if backends.is_empty() {
+        outbound::tls_route::distribution::Kind::FirstAvailable(
+            outbound::tls_route::distribution::FirstAvailable {
+                backends: vec![outbound::tls_route::RouteBackend {
+                    backend: Some(backend.clone()),
+                }],
+            },
+        )
+    } else {
+        outbound::tls_route::distribution::Kind::RandomAvailable(
+            outbound::tls_route::distribution::RandomAvailable { backends },
+        )
+    };
+
+    let rules = vec![outbound::tls_route::Rule {
+        backends: Some(outbound::tls_route::Distribution { kind: Some(dist) }),
+    }];
+
+    outbound::TlsRoute {
+        metadata,
+        snis,
+        rules,
+        error: None,
+    }
+}
+
+fn convert_backend(
+    backend: Backend,
+    target: OutboundDiscoverTarget,
+) -> outbound::tls_route::WeightedRouteBackend {
+    let original_dst_port = match target.kind {
+        Kind::EgressNetwork { original_dst, .. } => Some(original_dst.port()),
+        Kind::Service => None,
+    };
+
+    match backend {
+        Backend::Addr(addr) => {
+            let socket_addr = SocketAddr::new(addr.addr, addr.port.get());
+            outbound::tls_route::WeightedRouteBackend {
+                weight: addr.weight,
+                backend: Some(outbound::tls_route::RouteBackend {
+                    backend: Some(outbound::Backend {
+                        metadata: None,
+                        queue: Some(default_queue_config()),
+                        kind: Some(outbound::backend::Kind::Forward(
+                            destination::WeightedAddr {
+                                addr: Some(socket_addr.into()),
+                                weight: addr.weight,
+                                ..Default::default()
+                            },
+                        )),
+                    }),
+                }),
+                error: None,
+            }
+        }
+        Backend::Service(svc) if svc.exists => outbound::tls_route::WeightedRouteBackend {
+            weight: svc.weight,
+            backend: Some(outbound::tls_route::RouteBackend {
+                backend: Some(outbound::Backend {
+                    metadata: Some(super::service_meta(svc.clone())),
+                    queue: Some(default_queue_config()),
+                    kind: Some(outbound::backend::Kind::Balancer(
+                        outbound::backend::BalanceP2c {
+                            discovery: Some(outbound::backend::EndpointDiscovery {
+                                kind: Some(outbound::backend::endpoint_discovery::Kind::Dst(
+                                    outbound::backend::endpoint_discovery::DestinationGet {
+                                        path: svc.authority,
+                                    },
+                                )),
+                            }),
+                            load: Some(default_balancer_config()),
+                        },
+                    )),
+                }),
+            }),
+            error: None,
+        },
+        Backend::Service(svc) => invalid_backend(
+            svc.weight,
+            format!("Service not found {}", svc.name),
+            super::service_meta(svc),
+        ),
+        Backend::EgressNetwork(egress_net) if egress_net.exists => match target.kind {
+            Kind::EgressNetwork { original_dst, .. } => {
+                if target.name == egress_net.name && target.namespace == egress_net.namespace {
+                    outbound::tls_route::WeightedRouteBackend {
+                        weight: egress_net.weight,
+                        backend: Some(outbound::tls_route::RouteBackend {
+                            backend: Some(outbound::Backend {
+                                metadata: Some(super::egress_net_meta(
+                                    egress_net.clone(),
+                                    original_dst_port,
+                                )),
+                                queue: Some(default_queue_config()),
+                                kind: Some(outbound::backend::Kind::Forward(
+                                    destination::WeightedAddr {
+                                        addr: Some(original_dst.into()),
+                                        weight: egress_net.weight,
+                                        ..Default::default()
+                                    },
+                                )),
+                            }),
+                        }),
+                        error: None,
+                    }
+                } else {
+                    let weight = egress_net.weight;
+                    let message =  "Route with EgressNetwork backend needs to have the same EgressNetwork as a parent".to_string();
+                    invalid_backend(
+                        weight,
+                        message,
+                        super::egress_net_meta(egress_net, original_dst_port),
+                    )
+                }
+            }
+            Kind::Service { .. } => invalid_backend(
+                egress_net.weight,
+                "EgressNetwork backends attach to EgressNetwork parents only".to_string(),
+                super::egress_net_meta(egress_net, original_dst_port),
+            ),
+        },
+        Backend::EgressNetwork(egress_net) => invalid_backend(
+            egress_net.weight,
+            format!("EgressNetwork not found {}", egress_net.name),
+            super::egress_net_meta(egress_net, original_dst_port),
+        ),
+        Backend::Invalid { weight, message } => invalid_backend(
+            weight,
+            message,
+            meta::Metadata {
+                kind: Some(meta::metadata::Kind::Default("invalid".to_string())),
+            },
+        ),
+    }
+}
+
+fn invalid_backend(
+    weight: u32,
+    message: String,
+    meta: meta::Metadata,
+) -> outbound::tls_route::WeightedRouteBackend {
+    outbound::tls_route::WeightedRouteBackend {
+        weight,
+        backend: Some(outbound::tls_route::RouteBackend {
+            backend: Some(outbound::Backend {
+                metadata: Some(meta),
+                queue: Some(default_queue_config()),
+                kind: None,
+            }),
+        }),
+        error: Some(outbound::BackendError { message }),
+    }
+}
+
+pub(crate) fn default_outbound_egress_route(
+    backend: outbound::Backend,
+    traffic_policy: TrafficPolicy,
+) -> outbound::TlsRoute {
+    #![allow(deprecated)]
+    let (error, name) = match traffic_policy {
+        TrafficPolicy::Allow => (None, "tls-egress-allow"),
+        TrafficPolicy::Deny => (
+            Some(outbound::RouteError {
+                message: "traffic not allowed".to_string(),
+            }),
+            "tls-egress-deny",
+        ),
+    };
+
+    // This encoder sets deprecated timeouts for older proxies.
+    let metadata = Some(meta::Metadata {
+        kind: Some(meta::metadata::Kind::Default(name.to_string())),
+    });
+    let rules = vec![outbound::tls_route::Rule {
+        backends: Some(outbound::tls_route::Distribution {
+            kind: Some(outbound::tls_route::distribution::Kind::FirstAvailable(
+                outbound::tls_route::distribution::FirstAvailable {
+                    backends: vec![outbound::tls_route::RouteBackend {
+                        backend: Some(backend),
+                    }],
+                },
+            )),
+        }),
+    }];
+    outbound::TlsRoute {
+        metadata,
+        rules,
+        error,
+        ..Default::default()
+    }
+}

--- a/policy-controller/grpc/src/routes.rs
+++ b/policy-controller/grpc/src/routes.rs
@@ -1,4 +1,4 @@
-use linkerd2_proxy_api::{http_route as proto, http_types};
+use linkerd2_proxy_api::{http_route as proto, http_types, tls_route as tls_proto};
 use linkerd_policy_controller_core::routes::{
     HeaderModifierFilter, HostMatch, PathModifier, RequestRedirectFilter,
 };
@@ -12,6 +12,19 @@ pub(crate) fn convert_host_match(h: HostMatch) -> proto::HostMatch {
             HostMatch::Exact(host) => proto::host_match::Match::Exact(host),
             HostMatch::Suffix { reverse_labels } => {
                 proto::host_match::Match::Suffix(proto::host_match::Suffix {
+                    reverse_labels: reverse_labels.to_vec(),
+                })
+            }
+        }),
+    }
+}
+
+pub(crate) fn convert_sni_match(h: HostMatch) -> tls_proto::SniMatch {
+    tls_proto::SniMatch {
+        r#match: Some(match h {
+            HostMatch::Exact(host) => tls_proto::sni_match::Match::Exact(host),
+            HostMatch::Suffix { reverse_labels } => {
+                tls_proto::sni_match::Match::Suffix(tls_proto::sni_match::Suffix {
                     reverse_labels: reverse_labels.to_vec(),
                 })
             }

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ahash = "0.8"
 anyhow = "1"
+chrono = { version = "0.4.38", default_features = false }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 kube = { version = "0.87.1", default-features = false, features = [

--- a/policy-controller/k8s/index/src/inbound/index/grpc.rs
+++ b/policy-controller/k8s/index/src/inbound/index/grpc.rs
@@ -19,7 +19,7 @@ impl TryFrom<gateway::GrpcRoute> for RouteBinding<GrpcRoute> {
             .hostnames
             .into_iter()
             .flatten()
-            .map(crate::routes::http::host_match)
+            .map(crate::routes::host_match)
             .collect();
 
         let rules = route

--- a/policy-controller/k8s/index/src/inbound/index/http.rs
+++ b/policy-controller/k8s/index/src/inbound/index/http.rs
@@ -20,7 +20,7 @@ impl TryFrom<gateway::HttpRoute> for RouteBinding<HttpRoute> {
             .hostnames
             .into_iter()
             .flatten()
-            .map(crate::routes::http::host_match)
+            .map(crate::routes::host_match)
             .collect();
 
         let rules = route
@@ -66,7 +66,7 @@ impl TryFrom<policy::HttpRoute> for RouteBinding<HttpRoute> {
             .hostnames
             .into_iter()
             .flatten()
-            .map(crate::routes::http::host_match)
+            .map(crate::routes::host_match)
             .collect();
 
         let rules = route

--- a/policy-controller/k8s/index/src/outbound.rs
+++ b/policy-controller/k8s/index/src/outbound.rs
@@ -1,6 +1,6 @@
 pub mod index;
 
-pub use index::{metrics, Index, ServiceRef, SharedIndex};
+pub use index::{metrics, Index, ResourceRef, SharedIndex};
 
 #[cfg(test)]
 mod tests;

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -32,6 +32,11 @@ pub struct Index {
     // holds information about resources. currently EgressNetworks and Services
     resource_info: HashMap<ResourceRef, ResourceInfo>,
     cluster_networks: Vec<linkerd_k8s_api::Cidr>,
+
+    // holds a no-op sender to which all clients that have been returned
+    // a Fallback policy are subsribed. It is used to force these clients
+    // to reconnect an obtain new policy once the current one may no longer
+    // be valid
     fallback_polcy_tx: watch::Sender<()>,
 }
 

--- a/policy-controller/k8s/index/src/outbound/index/egress_network.rs
+++ b/policy-controller/k8s/index/src/outbound/index/egress_network.rs
@@ -1,0 +1,284 @@
+use chrono::{offset::Utc, DateTime};
+use linkerd_policy_controller_core::outbound;
+use linkerd_policy_controller_k8s_api::policy::{Cidr, Network, TrafficPolicy};
+use linkerd_policy_controller_k8s_api::{policy as linkerd_k8s_api, ResourceExt};
+use std::net::IpAddr;
+
+#[derive(Debug)]
+pub(crate) struct EgressNetwork {
+    pub networks: Vec<Network>,
+    pub name: String,
+    pub namespace: String,
+    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub traffic_policy: TrafficPolicy,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MatchedEgressNetwork {
+    matched_network_size: usize,
+    name: String,
+    namespace: String,
+    creation_timestamp: Option<DateTime<Utc>>,
+    pub traffic_policy: TrafficPolicy,
+}
+
+// === impl EgressNetwork ===
+
+impl EgressNetwork {
+    pub(crate) fn from_resource(
+        r: &linkerd_k8s_api::EgressNetwork,
+        cluster_networks: Vec<Cidr>,
+    ) -> Self {
+        let name = r.name_unchecked();
+        let namespace = r.namespace().expect("EgressNetwork must have a namespace");
+        let creation_timestamp = r.creation_timestamp().map(|d| d.0);
+        let traffic_policy = r.spec.traffic_policy.clone();
+
+        let networks = r.spec.networks.clone().unwrap_or_else(|| {
+            let (v6, v4) = cluster_networks.iter().cloned().partition(Cidr::is_ipv6);
+
+            vec![
+                Network {
+                    cidr: "0.0.0.0/0".parse().expect("should parse"),
+                    except: Some(v4),
+                },
+                Network {
+                    cidr: "::/0".parse().expect("should parse"),
+                    except: Some(v6),
+                },
+            ]
+        });
+
+        EgressNetwork {
+            name,
+            namespace,
+            networks,
+            creation_timestamp,
+            traffic_policy,
+        }
+    }
+}
+
+// Attempts to find the best matching network for a certain discovery look-up.
+// Logic is:
+// 1. if there are Egress networks in the source_namespace, only these are considered
+// 2. the target IP is matched against the networks of the EgressNetwork
+// 3. ambiguity is resolved as by comparing the networks using compare_matched_egress_network
+pub(crate) fn resolve_egress_network<'n>(
+    addr: IpAddr,
+    source_namespace: String,
+    nets: impl Iterator<Item = &'n EgressNetwork>,
+) -> Option<(super::ResourceRef, outbound::TrafficPolicy)> {
+    let (same_ns, rest): (Vec<_>, Vec<_>) = nets.partition(|un| un.namespace == source_namespace);
+    let to_pick_from = if !same_ns.is_empty() { same_ns } else { rest };
+
+    to_pick_from
+        .iter()
+        .filter_map(|egress_network| {
+            let matched_network_size = match_network(&egress_network.networks, addr)?;
+            Some(MatchedEgressNetwork {
+                name: egress_network.name.clone(),
+                namespace: egress_network.namespace.clone(),
+                matched_network_size,
+                creation_timestamp: egress_network.creation_timestamp,
+                traffic_policy: egress_network.traffic_policy.clone(),
+            })
+        })
+        .max_by(compare_matched_egress_network)
+        .map(|m| {
+            (
+                super::ResourceRef {
+                    kind: super::ResourceKind::EgressNetwork,
+                    name: m.name,
+                    namespace: m.namespace,
+                },
+                match m.traffic_policy {
+                    TrafficPolicy::Allow => outbound::TrafficPolicy::Allow,
+                    TrafficPolicy::Deny => outbound::TrafficPolicy::Deny,
+                },
+            )
+        })
+}
+
+// Finds a CIDR that contains the given IpAddr. When there are
+// multiple CIDRS that match this criteria, the CIDR that is most
+// specific (as in having the smallest address space) wins.
+fn match_network(networks: &[Network], addr: IpAddr) -> Option<usize> {
+    networks
+        .iter()
+        .filter(|c| c.contains(addr))
+        .min_by(|a, b| a.block_size().cmp(&b.block_size()))
+        .map(Network::block_size)
+}
+
+// This logic compares two MatchedEgressNetwork objects with the purpose
+// of picking the one that is more specific. The disambiguation rules are
+// as follows:
+//  1. prefer the more specific network match (smaller address space size)
+//  2. prefer older resource
+//  3. all being equal, rely on alphabetical sort of namespace/name
+fn compare_matched_egress_network(
+    a: &MatchedEgressNetwork,
+    b: &MatchedEgressNetwork,
+) -> std::cmp::Ordering {
+    b.matched_network_size
+        .cmp(&a.matched_network_size)
+        .then_with(|| a.creation_timestamp.cmp(&b.creation_timestamp).reverse())
+        .then_with(|| a.namespace.cmp(&b.namespace).reverse())
+        .then_with(|| a.name.cmp(&b.name).reverse())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_picks_smallest_cidr() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: None,
+                }],
+                name: "net-1".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/24".parse().unwrap(),
+                    except: None,
+                }],
+                name: "net-2".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+        ];
+
+        let resolved = resolve_egress_network(ip_addr, "ns".into(), networks.iter());
+        assert_eq!(resolved.unwrap().0.name, "net-2".to_string())
+    }
+
+    #[test]
+    fn test_picks_local_ns() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: None,
+                }],
+                name: "net-1".to_string(),
+                namespace: "ns-1".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/24".parse().unwrap(),
+                    except: None,
+                }],
+                name: "net-2".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+        ];
+
+        let resolved = resolve_egress_network(ip_addr, "ns-1".into(), networks.iter());
+        assert_eq!(resolved.unwrap().0.name, "net-1".to_string())
+    }
+
+    #[test]
+    fn test_picks_older_resource() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: None,
+                }],
+                name: "net-1".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: Some(DateTime::<Utc>::MAX_UTC),
+                traffic_policy: TrafficPolicy::Allow,
+            },
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: None,
+                }],
+                name: "net-2".to_string(),
+                namespace: "ns".to_string(),
+                creation_timestamp: Some(DateTime::<Utc>::MIN_UTC),
+                traffic_policy: TrafficPolicy::Allow,
+            },
+        ];
+
+        let resolved = resolve_egress_network(ip_addr, "ns".into(), networks.iter());
+        assert_eq!(resolved.unwrap().0.name, "net-2".to_string())
+    }
+
+    #[test]
+    fn test_picks_alphabetical_order() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: None,
+                }],
+                name: "b".to_string(),
+                namespace: "a".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: None,
+                }],
+                name: "d".to_string(),
+                namespace: "c".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+        ];
+
+        let resolved = resolve_egress_network(ip_addr, "ns".into(), networks.iter());
+        assert_eq!(resolved.unwrap().0.name, "b".to_string())
+    }
+
+    #[test]
+    fn test_respects_exception() {
+        let ip_addr = "192.168.0.4".parse().unwrap();
+        let networks = vec![
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: Some(vec!["192.168.0.4".parse().unwrap()]),
+                }],
+                name: "b".to_string(),
+                namespace: "a".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+            EgressNetwork {
+                networks: vec![Network {
+                    cidr: "192.168.0.1/16".parse().unwrap(),
+                    except: None,
+                }],
+                name: "d".to_string(),
+                namespace: "c".to_string(),
+                creation_timestamp: None,
+                traffic_policy: TrafficPolicy::Allow,
+            },
+        ];
+
+        let resolved = resolve_egress_network(ip_addr, "ns".into(), networks.iter());
+        assert_eq!(resolved.unwrap().0.name, "d".to_string())
+    }
+}

--- a/policy-controller/k8s/index/src/outbound/index/metrics.rs
+++ b/policy-controller/k8s/index/src/outbound/index/metrics.rs
@@ -33,7 +33,7 @@ impl Collector for Instrumented {
             None,
             MetricType::Gauge,
         )?;
-        let service_infos = ConstGauge::new(this.service_info.len() as u32);
+        let service_infos = ConstGauge::new(this.resource_info.len() as u32);
         service_infos.encode(service_info_encoder)?;
 
         let mut service_route_encoder = encoder.encode_descriptor(
@@ -57,7 +57,7 @@ impl Collector for Instrumented {
         )?;
         for (ns, index) in &this.namespaces.by_ns {
             let labels = vec![("namespace", ns.as_str())];
-            let service_port_routes = ConstGauge::new(index.service_port_routes.len() as u32);
+            let service_port_routes = ConstGauge::new(index.resource_port_routes.len() as u32);
             let service_port_route_encoder = service_port_route_encoder.encode_family(&labels)?;
             service_port_routes.encode(service_port_route_encoder)?;
         }

--- a/policy-controller/k8s/index/src/outbound/index/tcp.rs
+++ b/policy-controller/k8s/index/src/outbound/index/tcp.rs
@@ -1,0 +1,106 @@
+use std::num::NonZeroU16;
+
+use super::{ResourceInfo, ResourceKind, ResourceRef};
+use crate::ClusterInfo;
+use ahash::AHashMap as HashMap;
+use anyhow::{bail, Result};
+use linkerd_policy_controller_core::outbound::{Backend, WeightedEgressNetwork, WeightedService};
+use linkerd_policy_controller_core::outbound::{TcpRoute, TcpRouteRule};
+use linkerd_policy_controller_k8s_api::{gateway, Time};
+
+pub(super) fn convert_route(
+    ns: &str,
+    route: gateway::TcpRoute,
+    cluster: &ClusterInfo,
+    resource_info: &HashMap<ResourceRef, ResourceInfo>,
+) -> Result<TcpRoute> {
+    if route.spec.rules.len() != 1 {
+        bail!("TCPRoute needs to have one rule");
+    }
+
+    let rule = route.spec.rules.first().expect("already checked");
+
+    let backends = rule
+        .backend_refs
+        .clone()
+        .into_iter()
+        .filter_map(|b| convert_backend(ns, b, cluster, resource_info))
+        .collect();
+
+    let creation_timestamp = route.metadata.creation_timestamp.map(|Time(t)| t);
+
+    Ok(TcpRoute {
+        rule: TcpRouteRule { backends },
+        creation_timestamp,
+    })
+}
+
+pub(super) fn convert_backend(
+    ns: &str,
+    backend: gateway::BackendRef,
+    cluster: &ClusterInfo,
+    resources: &HashMap<ResourceRef, ResourceInfo>,
+) -> Option<Backend> {
+    let backend_kind = match super::backend_kind(&backend.inner) {
+        Some(backend_kind) => backend_kind,
+        None => {
+            return Some(Backend::Invalid {
+                weight: backend.weight.unwrap_or(1).into(),
+                message: format!(
+                    "unsupported backend type {group} {kind}",
+                    group = backend.inner.group.as_deref().unwrap_or("core"),
+                    kind = backend.inner.kind.as_deref().unwrap_or("<empty>"),
+                ),
+            });
+        }
+    };
+
+    let backend_ref = ResourceRef {
+        name: backend.inner.name.clone(),
+        namespace: backend.inner.namespace.unwrap_or_else(|| ns.to_string()),
+        kind: backend_kind.clone(),
+    };
+
+    let name = backend.inner.name;
+    let weight = backend.weight.unwrap_or(1);
+
+    let port = backend
+        .inner
+        .port
+        .and_then(|p| NonZeroU16::try_from(p).ok());
+
+    match backend_kind {
+        ResourceKind::Service => {
+            // The gateway API dictates:
+            //
+            // Port is required when the referent is a Kubernetes Service.
+            let port = match port {
+                Some(port) => port,
+                None => {
+                    return Some(Backend::Invalid {
+                        weight: weight.into(),
+                        message: format!("missing port for backend Service {name}"),
+                    })
+                }
+            };
+
+            Some(Backend::Service(WeightedService {
+                weight: weight.into(),
+                authority: cluster.service_dns_authority(&backend_ref.namespace, &name, port),
+                name,
+                namespace: backend_ref.namespace.to_string(),
+                port,
+                filters: vec![],
+                exists: resources.contains_key(&backend_ref),
+            }))
+        }
+        ResourceKind::EgressNetwork => Some(Backend::EgressNetwork(WeightedEgressNetwork {
+            weight: weight.into(),
+            name,
+            namespace: backend_ref.namespace.to_string(),
+            port,
+            filters: vec![],
+            exists: resources.contains_key(&backend_ref),
+        })),
+    }
+}

--- a/policy-controller/k8s/index/src/outbound/index/tls.rs
+++ b/policy-controller/k8s/index/src/outbound/index/tls.rs
@@ -1,0 +1,43 @@
+use super::tcp::convert_backend;
+use super::{ResourceInfo, ResourceRef};
+use crate::{routes, ClusterInfo};
+use ahash::AHashMap as HashMap;
+use anyhow::{bail, Result};
+use linkerd_policy_controller_core::outbound::{TcpRouteRule, TlsRoute};
+use linkerd_policy_controller_k8s_api::{gateway, Time};
+
+pub(super) fn convert_route(
+    ns: &str,
+    route: gateway::TlsRoute,
+    cluster: &ClusterInfo,
+    resource_info: &HashMap<ResourceRef, ResourceInfo>,
+) -> Result<TlsRoute> {
+    if route.spec.rules.len() != 1 {
+        bail!("TLSRoute needs to have one rule");
+    }
+
+    let rule = route.spec.rules.first().expect("already checked");
+
+    let hostnames = route
+        .spec
+        .hostnames
+        .into_iter()
+        .flatten()
+        .map(routes::host_match)
+        .collect();
+
+    let backends = rule
+        .backend_refs
+        .clone()
+        .into_iter()
+        .filter_map(|b| convert_backend(ns, b, cluster, resource_info))
+        .collect();
+
+    let creation_timestamp = route.metadata.creation_timestamp.map(|Time(t)| t);
+
+    Ok(TlsRoute {
+        hostnames,
+        rule: TcpRouteRule { backends },
+        creation_timestamp,
+    })
+}

--- a/policy-controller/k8s/index/src/outbound/tests.rs
+++ b/policy-controller/k8s/index/src/outbound/tests.rs
@@ -134,8 +134,8 @@ fn switch_to_another_egress_network_parent() {
 
     // first resolution is for network B
     let policy_b = rx_b.borrow_and_update();
-    assert_eq!(policy_b.namespace, "ns".to_string());
-    assert_eq!(policy_b.name, "b".to_string());
+    assert_eq!(policy_b.parent_namespace(), "ns");
+    assert_eq!(policy_b.parent_name(), "b");
     drop(policy_b);
 
     // Create network a.
@@ -167,8 +167,8 @@ fn switch_to_another_egress_network_parent() {
 
     // second resolution is for network A
     let policy_b = rx_a.borrow_and_update();
-    assert_eq!(policy_b.namespace, "ns".to_string());
-    assert_eq!(policy_b.name, "a".to_string());
+    assert_eq!(policy_b.parent_namespace(), "ns");
+    assert_eq!(policy_b.parent_name(), "a");
 }
 
 #[test]

--- a/policy-controller/k8s/index/src/outbound/tests.rs
+++ b/policy-controller/k8s/index/src/outbound/tests.rs
@@ -7,9 +7,14 @@ use crate::{
 };
 use k8s_openapi::chrono::Utc;
 use kubert::index::IndexNamespacedResource;
+use linkerd_policy_controller_core::outbound::{Kind, ResourceTarget};
 use linkerd_policy_controller_core::IpNet;
-use linkerd_policy_controller_k8s_api::{self as k8s, policy};
+use linkerd_policy_controller_k8s_api::{
+    self as k8s,
+    policy::{self, EgressNetwork},
+};
 use tokio::time;
+use tracing::Level;
 
 mod routes;
 
@@ -92,4 +97,120 @@ impl Default for TestConfig {
             cluster_only: true,
         })
     }
+}
+
+#[test]
+fn switch_to_another_egress_network_parent() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .try_init()
+        .ok();
+
+    let test = TestConfig::default();
+    // Create network b.
+    let network_b = mk_egress_network("ns", "b");
+    test.index.write().apply(network_b);
+
+    let (ns, name) = test
+        .index
+        .write()
+        .lookup_egress_network("192.168.0.1".parse().unwrap(), "ns".to_string())
+        .expect("should resolve");
+
+    assert_eq!(ns, "ns".to_string());
+    assert_eq!(name, "b".to_string());
+
+    let mut rx_b = test
+        .index
+        .write()
+        .outbound_policy_rx(ResourceTarget {
+            name,
+            namespace: ns.clone(),
+            port: 8080.try_into().unwrap(),
+            source_namespace: ns,
+            kind: Kind::EgressNetwork("192.168.0.1:8080".parse().unwrap()),
+        })
+        .expect("b.ns should exist");
+
+    // first resolution is for network B
+    let policy_b = rx_b.borrow_and_update();
+    assert_eq!(policy_b.namespace, "ns".to_string());
+    assert_eq!(policy_b.name, "b".to_string());
+    drop(policy_b);
+
+    // Create network a.
+    let network_a = mk_egress_network("ns", "a");
+    test.index.write().apply(network_a);
+
+    // watch should be dropped at this point
+    assert!(rx_b.has_changed().is_err());
+
+    // now a new resolution should resolve network a
+
+    let (ns, name) = test
+        .index
+        .write()
+        .lookup_egress_network("192.168.0.1".parse().unwrap(), "ns".to_string())
+        .expect("should resolve");
+
+    let mut rx_a = test
+        .index
+        .write()
+        .outbound_policy_rx(ResourceTarget {
+            name,
+            namespace: ns.clone(),
+            port: 8080.try_into().unwrap(),
+            source_namespace: ns,
+            kind: Kind::EgressNetwork("192.168.0.1:8080".parse().unwrap()),
+        })
+        .expect("a.ns should exist");
+
+    // second resolution is for network A
+    let policy_b = rx_a.borrow_and_update();
+    assert_eq!(policy_b.namespace, "ns".to_string());
+    assert_eq!(policy_b.name, "a".to_string());
+}
+
+#[test]
+fn fallback_rx_closed_when_egress_net_created() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .try_init()
+        .ok();
+
+    let test = TestConfig::default();
+
+    let fallback_rx = test.index.read().fallback_policy_rx();
+    assert!(fallback_rx.has_changed().is_ok());
+
+    // Create network.
+    let network = mk_egress_network("ns", "egress-net");
+    test.index.write().apply(network);
+
+    assert!(fallback_rx.has_changed().is_err());
+}
+
+#[test]
+fn fallback_rx_closed_when_egress_net_deleted() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .try_init()
+        .ok();
+
+    let test = TestConfig::default();
+
+    // Create network.
+    let network = mk_egress_network("ns", "egress-net");
+    test.index.write().apply(network);
+
+    let fallback_rx = test.index.read().fallback_policy_rx();
+    assert!(fallback_rx.has_changed().is_ok());
+
+    <Index as kubert::index::IndexNamespacedResource<EgressNetwork>>::delete(
+        &mut test.index.write(),
+        "ns".into(),
+        "egress-net".into(),
+    );
+
+    assert!(fallback_rx.has_changed().is_err());
 }

--- a/policy-controller/k8s/index/src/outbound/tests/routes.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes.rs
@@ -1,2 +1,9 @@
 mod grpc;
 mod http;
+mod tcp;
+mod tls;
+
+enum BackendKind {
+    Egress,
+    Service,
+}

--- a/policy-controller/k8s/index/src/outbound/tests/routes/grpc.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/grpc.rs
@@ -1,6 +1,8 @@
 use kube::Resource;
 use linkerd_policy_controller_core::{
-    outbound::{Backend, WeightedService},
+    outbound::{
+        self, Backend, Kind, OutboundDiscoverTarget, WeightedEgressNetwork, WeightedService,
+    },
     routes::GroupKindNamespaceName,
     POLICY_CONTROLLER_NAME,
 };
@@ -22,18 +24,26 @@ fn backend_service() {
     test.index.write().apply(apex);
 
     // Create httproute.
-    let route = mk_route("ns", "route", 8080, "apex", "backend");
+    let route = mk_route(
+        "ns",
+        "route",
+        8080,
+        "apex",
+        "backend",
+        super::BackendKind::Service,
+    );
     test.index.write().apply(route);
 
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(
-            "apex".to_string(),
-            "ns".to_string(),
-            8080.try_into().unwrap(),
-            "ns".to_string(),
-        )
+        .outbound_policy_rx(OutboundDiscoverTarget {
+            name: "apex".to_string(),
+            namespace: "ns".to_string(),
+            port: 8080.try_into().unwrap(),
+            source_namespace: "ns".to_string(),
+            kind: Kind::Service,
+        })
         .expect("apex.ns should exist");
 
     {
@@ -96,15 +106,88 @@ fn backend_service() {
     }
 }
 
+#[test]
+fn backend_egress_network() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .try_init()
+        .ok();
+
+    let test = TestConfig::default();
+    // Create apex service.
+    let apex = mk_egress_network("ns", "apex");
+    test.index.write().apply(apex);
+
+    // Create httproute.
+    let route = mk_route(
+        "ns",
+        "route",
+        8080,
+        "apex",
+        "apex",
+        super::BackendKind::Egress,
+    );
+    test.index.write().apply(route);
+
+    let mut rx = test
+        .index
+        .write()
+        .outbound_policy_rx(OutboundDiscoverTarget {
+            name: "apex".to_string(),
+            namespace: "ns".to_string(),
+            port: 8080.try_into().unwrap(),
+            source_namespace: "ns".to_string(),
+            kind: Kind::EgressNetwork {
+                original_dst: "192.168.0.1:8080".parse().unwrap(),
+                traffic_policy: outbound::TrafficPolicy::Allow,
+            },
+        })
+        .expect("apex.ns should exist");
+
+    {
+        let policy = rx.borrow_and_update();
+        let backend = policy
+            .grpc_routes
+            .get(&GroupKindNamespaceName {
+                group: k8s_gateway_api::GrpcRoute::group(&()),
+                kind: k8s_gateway_api::GrpcRoute::kind(&()),
+                namespace: "ns".into(),
+                name: "route".into(),
+            })
+            .expect("route should exist")
+            .rules
+            .first()
+            .expect("rule should exist")
+            .backends
+            .first()
+            .expect("backend should exist");
+
+        let exists = match backend {
+            Backend::Invalid { .. } => &false,
+            Backend::EgressNetwork(WeightedEgressNetwork { exists, .. }) => exists,
+            _ => panic!("backend should be an egress network, but got {backend:?}"),
+        };
+
+        // Backend should exist.
+        assert!(exists);
+    }
+}
+
 fn mk_route(
     ns: impl ToString,
     name: impl ToString,
     port: u16,
     parent: impl ToString,
-    backend: impl ToString,
+    backend_name: impl ToString,
+    backend: super::BackendKind,
 ) -> k8s_gateway_api::GrpcRoute {
-    use chrono::Utc;
     use k8s::{policy::httproute::*, Time};
+    let (group, kind) = match backend {
+        super::BackendKind::Service => ("core".to_string(), "Service".to_string()),
+        super::BackendKind::Egress => {
+            ("policy.linkerd.io".to_string(), "EgressNetwork".to_string())
+        }
+    };
 
     k8s_gateway_api::GrpcRoute {
         metadata: k8s::ObjectMeta {
@@ -116,8 +199,8 @@ fn mk_route(
         spec: k8s_gateway_api::GrpcRouteSpec {
             inner: CommonRouteSpec {
                 parent_refs: Some(vec![ParentReference {
-                    group: Some("core".to_string()),
-                    kind: Some("Service".to_string()),
+                    group: Some(group.clone()),
+                    kind: Some(kind.clone()),
                     namespace: Some(ns.to_string()),
                     name: parent.to_string(),
                     section_name: None,
@@ -138,10 +221,10 @@ fn mk_route(
                     filters: None,
                     weight: None,
                     inner: BackendObjectReference {
-                        group: Some("core".to_string()),
-                        kind: Some("Service".to_string()),
+                        group: Some(group.clone()),
+                        kind: Some(kind.clone()),
                         namespace: Some(ns.to_string()),
-                        name: backend.to_string(),
+                        name: backend_name.to_string(),
                         port: Some(port),
                     },
                 }]),
@@ -151,8 +234,8 @@ fn mk_route(
             inner: RouteStatus {
                 parents: vec![k8s::gateway::RouteParentStatus {
                     parent_ref: ParentReference {
-                        group: Some("core".to_string()),
-                        kind: Some("Service".to_string()),
+                        group: Some(group.clone()),
+                        kind: Some(kind.clone()),
                         namespace: Some(ns.to_string()),
                         name: parent.to_string(),
                         section_name: None,

--- a/policy-controller/k8s/index/src/outbound/tests/routes/grpc.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/grpc.rs
@@ -1,8 +1,6 @@
 use kube::Resource;
 use linkerd_policy_controller_core::{
-    outbound::{
-        self, Backend, Kind, OutboundDiscoverTarget, WeightedEgressNetwork, WeightedService,
-    },
+    outbound::{Backend, Kind, ResourceTarget, WeightedEgressNetwork, WeightedService},
     routes::GroupKindNamespaceName,
     POLICY_CONTROLLER_NAME,
 };
@@ -37,7 +35,7 @@ fn backend_service() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
@@ -132,15 +130,12 @@ fn backend_egress_network() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
             source_namespace: "ns".to_string(),
-            kind: Kind::EgressNetwork {
-                original_dst: "192.168.0.1:8080".parse().unwrap(),
-                traffic_policy: outbound::TrafficPolicy::Allow,
-            },
+            kind: Kind::EgressNetwork("192.168.0.1:8080".parse().unwrap()),
         })
         .expect("apex.ns should exist");
 

--- a/policy-controller/k8s/index/src/outbound/tests/routes/http.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/http.rs
@@ -1,8 +1,6 @@
 use kube::Resource;
 use linkerd_policy_controller_core::{
-    outbound::{
-        self, Backend, Kind, OutboundDiscoverTarget, WeightedEgressNetwork, WeightedService,
-    },
+    outbound::{Backend, Kind, ResourceTarget, WeightedEgressNetwork, WeightedService},
     routes::GroupKindNamespaceName,
     POLICY_CONTROLLER_NAME,
 };
@@ -38,7 +36,7 @@ fn backend_service() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
@@ -135,15 +133,12 @@ fn backend_egress_network() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
             source_namespace: "ns".to_string(),
-            kind: Kind::EgressNetwork {
-                original_dst: "192.168.0.1:8080".parse().unwrap(),
-                traffic_policy: outbound::TrafficPolicy::Allow,
-            },
+            kind: Kind::EgressNetwork("192.168.0.1:8080".parse().unwrap()),
         })
         .expect("apex.ns should exist");
 

--- a/policy-controller/k8s/index/src/outbound/tests/routes/tcp.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/tcp.rs
@@ -6,7 +6,7 @@ use linkerd_policy_controller_core::{
     routes::GroupKindNamespaceName,
     POLICY_CONTROLLER_NAME,
 };
-use linkerd_policy_controller_k8s_api::gateway::BackendRef;
+use linkerd_policy_controller_k8s_api::gateway as k8s_gateway_api;
 use tracing::Level;
 
 use super::super::*;
@@ -19,12 +19,11 @@ fn backend_service() {
         .ok();
 
     let test = TestConfig::default();
-
     // Create apex service.
     let apex = mk_service("ns", "apex", 8080);
     test.index.write().apply(apex);
 
-    // Create httproute.
+    // Create tcproute.
     let route = mk_route(
         "ns",
         "route",
@@ -50,25 +49,22 @@ fn backend_service() {
     {
         let policy = rx.borrow_and_update();
         let backend = policy
-            .http_routes
+            .tcp_routes
             .get(&GroupKindNamespaceName {
-                group: k8s::policy::HttpRoute::group(&()),
-                kind: k8s::policy::HttpRoute::kind(&()),
+                group: k8s_gateway_api::TcpRoute::group(&()),
+                kind: k8s_gateway_api::TcpRoute::kind(&()),
                 namespace: "ns".into(),
                 name: "route".into(),
             })
             .expect("route should exist")
-            .rules
-            .first()
-            .expect("rule should exist")
+            .rule
             .backends
             .first()
             .expect("backend should exist");
 
         let exists = match backend {
-            Backend::Invalid { .. } => &false,
             Backend::Service(WeightedService { exists, .. }) => exists,
-            _ => panic!("backend should be a service, but got {backend:?}"),
+            _ => panic!("backend should be a service"),
         };
 
         // Backend should not exist.
@@ -83,24 +79,22 @@ fn backend_service() {
     {
         let policy = rx.borrow_and_update();
         let backend = policy
-            .http_routes
+            .tcp_routes
             .get(&GroupKindNamespaceName {
-                group: k8s::policy::HttpRoute::group(&()),
-                kind: k8s::policy::HttpRoute::kind(&()),
+                group: k8s_gateway_api::TcpRoute::group(&()),
+                kind: k8s_gateway_api::TcpRoute::kind(&()),
                 namespace: "ns".into(),
                 name: "route".into(),
             })
             .expect("route should exist")
-            .rules
-            .first()
-            .expect("rule should exist")
+            .rule
             .backends
             .first()
             .expect("backend should exist");
 
         let exists = match backend {
             Backend::Service(WeightedService { exists, .. }) => exists,
-            backend => panic!("backend should be a service, but got {:?}", backend),
+            _ => panic!("backend should be a service"),
         };
 
         // Backend should exist.
@@ -116,12 +110,11 @@ fn backend_egress_network() {
         .ok();
 
     let test = TestConfig::default();
-
     // Create apex service.
     let apex = mk_egress_network("ns", "apex");
     test.index.write().apply(apex);
 
-    // Create httproute.
+    // Create tcproute.
     let route = mk_route(
         "ns",
         "route",
@@ -150,17 +143,15 @@ fn backend_egress_network() {
     {
         let policy = rx.borrow_and_update();
         let backend = policy
-            .http_routes
+            .tcp_routes
             .get(&GroupKindNamespaceName {
-                group: k8s::policy::HttpRoute::group(&()),
-                kind: k8s::policy::HttpRoute::kind(&()),
+                group: k8s_gateway_api::TcpRoute::group(&()),
+                kind: k8s_gateway_api::TcpRoute::kind(&()),
                 namespace: "ns".into(),
                 name: "route".into(),
             })
             .expect("route should exist")
-            .rules
-            .first()
-            .expect("rule should exist")
+            .rule
             .backends
             .first()
             .expect("backend should exist");
@@ -183,7 +174,7 @@ fn mk_route(
     parent: impl ToString,
     backend_name: impl ToString,
     backend: super::BackendKind,
-) -> k8s::policy::HttpRoute {
+) -> k8s_gateway_api::TcpRoute {
     use k8s::{policy::httproute::*, Time};
     let (group, kind) = match backend {
         super::BackendKind::Service => ("core".to_string(), "Service".to_string()),
@@ -192,14 +183,14 @@ fn mk_route(
         }
     };
 
-    HttpRoute {
+    k8s_gateway_api::TcpRoute {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
             creation_timestamp: Some(Time(Utc::now())),
             ..Default::default()
         },
-        spec: HttpRouteSpec {
+        spec: k8s_gateway_api::TcpRouteSpec {
             inner: CommonRouteSpec {
                 parent_refs: Some(vec![ParentReference {
                     group: Some(group.clone()),
@@ -210,39 +201,25 @@ fn mk_route(
                     port: Some(port),
                 }]),
             },
-            hostnames: None,
-            rules: Some(vec![HttpRouteRule {
-                matches: Some(vec![HttpRouteMatch {
-                    path: Some(HttpPathMatch::PathPrefix {
-                        value: "/foo/bar".to_string(),
-                    }),
-                    headers: None,
-                    query_params: None,
-                    method: Some("GET".to_string()),
-                }]),
-                filters: None,
-                backend_refs: Some(vec![HttpBackendRef {
-                    backend_ref: Some(BackendRef {
-                        weight: None,
-                        inner: BackendObjectReference {
-                            group: Some(group.clone()),
-                            kind: Some(kind.clone()),
-                            namespace: Some(ns.to_string()),
-                            name: backend_name.to_string(),
-                            port: Some(port),
-                        },
-                    }),
-                    filters: None,
-                }]),
-                timeouts: None,
-            }]),
+            rules: vec![k8s_gateway_api::TcpRouteRule {
+                backend_refs: vec![k8s_gateway_api::BackendRef {
+                    weight: None,
+                    inner: BackendObjectReference {
+                        group: Some(group.clone()),
+                        kind: Some(kind.clone()),
+                        namespace: Some(ns.to_string()),
+                        name: backend_name.to_string(),
+                        port: Some(port),
+                    },
+                }],
+            }],
         },
-        status: Some(HttpRouteStatus {
+        status: Some(k8s_gateway_api::TcpRouteStatus {
             inner: RouteStatus {
                 parents: vec![k8s::gateway::RouteParentStatus {
                     parent_ref: ParentReference {
-                        group: Some(group),
-                        kind: Some(kind),
+                        group: Some(group.clone()),
+                        kind: Some(kind.clone()),
                         namespace: Some(ns.to_string()),
                         name: parent.to_string(),
                         section_name: None,

--- a/policy-controller/k8s/index/src/outbound/tests/routes/tcp.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/tcp.rs
@@ -1,8 +1,6 @@
 use kube::Resource;
 use linkerd_policy_controller_core::{
-    outbound::{
-        self, Backend, Kind, OutboundDiscoverTarget, WeightedEgressNetwork, WeightedService,
-    },
+    outbound::{Backend, Kind, ResourceTarget, WeightedEgressNetwork, WeightedService},
     routes::GroupKindNamespaceName,
     POLICY_CONTROLLER_NAME,
 };
@@ -37,7 +35,7 @@ fn backend_service() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
@@ -128,15 +126,12 @@ fn backend_egress_network() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
             source_namespace: "ns".to_string(),
-            kind: Kind::EgressNetwork {
-                original_dst: "192.168.0.1:8080".parse().unwrap(),
-                traffic_policy: outbound::TrafficPolicy::Allow,
-            },
+            kind: Kind::EgressNetwork("192.168.0.1:8080".parse().unwrap()),
         })
         .expect("apex.ns should exist");
 

--- a/policy-controller/k8s/index/src/outbound/tests/routes/tls.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/tls.rs
@@ -6,7 +6,7 @@ use linkerd_policy_controller_core::{
     routes::GroupKindNamespaceName,
     POLICY_CONTROLLER_NAME,
 };
-use linkerd_policy_controller_k8s_api::gateway::BackendRef;
+use linkerd_policy_controller_k8s_api::gateway as k8s_gateway_api;
 use tracing::Level;
 
 use super::super::*;
@@ -19,12 +19,11 @@ fn backend_service() {
         .ok();
 
     let test = TestConfig::default();
-
     // Create apex service.
     let apex = mk_service("ns", "apex", 8080);
     test.index.write().apply(apex);
 
-    // Create httproute.
+    // Create tlsroute.
     let route = mk_route(
         "ns",
         "route",
@@ -50,25 +49,22 @@ fn backend_service() {
     {
         let policy = rx.borrow_and_update();
         let backend = policy
-            .http_routes
+            .tls_routes
             .get(&GroupKindNamespaceName {
-                group: k8s::policy::HttpRoute::group(&()),
-                kind: k8s::policy::HttpRoute::kind(&()),
+                group: k8s_gateway_api::TlsRoute::group(&()),
+                kind: k8s_gateway_api::TlsRoute::kind(&()),
                 namespace: "ns".into(),
                 name: "route".into(),
             })
             .expect("route should exist")
-            .rules
-            .first()
-            .expect("rule should exist")
+            .rule
             .backends
             .first()
             .expect("backend should exist");
 
         let exists = match backend {
-            Backend::Invalid { .. } => &false,
             Backend::Service(WeightedService { exists, .. }) => exists,
-            _ => panic!("backend should be a service, but got {backend:?}"),
+            _ => panic!("backend should be a service"),
         };
 
         // Backend should not exist.
@@ -83,24 +79,22 @@ fn backend_service() {
     {
         let policy = rx.borrow_and_update();
         let backend = policy
-            .http_routes
+            .tls_routes
             .get(&GroupKindNamespaceName {
-                group: k8s::policy::HttpRoute::group(&()),
-                kind: k8s::policy::HttpRoute::kind(&()),
+                group: k8s_gateway_api::TlsRoute::group(&()),
+                kind: k8s_gateway_api::TlsRoute::kind(&()),
                 namespace: "ns".into(),
                 name: "route".into(),
             })
             .expect("route should exist")
-            .rules
-            .first()
-            .expect("rule should exist")
+            .rule
             .backends
             .first()
             .expect("backend should exist");
 
         let exists = match backend {
             Backend::Service(WeightedService { exists, .. }) => exists,
-            backend => panic!("backend should be a service, but got {:?}", backend),
+            _ => panic!("backend should be a service"),
         };
 
         // Backend should exist.
@@ -116,12 +110,11 @@ fn backend_egress_network() {
         .ok();
 
     let test = TestConfig::default();
-
     // Create apex service.
     let apex = mk_egress_network("ns", "apex");
     test.index.write().apply(apex);
 
-    // Create httproute.
+    // Create tlsroute.
     let route = mk_route(
         "ns",
         "route",
@@ -150,17 +143,15 @@ fn backend_egress_network() {
     {
         let policy = rx.borrow_and_update();
         let backend = policy
-            .http_routes
+            .tls_routes
             .get(&GroupKindNamespaceName {
-                group: k8s::policy::HttpRoute::group(&()),
-                kind: k8s::policy::HttpRoute::kind(&()),
+                group: k8s_gateway_api::TlsRoute::group(&()),
+                kind: k8s_gateway_api::TlsRoute::kind(&()),
                 namespace: "ns".into(),
                 name: "route".into(),
             })
             .expect("route should exist")
-            .rules
-            .first()
-            .expect("rule should exist")
+            .rule
             .backends
             .first()
             .expect("backend should exist");
@@ -183,7 +174,7 @@ fn mk_route(
     parent: impl ToString,
     backend_name: impl ToString,
     backend: super::BackendKind,
-) -> k8s::policy::HttpRoute {
+) -> k8s_gateway_api::TlsRoute {
     use k8s::{policy::httproute::*, Time};
     let (group, kind) = match backend {
         super::BackendKind::Service => ("core".to_string(), "Service".to_string()),
@@ -192,14 +183,14 @@ fn mk_route(
         }
     };
 
-    HttpRoute {
+    k8s_gateway_api::TlsRoute {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
             creation_timestamp: Some(Time(Utc::now())),
             ..Default::default()
         },
-        spec: HttpRouteSpec {
+        spec: k8s_gateway_api::TlsRouteSpec {
             inner: CommonRouteSpec {
                 parent_refs: Some(vec![ParentReference {
                     group: Some(group.clone()),
@@ -211,38 +202,25 @@ fn mk_route(
                 }]),
             },
             hostnames: None,
-            rules: Some(vec![HttpRouteRule {
-                matches: Some(vec![HttpRouteMatch {
-                    path: Some(HttpPathMatch::PathPrefix {
-                        value: "/foo/bar".to_string(),
-                    }),
-                    headers: None,
-                    query_params: None,
-                    method: Some("GET".to_string()),
-                }]),
-                filters: None,
-                backend_refs: Some(vec![HttpBackendRef {
-                    backend_ref: Some(BackendRef {
-                        weight: None,
-                        inner: BackendObjectReference {
-                            group: Some(group.clone()),
-                            kind: Some(kind.clone()),
-                            namespace: Some(ns.to_string()),
-                            name: backend_name.to_string(),
-                            port: Some(port),
-                        },
-                    }),
-                    filters: None,
-                }]),
-                timeouts: None,
-            }]),
+            rules: vec![k8s_gateway_api::TlsRouteRule {
+                backend_refs: vec![k8s_gateway_api::BackendRef {
+                    weight: None,
+                    inner: BackendObjectReference {
+                        group: Some(group.clone()),
+                        kind: Some(kind.clone()),
+                        namespace: Some(ns.to_string()),
+                        name: backend_name.to_string(),
+                        port: Some(port),
+                    },
+                }],
+            }],
         },
-        status: Some(HttpRouteStatus {
+        status: Some(k8s_gateway_api::TlsRouteStatus {
             inner: RouteStatus {
                 parents: vec![k8s::gateway::RouteParentStatus {
                     parent_ref: ParentReference {
-                        group: Some(group),
-                        kind: Some(kind),
+                        group: Some(group.clone()),
+                        kind: Some(kind.clone()),
                         namespace: Some(ns.to_string()),
                         name: parent.to_string(),
                         section_name: None,

--- a/policy-controller/k8s/index/src/outbound/tests/routes/tls.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/tls.rs
@@ -1,8 +1,6 @@
 use kube::Resource;
 use linkerd_policy_controller_core::{
-    outbound::{
-        self, Backend, Kind, OutboundDiscoverTarget, WeightedEgressNetwork, WeightedService,
-    },
+    outbound::{Backend, Kind, ResourceTarget, WeightedEgressNetwork, WeightedService},
     routes::GroupKindNamespaceName,
     POLICY_CONTROLLER_NAME,
 };
@@ -37,7 +35,7 @@ fn backend_service() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
@@ -128,15 +126,12 @@ fn backend_egress_network() {
     let mut rx = test
         .index
         .write()
-        .outbound_policy_rx(OutboundDiscoverTarget {
+        .outbound_policy_rx(ResourceTarget {
             name: "apex".to_string(),
             namespace: "ns".to_string(),
             port: 8080.try_into().unwrap(),
             source_namespace: "ns".to_string(),
-            kind: Kind::EgressNetwork {
-                original_dst: "192.168.0.1:8080".parse().unwrap(),
-                traffic_policy: outbound::TrafficPolicy::Allow,
-            },
+            kind: Kind::EgressNetwork("192.168.0.1:8080".parse().unwrap()),
         })
         .expect("apex.ns should exist");
 

--- a/policy-controller/k8s/index/src/routes.rs
+++ b/policy-controller/k8s/index/src/routes.rs
@@ -1,4 +1,4 @@
-use linkerd_policy_controller_core::routes::{GroupKindName, GroupKindNamespaceName};
+use linkerd_policy_controller_core::routes::{GroupKindName, GroupKindNamespaceName, HostMatch};
 use linkerd_policy_controller_k8s_api::{gateway as api, policy, Resource, ResourceExt};
 
 pub mod grpc;
@@ -75,5 +75,19 @@ impl ExplicitGKN for str {
         let (kind, group, name) = (R::kind(&()), R::group(&()), self.to_string().into());
 
         GroupKindName { group, kind, name }
+    }
+}
+
+pub fn host_match(hostname: api::Hostname) -> HostMatch {
+    if hostname.starts_with("*.") {
+        let mut reverse_labels = hostname
+            .split('.')
+            .skip(1)
+            .map(|label| label.to_string())
+            .collect::<Vec<String>>();
+        reverse_labels.reverse();
+        HostMatch::Suffix { reverse_labels }
+    } else {
+        HostMatch::Exact(hostname)
     }
 }

--- a/policy-controller/k8s/index/src/routes/http.rs
+++ b/policy-controller/k8s/index/src/routes/http.rs
@@ -54,20 +54,6 @@ pub fn path_match(path_match: api::HttpPathMatch) -> Result<routes::PathMatch> {
     }
 }
 
-pub fn host_match(hostname: api::Hostname) -> routes::HostMatch {
-    if hostname.starts_with("*.") {
-        let mut reverse_labels = hostname
-            .split('.')
-            .skip(1)
-            .map(|label| label.to_string())
-            .collect::<Vec<String>>();
-        reverse_labels.reverse();
-        routes::HostMatch::Suffix { reverse_labels }
-    } else {
-        routes::HostMatch::Exact(hostname)
-    }
-}
-
 pub fn header_match(header_match: api::HttpHeaderMatch) -> Result<routes::HeaderMatch> {
     match header_match {
         api::HttpHeaderMatch::Exact { name, value } => {

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -9,7 +9,7 @@ use linkerd_policy_controller_core::inbound::{
     DiscoverInboundServer, InboundServer, InboundServerStream,
 };
 use linkerd_policy_controller_core::outbound::{
-    DiscoverOutboundPolicy, FallbackPolicyStream, Kind, OutboundDiscoverTarget, OutboundPolicy,
+    DiscoverOutboundPolicy, ExternalPolicyStream, Kind, OutboundDiscoverTarget, OutboundPolicy,
     OutboundPolicyStream, ResourceTarget,
 };
 pub use linkerd_policy_controller_core::IpNet;
@@ -113,7 +113,7 @@ impl DiscoverOutboundPolicy<ResourceTarget, OutboundDiscoverTarget> for Outbound
         }
     }
 
-    async fn watch_fallback_policy(&self) -> FallbackPolicyStream {
+    async fn watch_external_policy(&self) -> ExternalPolicyStream {
         Box::pin(tokio_stream::wrappers::WatchStream::new(
             self.0.read().fallback_policy_rx(),
         ))
@@ -150,7 +150,7 @@ impl DiscoverOutboundPolicy<ResourceTarget, OutboundDiscoverTarget> for Outbound
 
         if !index.is_address_in_cluster(addr) {
             let original_dst = SocketAddr::new(addr, port.into());
-            return Some(OutboundDiscoverTarget::Fallback(original_dst));
+            return Some(OutboundDiscoverTarget::External(original_dst));
         }
 
         None

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -116,7 +116,7 @@ impl DiscoverOutboundPolicy<OutboundDiscoverTarget> for OutboundDiscover {
                         policy: policy.clone(),
                     },
 
-                    (ParentMeta::Service { authority }, Kind::EgressNetwork(_)) => {
+                    (ParentMeta::Service { authority }, Kind::Service) => {
                         ResourceOutboundPolicy::Service {
                             authority: authority.clone(),
                             policy,
@@ -162,7 +162,7 @@ impl DiscoverOutboundPolicy<OutboundDiscoverTarget> for OutboundDiscover {
                                         policy: policy.clone(),
                                     }),
 
-                                    (ParentMeta::Service { authority }, Kind::EgressNetwork(_)) => {
+                                    (ParentMeta::Service { authority }, Kind::Service) => {
                                         Some(ResourceOutboundPolicy::Service { authority, policy })
                                     }
                                     (policy_kind, resource_kind) => {

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -296,7 +296,9 @@ async fn main() -> Result<()> {
 
     if api_resource_exists::<k8s_gateway_api::TlsRoute>(&runtime.client()).await {
         let tls_routes = runtime.watch_all::<k8s_gateway_api::TlsRoute>(watcher::Config::default());
-        let tls_routes_indexes = IndexList::new(status_index.clone()).shared();
+        let tls_routes_indexes = IndexList::new(status_index.clone())
+            .push(outbound_index.clone())
+            .shared();
         tokio::spawn(
             kubert::index::namespaced(tls_routes_indexes.clone(), tls_routes)
                 .instrument(info_span!("tlsroutes.gateway.networking.k8s.io")),
@@ -309,7 +311,9 @@ async fn main() -> Result<()> {
 
     if api_resource_exists::<k8s_gateway_api::TcpRoute>(&runtime.client()).await {
         let tcp_routes = runtime.watch_all::<k8s_gateway_api::TcpRoute>(watcher::Config::default());
-        let tcp_routes_indexes = IndexList::new(status_index.clone()).shared();
+        let tcp_routes_indexes = IndexList::new(status_index.clone())
+            .push(outbound_index.clone())
+            .shared();
         tokio::spawn(
             kubert::index::namespaced(tcp_routes_indexes.clone(), tcp_routes)
                 .instrument(info_span!("tcproutes.gateway.networking.k8s.io")),
@@ -330,7 +334,9 @@ async fn main() -> Result<()> {
 
     let egress_networks =
         runtime.watch_all::<k8s::policy::EgressNetwork>(watcher::Config::default());
-    let egress_networks_indexes = IndexList::new(status_index.clone()).shared();
+    let egress_networks_indexes = IndexList::new(status_index.clone())
+        .push(outbound_index.clone())
+        .shared();
     tokio::spawn(
         kubert::index::namespaced(egress_networks_indexes, egress_networks)
             .instrument(info_span!("egressnetworks")),

--- a/policy-test/src/grpc.rs
+++ b/policy-test/src/grpc.rs
@@ -295,7 +295,6 @@ impl OutboundPolicyClient {
         svc: &k8s::Service,
         port: u16,
     ) -> Result<tonic::Streaming<outbound::OutboundPolicy>, tonic::Status> {
-        use std::net::Ipv4Addr;
         let address = svc
             .spec
             .as_ref()
@@ -303,7 +302,17 @@ impl OutboundPolicyClient {
             .cluster_ip
             .as_ref()
             .expect("Service must have a cluster ip");
-        let ip = address.parse::<Ipv4Addr>().unwrap();
+        self.watch_ip(ns, address, port).await
+    }
+
+    pub async fn watch_ip(
+        &mut self,
+        ns: &str,
+        addr: &str,
+        port: u16,
+    ) -> Result<tonic::Streaming<outbound::OutboundPolicy>, tonic::Status> {
+        use std::net::Ipv4Addr;
+        let ip = addr.parse::<Ipv4Addr>().unwrap();
         let rsp = self
             .client
             .watch(tonic::Request::new(outbound::TrafficSpec {

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -435,7 +435,7 @@ where
         drop(_tracing);
     }
 
-    if std::env::var("POLICY_TEST_NO_CLEANUP").is_ok() {
+    if std::env::var("POLICY_TEST_NO_CLEANUP").is_err() {
         tracing::debug!(ns = %ns.name_unchecked(), "Deleting");
         api.delete(&ns.name_unchecked(), &kube::api::DeleteParams::background())
             .await

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -435,7 +435,7 @@ where
         drop(_tracing);
     }
 
-    if std::env::var("POLICY_TEST_NO_CLEANUP").is_err() {
+    if std::env::var("POLICY_TEST_NO_CLEANUP").is_ok() {
         tracing::debug!(ns = %ns.name_unchecked(), "Deleting");
         api.delete(&ns.name_unchecked(), &kube::api::DeleteParams::background())
             .await

--- a/policy-test/tests/outbound_api_gateway.rs
+++ b/policy-test/tests/outbound_api_gateway.rs
@@ -20,7 +20,7 @@ async fn service_does_not_exist() {
         // Build a service but don't apply it to the cluster.
         let mut svc = mk_service(&ns, "my-svc", 4191);
         // Give it a bogus cluster ip.
-        svc.spec.as_mut().unwrap().cluster_ip = Some("1.1.1.1".to_string());
+        svc.spec.as_mut().unwrap().cluster_ip = Some("192.168.0.2".to_string());
 
         let mut policy_api = grpc::OutboundPolicyClient::port_forwarded(&client).await;
         let rsp = policy_api.watch(&ns, &svc, 4191).await;

--- a/policy-test/tests/outbound_api_linkerd.rs
+++ b/policy-test/tests/outbound_api_linkerd.rs
@@ -26,7 +26,6 @@ async fn service_does_not_exist() {
         let mut policy_api = grpc::OutboundPolicyClient::port_forwarded(&client).await;
         let rsp = policy_api.watch(&ns, &svc, 4191).await;
 
-        println!("{:?}", rsp);
         assert!(rsp.is_err());
         assert_eq!(rsp.err().unwrap().code(), tonic::Code::NotFound);
     })

--- a/policy-test/tests/outbound_api_linkerd.rs
+++ b/policy-test/tests/outbound_api_linkerd.rs
@@ -21,7 +21,7 @@ async fn service_does_not_exist() {
         // Build a service but don't apply it to the cluster.
         let mut svc = mk_service(&ns, "my-svc", 4191);
         // Give it a bogus cluster ip.
-        svc.spec.as_mut().unwrap().cluster_ip = Some("1.1.1.1".to_string());
+        svc.spec.as_mut().unwrap().cluster_ip = Some("192.168.0.2".to_string());
 
         let mut policy_api = grpc::OutboundPolicyClient::port_forwarded(&client).await;
         let rsp = policy_api.watch(&ns, &svc, 4191).await;

--- a/policy-test/tests/outbound_api_linkerd.rs
+++ b/policy-test/tests/outbound_api_linkerd.rs
@@ -26,6 +26,7 @@ async fn service_does_not_exist() {
         let mut policy_api = grpc::OutboundPolicyClient::port_forwarded(&client).await;
         let rsp = policy_api.watch(&ns, &svc, 4191).await;
 
+        println!("{:?}", rsp);
         assert!(rsp.is_err());
         assert_eq!(rsp.err().unwrap().code(), tonic::Code::NotFound);
     })


### PR DESCRIPTION
This PR adds a few notable changes associated with the egress functionality of Linkerd:

- `EgressNetwork` objects are indexed into the outbound index
- outbound policy lookups are classfieid as either in-cluster or egress based on the `ip:port` combination
- `TCPRoute`, `TLSRoute`, `GRPCRoute` and `HTTPRoute` attachments are reflected for both `EgressNetwork` and `Service` targets
- the default traffic policy for `EgressNetwork` is honored by returning the appropriate default (failure/success) routes for all protocols

Note that this PR depends on an unreleased version of the linkerd2-proxy-api repo.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
