### PR TITLE
Remove empty `shortnames: []` from HTTPLocalRateLimitPolicy

### DIFF
--- a/charts/linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
+++ b/charts/linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
@@ -15,7 +15,6 @@ spec:
     listKind: HTTPLocalRateLimitPolicyList
     plural: httplocalratelimitpolicies
     singular: httplocalratelimitpolicy
-    shortNames: []
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -237,7 +237,6 @@ spec:
     listKind: HTTPLocalRateLimitPolicyList
     plural: httplocalratelimitpolicies
     singular: httplocalratelimitpolicy
-    shortNames: []
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -243,7 +243,6 @@ spec:
     listKind: HTTPLocalRateLimitPolicyList
     plural: httplocalratelimitpolicies
     singular: httplocalratelimitpolicy
-    shortNames: []
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -243,7 +243,6 @@ spec:
     listKind: HTTPLocalRateLimitPolicyList
     plural: httplocalratelimitpolicies
     singular: httplocalratelimitpolicy
-    shortNames: []
   scope: Namespaced
   versions:
     - name: v1alpha1


### PR DESCRIPTION
ArgoCD is not compatible with an empty `shortnames` entry. (We encountered this same issue in the past with ExternalWorkloads: #12793)

Fixes #13295