### PR TITLE
fix(test): ensure that the controller sets rate limit status

### DIFF
--- a/policy-test/tests/inbound_api.rs
+++ b/policy-test/tests/inbound_api.rs
@@ -1,7 +1,4 @@
-use std::time::Duration;
-
 use futures::prelude::*;
-use k8s_openapi::chrono;
 use kube::ResourceExt;
 use linkerd_policy_controller_core::{Ipv4Net, Ipv6Net};
 use linkerd_policy_controller_k8s_api as k8s;
@@ -613,7 +610,7 @@ async fn http_routes_ordered_by_creation() {
         // Creation timestamps in Kubernetes only have second precision, so we
         // must wait a whole second between creating each of these routes in
         // order for them to have different creation timestamps.
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
         create(
             &client,
             mk_admin_route_with_path(ns.as_ref(), "a", "/ready"),
@@ -621,7 +618,7 @@ async fn http_routes_ordered_by_creation() {
         .await;
         next_config(&mut rx).await;
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
         create(
             &client,
             mk_admin_route_with_path(ns.as_ref(), "c", "/shutdown"),
@@ -629,7 +626,7 @@ async fn http_routes_ordered_by_creation() {
         .await;
         next_config(&mut rx).await;
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
         create(
             &client,
             mk_admin_route_with_path(ns.as_ref(), "b", "/proxy-log-level"),
@@ -819,7 +816,7 @@ async fn retry_watch_server(
             Ok(rx) => return rx,
             Err(error) => {
                 tracing::error!(?error, ns, pod_name, "failed to watch policy for port 4191");
-                time::sleep(Duration::from_secs(1)).await;
+                time::sleep(time::Duration::from_secs(1)).await;
             }
         }
     }

--- a/policy-test/tests/inbound_api.rs
+++ b/policy-test/tests/inbound_api.rs
@@ -610,7 +610,7 @@ async fn http_routes_ordered_by_creation() {
         // Creation timestamps in Kubernetes only have second precision, so we
         // must wait a whole second between creating each of these routes in
         // order for them to have different creation timestamps.
-        tokio::time::sleep(time::Duration::from_secs(1)).await;
+        time::sleep(time::Duration::from_secs(1)).await;
         create(
             &client,
             mk_admin_route_with_path(ns.as_ref(), "a", "/ready"),
@@ -618,7 +618,7 @@ async fn http_routes_ordered_by_creation() {
         .await;
         next_config(&mut rx).await;
 
-        tokio::time::sleep(time::Duration::from_secs(1)).await;
+        time::sleep(time::Duration::from_secs(1)).await;
         create(
             &client,
             mk_admin_route_with_path(ns.as_ref(), "c", "/shutdown"),
@@ -626,7 +626,7 @@ async fn http_routes_ordered_by_creation() {
         .await;
         next_config(&mut rx).await;
 
-        tokio::time::sleep(time::Duration::from_secs(1)).await;
+        time::sleep(time::Duration::from_secs(1)).await;
         create(
             &client,
             mk_admin_route_with_path(ns.as_ref(), "b", "/proxy-log-level"),


### PR DESCRIPTION
The http_local_rate_limit_policy test creates a resource with a status already hydrated, but status setting is a job of the controller.

This change updates the test to create a resource without a status and then to wait for the status to be set properly.

This will hopefully help us to avoid race conditions in this test whereby the API lookup can occur before the controller observes the resource creation.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
