### PR TITLE
Add federated service watcher

### DIFF
--- a/controller/api/destination/federated_service_watcher.go
+++ b/controller/api/destination/federated_service_watcher.go
@@ -1,0 +1,427 @@
+package destination
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
+	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
+	"github.com/linkerd/linkerd2/controller/k8s"
+	labels "github.com/linkerd/linkerd2/pkg/k8s"
+	logging "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// FederatedServiceWatcher watches federated services for the local discovery
+// and remote discovery annotations and subscribes to the approprite local and
+// remote services.
+type federatedServiceWatcher struct {
+	services       map[watcher.ServiceID]*federatedService
+	k8sAPI         *k8s.API
+	metadataAPI    *k8s.MetadataAPI
+	config         *Config
+	clusterStore   *watcher.ClusterStore
+	localEndpoints *watcher.EndpointsWatcher
+
+	log *logging.Entry
+}
+
+type remoteDiscoveryID struct {
+	cluster string
+	service watcher.ServiceID
+}
+
+// FederatedService represents a federated service and it may have a local
+// discovery target and remote discovery targets. This struct holds a list of
+// subsribers that are subscribed to the federated service.
+type federatedService struct {
+	namespace string
+
+	localDiscovery  string
+	remoteDiscovery []remoteDiscoveryID
+	subscribers     []federatedServiceSubscriber
+
+	metadataAPI    *k8s.MetadataAPI
+	config         *Config
+	localEndpoints *watcher.EndpointsWatcher
+	clusterStore   *watcher.ClusterStore
+	log            *logging.Entry
+}
+
+// FederatedServiceSubscriber holds all the state for an individual subscriber
+// stream to a federated service.
+type federatedServiceSubscriber struct {
+	port       uint32
+	nodeName   string
+	instanceID string
+
+	localTranslators  map[string]*endpointTranslator
+	remoteTranslators map[remoteDiscoveryID]*endpointTranslator
+
+	stream    pb.Destination_GetServer
+	endStream chan struct{}
+}
+
+func newFederatedServiceWatcher(
+	k8sAPI *k8s.API,
+	metadataAPI *k8s.MetadataAPI,
+	config *Config,
+	clusterStore *watcher.ClusterStore,
+	localEndpoints *watcher.EndpointsWatcher,
+	log *logging.Entry,
+) (*federatedServiceWatcher, error) {
+	fsw := &federatedServiceWatcher{
+		services:       make(map[watcher.ServiceID]*federatedService),
+		k8sAPI:         k8sAPI,
+		metadataAPI:    metadataAPI,
+		config:         config,
+		clusterStore:   clusterStore,
+		localEndpoints: localEndpoints,
+		log: log.WithFields(logging.Fields{
+			"component": "federated-service-watcher",
+		}),
+	}
+
+	var err error
+	_, err = k8sAPI.Svc().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    fsw.addService,
+		DeleteFunc: fsw.deleteService,
+		UpdateFunc: fsw.updateService,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return fsw, nil
+}
+
+func (fsw *federatedServiceWatcher) Subscribe(
+	service string,
+	namespace string,
+	port uint32,
+	nodeName string,
+	instanceID string,
+	stream pb.Destination_GetServer,
+	endStream chan struct{},
+) error {
+	id := watcher.ServiceID{Namespace: namespace, Name: service}
+	if federatedService, ok := fsw.services[id]; ok {
+		fsw.log.Debugf("Subscribing to federated service %s/%s", namespace, service)
+		federatedService.subscribe(port, nodeName, instanceID, stream, endStream)
+		return nil
+	}
+	return fmt.Errorf("service %s/%s is not a federated service", namespace, service)
+}
+
+func (fsw *federatedServiceWatcher) Unsubscribe(
+	service string,
+	namespace string,
+	stream pb.Destination_GetServer,
+) {
+	id := watcher.ServiceID{Namespace: namespace, Name: service}
+	if federatedService, ok := fsw.services[id]; ok {
+		fsw.log.Debugf("Unsubscribing from federated service %s/%s", namespace, service)
+		federatedService.unsubscribe(stream)
+	}
+}
+
+func (fsw *federatedServiceWatcher) addService(obj interface{}) {
+	service := obj.(*corev1.Service)
+	id := watcher.ServiceID{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+
+	if isFederatedService(service) {
+		if federatedService, ok := fsw.services[id]; ok {
+			fsw.log.Debugf("Updating federated service %s/%s", service.Namespace, service.Name)
+			federatedService.update(service)
+		} else {
+			fsw.log.Debugf("Adding federated service %s/%s", service.Namespace, service.Name)
+			federatedService = fsw.newFederatedService(service)
+			fsw.services[id] = federatedService
+			federatedService.update(service)
+		}
+	} else {
+		if federatedService, ok := fsw.services[id]; ok {
+			fsw.log.Debugf("Service %s/%s is no longer a federated service", service.Namespace, service.Name)
+			federatedService.delete()
+			delete(fsw.services, id)
+		}
+	}
+}
+
+func (fsw *federatedServiceWatcher) updateService(oldObj interface{}, newObj interface{}) {
+	fsw.addService(newObj)
+}
+
+func (fsw *federatedServiceWatcher) deleteService(obj interface{}) {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			fsw.log.Errorf("couldn't get object from DeletedFinalStateUnknown %#v", obj)
+			return
+		}
+		service, ok = tombstone.Obj.(*corev1.Service)
+		if !ok {
+			fsw.log.Errorf("DeletedFinalStateUnknown contained object that is not a Service %#v", obj)
+			return
+		}
+	}
+
+	id := watcher.ServiceID{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	if federatedService, ok := fsw.services[id]; ok {
+		federatedService.delete()
+		delete(fsw.services, id)
+	}
+}
+
+func (fsw *federatedServiceWatcher) newFederatedService(service *corev1.Service) *federatedService {
+	return &federatedService{
+		namespace: service.Namespace,
+
+		localDiscovery:  service.Annotations[labels.LocalDiscoveryAnnotation],
+		remoteDiscovery: remoteDiscoveryIDs(service, fsw.log),
+		subscribers:     []federatedServiceSubscriber{},
+
+		metadataAPI:    fsw.metadataAPI,
+		config:         fsw.config,
+		localEndpoints: fsw.localEndpoints,
+		clusterStore:   fsw.clusterStore,
+		log:            fsw.log.WithFields(logging.Fields{"service": service.Name, "namespace": service.Namespace}),
+	}
+}
+
+func (fs *federatedService) update(service *corev1.Service) {
+	newRemoteDiscovery := remoteDiscoveryIDs(service, fs.log)
+	for _, id := range newRemoteDiscovery {
+		if !slices.Contains(fs.remoteDiscovery, id) {
+			for i := range fs.subscribers {
+				fs.remoteDiscoverySubscribe(&fs.subscribers[i], id)
+			}
+		}
+	}
+	for _, id := range fs.remoteDiscovery {
+		if !slices.Contains(newRemoteDiscovery, id) {
+			for i := range fs.subscribers {
+				fs.remoteDiscoveryUnsubscribe(&fs.subscribers[i], id)
+			}
+		}
+	}
+	fs.remoteDiscovery = newRemoteDiscovery
+
+	newLocalDiscovery := service.Annotations[labels.LocalDiscoveryAnnotation]
+	if fs.localDiscovery != service.Annotations[labels.LocalDiscoveryAnnotation] {
+		if newLocalDiscovery != "" {
+			for i := range fs.subscribers {
+				if fs.localDiscovery != "" {
+					fs.localDiscoveryUnsubscribe(&fs.subscribers[i], fs.localDiscovery)
+				}
+				fs.localDiscoverySubscribe(&fs.subscribers[i], newLocalDiscovery)
+			}
+		} else {
+			for i := range fs.subscribers {
+				fs.localDiscoveryUnsubscribe(&fs.subscribers[i], fs.localDiscovery)
+			}
+		}
+	}
+	fs.localDiscovery = newLocalDiscovery
+}
+
+func (fs *federatedService) delete() {
+	for _, subscriber := range fs.subscribers {
+		for id, translator := range subscriber.remoteTranslators {
+			remoteWatcher, _, found := fs.clusterStore.Get(id.cluster)
+			if !found {
+				fs.log.Errorf("Failed to get remote cluster %s", id.cluster)
+				continue
+			}
+			remoteWatcher.Unsubscribe(id.service, subscriber.port, subscriber.instanceID, translator)
+			translator.Stop()
+		}
+		for localDiscovery, translator := range subscriber.localTranslators {
+			fs.localEndpoints.Unsubscribe(watcher.ServiceID{Namespace: fs.namespace, Name: localDiscovery}, subscriber.port, subscriber.instanceID, translator)
+			translator.Stop()
+		}
+		close(subscriber.endStream)
+	}
+}
+
+func (fs *federatedService) subscribe(
+	port uint32,
+	nodeName string,
+	instanceID string,
+	stream pb.Destination_GetServer,
+	endStream chan struct{},
+) {
+	subscriber := federatedServiceSubscriber{
+		stream:            stream,
+		endStream:         endStream,
+		remoteTranslators: make(map[remoteDiscoveryID]*endpointTranslator, 0),
+		localTranslators:  make(map[string]*endpointTranslator, 0),
+		port:              port,
+		nodeName:          nodeName,
+		instanceID:        instanceID,
+	}
+	for _, id := range fs.remoteDiscovery {
+		fs.remoteDiscoverySubscribe(&subscriber, id)
+	}
+	if fs.localDiscovery != "" {
+		fs.localDiscoverySubscribe(&subscriber, fs.localDiscovery)
+	}
+	fs.subscribers = append(fs.subscribers, subscriber)
+}
+
+func (fs *federatedService) unsubscribe(
+	stream pb.Destination_GetServer,
+) {
+	subscribers := make([]federatedServiceSubscriber, 0)
+	for i, subscriber := range fs.subscribers {
+		if subscriber.stream == stream {
+			for id := range subscriber.remoteTranslators {
+				fs.remoteDiscoveryUnsubscribe(&fs.subscribers[i], id)
+			}
+			for localDiscovery := range subscriber.localTranslators {
+				fs.localDiscoveryUnsubscribe(&fs.subscribers[i], localDiscovery)
+			}
+		} else {
+			subscribers = append(subscribers, subscriber)
+		}
+	}
+	fs.subscribers = subscribers
+}
+
+func (fs *federatedService) remoteDiscoverySubscribe(
+	subscriber *federatedServiceSubscriber,
+	id remoteDiscoveryID,
+) {
+	remoteWatcher, remoteConfig, found := fs.clusterStore.Get(id.cluster)
+	if !found {
+		fs.log.Errorf("Failed to get remote cluster %s", id.cluster)
+	}
+
+	translator := newEndpointTranslator(
+		fs.config.ControllerNS,
+		remoteConfig.TrustDomain,
+		fs.config.EnableH2Upgrade,
+		false, // Disable endpoint filtering for remote discovery.
+		fs.config.EnableIPv6,
+		fs.config.ExtEndpointZoneWeights,
+		fs.config.MeshedHttp2ClientParams,
+		fmt.Sprintf("%s.%s.svc.%s:%d", id.service, fs.namespace, remoteConfig.ClusterDomain, subscriber.port),
+		subscriber.nodeName,
+		fs.config.DefaultOpaquePorts,
+		fs.metadataAPI,
+		subscriber.stream,
+		subscriber.endStream,
+		fs.log,
+	)
+	translator.Start()
+	subscriber.remoteTranslators[id] = translator
+
+	fs.log.Debugf("Subscribing to remote discovery service %s in cluster %s", id.service, id.cluster)
+	err := remoteWatcher.Subscribe(watcher.ServiceID{Namespace: id.service.Namespace, Name: id.service.Name}, subscriber.port, subscriber.instanceID, translator)
+	if err != nil {
+		fs.log.Errorf("Failed to subscribe to remote disocvery service %q in cluster %s: %s", id.service.Name, id.cluster, err)
+	}
+}
+
+func (fs *federatedService) remoteDiscoveryUnsubscribe(
+	subscriber *federatedServiceSubscriber,
+	id remoteDiscoveryID,
+) {
+	remoteWatcher, _, found := fs.clusterStore.Get(id.cluster)
+	if !found {
+		fs.log.Errorf("Failed to get remote cluster %s", id.cluster)
+		return
+	}
+
+	translator := subscriber.remoteTranslators[id]
+	fs.log.Debugf("Unsubscribing from remote discovery service %s in cluster %s", id.service, id.cluster)
+	remoteWatcher.Unsubscribe(id.service, subscriber.port, subscriber.instanceID, translator)
+	translator.NoEndpoints(true)
+	translator.DrainAndStop()
+	delete(subscriber.remoteTranslators, id)
+}
+
+func (fs *federatedService) localDiscoverySubscribe(
+	subscriber *federatedServiceSubscriber,
+	localDiscovery string,
+) {
+	translator := newEndpointTranslator(
+		fs.config.ControllerNS,
+		fs.config.IdentityTrustDomain,
+		fs.config.EnableH2Upgrade,
+		true,
+		fs.config.EnableIPv6,
+		fs.config.ExtEndpointZoneWeights,
+		fs.config.MeshedHttp2ClientParams,
+		localDiscovery,
+		subscriber.nodeName,
+		fs.config.DefaultOpaquePorts,
+		fs.metadataAPI,
+		subscriber.stream,
+		subscriber.endStream,
+		fs.log,
+	)
+	translator.Start()
+	subscriber.localTranslators[localDiscovery] = translator
+
+	fs.log.Debugf("Subscribing to local discovery service %s", localDiscovery)
+	err := fs.localEndpoints.Subscribe(watcher.ServiceID{Namespace: fs.namespace, Name: localDiscovery}, subscriber.port, subscriber.instanceID, translator)
+	if err != nil {
+		fs.log.Errorf("Failed to subscribe to %s: %s", localDiscovery, err)
+	}
+}
+
+func (fs *federatedService) localDiscoveryUnsubscribe(
+	subscriber *federatedServiceSubscriber,
+	localDiscovery string,
+) {
+	translator, found := subscriber.localTranslators[localDiscovery]
+	if found {
+		fs.log.Debugf("Unsubscribing to local discovery service %s", localDiscovery)
+		fs.localEndpoints.Unsubscribe(watcher.ServiceID{Namespace: fs.namespace, Name: localDiscovery}, subscriber.port, subscriber.instanceID, translator)
+		translator.NoEndpoints(true)
+		translator.DrainAndStop()
+		delete(subscriber.localTranslators, localDiscovery)
+	}
+}
+
+func remoteDiscoveryIDs(service *corev1.Service, log *logging.Entry) []remoteDiscoveryID {
+	remoteDiscovery, remoteDiscoveryFound := service.Annotations[labels.RemoteDiscoveryAnnotation]
+	if !remoteDiscoveryFound {
+		return nil
+	}
+
+	remotes := strings.Split(remoteDiscovery, ",")
+	ids := make([]remoteDiscoveryID, 0)
+	for _, remote := range remotes {
+		parts := strings.Split(remote, "@")
+		if len(parts) != 2 {
+			log.Errorf("Invalid remote discovery service '%s'", remote)
+			continue
+		}
+		remoteSvc := parts[0]
+		cluster := parts[1]
+		ids = append(ids, remoteDiscoveryID{
+			cluster: cluster,
+			service: watcher.ServiceID{
+				Namespace: service.Namespace,
+				Name:      remoteSvc,
+			},
+		})
+	}
+	return ids
+}
+
+func isFederatedService(service *corev1.Service) bool {
+	_, localDiscoveryFound := service.Annotations[labels.LocalDiscoveryAnnotation]
+	_, remoteDiscoveryFound := service.Annotations[labels.RemoteDiscoveryAnnotation]
+	return localDiscoveryFound || remoteDiscoveryFound
+}

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -45,11 +45,12 @@ type (
 
 		config Config
 
-		workloads    *watcher.WorkloadWatcher
-		endpoints    *watcher.EndpointsWatcher
-		opaquePorts  *watcher.OpaquePortsWatcher
-		profiles     *watcher.ProfileWatcher
-		clusterStore *watcher.ClusterStore
+		workloads         *watcher.WorkloadWatcher
+		endpoints         *watcher.EndpointsWatcher
+		opaquePorts       *watcher.OpaquePortsWatcher
+		profiles          *watcher.ProfileWatcher
+		clusterStore      *watcher.ClusterStore
+		federatedServices *federatedServiceWatcher
 
 		k8sAPI      *k8s.API
 		metadataAPI *k8s.MetadataAPI
@@ -105,6 +106,10 @@ func NewServer(
 	if err != nil {
 		return nil, err
 	}
+	federatedServices, err := newFederatedServiceWatcher(k8sAPI, metadataAPI, &config, clusterStore, endpoints, log)
+	if err != nil {
+		return nil, err
+	}
 
 	srv := server{
 		pb.UnimplementedDestinationServer{},
@@ -114,6 +119,7 @@ func NewServer(
 		opaquePorts,
 		profiles,
 		clusterStore,
+		federatedServices,
 		k8sAPI,
 		metadataAPI,
 		log,
@@ -172,7 +178,19 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 		return status.Errorf(codes.Internal, "Failed to get service %s", dest.GetPath())
 	}
 
-	if cluster, found := svc.Labels[labels.RemoteDiscoveryLabel]; found {
+	if isFederatedService(svc) {
+		// Federated service
+		remoteDiscovery := svc.Annotations[labels.RemoteDiscoveryAnnotation]
+		localDiscovery := svc.Annotations[labels.LocalDiscoveryAnnotation]
+		log.Debugf("Federated service discovery, remote:[%s] local:[%s]", remoteDiscovery, localDiscovery)
+		err := s.federatedServices.Subscribe(svc.Name, svc.Namespace, port, token.NodeName, instanceID, stream, streamEnd)
+		if err != nil {
+			log.Errorf("Failed to subscribe to federated service %q: %s", dest.GetPath(), err)
+			return err
+		}
+		defer s.federatedServices.Unsubscribe(svc.Name, svc.Namespace, stream)
+	} else if cluster, found := svc.Labels[labels.RemoteDiscoveryLabel]; found {
+		log.Debug("Remote discovery service detected")
 		// Remote discovery
 		remoteSvc, found := svc.Labels[labels.RemoteServiceLabel]
 		if !found {
@@ -210,12 +228,13 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 				log.Debugf("Invalid remote discovery service %s", dest.GetPath())
 				return status.Errorf(codes.InvalidArgument, "Invalid authority: %s", dest.GetPath())
 			}
-			log.Errorf("Failed to subscribe to remote disocvery service %q in cluster %s: %s", dest.GetPath(), cluster, err)
+			log.Errorf("Failed to subscribe to remote discovery service %q in cluster %s: %s", dest.GetPath(), cluster, err)
 			return err
 		}
 		defer remoteWatcher.Unsubscribe(watcher.ServiceID{Namespace: service.Namespace, Name: remoteSvc}, port, instanceID, translator)
 
 	} else {
+		log.Debug("Local discovery service detected")
 		// Local discovery
 		translator := newEndpointTranslator(
 			s.config.ControllerNS,

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -961,6 +961,11 @@ spec:
 		t.Fatalf("can't create cluster store: %s", err)
 	}
 
+	federatedServices, err := newFederatedServiceWatcher(k8sAPI, metadataAPI, &Config{}, clusterStore, endpoints, log)
+	if err != nil {
+		t.Fatalf("can't create federated service watcher: %s", err)
+	}
+
 	// Sync after creating watchers so that the indexers added get updated
 	// properly
 	k8sAPI.Sync(nil)
@@ -982,6 +987,7 @@ spec:
 		opaquePorts,
 		profiles,
 		clusterStore,
+		federatedServices,
 		k8sAPI,
 		metadataAPI,
 		log,

--- a/controller/api/destination/watcher/cluster_store.go
+++ b/controller/api/destination/watcher/cluster_store.go
@@ -42,14 +42,14 @@ type (
 	// remoteCluster is a helper struct that represents a store item
 	remoteCluster struct {
 		watcher *EndpointsWatcher
-		config  clusterConfig
+		config  ClusterConfig
 
 		// Used to signal shutdown to the associated watcher's informers
 		stopCh chan<- struct{}
 	}
 
 	// clusterConfig holds immutable configuration for a given cluster
-	clusterConfig struct {
+	ClusterConfig struct {
 		TrustDomain   string
 		ClusterDomain string
 	}
@@ -166,7 +166,7 @@ func NewClusterStoreWithDecoder(client kubernetes.Interface, namespace string, e
 }
 
 // Get safely retrieves a store item given a cluster name.
-func (cs *ClusterStore) Get(clusterName string) (*EndpointsWatcher, clusterConfig, bool) {
+func (cs *ClusterStore) Get(clusterName string) (*EndpointsWatcher, ClusterConfig, bool) {
 	cs.RLock()
 	defer cs.RUnlock()
 	cw, found := cs.store[clusterName]
@@ -234,7 +234,7 @@ func (cs *ClusterStore) addCluster(clusterName string, secret *v1.Secret) error 
 	defer cs.Unlock()
 	cs.store[clusterName] = remoteCluster{
 		watcher,
-		clusterConfig{
+		ClusterConfig{
 			trustDomain,
 			clusterDomain,
 		},

--- a/controller/api/destination/watcher/cluster_store_test.go
+++ b/controller/api/destination/watcher/cluster_store_test.go
@@ -12,7 +12,7 @@ func TestClusterStoreHandlers(t *testing.T) {
 		name                 string
 		k8sConfigs           []string
 		enableEndpointSlices bool
-		expectedClusters     map[string]clusterConfig
+		expectedClusters     map[string]ClusterConfig
 		deleteClusters       map[string]struct{}
 	}{
 		{
@@ -21,7 +21,7 @@ func TestClusterStoreHandlers(t *testing.T) {
 				validRemoteSecret,
 			},
 			enableEndpointSlices: true,
-			expectedClusters: map[string]clusterConfig{
+			expectedClusters: map[string]ClusterConfig{
 				"remote": {
 					TrustDomain:   "identity.org",
 					ClusterDomain: "cluster.local",
@@ -38,7 +38,7 @@ func TestClusterStoreHandlers(t *testing.T) {
 				validTargetSecret,
 			},
 			enableEndpointSlices: false,
-			expectedClusters: map[string]clusterConfig{
+			expectedClusters: map[string]ClusterConfig{
 				"remote": {
 					TrustDomain:   "identity.org",
 					ClusterDomain: "cluster.local",
@@ -62,7 +62,7 @@ func TestClusterStoreHandlers(t *testing.T) {
 				invalidTypeSecret,
 			},
 			enableEndpointSlices: true,
-			expectedClusters: map[string]clusterConfig{
+			expectedClusters: map[string]ClusterConfig{
 				"remote": {
 					TrustDomain:   "identity.org",
 					ClusterDomain: "cluster.local",

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -453,6 +453,19 @@ const (
 	// RemoteServiceLabel is the name of the service in the remote cluster.
 	RemoteServiceLabel = MulticlusterPrefix + "/remote-service"
 
+	// RemoteDiscoveryAnnotation indicates that this service is a remote discovery
+	// service and the value of this label is a comma-separated list of remote
+	// discovery targets of the form <service>@<cluster>. This can be used in
+	// conjunction with LocalDiscoveryAnnotation and the endpoints will be
+	// unioned.
+	RemoteDiscoveryAnnotation = MulticlusterPrefix + "/remote-discovery"
+
+	// LocalDiscoveryAnnotation indicates that service discovery information for
+	// this service should be fetched from another service in the local cluster
+	// instead of the target service itself. This can be used in conjunction
+	// with RemoteDiscoveryAnnotation and the endpoints will be unioned.
+	LocalDiscoveryAnnotation = MulticlusterPrefix + "/local-discovery"
+
 	// RemoteResourceVersionAnnotation is the last observed remote resource
 	// version of a mirrored resource. Useful when doing updates
 	RemoteResourceVersionAnnotation = SvcMirrorPrefix + "/remote-resource-version"


### PR DESCRIPTION
We add support for federated services to the destination controller by adding a new FederatedServiceWatcher.  When the destination controller receives a `Get` request for a Service with the `multicluster.linkerd.io/remote-discovery` and/or the `multicluster.linkerd.io/local-discovery` annotations, it subscribes to the FederatedServiceWatcher instead of subscribing to the EndpointsWatcher directly.  The FederatedServiceWatcher watches the federated service for any changes to these annotations, and maintains the appropriate watches on the local EndpointWatcher and/or remote EndpointWatchers fetched through the ClusterStore.

This means that we will often have multiple EndpointTranslators writing to the same `Get` response stream.  In order for a `NoEndpoints` message sent to one EndpointTranslator to not clobber the whole stream, we make a change where `NoEndpoints` messages are no longer sent to the response stream, but are replaced by a `Remove` message containing all of the addresses from that EndpointTranslator.  This allows multiple EndpointTranslators to coexist on the same stream.

TODO: Writing to a `Get` response stream is not a thread-safe operation.  Writes from multiple EndpointTranslators need to be synchronized.
TODO: mutexs need to be added to FederatedServiceWatcher to prevent concurrent modification of the FederatedServiceWatchers internal data structures.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
