### PR TITLE
build(deps): temporarily pin linkerd2-proxy-api to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=c5648ae2a1e405cc6b8aca20522356ebdf20f1ea#c5648ae2a1e405cc6b8aca20522356ebdf20f1ea"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#6c316cc41a3a0e194a70f22b5698ec21ce245e99"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ lto = "thin"
 
 [patch.crates-io]
 # TODO(Zahari): switch released version once TLS protocol support is out.
-linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', rev = 'c5648ae2a1e405cc6b8aca20522356ebdf20f1ea' }
+linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'main' }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/linkerd/linkerd2
 
 go 1.22.0
 
+// Use the unreleased version of the proxy API to validate changes end-to-end.
+replace github.com/linkerd/linkerd2-proxy-api => github.com/linkerd/linkerd2-proxy-api v0.14.1-0.20241106205231-6c316cc41a3a
+
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.0
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
-github.com/linkerd/linkerd2-proxy-api v0.14.0 h1:gSMKSFzA43yyut6DOHFbGWggNgqIuFz90Y3+Ox17v/8=
-github.com/linkerd/linkerd2-proxy-api v0.14.0/go.mod h1:ElmA+VVHurWqjtcEcKApJ9dbox76Aeo8lUPpJ6wWMu4=
+github.com/linkerd/linkerd2-proxy-api v0.14.1-0.20241106205231-6c316cc41a3a h1:oVj8r0T7eUFLnwTvKmikeqedeJ8fnLE9keOdtpES8tE=
+github.com/linkerd/linkerd2-proxy-api v0.14.1-0.20241106205231-6c316cc41a3a/go.mod h1:gV0wEXbhnurC6HQPEI9Ea1f4gTfVXEJYC6MPVM21Xs8=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/policy-controller/grpc/src/inbound.rs
+++ b/policy-controller/grpc/src/inbound.rs
@@ -147,16 +147,19 @@ fn to_server(srv: &InboundServer, cluster_networks: &[IpNet]) -> proto::Server {
                 proto::proxy_protocol::Detect {
                     timeout: timeout.try_into().map_err(|error| tracing::warn!(%error, "failed to convert protocol detect timeout to protobuf")).ok(),
                     http_routes: http::to_route_list(&srv.http_routes, cluster_networks),
+                    http_local_rate_limit: None,
                 },
             )),
             ProxyProtocol::Http1 => Some(proto::proxy_protocol::Kind::Http1(
                 proto::proxy_protocol::Http1 {
                     routes: http::to_route_list(&srv.http_routes, cluster_networks),
+                    local_rate_limit: None,
                 },
             )),
             ProxyProtocol::Http2 => Some(proto::proxy_protocol::Kind::Http2(
                 proto::proxy_protocol::Http2 {
                     routes: http::to_route_list(&srv.http_routes, cluster_networks),
+                    local_rate_limit: None,
                 },
             )),
             ProxyProtocol::Grpc => Some(proto::proxy_protocol::Kind::Grpc(

--- a/policy-test/src/grpc.rs
+++ b/policy-test/src/grpc.rs
@@ -52,6 +52,7 @@ macro_rules! assert_protocol_detect {
                             $crate::grpc::defaults::http_route(),
                             $crate::grpc::defaults::probe_route(),
                         ],
+                        http_local_rate_limit: None,
                     }
                 )),
             }),
@@ -71,6 +72,7 @@ macro_rules! assert_protocol_detect_external {
                     inbound::proxy_protocol::Detect {
                         timeout: Some(std::time::Duration::from_secs(10).try_into().unwrap()),
                         http_routes: vec![$crate::grpc::defaults::http_route()],
+                        http_local_rate_limit: None,
                     }
                 ))
             })
@@ -381,6 +383,7 @@ pub mod defaults {
         inbound::ProxyProtocol {
             kind: Some(Kind::Http1(Http1 {
                 routes: vec![http_route(), probe_route()],
+                local_rate_limit: None,
             })),
         }
     }
@@ -390,6 +393,7 @@ pub mod defaults {
         inbound::ProxyProtocol {
             kind: Some(Kind::Http1(Http1 {
                 routes: vec![http_route()],
+                local_rate_limit: None,
             })),
         }
     }


### PR DESCRIPTION
In order to validate changes end-to-end before tagging a new proxy-api release, this change updates the proxy API to linkerd2-proxy-api@main#6c316cc.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
