### PR TITLE
policy: use TLS/TCP filters in new version of proxy API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#22b68a1a3b4d0c0e470efbfedfc239bfbd5cd9ee"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#5a3dae76f9245fb51f6250669bc51416e33e840b"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,8 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#5a3dae76f9245fb51f6250669bc51416e33e840b"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4682c00263191a5bfa4fbe64f6d80b22ff2b49aaa294da5aac062f5abc6eb9e"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#6c316cc41a3a0e194a70f22b5698ec21ce245e99"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#22b68a1a3b4d0c0e470efbfedfc239bfbd5cd9ee"
 dependencies = [
  "http",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ lto = "thin"
 
 [patch.crates-io]
 # TODO(Zahari): switch released version once TLS protocol support is out.
-linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'main' }
+linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/errors-to-filters' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,3 @@ members = [
 
 [profile.release]
 lto = "thin"
-
-[patch.crates-io]
-# TODO(Zahari): switch released version once TLS protocol support is out.
-linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/errors-to-filters' }

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -22,5 +22,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.14"
+version = "0.15"
 features = ["inbound", "outbound"]

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -310,13 +310,13 @@ fn fallback(original_dst: SocketAddr) -> outbound::OutboundPolicy {
                         outbound::opaque_route::distribution::FirstAvailable {
                             backends: vec![outbound::opaque_route::RouteBackend {
                                 backend: Some(backend.clone()),
-                                invalid: None,
+                                filters: Vec::new(),
                             }],
                         },
                     )),
                 }),
+                filters: Vec::new(),
             }],
-            error: None,
         }],
     };
 
@@ -586,18 +586,15 @@ fn default_outbound_opaq_route(
                         outbound::opaque_route::distribution::FirstAvailable {
                             backends: vec![outbound::opaque_route::RouteBackend {
                                 backend: Some(backend),
-                                invalid: None,
+                                filters: Vec::new(),
                             }],
                         },
                     )),
                 }),
+                filters: Vec::new(),
             }];
 
-            outbound::OpaqueRoute {
-                metadata,
-                rules,
-                error: None,
-            }
+            outbound::OpaqueRoute { metadata, rules }
         }
     }
 }

--- a/policy-controller/grpc/src/outbound/tcp.rs
+++ b/policy-controller/grpc/src/outbound/tcp.rs
@@ -1,5 +1,5 @@
 use super::{default_balancer_config, default_queue_config};
-use linkerd2_proxy_api::{destination, meta, outbound};
+use linkerd2_proxy_api::{self, destination, meta, outbound};
 use linkerd_policy_controller_core::{
     outbound::{Backend, ParentInfo, TcpRoute, TrafficPolicy},
     routes::GroupKindNamespaceName,
@@ -71,7 +71,7 @@ fn convert_outbound_route(
             outbound::opaque_route::distribution::FirstAvailable {
                 backends: vec![outbound::opaque_route::RouteBackend {
                     backend: Some(backend.clone()),
-                    invalid: None,
+                    filters: Vec::new(),
                 }],
             },
         )
@@ -83,13 +83,10 @@ fn convert_outbound_route(
 
     let rules = vec![outbound::opaque_route::Rule {
         backends: Some(outbound::opaque_route::Distribution { kind: Some(dist) }),
+        filters: Vec::new(),
     }];
 
-    outbound::OpaqueRoute {
-        metadata,
-        rules,
-        error: None,
-    }
+    outbound::OpaqueRoute { metadata, rules }
 }
 
 fn convert_backend(
@@ -116,7 +113,7 @@ fn convert_backend(
                             },
                         )),
                     }),
-                    invalid: None,
+                    filters: Vec::new(),
                 }),
             }
         }
@@ -139,7 +136,7 @@ fn convert_backend(
                         },
                     )),
                 }),
-                invalid: None,
+                filters: Vec::new(),
             }),
         },
         Backend::Service(svc) => invalid_backend(
@@ -173,7 +170,7 @@ fn convert_backend(
                                         },
                                     )),
                                 }),
-                                invalid: None,
+                                filters: Vec::new(),
                             }),
                         }
                     } else {
@@ -226,7 +223,12 @@ fn invalid_backend(
                 queue: Some(default_queue_config()),
                 kind: None,
             }),
-            invalid: Some(outbound::opaque_route::route_backend::Invalid { message }),
+
+            filters: vec![outbound::opaque_route::Filter {
+                kind: Some(outbound::opaque_route::filter::Kind::InvalidBackendError(
+                    linkerd2_proxy_api::opaque_route::InvalidBackendError { message },
+                )),
+            }],
         }),
     }
 }
