### PR TITLE
lint: fix docker build warnings

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -2,7 +2,7 @@ ARG RUNTIME_IMAGE=gcr.io/distroless/cc-debian12
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -10,7 +10,7 @@ RUN go mod download
 ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
-FROM --platform=$BUILDPLATFORM debian:bookworm-slim as fetch
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS fetch
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq && \
     rm -rf /var/lib/apt/lists/*
@@ -32,7 +32,7 @@ RUN bin/scurl -O https://github.com/linkerd/linkerd2-proxy-init/releases/downloa
 RUN tar -zxvf linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}.tgz && mv linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}/linkerd-network-validator .
 
 ## compile proxy-identity agent
-FROM go-deps as golang
+FROM go-deps AS golang
 WORKDIR /linkerd-build
 COPY pkg/util pkg/util
 COPY pkg/flags pkg/flags
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -mod=readonly ./pkg/...
 COPY proxy-identity proxy-identity
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/proxy-identity -mod=readonly -ldflags "-s -w" ./proxy-identity
 
-FROM $RUNTIME_IMAGE as runtime
+FROM $RUNTIME_IMAGE AS runtime
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY --from=fetch /build/target/proxy/LICENSE /usr/lib/linkerd/LICENSE
 COPY --from=fetch /build/proxy-version /usr/lib/linkerd/linkerd2-proxy-version.txt

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -9,7 +9,7 @@ RUN go mod download
 RUN ./bin/install-deps
 
 ## compile binaries
-FROM go-deps as go-gen
+FROM go-deps AS go-gen
 WORKDIR /linkerd-build
 COPY cli cli
 COPY charts charts
@@ -31,39 +31,39 @@ RUN go generate -mod=readonly ./viz/static
 
 RUN mkdir -p /out
 
-FROM go-gen as linux-amd64-full
+FROM go-gen AS linux-amd64-full
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/linkerd -tags prod -mod=readonly -ldflags "-s -w" ./cli
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/linkerd -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 
-FROM go-gen as linux-arm64-full
+FROM go-gen AS linux-arm64-full
 RUN ./bin/install-deps arm64
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /out/linkerd -tags prod -mod=readonly -ldflags "-s -w" ./cli
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /out/linkerd -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 
-FROM go-gen as linux-arm-full
+FROM go-gen AS linux-arm-full
 RUN ./bin/install-deps arm
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -o /out/linkerd -tags prod -mod=readonly -ldflags "-s -w" ./cli
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -o /out/linkerd -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 
-FROM go-gen as darwin-full
+FROM go-gen AS darwin-full
 RUN CGO_ENABLED=0 GOOS=darwin go build -o /out/linkerd -tags prod -mod=readonly -ldflags "-s -w" ./cli
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
 RUN CGO_ENABLED=0 GOOS=darwin go build -o /out/linkerd -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 
-FROM go-gen as darwin-arm64-full
+FROM go-gen AS darwin-arm64-full
 RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /out/linkerd -tags prod -mod=readonly -ldflags "-s -w" ./cli
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
 RUN CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /out/linkerd -tags prod -mod=readonly -ldflags "${GO_LDFLAGS}" ./cli
 
-FROM go-gen as windows-full
+FROM go-gen AS windows-full
 RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd -tags prod -mod=readonly -ldflags "-s -w" ./cli
 ARG LINKERD_VERSION
 ENV GO_LDFLAGS="-s -w -X github.com/linkerd/linkerd2/pkg/version.Version=${LINKERD_VERSION}"
@@ -75,7 +75,7 @@ RUN CGO_ENABLED=0 GOOS=windows go build -o /out/linkerd -tags prod -mod=readonly
 # depending on the host's OS and arch.
 #
 
-FROM scratch as linux-amd64
+FROM scratch AS linux-amd64
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-amd64-full /out/linkerd /out/linkerd-linux-amd64
@@ -83,37 +83,37 @@ COPY --from=linux-amd64-full /out/linkerd /out/linkerd-linux-amd64
 # response from daemon: No command specified."
 ENTRYPOINT ["/out/linkerd-linux-amd64"]
 
-FROM scratch as linux-arm64
+FROM scratch AS linux-arm64
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-arm64-full /out/linkerd /out/linkerd-linux-arm64
 ENTRYPOINT ["/out/linkerd-linux-arm64"]
 
-FROM scratch as linux-arm
+FROM scratch AS linux-arm
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-arm64-full /out/linkerd /out/linkerd-linux-arm
 ENTRYPOINT ["/out/linkerd-linux-arm"]
 
-FROM scratch as darwin
+FROM scratch AS darwin
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=darwin-full /out/linkerd /out/linkerd-darwin
 ENTRYPOINT ["/out/linkerd-darwin"]
 
-FROM scratch as darwin-arm64
+FROM scratch AS darwin-arm64
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=darwin-arm64-full /out/linkerd /out/linkerd-darwin-arm64
 ENTRYPOINT ["/out/linkerd-darwin-arm64"]
 
-FROM scratch as windows
+FROM scratch AS windows
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=windows-full /out/linkerd /out/linkerd-windows
 ENTRYPOINT ["/out/linkerd-windows"]
 
-FROM scratch as multi-arch
+FROM scratch AS multi-arch
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY LICENSE /linkerd/LICENSE
 COPY --from=linux-amd64-full /out/linkerd /out/linkerd-linux-amd64

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## compile controller service
-FROM go-deps as golang
+FROM go-deps AS golang
 WORKDIR /linkerd-build
 COPY controller/gen controller/gen
 COPY pkg pkg

--- a/jaeger/injector/Dockerfile
+++ b/jaeger/injector/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## compile controller service
-FROM go-deps as golang
+FROM go-deps AS golang
 WORKDIR /linkerd-build
 COPY jaeger jaeger
 COPY controller/gen controller/gen

--- a/policy-controller/Dockerfile
+++ b/policy-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v43-rust-musl as controller
+FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v43-rust-musl AS controller
 ARG BUILD_TYPE="release"
 WORKDIR /build
 RUN mkdir -p target/bin
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=target \
     just-cargo profile=$BUILD_TYPE target=$target build --package=linkerd-policy-controller && \
     mv "target/$target/$BUILD_TYPE/linkerd-policy-controller" /tmp/
 
-FROM scratch as runtime
+FROM scratch AS runtime
 LABEL org.opencontainers.image.source=https://github.com/linkerd/linkerd2
 COPY --from=controller /tmp/linkerd-policy-controller /bin/
 ENTRYPOINT ["/bin/linkerd-policy-controller"]

--- a/viz/metrics-api/Dockerfile
+++ b/viz/metrics-api/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## compile metrics-apiservice
-FROM go-deps as golang
+FROM go-deps AS golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 COPY controller controller

--- a/viz/tap/Dockerfile
+++ b/viz/tap/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## compile tap
-FROM go-deps as golang
+FROM go-deps AS golang
 WORKDIR /linkerd-build
 COPY pkg pkg
 # TODO: remove after https://github.com/linkerd/linkerd2/issues/5661

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine as go-deps
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN ./bin/install-deps $TARGETARCH
 
 ## bundle web assets
-FROM --platform=$BUILDPLATFORM node:20-bookworm as webpack-bundle
+FROM --platform=$BUILDPLATFORM node:20-bookworm AS webpack-bundle
 RUN bin/scurl --retry=2 https://yarnpkg.com/install.sh | bash -s -- --version 1.22.10 --network-concurrency 1
 
 ENV PATH /root/.yarn/bin:$PATH
@@ -32,7 +32,7 @@ COPY web/app ./web/app
 RUN ./bin/web build
 
 ## compile go server
-FROM go-deps as golang
+FROM go-deps AS golang
 WORKDIR /linkerd-build
 RUN mkdir -p web
 COPY web/main.go web


### PR DESCRIPTION
**Commit Message:**

```
    lint: fix docker build warnings
    
    Docker builds emit a warning because the case of 'FROM' and 'as' don't match. Fix this everywhere.
    
    Signed-off-by: Derek Brown <6845676+DerekTBrown@users.noreply.github.com>
```

**Context:**

When running Docker builds, I see the following warning:
```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)     
...                                                                                                                                                    
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 27)    
```

Fix this pattern everywhere.
