### PR TITLE
Add check for link version

### DIFF
--- a/pkg/multicluster/link.go
+++ b/pkg/multicluster/link.go
@@ -39,6 +39,7 @@ type (
 	Link struct {
 		Name                          string
 		Namespace                     string
+		CreatedBy                     string
 		TargetClusterName             string
 		TargetClusterDomain           string
 		TargetClusterLinkerdNamespace string
@@ -177,6 +178,7 @@ func NewLink(u unstructured.Unstructured) (Link, error) {
 	return Link{
 		Name:                          u.GetName(),
 		Namespace:                     u.GetNamespace(),
+		CreatedBy:                     u.GetAnnotations()[k8s.CreatedByAnnotation],
 		TargetClusterName:             targetClusterName,
 		TargetClusterDomain:           targetClusterDomain,
 		TargetClusterLinkerdNamespace: targetClusterLinkerdNamespace,
@@ -260,6 +262,9 @@ func (l Link) ToUnstructured() (unstructured.Unstructured, error) {
 			"metadata": map[string]interface{}{
 				"name":      l.Name,
 				"namespace": l.Namespace,
+				"annotations": map[string]string{
+					k8s.CreatedByAnnotation: k8s.CreatedByAnnotationValue(),
+				},
 			},
 			"spec":   spec,
 			"status": map[string]interface{}{},


### PR DESCRIPTION
We add a `linkerd.io/created-by` annotation to Link resources which specifies the version of the CLI which was used to create the Link.  This annotation is already used in this way by control plane components.  This allows us to easily see what version of Linkerd was used to generated a Link.  We add a check that inspects this value and warns if any Links don't match the current version of the CLI.

Additionally, we fix an issue with the orphaned services check where it was incorrectly warning that federated services were orphaned because they don't have a specific target cluster.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