@@ -235,12 +237,16 @@ pub(crate) fn default_outbound_egress_route(
     backend: outbound::Backend,
     traffic_policy: &TrafficPolicy,
 ) -> outbound::OpaqueRoute {
-    let (error, name) = match traffic_policy {
-        TrafficPolicy::Allow => (None, "tcp-egress-allow"),
+    let (filters, name) = match traffic_policy {
+        TrafficPolicy::Allow => (Vec::default(), "tcp-egress-allow"),
         TrafficPolicy::Deny => (
-            Some(outbound::opaque_route::RouteError {
-                kind: outbound::opaque_route::route_error::Kind::Forbidden as i32,
-            }),
+            vec![outbound::opaque_route::Filter {
+                kind: Some(outbound::opaque_route::filter::Kind::RouteError(
+                    linkerd2_proxy_api::opaque_route::RouteError {
+                        kind: linkerd2_proxy_api::opaque_route::route_error::Kind::Forbidden as i32,
+                    },
+                )),
+            }],
             "tcp-egress-deny",
         ),
     };
@@ -254,15 +260,12 @@ pub(crate) fn default_outbound_egress_route(
                 outbound::opaque_route::distribution::FirstAvailable {
                     backends: vec![outbound::opaque_route::RouteBackend {
                         backend: Some(backend),
-                        invalid: None,
+                        filters: Vec::new(),
                     }],
                 },
             )),
         }),
+        filters,
     }];
-    outbound::OpaqueRoute {
-        metadata,
-        rules,
-        error,
-    }
+    outbound::OpaqueRoute { metadata, rules }
 }

--- a/policy-controller/grpc/src/outbound/tcp.rs
+++ b/policy-controller/grpc/src/outbound/tcp.rs
@@ -225,8 +225,8 @@ fn invalid_backend(
             }),
 
             filters: vec![outbound::opaque_route::Filter {
-                kind: Some(outbound::opaque_route::filter::Kind::InvalidBackendError(
-                    linkerd2_proxy_api::opaque_route::InvalidBackendError { message },
+                kind: Some(outbound::opaque_route::filter::Kind::Invalid(
+                    linkerd2_proxy_api::opaque_route::Invalid { message },
                 )),
             }],
         }),
@@ -241,10 +241,8 @@ pub(crate) fn default_outbound_egress_route(
         TrafficPolicy::Allow => (Vec::default(), "tcp-egress-allow"),
         TrafficPolicy::Deny => (
             vec![outbound::opaque_route::Filter {
-                kind: Some(outbound::opaque_route::filter::Kind::RouteError(
-                    linkerd2_proxy_api::opaque_route::RouteError {
-                        kind: linkerd2_proxy_api::opaque_route::route_error::Kind::Forbidden as i32,
-                    },
+                kind: Some(outbound::opaque_route::filter::Kind::Forbidden(
+                    linkerd2_proxy_api::opaque_route::Forbidden {},
                 )),
             }],
             "tcp-egress-deny",

--- a/policy-controller/grpc/src/outbound/tls.rs
+++ b/policy-controller/grpc/src/outbound/tls.rs
@@ -226,8 +226,8 @@ fn invalid_backend(
                 kind: None,
             }),
             filters: vec![outbound::tls_route::Filter {
-                kind: Some(outbound::tls_route::filter::Kind::InvalidBackendError(
-                    linkerd2_proxy_api::tls_route::InvalidBackendError { message },
+                kind: Some(outbound::tls_route::filter::Kind::Invalid(
+                    linkerd2_proxy_api::opaque_route::Invalid { message },
                 )),
             }],
         }),
@@ -242,10 +242,8 @@ pub(crate) fn default_outbound_egress_route(
         TrafficPolicy::Allow => (Vec::default(), "tls-egress-allow"),
         TrafficPolicy::Deny => (
             vec![outbound::tls_route::Filter {
-                kind: Some(outbound::tls_route::filter::Kind::RouteError(
-                    linkerd2_proxy_api::tls_route::RouteError {
-                        kind: linkerd2_proxy_api::tls_route::route_error::Kind::Forbidden as i32,
-                    },
+                kind: Some(outbound::tls_route::filter::Kind::Forbidden(
+                    linkerd2_proxy_api::opaque_route::Forbidden {},
                 )),
             }],
             "tls-egress-deny",

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -31,7 +31,7 @@ default-features = false
 features = ["client", "openssl-tls", "runtime", "ws"]
 
 [dependencies.linkerd2-proxy-api]
-version = "0.14"
+version = "0.15"
 features = ["inbound", "outbound"]
 
 [dev-dependencies]


### PR DESCRIPTION
This PR updates the proxy API dependency to a new version that uses filters to express errors for TLS and TCP routes. 

This PR depends on https://github.com/linkerd/linkerd2-proxy-api/pull/405

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>