### PR TITLE
Update outbound policy watches when routes change parents

### DIFF
--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -217,6 +217,49 @@ pub async fn await_route_status(
     route_status
 }
 
+// Waits until an HttpRoute with the given namespace and name has a status set
+// on it, then returns the generic route status representation.
+pub async fn await_gateway_route_status(
+    client: &kube::Client,
+    ns: &str,
+    name: &str,
+) -> k8s::policy::httproute::RouteStatus {
+    use k8s::gateway as api;
+    let route_status = await_condition(client, ns, name, |obj: Option<&api::HttpRoute>| -> bool {
+        obj.and_then(|route| route.status.as_ref()).is_some()
+    })
+    .await
+    .expect("must fetch route")
+    .status
+    .expect("route must contain a status representation")
+    .inner;
+    tracing::trace!(?route_status, name, ns, "got route status");
+    route_status
+}
+
+// Waits until an GrpcRoute with the given namespace and name has a status set
+// on it, then returns the generic route status representation.
+pub async fn await_grpc_route_status(
+    client: &kube::Client,
+    ns: &str,
+    name: &str,
+) -> k8s::gateway::GrpcRouteStatus {
+    let route_status = await_condition(
+        client,
+        ns,
+        name,
+        |obj: Option<&k8s::gateway::GrpcRoute>| -> bool {
+            obj.and_then(|route| route.status.as_ref()).is_some()
+        },
+    )
+    .await
+    .expect("must fetch route")
+    .status
+    .expect("route must contain a status representation");
+    tracing::trace!(?route_status, name, ns, "got route status");
+    route_status
+}
+
 // Wait for the endpoints controller to populate the Endpoints resource.
 pub fn endpoints_ready(obj: Option<&k8s::Endpoints>) -> bool {
     if let Some(ep) = obj {

--- a/policy-test/src/outbound_api.rs
+++ b/policy-test/src/outbound_api.rs
@@ -249,7 +249,12 @@ pub fn assert_singleton<T>(ts: &[T]) -> &T {
 
 #[track_caller]
 pub fn assert_route_name_eq(route: &grpc::outbound::HttpRoute, name: &str) {
-    let kind = route.metadata.as_ref().unwrap().kind.as_ref().unwrap();
+    assert_name_eq(route.metadata.as_ref().unwrap(), name)
+}
+
+#[track_caller]
+pub fn assert_name_eq(meta: &grpc::meta::Metadata, name: &str) {
+    let kind = meta.kind.as_ref().unwrap();
     match kind {
         grpc::meta::metadata::Kind::Default(d) => {
             panic!("route expected to not be default, but got default {d:?}")

--- a/policy-test/tests/outbound_api_gateway.rs
+++ b/policy-test/tests/outbound_api_gateway.rs
@@ -3,9 +3,10 @@ use kube::ResourceExt;
 use linkerd2_proxy_api::meta;
 use linkerd_policy_controller_k8s_api as k8s;
 use linkerd_policy_test::{
-    assert_default_accrual_backoff, assert_svc_meta, create, create_annotated_service,
-    create_cluster_scoped, create_egress_network, create_opaque_service, create_service, delete,
-    delete_cluster_scoped, grpc, mk_service, outbound_api::*, with_temp_ns,
+    assert_default_accrual_backoff, assert_svc_meta, await_gateway_route_status, create,
+    create_annotated_service, create_cluster_scoped, create_egress_network, create_opaque_service,
+    create_service, delete, delete_cluster_scoped, grpc, mk_service, outbound_api::*, update,
+    with_temp_ns,
 };
 use maplit::{btreemap, convert_args};
 use std::{collections::BTreeMap, time::Duration};
@@ -1250,6 +1251,7 @@ async fn http_route_retries_and_timeouts() {
                 .build(),
         )
         .await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let mut rx = retry_watch_outbound_policy(&client, &ns, &svc, 4191).await;
         let config = rx
@@ -1339,6 +1341,86 @@ async fn service_retries_and_timeouts() {
             assert_eq!(timeouts.response, None);
             let request_timeout = timeouts.request.as_ref().expect("request timeout expected");
             assert_eq!(request_timeout.seconds, 5);
+        });
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn service_http_route_reattachment() {
+    with_temp_ns(|client, ns| async move {
+        // Create a service
+        let svc = create_service(&client, &ns, "my-svc", 4191).await;
+
+        let mut route = create(&client, mk_empty_http_route(&ns, "foo-route", &svc, 4191)).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
+
+        let mut rx = retry_watch_outbound_policy(&client, &ns, &svc, 4191).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+
+        assert_svc_meta(&config.metadata, &svc, 4191);
+
+        // The route should be attached.
+        detect_http_routes(&config, |routes| {
+            let route: &grpc::outbound::HttpRoute = assert_singleton(routes);
+            assert_route_name_eq(route, "foo-route");
+        });
+
+        route
+            .spec
+            .inner
+            .parent_refs
+            .as_mut()
+            .unwrap()
+            .first_mut()
+            .unwrap()
+            .name = "other".to_string();
+        update(&client, route.clone()).await;
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an updated config");
+        tracing::trace!(?config);
+
+        assert_svc_meta(&config.metadata, &svc, 4191);
+
+        // The route should be unattached and the default route should be present.
+        detect_http_routes(&config, |routes| {
+            let route = assert_singleton(routes);
+            assert_route_is_default(route, &svc, 4191);
+        });
+
+        route
+            .spec
+            .inner
+            .parent_refs
+            .as_mut()
+            .unwrap()
+            .first_mut()
+            .unwrap()
+            .name = svc.name_unchecked();
+        update(&client, route).await;
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an updated config");
+        tracing::trace!(?config);
+
+        assert_svc_meta(&config.metadata, &svc, 4191);
+
+        // The route should be attached again.
+        detect_http_routes(&config, |routes| {
+            let route = assert_singleton(routes);
+            assert_route_name_eq(route, "foo-route");
         });
     })
     .await;

--- a/policy-test/tests/outbound_api_gateway.rs
+++ b/policy-test/tests/outbound_api_gateway.rs
@@ -158,6 +158,7 @@ async fn service_with_http_route_without_rules() {
         });
 
         let _route = create(&client, mk_empty_http_route(&ns, "foo-route", &svc, 4191)).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -204,6 +205,7 @@ async fn service_with_http_routes_without_backends() {
             mk_http_route(&ns, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -256,6 +258,7 @@ async fn service_with_http_routes_with_backend() {
             None,
         );
         let _route = create(&client, route.build()).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -325,6 +328,7 @@ async fn service_with_http_routes_with_cross_namespace_backend() {
             None,
         );
         let _route = create(&client, route.build()).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -380,6 +384,7 @@ async fn service_with_http_routes_with_invalid_backend() {
             None,
         );
         let _route = create(&client, route.build()).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -433,6 +438,7 @@ async fn service_with_multiple_http_routes() {
             mk_http_route(&ns, "a-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_gateway_route_status(&client, &ns, "a-route").await;
 
         // First route update.
         let config = rx
@@ -449,6 +455,7 @@ async fn service_with_multiple_http_routes() {
             mk_http_route(&ns, "b-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_gateway_route_status(&client, &ns, "b-route").await;
 
         // Second route update.
         let config = rx
@@ -780,6 +787,7 @@ async fn route_with_filters() {
                 },
             ]));
         let _route = create(&client, route.build()).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -890,6 +898,7 @@ async fn backend_with_filters() {
                 },
             ]));
         let _route = create(&client, route.build()).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -986,6 +995,7 @@ async fn http_route_with_no_port() {
         });
 
         let _route = create(&client, mk_http_route(&ns, "foo-route", &svc, None).build()).await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let config_4191 = rx_4191
             .next()
@@ -1056,6 +1066,7 @@ async fn producer_route() {
             mk_http_route(&ns, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let producer_config = producer_rx
             .next()
@@ -1101,6 +1112,7 @@ async fn pre_existing_producer_route() {
             mk_http_route(&ns, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let mut producer_rx = retry_watch_outbound_policy(&client, &ns, &svc, 4191).await;
         let producer_config = producer_rx
@@ -1203,6 +1215,7 @@ async fn consumer_route() {
             mk_http_route(&consumer_ns_name, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_gateway_route_status(&client, &consumer_ns_name, "foo-route").await;
 
         // The route should NOT be returned in queries from the producer namespace.
         // There should be a default route.
@@ -1313,6 +1326,7 @@ async fn service_retries_and_timeouts() {
                 .build(),
         )
         .await;
+        await_gateway_route_status(&client, &ns, "foo-route").await;
 
         let mut rx = retry_watch_outbound_policy(&client, &ns, &svc, 4191).await;
         let config = rx

--- a/policy-test/tests/outbound_api_linkerd.rs
+++ b/policy-test/tests/outbound_api_linkerd.rs
@@ -80,6 +80,7 @@ async fn service_with_http_route_without_rules() {
         });
 
         let _route = create(&client, mk_empty_http_route(&ns, "foo-route", &svc, 4191)).await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -126,6 +127,7 @@ async fn service_with_http_routes_without_backends() {
             mk_http_route(&ns, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -178,6 +180,7 @@ async fn service_with_http_routes_with_backend() {
             None,
         );
         let _route = create(&client, route.build()).await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -247,6 +250,7 @@ async fn service_with_http_routes_with_cross_namespace_backend() {
             None,
         );
         let _route = create(&client, route.build()).await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -302,6 +306,7 @@ async fn service_with_http_routes_with_invalid_backend() {
             None,
         );
         let _route = create(&client, route.build()).await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -355,6 +360,7 @@ async fn service_with_multiple_http_routes() {
             mk_http_route(&ns, "a-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_route_status(&client, &ns, "a-route").await;
 
         // First route update.
         let config = rx
@@ -371,6 +377,7 @@ async fn service_with_multiple_http_routes() {
             mk_http_route(&ns, "b-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_route_status(&client, &ns, "b-route").await;
 
         // Second route update.
         let config = rx
@@ -715,6 +722,7 @@ async fn route_rule_with_filters() {
             route.build(),
         )
         .await;
+    await_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -832,6 +840,7 @@ async fn backend_with_filters() {
             ]));
         let _route = create(&client, route.build())
         .await;
+    await_route_status(&client, &ns, "foo-route").await;
 
         let config = rx
             .next()
@@ -934,6 +943,7 @@ async fn http_route_with_no_port() {
         });
 
         let _route = create(&client, mk_http_route(&ns, "foo-route", &svc, None).build()).await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let config_4191 = rx_4191
             .next()
@@ -1004,6 +1014,7 @@ async fn producer_route() {
             mk_http_route(&ns, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let producer_config = producer_rx
             .next()
@@ -1049,6 +1060,7 @@ async fn pre_existing_producer_route() {
             mk_http_route(&ns, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let mut producer_rx = retry_watch_outbound_policy(&client, &ns, &svc, 4191).await;
         let producer_config = producer_rx
@@ -1151,6 +1163,7 @@ async fn consumer_route() {
             mk_http_route(&consumer_ns_name, "foo-route", &svc, Some(4191)).build(),
         )
         .await;
+        await_route_status(&client, &consumer_ns_name, "foo-route").await;
 
         // The route should NOT be returned in queries from the producer namespace.
         // There should be a default route.
@@ -1198,6 +1211,7 @@ async fn http_route_retries_and_timeouts() {
                 .build(),
         )
         .await;
+        await_route_status(&client, &ns, "foo-route").await;
 
         let mut rx = retry_watch_outbound_policy(&client, &ns, &svc, 4191).await;
         let config = rx


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/13280

When an xRoute resource is updated to change its parent_refs, the route may attach to new parents or become unattached to parents it was previously attached to.  However, in the policy-controller, the xRoute update will only be sent to the parents on the new version of the route resource and any existing watches on parents that the route was unattached from will not be updated.

Unfortunately, the kube-rs watch interface only provides the new version of a resource when it is updated, and not the previous state.  This means that we cannot know which parents the route might have been unattached to when it was updated.  Therefore, we send the route update to all NamespaceIndexes and each one removes that route from each parent if that parent is not currently an accepted parent of the route.

We also add integration tests for this behavior.

This issue applies to all xRoutes: policy HttpRoute, gateway HttpRoute, GrpcRoute, TlsRoute, and TcpRoute.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
