### PR TITLE
feat(destination): set parent and profile references

### DIFF
--- a/controller/api/destination/destination_fuzzer.go
+++ b/controller/api/destination/destination_fuzzer.go
@@ -91,9 +91,10 @@ func FuzzProfileTranslatorUpdate(data []byte) int {
 		return 0
 	}
 	t := &testing.T{}
-	mockGetProfileServer := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
 
-	translator := newProfileTranslator(mockGetProfileServer, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
+	id := watcher.ServiceID{Namespace: "bar", Name: "foo"}
+	server := &mockDestinationGetProfileServer{profilesReceived: make(chan *pb.DestinationProfile, 50)}
+	translator := newProfileTranslator(id, server, logging.WithField("test", t.Name()), "foo.bar.svc.cluster.local", 80, nil)
 	translator.Start()
 	defer translator.Stop()
 	translator.Update(profile)

--- a/controller/api/destination/profile_translator.go
+++ b/controller/api/destination/profile_translator.go
@@ -47,19 +47,16 @@ var profileUpdatesQueueOverflowCounter = promauto.NewCounterVec(
 )
 
 func newProfileTranslator(serviceID watcher.ServiceID, stream pb.Destination_GetProfileServer, log *logging.Entry, fqn string, port uint32, endStream chan struct{}) *profileTranslator {
-	var parentRef *meta.Metadata
-	if serviceID.Namespace != "" {
-		parentRef = &meta.Metadata{
-			Kind: &meta.Metadata_Resource{
-				Resource: &meta.Resource{
-					Group:     "core",
-					Kind:      "Service",
-					Name:      serviceID.Name,
-					Namespace: serviceID.Namespace,
-					Port:      port,
-				},
+	parentRef := &meta.Metadata{
+		Kind: &meta.Metadata_Resource{
+			Resource: &meta.Resource{
+				Group:     "core",
+				Kind:      "Service",
+				Name:      serviceID.Name,
+				Namespace: serviceID.Namespace,
+				Port:      port,
 			},
-		}
+		},
 	}
 
 	return &profileTranslator{

--- a/controller/api/destination/profile_translator.go
+++ b/controller/api/destination/profile_translator.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes/duration"
 	pb "github.com/linkerd/linkerd2-proxy-api/go/destination"
+	meta "github.com/linkerd/linkerd2-proxy-api/go/meta"
+	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
 	sp "github.com/linkerd/linkerd2/controller/gen/apis/serviceprofile/v1alpha2"
 	"github.com/linkerd/linkerd2/pkg/profiles"
 	"github.com/linkerd/linkerd2/pkg/util"
@@ -22,6 +24,7 @@ const millisPerDecimilli = 10
 type profileTranslator struct {
 	fullyQualifiedName string
 	port               uint32
+	parentRef          *meta.Metadata
 
 	stream          pb.Destination_GetProfileServer
 	endStream       chan struct{}
@@ -43,10 +46,26 @@ var profileUpdatesQueueOverflowCounter = promauto.NewCounterVec(
 	},
 )
 
-func newProfileTranslator(stream pb.Destination_GetProfileServer, log *logging.Entry, fqn string, port uint32, endStream chan struct{}) *profileTranslator {
+func newProfileTranslator(serviceID watcher.ServiceID, stream pb.Destination_GetProfileServer, log *logging.Entry, fqn string, port uint32, endStream chan struct{}) *profileTranslator {
+	var parentRef *meta.Metadata
+	if serviceID.Namespace != "" {
+		parentRef = &meta.Metadata{
+			Kind: &meta.Metadata_Resource{
+				Resource: &meta.Resource{
+					Group:     "core",
+					Kind:      "Service",
+					Name:      serviceID.Name,
+					Namespace: serviceID.Namespace,
+					Port:      port,
+				},
+			},
+		}
+	}
+
 	return &profileTranslator{
 		fullyQualifiedName: fqn,
 		port:               port,
+		parentRef:          parentRef,
 
 		stream:          stream,
 		endStream:       endStream,
@@ -154,6 +173,19 @@ func toDuration(d time.Duration) *duration.Duration {
 // createDestinationProfile returns a Proxy API DestinationProfile, given a
 // ServiceProfile.
 func (pt *profileTranslator) createDestinationProfile(profile *sp.ServiceProfile) (*pb.DestinationProfile, error) {
+	var profileRef *meta.Metadata
+	if profile != nil {
+		profileRef = &meta.Metadata{
+			Kind: &meta.Metadata_Resource{
+				Resource: &meta.Resource{
+					Group:     sp.SchemeGroupVersion.Group,
+					Kind:      profile.Kind,
+					Name:      profile.Name,
+					Namespace: profile.Namespace,
+				},
+			},
+		}
+	}
 	routes := make([]*pb.Route, 0)
 	for _, route := range profile.Spec.Routes {
 		pbRoute, err := toRoute(profile, route)
@@ -177,6 +209,8 @@ func (pt *profileTranslator) createDestinationProfile(profile *sp.ServiceProfile
 		_, opaqueProtocol = profile.Spec.OpaquePorts[pt.port]
 	}
 	return &pb.DestinationProfile{
+		ParentRef:          pt.parentRef,
+		ProfileRef:         profileRef,
 		Routes:             routes,
 		RetryBudget:        budget,
 		DstOverrides:       toDstOverrides(profile.Spec.DstOverrides, pt.port),

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -394,7 +394,7 @@ func (s *server) subscribeToServiceProfile(
 	// We build up the pipeline of profile updaters backwards, starting from
 	// the translator which takes profile updates, translates them to protobuf
 	// and pushes them onto the gRPC stream.
-	translator := newProfileTranslator(stream, log, fqn, port, streamEnd)
+	translator := newProfileTranslator(service, stream, log, fqn, port, streamEnd)
 	translator.Start()
 	defer translator.Stop()
 


### PR DESCRIPTION
In order for proxies to properly reflect the resources used to drive policy decisions, the proxy API has been updated to include resource metadata on ServiceProfile responses.

This change updates the profile translator to include ParentRef and ProfileRef metadata when it is configured.

This change does not set backend or endpoint references.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
