### PR TITLE
Add HTTPLocalRateLimitPolicy support

### DIFF
--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -180,6 +180,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -224,6 +225,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications

--- a/charts/linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
+++ b/charts/linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httplocalratelimitpolicies.policy.linkerd.io
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    linkerd.io/control-plane-ns: {{.Release.Namespace}}
+spec:
+  group: policy.linkerd.io
+  names:
+    kind: HTTPLocalRateLimitPolicy
+    listKind: HTTPLocalRateLimitPolicyList
+    plural: httplocalratelimitpolicies
+    singular: httplocalratelimitpolicy
+    shortNames: []
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [targetRef]
+              properties:
+                targetRef:
+                  description: >-
+                    TargetRef references a resource to which the rate limit
+                    policy applies. Only Server is allowed.
+                  type: object
+                  required: [kind, name]
+                  properties:
+                    group:
+                      description: >-
+                        Group is the group of the referent. When empty, the
+                        Kubernetes core API group is inferred.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is the kind of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                total:
+                  description: >-
+                    Overall rate-limit, which all traffic coming to this
+                    target should abide.
+                    If unset no overall limit is applied.
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                identity:
+                  description: >-
+                    Fairness for individual identities; each separate client,
+                    grouped by identity, will have this rate-limit. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                overrides:
+                  description: >-
+                    Overrides for traffic from a specific client. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: array
+                  items:
+                    type: object
+                    required: [requestsPerSecond, clientRefs]
+                    properties:
+                      requestsPerSecond:
+                        format: int64
+                        type: integer
+                      clientRefs:
+                        type: array
+                        items:
+                          type: object
+                          required: [kind, name]
+                          properties:
+                            group:
+                              description: >-
+                                Group is the group of the referent. When empty, the
+                                Kubernetes core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              description: Kind is the kind of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            namespace:
+                              description: >-
+                                  Namespace is the namespace of the referent.
+                                  When unspecified (or empty string), this refers to the
+                                  local namespace of the Policy.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+      additionalPrinterColumns:
+      - name: Target_kind
+        description: The resource kind to which the rate-limit applies
+        type: string
+        jsonPath: .spec.targetRef.kind
+      - name: Target_name
+        type: string
+        description: The resource name to which the rate-limit applies
+        jsonPath: .spec.targetRef.name
+      - name: Total_RPS
+        description: The overall rate-limit
+        type: integer
+        format: int32
+        jsonPath: .spec.total.requestsPerSecond
+      - name: Identity_RPS
+        description: The rate-limit per identity
+        type: integer
+        format: int32
+        jsonPath: .spec.identity.requestsPerSecond

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -51,6 +51,7 @@ var (
 	TemplatesCrdFiles = []string{
 		"templates/policy/authorization-policy.yaml",
 		"templates/policy/egress-network.yaml",
+		"templates/policy/http-local-ratelimit-policy.yaml",
 		"templates/policy/httproute.yaml",
 		"templates/policy/meshtls-authentication.yaml",
 		"templates/policy/network-authentication.yaml",

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1344,7 +1346,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -224,6 +224,153 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: httplocalratelimitpolicies.policy.linkerd.io
+  annotations:
+    linkerd.io/created-by: linkerd/cli dev-undefined
+  labels:
+    helm.sh/chart: linkerd-crds-0.0.0-undefined
+    linkerd.io/control-plane-ns: linkerd
+spec:
+  group: policy.linkerd.io
+  names:
+    kind: HTTPLocalRateLimitPolicy
+    listKind: HTTPLocalRateLimitPolicyList
+    plural: httplocalratelimitpolicies
+    singular: httplocalratelimitpolicy
+    shortNames: []
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [targetRef]
+              properties:
+                targetRef:
+                  description: >-
+                    TargetRef references a resource to which the rate limit
+                    policy applies. Only Server is allowed.
+                  type: object
+                  required: [kind, name]
+                  properties:
+                    group:
+                      description: >-
+                        Group is the group of the referent. When empty, the
+                        Kubernetes core API group is inferred.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is the kind of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                total:
+                  description: >-
+                    Overall rate-limit, which all traffic coming to this
+                    target should abide.
+                    If unset no overall limit is applied.
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                identity:
+                  description: >-
+                    Fairness for individual identities; each separate client,
+                    grouped by identity, will have this rate-limit. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                overrides:
+                  description: >-
+                    Overrides for traffic from a specific client. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: array
+                  items:
+                    type: object
+                    required: [requestsPerSecond, clientRefs]
+                    properties:
+                      requestsPerSecond:
+                        format: int64
+                        type: integer
+                      clientRefs:
+                        type: array
+                        items:
+                          type: object
+                          required: [kind, name]
+                          properties:
+                            group:
+                              description: >-
+                                Group is the group of the referent. When empty, the
+                                Kubernetes core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              description: Kind is the kind of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            namespace:
+                              description: >-
+                                  Namespace is the namespace of the referent.
+                                  When unspecified (or empty string), this refers to the
+                                  local namespace of the Policy.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+      additionalPrinterColumns:
+      - name: Target_kind
+        description: The resource kind to which the rate-limit applies
+        type: string
+        jsonPath: .spec.targetRef.kind
+      - name: Target_name
+        type: string
+        description: The resource name to which the rate-limit applies
+        jsonPath: .spec.targetRef.name
+      - name: Total_RPS
+        description: The overall rate-limit
+        type: integer
+        format: int32
+        jsonPath: .spec.total.requestsPerSecond
+      - name: Identity_RPS
+        description: The rate-limit per identity
+        type: integer
+        format: int32
+        jsonPath: .spec.identity.requestsPerSecond
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: httproutes.policy.linkerd.io
   annotations:
     linkerd.io/created-by: linkerd/cli dev-undefined

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1343,7 +1345,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1343,7 +1345,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1343,7 +1345,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1343,7 +1345,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1334,7 +1336,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1347,7 +1349,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1446,7 +1448,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 02b4e06690c7d152f22038a65218d7bd14f7afa20d872db332cdc66b5d8aa477
+        checksum/config: b53320781231a300833e58dd60e59dfc76812535b6d8baceac8e9aebf532115f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1446,7 +1448,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 02b4e06690c7d152f22038a65218d7bd14f7afa20d872db332cdc66b5d8aa477
+        checksum/config: b53320781231a300833e58dd60e59dfc76812535b6d8baceac8e9aebf532115f
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1274,7 +1276,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -167,6 +167,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -210,6 +211,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1318,7 +1320,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a3ab7df29a1f48d7fb7479bacd63a866ae3679b1fe06d0b949018f212fcbd480
+        checksum/config: 135a435d8eac25e6b0cb52bdcb59c99c293707c5ead497c969ab6a0fdbbd2017
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -167,6 +167,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -210,6 +211,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1421,7 +1423,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 897be9c3f1c955b3a7624feb8435bd3eefd946a954634d04cf38d9c9813c5977
+        checksum/config: 1c02562d84ed479248921e406146be0e36935c87b0d28a1c903c3b90a117cc5b
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -167,6 +167,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -210,6 +211,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1425,7 +1427,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 897be9c3f1c955b3a7624feb8435bd3eefd946a954634d04cf38d9c9813c5977
+        checksum/config: 1c02562d84ed479248921e406146be0e36935c87b0d28a1c903c3b90a117cc5b
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -225,6 +225,155 @@ spec:
                 - status
                 - type
 ---
+# Source: linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httplocalratelimitpolicies.policy.linkerd.io
+  annotations:
+    linkerd.io/created-by: linkerd/helm linkerd-version
+  labels:
+    helm.sh/chart: linkerd-crds-
+    linkerd.io/control-plane-ns: linkerd-dev
+spec:
+  group: policy.linkerd.io
+  names:
+    kind: HTTPLocalRateLimitPolicy
+    listKind: HTTPLocalRateLimitPolicyList
+    plural: httplocalratelimitpolicies
+    singular: httplocalratelimitpolicy
+    shortNames: []
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [targetRef]
+              properties:
+                targetRef:
+                  description: >-
+                    TargetRef references a resource to which the rate limit
+                    policy applies. Only Server is allowed.
+                  type: object
+                  required: [kind, name]
+                  properties:
+                    group:
+                      description: >-
+                        Group is the group of the referent. When empty, the
+                        Kubernetes core API group is inferred.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is the kind of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                total:
+                  description: >-
+                    Overall rate-limit, which all traffic coming to this
+                    target should abide.
+                    If unset no overall limit is applied.
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                identity:
+                  description: >-
+                    Fairness for individual identities; each separate client,
+                    grouped by identity, will have this rate-limit. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                overrides:
+                  description: >-
+                    Overrides for traffic from a specific client. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: array
+                  items:
+                    type: object
+                    required: [requestsPerSecond, clientRefs]
+                    properties:
+                      requestsPerSecond:
+                        format: int64
+                        type: integer
+                      clientRefs:
+                        type: array
+                        items:
+                          type: object
+                          required: [kind, name]
+                          properties:
+                            group:
+                              description: >-
+                                Group is the group of the referent. When empty, the
+                                Kubernetes core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              description: Kind is the kind of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            namespace:
+                              description: >-
+                                  Namespace is the namespace of the referent.
+                                  When unspecified (or empty string), this refers to the
+                                  local namespace of the Policy.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+      additionalPrinterColumns:
+      - name: Target_kind
+        description: The resource kind to which the rate-limit applies
+        type: string
+        jsonPath: .spec.targetRef.kind
+      - name: Target_name
+        type: string
+        description: The resource name to which the rate-limit applies
+        jsonPath: .spec.targetRef.name
+      - name: Total_RPS
+        description: The overall rate-limit
+        type: integer
+        format: int32
+        jsonPath: .spec.total.requestsPerSecond
+      - name: Identity_RPS
+        description: The rate-limit per identity
+        type: integer
+        format: int32
+        jsonPath: .spec.identity.requestsPerSecond
+---
 # Source: linkerd-crds/templates/policy/httproute.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -225,6 +225,155 @@ spec:
                 - status
                 - type
 ---
+# Source: linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httplocalratelimitpolicies.policy.linkerd.io
+  annotations:
+    linkerd.io/created-by: linkerd/helm linkerd-version
+  labels:
+    helm.sh/chart: linkerd-crds-
+    linkerd.io/control-plane-ns: linkerd-dev
+spec:
+  group: policy.linkerd.io
+  names:
+    kind: HTTPLocalRateLimitPolicy
+    listKind: HTTPLocalRateLimitPolicyList
+    plural: httplocalratelimitpolicies
+    singular: httplocalratelimitpolicy
+    shortNames: []
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [targetRef]
+              properties:
+                targetRef:
+                  description: >-
+                    TargetRef references a resource to which the rate limit
+                    policy applies. Only Server is allowed.
+                  type: object
+                  required: [kind, name]
+                  properties:
+                    group:
+                      description: >-
+                        Group is the group of the referent. When empty, the
+                        Kubernetes core API group is inferred.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is the kind of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                total:
+                  description: >-
+                    Overall rate-limit, which all traffic coming to this
+                    target should abide.
+                    If unset no overall limit is applied.
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                identity:
+                  description: >-
+                    Fairness for individual identities; each separate client,
+                    grouped by identity, will have this rate-limit. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: object
+                  required: [requestsPerSecond]
+                  properties:
+                    requestsPerSecond:
+                      format: int64
+                      type: integer
+                overrides:
+                  description: >-
+                    Overrides for traffic from a specific client. The
+                    requestsPerSecond value should be less than or equal to the
+                    total requestsPerSecond (if set).
+                  type: array
+                  items:
+                    type: object
+                    required: [requestsPerSecond, clientRefs]
+                    properties:
+                      requestsPerSecond:
+                        format: int64
+                        type: integer
+                      clientRefs:
+                        type: array
+                        items:
+                          type: object
+                          required: [kind, name]
+                          properties:
+                            group:
+                              description: >-
+                                Group is the group of the referent. When empty, the
+                                Kubernetes core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              description: Kind is the kind of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            namespace:
+                              description: >-
+                                  Namespace is the namespace of the referent.
+                                  When unspecified (or empty string), this refers to the
+                                  local namespace of the Policy.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+      additionalPrinterColumns:
+      - name: Target_kind
+        description: The resource kind to which the rate-limit applies
+        type: string
+        jsonPath: .spec.targetRef.kind
+      - name: Target_name
+        type: string
+        description: The resource name to which the rate-limit applies
+        jsonPath: .spec.targetRef.name
+      - name: Total_RPS
+        description: The overall rate-limit
+        type: integer
+        format: int32
+        jsonPath: .spec.total.requestsPerSecond
+      - name: Identity_RPS
+        description: The rate-limit per identity
+        type: integer
+        format: int32
+        jsonPath: .spec.identity.requestsPerSecond
+---
 # Source: linkerd-crds/templates/policy/httproute.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -167,6 +167,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -210,6 +211,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1429,7 +1431,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 897be9c3f1c955b3a7624feb8435bd3eefd946a954634d04cf38d9c9813c5977
+        checksum/config: 1c02562d84ed479248921e406146be0e36935c87b0d28a1c903c3b90a117cc5b
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -167,6 +167,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -210,6 +211,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1411,7 +1413,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6ea3f771978787f69c67c9e5ab356c7216ca31ae0e42c39b0cc88beb6a72af25
+        checksum/config: 412d4349fe71497326ed1946ce0d9c31985fd1db5c8d6a1be1d681987d0c6a33
         linkerd.io/created-by: linkerd/helm linkerd-version
         linkerd.io/proxy-version: test-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1336,7 +1338,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -173,6 +173,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -216,6 +217,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1282,7 +1284,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 517aa09718582375a57ef993e2e182ee3303d0f257a8b967c2680181b076dc42
+        checksum/config: 6b107c2b9d26d1c49f0d8912d5793a0c52438cdd5b3de537d13de0ec18da365e
         linkerd.io/created-by: CliVersion
         linkerd.io/proxy-version: ProxyVersion
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1343,7 +1345,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -176,6 +176,7 @@ webhooks:
     apiVersions: ["*"]
     resources:
     - authorizationpolicies
+    - httplocalratelimitpolicies
     - httproutes
     - networkauthentications
     - meshtlsauthentications
@@ -219,6 +220,7 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
+      - httplocalratelimitpolicies
       - httproutes
       - meshtlsauthentications
       - networkauthentications
@@ -1343,7 +1345,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 742b40a4b565b2bb0fe1bb5c644952dfd4fe4c0d015fa618a9a895cd107b6627
+        checksum/config: 726a0d9a61f222ca9efb64bc6ec38ad1d4beeab125c79f00b45a1d64be642875
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: install-proxy-version
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/policy-controller/core/src/inbound.rs
+++ b/policy-controller/core/src/inbound.rs
@@ -72,6 +72,25 @@ pub enum ClientAuthentication {
     TlsAuthenticated(Vec<IdentityMatch>),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RateLimit {
+    pub name: String,
+    pub total: Option<Limit>,
+    pub identity: Option<Limit>,
+    pub overrides: Vec<Override>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Limit {
+    pub requests_per_second: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Override {
+    pub requests_per_second: u32,
+    pub client_identities: Vec<String>,
+}
+
 /// Models inbound server configuration discovery.
 #[async_trait::async_trait]
 pub trait DiscoverInboundServer<T> {
@@ -89,6 +108,7 @@ pub struct InboundServer {
 
     pub protocol: ProxyProtocol,
     pub authorizations: HashMap<AuthorizationRef, ClientAuthorization>,
+    pub ratelimit: Option<RateLimit>,
     pub http_routes: HashMap<RouteRef, InboundRoute<HttpRouteMatch>>,
     pub grpc_routes: HashMap<RouteRef, InboundRoute<GrpcRouteMatch>>,
 }

--- a/policy-controller/grpc/src/inbound.rs
+++ b/policy-controller/grpc/src/inbound.rs
@@ -11,7 +11,7 @@ use linkerd2_proxy_api::{
 use linkerd_policy_controller_core::{
     inbound::{
         AuthorizationRef, ClientAuthentication, ClientAuthorization, DiscoverInboundServer,
-        InboundServer, InboundServerStream, ProxyProtocol, ServerRef,
+        InboundServer, InboundServerStream, ProxyProtocol, RateLimit, ServerRef,
     },
     IdentityMatch, IpNet, NetworkMatch,
 };
@@ -147,19 +147,19 @@ fn to_server(srv: &InboundServer, cluster_networks: &[IpNet]) -> proto::Server {
                 proto::proxy_protocol::Detect {
                     timeout: timeout.try_into().map_err(|error| tracing::warn!(%error, "failed to convert protocol detect timeout to protobuf")).ok(),
                     http_routes: http::to_route_list(&srv.http_routes, cluster_networks),
-                    http_local_rate_limit: None,
+                    http_local_rate_limit: srv.ratelimit.as_ref().map(to_rate_limit),
                 },
             )),
             ProxyProtocol::Http1 => Some(proto::proxy_protocol::Kind::Http1(
                 proto::proxy_protocol::Http1 {
                     routes: http::to_route_list(&srv.http_routes, cluster_networks),
-                    local_rate_limit: None,
+                    local_rate_limit: srv.ratelimit.as_ref().map(to_rate_limit),
                 },
             )),
             ProxyProtocol::Http2 => Some(proto::proxy_protocol::Kind::Http2(
                 proto::proxy_protocol::Http2 {
                     routes: http::to_route_list(&srv.http_routes, cluster_networks),
-                    local_rate_limit: None,
+                    local_rate_limit: srv.ratelimit.as_ref().map(to_rate_limit),
                 },
             )),
             ProxyProtocol::Grpc => Some(proto::proxy_protocol::Kind::Grpc(
@@ -328,5 +328,50 @@ fn to_authz(
         labels,
         networks,
         authentication: Some(authn),
+    }
+}
+
+fn to_rate_limit(rl: &RateLimit) -> proto::HttpLocalRateLimit {
+    let meta = Metadata {
+        kind: Some(metadata::Kind::Resource(api::meta::Resource {
+            group: "policy.linkerd.io".to_string(),
+            kind: "HTTPLocalRateLimitPolicy".to_string(),
+            name: rl.name.to_string(),
+            ..Default::default()
+        })),
+    };
+
+    proto::HttpLocalRateLimit {
+        metadata: Some(meta),
+        total: rl
+            .total
+            .as_ref()
+            .map(|lim| proto::http_local_rate_limit::Limit {
+                requests_per_second: lim.requests_per_second,
+            }),
+        identity: rl
+            .identity
+            .as_ref()
+            .map(|lim| proto::http_local_rate_limit::Limit {
+                requests_per_second: lim.requests_per_second,
+            }),
+        overrides: rl
+            .overrides
+            .iter()
+            .map(|ovr| proto::http_local_rate_limit::Override {
+                limit: Some(proto::http_local_rate_limit::Limit {
+                    requests_per_second: ovr.requests_per_second,
+                }),
+                clients: Some(proto::http_local_rate_limit::r#override::ClientIdentities {
+                    identities: ovr
+                        .client_identities
+                        .iter()
+                        .map(|id| proto::Identity {
+                            name: id.to_string(),
+                        })
+                        .collect(),
+                }),
+            })
+            .collect(),
     }
 }

--- a/policy-controller/k8s/api/src/policy.rs
+++ b/policy-controller/k8s/api/src/policy.rs
@@ -4,6 +4,7 @@ pub mod httproute;
 pub mod meshtls_authentication;
 mod network;
 pub mod network_authentication;
+pub mod ratelimit_policy;
 pub mod server;
 pub mod server_authorization;
 pub mod target_ref;
@@ -15,6 +16,7 @@ pub use self::{
     meshtls_authentication::{MeshTLSAuthentication, MeshTLSAuthenticationSpec},
     network::{Cidr, Network},
     network_authentication::{NetworkAuthentication, NetworkAuthenticationSpec},
+    ratelimit_policy::{HTTPLocalRateLimitPolicy, Limit, Override, RateLimitPolicySpec},
     server::{Server, ServerSpec},
     server_authorization::{ServerAuthorization, ServerAuthorizationSpec},
     target_ref::{ClusterTargetRef, LocalTargetRef, NamespacedTargetRef},

--- a/policy-controller/k8s/api/src/policy/ratelimit_policy.rs
+++ b/policy-controller/k8s/api/src/policy/ratelimit_policy.rs
@@ -1,0 +1,31 @@
+use super::{LocalTargetRef, NamespacedTargetRef};
+
+#[derive(
+    Clone, Debug, kube::CustomResource, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
+#[kube(
+    group = "policy.linkerd.io",
+    version = "v1alpha1",
+    kind = "HTTPLocalRateLimitPolicy",
+    namespaced
+)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitPolicySpec {
+    pub target_ref: LocalTargetRef,
+    pub total: Option<Limit>,
+    pub identity: Option<Limit>,
+    pub overrides: Option<Vec<Override>>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Limit {
+    pub requests_per_second: u32,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Override {
+    pub requests_per_second: u32,
+    pub client_refs: Vec<NamespacedTargetRef>,
+}

--- a/policy-controller/k8s/index/src/inbound.rs
+++ b/policy-controller/k8s/index/src/inbound.rs
@@ -2,6 +2,7 @@ pub mod authorization_policy;
 pub mod index;
 mod meshtls_authentication;
 mod network_authentication;
+mod ratelimit_policy;
 mod routes;
 mod server;
 pub mod server_authorization;

--- a/policy-controller/k8s/index/src/inbound/index.rs
+++ b/policy-controller/k8s/index/src/inbound/index.rs
@@ -7,8 +7,8 @@
 //! kubernetes resources.
 
 use super::{
-    authorization_policy, meshtls_authentication, network_authentication, routes::RouteBinding,
-    server, server_authorization, workload,
+    authorization_policy, meshtls_authentication, network_authentication, ratelimit_policy,
+    routes::RouteBinding, server, server_authorization, workload,
 };
 use crate::{
     ports::{PortHasher, PortMap, PortSet},
@@ -20,7 +20,8 @@ use anyhow::{anyhow, bail, Result};
 use linkerd_policy_controller_core::{
     inbound::{
         AuthorizationRef, ClientAuthentication, ClientAuthorization, GrpcRoute, HttpRoute,
-        InboundRouteRule, InboundServer, ProxyProtocol, RouteRef, ServerRef,
+        InboundRouteRule, InboundServer, Limit, Override, ProxyProtocol, RateLimit, RouteRef,
+        ServerRef,
     },
     routes::{GroupKindName, HttpRouteMatch, Method, PathMatch},
     IdentityMatch, Ipv4Net, Ipv6Net, NetworkMatch,
@@ -162,6 +163,7 @@ struct PolicyIndex {
     server_authorizations: HashMap<String, server_authorization::ServerAuthz>,
 
     authorization_policies: HashMap<String, authorization_policy::Spec>,
+    ratelimit_policies: HashMap<String, ratelimit_policy::Spec>,
     http_routes: HashMap<GroupKindName, RouteBinding<HttpRoute>>,
     grpc_routes: HashMap<GroupKindName, RouteBinding<GrpcRoute>>,
 }
@@ -936,6 +938,90 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::NetworkAuthentication> 
     }
 }
 
+impl kubert::index::IndexNamespacedResource<k8s::policy::HTTPLocalRateLimitPolicy> for Index {
+    fn apply(&mut self, policy: k8s::policy::HTTPLocalRateLimitPolicy) {
+        let ns = policy.namespace().unwrap();
+        let name = policy.name_unchecked();
+        let _span = info_span!("apply", %ns, saz = %name).entered();
+
+        let spec = match ratelimit_policy::Spec::try_from(policy.spec) {
+            Ok(spec) => spec,
+            Err(error) => {
+                tracing::warn!(%error, "Invalid rate limit policy");
+                return;
+            }
+        };
+
+        self.ns_or_default_with_reindex(ns, |ns| ns.policy.update_ratelimit_policy(name, spec))
+    }
+
+    fn delete(&mut self, ns: String, ap: String) {
+        let _span = info_span!("delete", %ns, %ap).entered();
+        tracing::trace!(name = %ap, "Delete");
+        self.ns_with_reindex(ns, |ns| ns.policy.ratelimit_policies.remove(&ap).is_some())
+    }
+
+    fn reset(
+        &mut self,
+        policies: Vec<k8s::policy::HTTPLocalRateLimitPolicy>,
+        deleted: HashMap<String, HashSet<String>>,
+    ) {
+        let _span = info_span!("reset");
+
+        tracing::trace!(?deleted, ?policies, "Reset");
+        // Aggregate all of the updates by namespace so that we only reindex
+        // once per namespace.
+        type Ns = NsUpdate<String, ratelimit_policy::Spec>;
+        let mut updates_by_ns = HashMap::<String, Ns>::default();
+        for policy in policies.into_iter() {
+            let namespace = policy
+                .namespace()
+                .expect("ratelimitolicy must be namespaced");
+            let name = policy.name_unchecked();
+            match ratelimit_policy::Spec::try_from(policy.spec) {
+                Ok(spec) => updates_by_ns
+                    .entry(namespace)
+                    .or_default()
+                    .added
+                    .push((name, spec)),
+                Err(error) => {
+                    tracing::error!(ns = %namespace, %name, %error, "Illegal server ratelimit update")
+                }
+            }
+        }
+        for (ns, names) in deleted.into_iter() {
+            updates_by_ns.entry(ns).or_default().removed = names;
+        }
+
+        for (namespace, Ns { added, removed }) in updates_by_ns.into_iter() {
+            if added.is_empty() {
+                // If there are no live resources in the namespace, we do not
+                // want to create a default namespace instance, we just want to
+                // clear out all resources for the namespace (and then drop the
+                // whole namespace, if necessary).
+                self.ns_with_reindex(namespace, |ns| {
+                    ns.policy.ratelimit_policies.clear();
+                    true
+                });
+            } else {
+                // Otherwise, we take greater care to reindex only when the
+                // state actually changed. The vast majority of resets will see
+                // no actual data change.
+                self.ns_or_default_with_reindex(namespace, |ns| {
+                    let mut changed = !removed.is_empty();
+                    for name in removed.into_iter() {
+                        ns.policy.ratelimit_policies.remove(&name);
+                    }
+                    for (name, spec) in added.into_iter() {
+                        changed = ns.policy.update_ratelimit_policy(name, spec) || changed;
+                    }
+                    changed
+                });
+            }
+        }
+    }
+}
+
 impl kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute> for Index {
     fn apply(&mut self, route: k8s::policy::HttpRoute) {
         self.apply_http_route(route)
@@ -1059,6 +1145,7 @@ impl Namespace {
                 servers: HashMap::default(),
                 server_authorizations: HashMap::default(),
                 authorization_policies: HashMap::default(),
+                ratelimit_policies: HashMap::default(),
                 http_routes: HashMap::default(),
                 grpc_routes: HashMap::default(),
             },
@@ -1628,6 +1715,22 @@ impl PolicyIndex {
         true
     }
 
+    fn update_ratelimit_policy(&mut self, name: String, spec: ratelimit_policy::Spec) -> bool {
+        match self.ratelimit_policies.entry(name) {
+            Entry::Vacant(entry) => {
+                entry.insert(spec);
+            }
+            Entry::Occupied(entry) => {
+                let rl = entry.into_mut();
+                if *rl == spec {
+                    return false;
+                }
+                *rl = spec;
+            }
+        }
+        true
+    }
+
     fn default_inbound_server<'p>(
         port: NonZeroU16,
         settings: &workload::Settings,
@@ -1655,12 +1758,15 @@ impl PolicyIndex {
 
         let authorizations = policy.default_authzs(config);
 
+        let ratelimit = Default::default();
+
         let http_routes = config.default_inbound_http_routes(probe_paths);
 
         InboundServer {
             reference: ServerRef::Default(policy.as_str()),
             protocol,
             authorizations,
+            ratelimit,
             http_routes,
             grpc_routes: HashMap::default(),
         }
@@ -1675,12 +1781,14 @@ impl PolicyIndex {
     ) -> InboundServer {
         tracing::trace!(%name, ?server, "Creating inbound server");
         let authorizations = self.client_authzs(&name, server, authentications);
+        let ratelimit = self.client_ratelimit(&name);
         let http_routes = self.http_routes(&name, authentications, probe_paths);
         let grpc_routes = self.grpc_routes(&name, authentications);
 
         InboundServer {
             reference: ServerRef::Server(name),
             authorizations,
+            ratelimit,
             protocol: server.protocol.clone(),
             http_routes,
             grpc_routes,
@@ -1758,6 +1866,65 @@ impl PolicyIndex {
         }
 
         authzs
+    }
+
+    fn client_ratelimit(&self, server_name: &str) -> Option<RateLimit> {
+        for (name, spec) in self.ratelimit_policies.iter() {
+            // Skip the policy if it doesn't apply to the server.
+            let ratelimit_policy::Target::Server(this_name) = &spec.target;
+            if this_name != server_name {
+                tracing::trace!(
+                    ns = %self.namespace,
+                    ratelimitpolicy = %name,
+                    server = %server_name,
+                    target = %name,
+                    "HTTPLocalRateLimitPolicy does not target server",
+                );
+                continue;
+            }
+
+            tracing::trace!(
+                ns = %self.namespace,
+                ratelimitpolicy = %name,
+                server = %server_name,
+                "HTTPLocalRateLimitPolicy targets server",
+            );
+
+            let overrides = spec
+                .overrides
+                .iter()
+                .map(|ovr| {
+                    let client_identities = ovr
+                        .client_refs
+                        .iter()
+                        .map(|client_ref| {
+                            let ratelimit_policy::ClientRef::ServiceAccount { namespace, name } =
+                                client_ref;
+                            let namespace = namespace.as_deref().unwrap_or(&self.namespace);
+                            self.cluster_info.service_account_identity(namespace, name)
+                        })
+                        .collect();
+
+                    Override {
+                        requests_per_second: ovr.requests_per_second,
+                        client_identities,
+                    }
+                })
+                .collect();
+
+            return Some(RateLimit {
+                name: name.to_string(),
+                total: spec.total.as_ref().map(|l| Limit {
+                    requests_per_second: l.requests_per_second,
+                }),
+                identity: spec.identity.as_ref().map(|l| Limit {
+                    requests_per_second: l.requests_per_second,
+                }),
+                overrides,
+            });
+        }
+
+        None
     }
 
     fn route_client_authzs(

--- a/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
@@ -1,12 +1,14 @@
 use anyhow::Result;
+use chrono::{offset::Utc, DateTime};
 use linkerd_policy_controller_k8s_api::{
     self as k8s,
     policy::{LocalTargetRef, NamespacedTargetRef},
-    ServiceAccount,
+    ServiceAccount, Time,
 };
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Spec {
+    pub creation_timestamp: Option<DateTime<Utc>>,
     pub target: Target,
     pub total: Option<Limit>,
     pub identity: Option<Limit>,
@@ -37,19 +39,22 @@ pub(crate) enum ClientRef {
     },
 }
 
-impl TryFrom<k8s::policy::RateLimitPolicySpec> for Spec {
+impl TryFrom<k8s::policy::HTTPLocalRateLimitPolicy> for Spec {
     type Error = anyhow::Error;
 
-    fn try_from(rl: k8s::policy::RateLimitPolicySpec) -> Result<Self> {
+    fn try_from(rl: k8s::policy::HTTPLocalRateLimitPolicy) -> Result<Self> {
+        let creation_timestamp = rl.metadata.creation_timestamp.map(|Time(t)| t);
         Ok(Self {
-            target: target(rl.target_ref)?,
-            total: rl.total.map(|lim| Limit {
+            creation_timestamp,
+            target: target(rl.spec.target_ref)?,
+            total: rl.spec.total.map(|lim| Limit {
                 requests_per_second: lim.requests_per_second,
             }),
-            identity: rl.identity.map(|lim| Limit {
+            identity: rl.spec.identity.map(|lim| Limit {
                 requests_per_second: lim.requests_per_second,
             }),
             overrides: rl
+                .spec
                 .overrides
                 .unwrap_or_default()
                 .into_iter()

--- a/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use linkerd_policy_controller_k8s_api::{
+    self as k8s,
+    policy::{LocalTargetRef, NamespacedTargetRef},
+    ServiceAccount,
+};
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Spec {
+    pub target: Target,
+    pub total: Option<Limit>,
+    pub identity: Option<Limit>,
+    pub overrides: Vec<Override>,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum Target {
+    Server(String),
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Limit {
+    pub requests_per_second: u32,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Override {
+    pub requests_per_second: u32,
+    pub client_refs: Vec<ClientRef>,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum ClientRef {
+    ServiceAccount {
+        namespace: Option<String>,
+        name: String,
+    },
+}
+
+impl TryFrom<k8s::policy::RateLimitPolicySpec> for Spec {
+    type Error = anyhow::Error;
+
+    fn try_from(rl: k8s::policy::RateLimitPolicySpec) -> Result<Self> {
+        Ok(Self {
+            target: target(rl.target_ref)?,
+            total: rl.total.map(|lim| Limit {
+                requests_per_second: lim.requests_per_second,
+            }),
+            identity: rl.identity.map(|lim| Limit {
+                requests_per_second: lim.requests_per_second,
+            }),
+            overrides: rl
+                .overrides
+                .unwrap_or_default()
+                .into_iter()
+                .map(|o| {
+                    let client_refs = o
+                        .client_refs
+                        .into_iter()
+                        .map(client_ref)
+                        .collect::<Result<Vec<_>>>();
+                    client_refs.map(|refs| Override {
+                        requests_per_second: o.requests_per_second,
+                        client_refs: refs,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+fn target(t: LocalTargetRef) -> Result<Target> {
+    match t {
+        t if t.targets_kind::<k8s::policy::Server>() => Ok(Target::Server(t.name)),
+        _ => anyhow::bail!("unsupported rate limit target type: {}", t.canonical_kind()),
+    }
+}
+
+fn client_ref(t: NamespacedTargetRef) -> Result<ClientRef> {
+    if t.targets_kind::<ServiceAccount>() {
+        Ok(ClientRef::ServiceAccount {
+            namespace: t.namespace.map(Into::into),
+            name: t.name,
+        })
+    } else {
+        anyhow::bail!("unsupported client reference: {}", t.canonical_kind());
+    }
+}

--- a/policy-controller/k8s/index/src/inbound/tests.rs
+++ b/policy-controller/k8s/index/src/inbound/tests.rs
@@ -2,6 +2,7 @@ mod annotation;
 mod authorization_policy;
 mod grpc_routes;
 mod http_routes;
+mod ratelimit_policy;
 mod server_authorization;
 
 use crate::{
@@ -241,6 +242,7 @@ impl TestConfig {
         InboundServer {
             reference: ServerRef::Default(self.default_policy.as_str()),
             authorizations: mk_default_policy(self.default_policy, self.cluster.networks.clone()),
+            ratelimit: None,
             protocol: ProxyProtocol::Detect {
                 timeout: self.detect_timeout,
             },

--- a/policy-controller/k8s/index/src/inbound/tests/annotation.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/annotation.rs
@@ -114,6 +114,7 @@ fn authenticated_annotated() {
             InboundServer {
                 reference: ServerRef::Default(policy.as_str()),
                 authorizations: mk_default_policy(policy, test.cluster.networks),
+                ratelimit: None,
                 protocol: ProxyProtocol::Detect {
                     timeout: test.detect_timeout,
                 },

--- a/policy-controller/k8s/index/src/inbound/tests/authorization_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/authorization_policy.rs
@@ -33,6 +33,7 @@ fn links_authorization_policy_with_mtls_name() {
         InboundServer {
             reference: ServerRef::Server("srv-8080".to_string()),
             authorizations: Default::default(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),
@@ -88,6 +89,7 @@ fn links_authorization_policy_with_mtls_name() {
             )
             .into_iter()
             .collect(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),
@@ -125,6 +127,7 @@ fn authorization_targets_namespace() {
         InboundServer {
             reference: ServerRef::Server("srv-8080".to_string()),
             authorizations: Default::default(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),
@@ -180,6 +183,7 @@ fn authorization_targets_namespace() {
             )
             .into_iter()
             .collect(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),
@@ -217,6 +221,7 @@ fn links_authorization_policy_with_service_account() {
         InboundServer {
             reference: ServerRef::Server("srv-8080".to_string()),
             authorizations: Default::default(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),
@@ -266,6 +271,7 @@ fn links_authorization_policy_with_service_account() {
             )
             .into_iter()
             .collect(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),
@@ -368,6 +374,7 @@ fn authorization_policy_prevents_index_deletion() {
         InboundServer {
             reference: ServerRef::Server("srv-8080".to_string()),
             authorizations: Default::default(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: hashmap!(RouteRef::Resource(routes::GroupKindName{
                 group: "policy.linkerd.io".into(),

--- a/policy-controller/k8s/index/src/inbound/tests/grpc_routes.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/grpc_routes.rs
@@ -31,6 +31,7 @@ fn server_with_default_route() {
         InboundServer {
             reference: ServerRef::Server("srv-8080".to_string()),
             authorizations: Default::default(),
+            ratelimit: None,
             protocol: ProxyProtocol::Grpc,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),

--- a/policy-controller/k8s/index/src/inbound/tests/http_routes.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/http_routes.rs
@@ -39,6 +39,7 @@ fn route_attaches_to_server() {
         InboundServer {
             reference: ServerRef::Server("srv-8080".to_string()),
             authorizations: Default::default(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),

--- a/policy-controller/k8s/index/src/inbound/tests/ratelimit_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/ratelimit_policy.rs
@@ -1,0 +1,109 @@
+use super::*;
+use linkerd_policy_controller_core::inbound::{Limit, Override, RateLimit};
+
+#[test]
+fn ratelimit_policy_with_server() {
+    let test = TestConfig::default();
+
+    let mut pod = mk_pod("ns-0", "pod-0", Some(("container-0", None)));
+    pod.labels_mut()
+        .insert("app".to_string(), "app-0".to_string());
+    test.index.write().apply(pod);
+
+    let mut rx = test
+        .index
+        .write()
+        .pod_server_rx("ns-0", "pod-0", 8080.try_into().unwrap())
+        .expect("pod-0.ns-0 should exist");
+    assert_eq!(*rx.borrow_and_update(), test.default_server());
+
+    test.index.write().apply(mk_server(
+        "ns-0",
+        "srv-8080",
+        Port::Number(8080.try_into().unwrap()),
+        None,
+        Some(("app", "app-0")),
+        Some(k8s::policy::server::ProxyProtocol::Http1),
+    ));
+    assert!(rx.has_changed().unwrap());
+    assert_eq!(
+        *rx.borrow_and_update(),
+        InboundServer {
+            reference: ServerRef::Server("srv-8080".to_string()),
+            authorizations: Default::default(),
+            ratelimit: None,
+            protocol: ProxyProtocol::Http1,
+            http_routes: mk_default_http_routes(),
+            grpc_routes: mk_default_grpc_routes(),
+        },
+    );
+
+    let ratelimit = RateLimit {
+        name: "ratelimit-0".to_string(),
+        total: Some(Limit {
+            requests_per_second: 1000,
+        }),
+        identity: None,
+        overrides: vec![Override {
+            requests_per_second: 500,
+            client_identities: vec![
+                "client-0.ns-0.serviceaccount.identity.linkerd.cluster.example.com".to_string(),
+            ],
+        }],
+    };
+    test.index.write().apply(mk_ratelimit(
+        "ns-0",
+        "ratelimit-0",
+        Some(k8s::policy::Limit {
+            requests_per_second: 1000,
+        }),
+        vec![k8s::policy::Override {
+            requests_per_second: 500,
+            client_refs: vec![NamespacedTargetRef {
+                group: None,
+                kind: "ServiceAccount".to_string(),
+                name: "client-0".to_string(),
+                namespace: None,
+            }],
+        }],
+        "srv-8080",
+    ));
+    assert!(rx.has_changed().unwrap());
+    assert_eq!(
+        *rx.borrow_and_update(),
+        InboundServer {
+            reference: ServerRef::Server("srv-8080".to_string()),
+            authorizations: Default::default(),
+            ratelimit: Some(ratelimit),
+            protocol: ProxyProtocol::Http1,
+            http_routes: mk_default_http_routes(),
+            grpc_routes: mk_default_grpc_routes(),
+        },
+    );
+}
+
+fn mk_ratelimit(
+    ns: impl ToString,
+    name: impl ToString,
+    total: Option<k8s::policy::Limit>,
+    overrides: Vec<k8s::policy::Override>,
+    server_name: impl ToString,
+) -> k8s::policy::HTTPLocalRateLimitPolicy {
+    k8s::policy::HTTPLocalRateLimitPolicy {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        spec: k8s::policy::RateLimitPolicySpec {
+            target_ref: LocalTargetRef {
+                group: Some("policy.linkerd.io".to_string()),
+                kind: "Server".to_string(),
+                name: server_name.to_string(),
+            },
+            total,
+            identity: None,
+            overrides: Some(overrides),
+        },
+    }
+}

--- a/policy-controller/k8s/index/src/inbound/tests/server_authorization.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/server_authorization.rs
@@ -42,6 +42,7 @@ fn link_server_authz(selector: ServerSelector) {
         InboundServer {
             reference: ServerRef::Server("srv-8080".to_string()),
             authorizations: Default::default(),
+            ratelimit: None,
             protocol: ProxyProtocol::Http1,
             http_routes: mk_default_http_routes(),
             grpc_routes: mk_default_grpc_routes(),

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -253,6 +253,13 @@ async fn main() -> Result<()> {
             .instrument(info_span!("networkauthentications")),
     );
 
+    let ratelimit_policies =
+        runtime.watch_all::<k8s::policy::HTTPLocalRateLimitPolicy>(watcher::Config::default());
+    tokio::spawn(
+        kubert::index::namespaced(inbound_index.clone(), ratelimit_policies)
+            .instrument(info_span!("httplocalratelimitpolicies")),
+    );
+
     let http_routes_indexes = IndexList::new(inbound_index.clone())
         .push(outbound_index.clone())
         .push(status_index.clone())

--- a/policy-test/src/grpc.rs
+++ b/policy-test/src/grpc.rs
@@ -378,14 +378,20 @@ impl hyper::service::Service<hyper::Request<tonic::body::BoxBody>> for GrpcHttp 
 pub mod defaults {
     use super::*;
 
-    pub fn proxy_protocol() -> inbound::ProxyProtocol {
+    pub fn proxy_protocol(
+        local_rate_limit: Option<inbound::HttpLocalRateLimit>,
+    ) -> inbound::ProxyProtocol {
         use inbound::proxy_protocol::{Http1, Kind};
         inbound::ProxyProtocol {
             kind: Some(Kind::Http1(Http1 {
                 routes: vec![http_route(), probe_route()],
-                local_rate_limit: None,
+                local_rate_limit,
             })),
         }
+    }
+
+    pub fn proxy_protocol_no_ratelimit() -> inbound::ProxyProtocol {
+        proxy_protocol(None)
     }
 
     pub fn proxy_protocol_external() -> inbound::ProxyProtocol {
@@ -395,6 +401,55 @@ pub mod defaults {
                 routes: vec![http_route()],
                 local_rate_limit: None,
             })),
+        }
+    }
+
+    pub fn http_local_ratelimit(
+        name: &str,
+        rps_total: Option<u32>,
+        rps_identity: Option<u32>,
+        overrides: Vec<(u32, Vec<String>)>,
+    ) -> inbound::HttpLocalRateLimit {
+        use inbound::http_local_rate_limit::{r#override, Limit, Override};
+        use meta::{metadata, Metadata, Resource};
+
+        let overrides = overrides
+            .iter()
+            .map(|ovr| {
+                let identities = r#override::ClientIdentities {
+                    identities: ovr
+                        .1
+                        .iter()
+                        .map(|name| inbound::Identity {
+                            name: name.to_string(),
+                        })
+                        .collect(),
+                };
+                Override {
+                    limit: Some(Limit {
+                        requests_per_second: ovr.0,
+                    }),
+                    clients: Some(identities),
+                }
+            })
+            .collect();
+
+        inbound::HttpLocalRateLimit {
+            metadata: Some(Metadata {
+                kind: Some(metadata::Kind::Resource(Resource {
+                    group: "policy.linkerd.io".to_string(),
+                    kind: "HTTPLocalRateLimitPolicy".to_string(),
+                    name: name.to_owned(),
+                    ..Default::default()
+                })),
+            }),
+            total: rps_total.map(|requests_per_second| Limit {
+                requests_per_second,
+            }),
+            identity: rps_identity.map(|requests_per_second| Limit {
+                requests_per_second,
+            }),
+            overrides,
         }
     }
 


### PR DESCRIPTION
This adds the HTTPLocalRateLimitPolicy CRD, which is indexed by the policy controller and exposed by the inbound API.

- 81ebc08bd: HTTPLocalRateLimitPolicy CRD and related changes
- 01afd2304: policy controller central changes
- b09892529: rust tests updates and additions
- 2f455973c: golden files updates.

## Testing

In a cluster with linkerd and emojivoto injected, deploy these resources:

```yaml
 apiVersion: policy.linkerd.io/v1beta3
kind: Server
metadata:
  namespace: emojivoto
  name: web-http
spec:
  # permissive policy, so we don't require setting up authz
  accessPolicy: all-unauthenticated
  podSelector:
    matchLabels:
      app: web-svc
  port: http
  proxyProtocol: HTTP/1
```
```yaml
apiVersion: policy.linkerd.io/v1alpha1
kind: HTTPLocalRateLimitPolicy
metadata:
  namespace: emojivoto
  name: web-rl
spec:
  targetRef:
    group: policy.linkerd.io
    kind: Server
    name: web-http
  total:
    requestsPerSecond: 100
  identity:
    requestsPerSecond: 20
  overrides:
  - requestsPerSecond: 10
    clientRefs:
    - kind: ServiceAccount
      namespace: emojivoto
      name: default
```

```console
$ kubectl -n emojivoto get httplocalratelimitpolicies.policy.linkerd.io
NAME     TARGET_KIND   TARGET_NAME   TOTAL_RPS   IDENTITY_RPS
web-rl   Server        web-http      100         20
```

Then see how the RL policy is exposed at the inbound API under the protocol section, with `linkerd dg policy -n emojivoto po/web-85f6fb8564-jp67d 8080`:

```yaml
...
protocol:
  Kind:
    Http1:
      local_rate_limit:
        identity:
          requestsPerSecond: 20
        metadata:
          Kind:
            Resource:
              group: policy.linkerd.io
              kind: httplocalratelimitpolicy
              name: web-rl
        overrides:
        - clients:
            identities:
            - name: default.emojivoto.serviceaccount.identity.linkerd.cluster.local
          limit:
            requestsPerSecond: 10
        total:
          requestsPerSecond: 100
...
```