### PR TITLE
feat(policy): check Service port in admission controller

### DIFF
--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -656,7 +656,7 @@ fn validate_backend_if_service(br: &k8s_gateway_api::BackendObjectReference) -> 
             && matches!(br.kind.as_deref(), Some("Service") | None)
     }
 
-    // If the backend references is a Service, it must have a port. If it is not
+    // If the backend reference is a Service, it must have a port. If it is not
     // a Service, then we have to admit it for interoperability with other
     // controllers.
     if is_service(br) && matches!(br.port, None | Some(0)) {

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -656,14 +656,10 @@ fn validate_backend_if_service(br: &k8s_gateway_api::BackendObjectReference) -> 
             && matches!(br.kind.as_deref(), Some("Service") | None)
     }
 
-    // If the backend references something Linkerd doesn't know about it, let
-    // status resolution determine the handling of the route.
-    if !is_service(br) {
-        return Ok(());
-    }
-
-    // But if a service is specified, it must have a port.
-    if matches!(br.port, None | Some(0)) {
+    // If the backend references is a Service, it must have a port. If it is not
+    // a Service, then we have to admit it for interoperability with other
+    // controllers.
+    if is_service(br) && matches!(br.port, None | Some(0)) {
         bail!("cannot reference a Service without a port");
     }
 

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -651,15 +651,13 @@ impl Validate<HttpRouteSpec> for Admission {
 }
 
 fn validate_backend_if_service(br: &k8s_gateway_api::BackendObjectReference) -> Result<()> {
-    fn is_service(br: &k8s_gateway_api::BackendObjectReference) -> bool {
-        matches!(br.group.as_deref(), Some("core") | Some("") | None)
-            && matches!(br.kind.as_deref(), Some("Service") | None)
-    }
+    let is_service = matches!(br.group.as_deref(), Some("core") | Some("") | None)
+        && matches!(br.kind.as_deref(), Some("Service") | None);
 
     // If the backend reference is a Service, it must have a port. If it is not
     // a Service, then we have to admit it for interoperability with other
     // controllers.
-    if is_service(br) && matches!(br.port, None | Some(0)) {
+    if is_service && matches!(br.port, None | Some(0)) {
         bail!("cannot reference a Service without a port");
     }
 

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -738,7 +738,6 @@ impl Validate<k8s_gateway_api::HttpRouteSpec> for Admission {
                 .flatten()
                 .filter_map(|br| br.backend_ref.as_ref())
             {
-                tracing::info!("validating backendRef: {:?}", br);
                 validate_backend_if_service(&br.inner).context("invalid backendRef")?;
             }
         }

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -6,7 +6,7 @@ use crate::k8s::policy::{
     NetworkAuthentication, NetworkAuthenticationSpec, RateLimitPolicySpec, Server,
     ServerAuthorization, ServerAuthorizationSpec, ServerSpec,
 };
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use futures::future;
 use hyper::{body::Buf, http, Body, Request, Response};
 use k8s_openapi::api::core::v1::{self as corev1, Namespace, ServiceAccount};
@@ -740,7 +740,7 @@ impl Validate<k8s_gateway_api::HttpRouteSpec> for Admission {
                 .flatten()
                 .filter_map(|br| br.backend_ref.as_ref())
             {
-                validate_backend(br)?;
+                validate_backend(br).context("invalid backendRef")?;
             }
         }
 

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -663,11 +663,8 @@ fn validate_backend_if_service(br: &k8s_gateway_api::BackendObjectReference) -> 
     }
 
     // But if a service is specified, it must have a port.
-    let Some(port) = br.port else {
-        bail!("cannot reference a Service without specifying a port");
-    };
-    if port == 0 {
-        bail!("cannot reference a Service with port 0");
+    if matches!(br.port, None | Some(0)) {
+        bail!("cannot reference a Service without a port");
     }
 
     Ok(())

--- a/policy-test/tests/admit_http_route_gateway.rs
+++ b/policy-test/tests/admit_http_route_gateway.rs
@@ -310,7 +310,7 @@ async fn rejects_relative_redirect_path() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn rejects_backend_service_without_port() {
-    admission::accepts(|ns| HttpRoute {
+    admission::rejects(|ns| HttpRoute {
         metadata: meta(&ns),
         spec: HttpRouteSpec {
             inner: CommonRouteSpec {
@@ -347,7 +347,7 @@ async fn rejects_backend_service_without_port() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn rejects_backend_service_implicit_without_port() {
-    admission::accepts(|ns| HttpRoute {
+    admission::rejects(|ns| HttpRoute {
         metadata: meta(&ns),
         spec: HttpRouteSpec {
             inner: CommonRouteSpec {

--- a/policy-test/tests/admit_http_route_gateway.rs
+++ b/policy-test/tests/admit_http_route_gateway.rs
@@ -138,6 +138,117 @@ async fn accepts_not_implemented_extensionref() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn accepts_backend_unknown_kind() {
+    admission::accepts(|ns| HttpRoute {
+        metadata: meta(&ns),
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![server_parent_ref(ns)]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::Exact {
+                        value: "/foo".to_string(),
+                    }),
+                    ..HttpRouteMatch::default()
+                }]),
+                filters: None,
+                backend_refs: Some(vec![k8s_gateway_api::HttpBackendRef {
+                    backend_ref: Some(k8s_gateway_api::BackendRef {
+                        weight: None,
+                        inner: BackendObjectReference {
+                            group: Some("alien.example.com".to_string()),
+                            kind: Some("ExoService".to_string()),
+                            namespace: Some("foo".to_string()),
+                            name: "foo".to_string(),
+                            port: None,
+                        },
+                    }),
+                    filters: None,
+                }]),
+            }]),
+        },
+        status: None,
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn accepts_backend_service_with_port() {
+    admission::accepts(|ns| HttpRoute {
+        metadata: meta(&ns),
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![server_parent_ref(ns)]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::Exact {
+                        value: "/foo".to_string(),
+                    }),
+                    ..HttpRouteMatch::default()
+                }]),
+                filters: None,
+                backend_refs: Some(vec![k8s_gateway_api::HttpBackendRef {
+                    backend_ref: Some(k8s_gateway_api::BackendRef {
+                        weight: None,
+                        inner: BackendObjectReference {
+                            group: Some("core".to_string()),
+                            kind: Some("Service".to_string()),
+                            namespace: Some("foo".to_string()),
+                            name: "foo".to_string(),
+                            port: Some(8080),
+                        },
+                    }),
+                    filters: None,
+                }]),
+            }]),
+        },
+        status: None,
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn accepts_backend_service_implicit_with_port() {
+    admission::accepts(|ns| HttpRoute {
+        metadata: meta(&ns),
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![server_parent_ref(ns)]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::Exact {
+                        value: "/foo".to_string(),
+                    }),
+                    ..HttpRouteMatch::default()
+                }]),
+                filters: None,
+                backend_refs: Some(vec![k8s_gateway_api::HttpBackendRef {
+                    backend_ref: Some(k8s_gateway_api::BackendRef {
+                        weight: None,
+                        inner: BackendObjectReference {
+                            group: None,
+                            kind: None,
+                            namespace: Some("foo".to_string()),
+                            name: "foo".to_string(),
+                            port: Some(8080),
+                        },
+                    }),
+                    filters: None,
+                }]),
+            }]),
+        },
+        status: None,
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn rejects_relative_path_match() {
     admission::rejects(|ns| HttpRoute {
         metadata: meta(&ns),
@@ -190,6 +301,80 @@ async fn rejects_relative_redirect_path() {
                     },
                 }]),
                 backend_refs: None,
+            }]),
+        },
+        status: None,
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejects_backend_service_without_port() {
+    admission::accepts(|ns| HttpRoute {
+        metadata: meta(&ns),
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![server_parent_ref(ns)]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::Exact {
+                        value: "/foo".to_string(),
+                    }),
+                    ..HttpRouteMatch::default()
+                }]),
+                filters: None,
+                backend_refs: Some(vec![k8s_gateway_api::HttpBackendRef {
+                    backend_ref: Some(k8s_gateway_api::BackendRef {
+                        weight: None,
+                        inner: BackendObjectReference {
+                            group: Some("core".to_string()),
+                            kind: Some("Service".to_string()),
+                            namespace: Some("foo".to_string()),
+                            name: "foo".to_string(),
+                            port: None,
+                        },
+                    }),
+                    filters: None,
+                }]),
+            }]),
+        },
+        status: None,
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejects_backend_service_implicit_without_port() {
+    admission::accepts(|ns| HttpRoute {
+        metadata: meta(&ns),
+        spec: HttpRouteSpec {
+            inner: CommonRouteSpec {
+                parent_refs: Some(vec![server_parent_ref(ns)]),
+            },
+            hostnames: None,
+            rules: Some(vec![HttpRouteRule {
+                matches: Some(vec![HttpRouteMatch {
+                    path: Some(HttpPathMatch::Exact {
+                        value: "/foo".to_string(),
+                    }),
+                    ..HttpRouteMatch::default()
+                }]),
+                filters: None,
+                backend_refs: Some(vec![k8s_gateway_api::HttpBackendRef {
+                    backend_ref: Some(k8s_gateway_api::BackendRef {
+                        weight: None,
+                        inner: BackendObjectReference {
+                            group: None,
+                            kind: None,
+                            namespace: Some("foo".to_string()),
+                            name: "foo".to_string(),
+                            port: None,
+                        },
+                    }),
+                    filters: None,
+                }]),
             }]),
         },
         status: None,


### PR DESCRIPTION
Our Gateway API bindings say:

    Port specifies the destination port number to use for this resource.
    Port is required when the referent is a Kubernetes Service. For other
    resources, destination port might be derived from the referent resource
    or this field.

Therefore, when the port is omitted on a Service, we cause all requests to the backend to fail. This is a jarring user experience.

To improve on this, we can check the port's validity in the admission controller.

This change adds a validation for Gateway API HTTPRoute resources that checks that a valid port is specified when a backend is a Service.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
