### PR TITLE
chore(policy): polish logging

### DIFF
--- a/policy-controller/grpc/src/inbound.rs
+++ b/policy-controller/grpc/src/inbound.rs
@@ -145,7 +145,7 @@ fn to_server(srv: &InboundServer, cluster_networks: &[IpNet]) -> proto::Server {
         kind: match srv.protocol {
             ProxyProtocol::Detect { timeout } => Some(proto::proxy_protocol::Kind::Detect(
                 proto::proxy_protocol::Detect {
-                    timeout: timeout.try_into().map_err(|error| tracing::warn!(%error, "failed to convert protocol detect timeout to protobuf")).ok(),
+                    timeout: timeout.try_into().map_err(|error| tracing::warn!(%error, "Failed to convert protocol detect timeout to protobuf")).ok(),
                     http_routes: http::to_route_list(&srv.http_routes, cluster_networks),
                     http_local_rate_limit: srv.ratelimit.as_ref().map(to_rate_limit),
                 },

--- a/policy-controller/grpc/src/outbound/grpc.rs
+++ b/policy-controller/grpc/src/outbound/grpc.rs
@@ -454,11 +454,11 @@ fn convert_to_filter(filter: Filter) -> outbound::grpc_route::Filter {
                 convert_request_header_modifier_filter(filter),
             )),
             Filter::RequestRedirect(filter) => {
-                tracing::warn!(filter = ?filter, "declining to convert invalid filter type for GrpcRoute");
+                tracing::warn!(filter = ?filter, "Declining to convert invalid filter type for GrpcRoute");
                 None
             }
             Filter::ResponseHeaderModifier(filter) => {
-                tracing::warn!(filter = ?filter, "declining to convert invalid filter type for GrpcRoute");
+                tracing::warn!(filter = ?filter, "Declining to convert invalid filter type for GrpcRoute");
                 None
             }
         },

--- a/policy-controller/grpc/src/workload.rs
+++ b/policy-controller/grpc/src/workload.rs
@@ -23,7 +23,7 @@ impl FromStr for Workload {
     fn from_str(s: &str) -> Result<Self, tonic::Status> {
         if s.starts_with('{') {
             return serde_json::from_str(s).map_err(|error| {
-                tracing::error!(%error, "Invalid {s} workload string");
+                tracing::warn!(%error, "Invalid {s} workload string");
                 tonic::Status::invalid_argument(format!("Invalid workload: {}", s))
             });
         }

--- a/policy-controller/k8s/api/src/labels.rs
+++ b/policy-controller/k8s/api/src/labels.rs
@@ -182,7 +182,7 @@ impl Expression {
             (Operator::Exists, key, None) => labels.contains_key(key),
             (Operator::DoesNotExist, key, None) => !labels.contains_key(key),
             (operator, key, values) => {
-                tracing::warn!(?operator, %key, ?values, "illegal match expression");
+                tracing::warn!(?operator, %key, ?values, "Illegal match expression");
                 false
             }
         }

--- a/policy-controller/k8s/index/src/inbound/index.rs
+++ b/policy-controller/k8s/index/src/inbound/index.rs
@@ -478,7 +478,7 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for Index {
             Ok(None) => {}
             Ok(Some(pod)) => pod.reindex_servers(&ns.policy, &self.authentications),
             Err(error) => {
-                tracing::error!(%error, "Illegal pod update");
+                tracing::warn!(%error, "Illegal pod update");
             }
         }
     }
@@ -523,7 +523,7 @@ impl kubert::index::IndexNamespacedResource<k8s::external_workload::ExternalWork
             // Update, so re-index
             Ok(Some(workload)) => workload.reindex_servers(&ns.policy, &self.authentications),
             Err(error) => {
-                tracing::error!(%error, "Illegal external workload update");
+                tracing::warn!(%error, "Illegal external workload update");
             }
         }
     }
@@ -626,7 +626,7 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::ServerAuthorization> fo
             Ok(meta) => self.ns_or_default_with_reindex(ns, move |ns| {
                 ns.policy.update_server_authz(name, meta)
             }),
-            Err(error) => tracing::error!(%error, "Illegal server authorization update"),
+            Err(error) => tracing::warn!(%error, "Illegal server authorization update"),
         }
     }
 
@@ -660,7 +660,7 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::ServerAuthorization> fo
                     .added
                     .push((name, saz)),
                 Err(error) => {
-                    tracing::error!(ns = %namespace, %name, %error, "Illegal server authorization update")
+                    tracing::warn!(ns = %namespace, %name, %error, "Illegal server authorization update")
                 }
             }
         }
@@ -746,7 +746,7 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::AuthorizationPolicy> fo
                     .added
                     .push((name, spec)),
                 Err(error) => {
-                    tracing::error!(ns = %namespace, %name, %error, "Illegal server authorization update")
+                    tracing::warn!(ns = %namespace, %name, %error, "Illegal server authorization update")
                 }
             }
         }
@@ -985,7 +985,7 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::HttpLocalRateLimitPolic
                     .added
                     .push((name, spec)),
                 Err(error) => {
-                    tracing::error!(ns = %namespace, %name, %error, "Illegal server ratelimit update")
+                    tracing::warn!(ns = %namespace, %name, %error, "Illegal server ratelimit update")
                 }
             }
         }

--- a/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
@@ -82,7 +82,7 @@ impl TryFrom<k8s::policy::HttpLocalRateLimitPolicy> for Spec {
                 let type_ = match condition.type_.as_ref() {
                     "Accepted" => ConditionType::Accepted,
                     condition_type => {
-                        tracing::error!(%status.target_ref.name, %condition_type, "Unexpected condition type found in status");
+                        tracing::warn!(%status.target_ref.name, %condition_type, "Unexpected condition type found in status");
                         return None;
                     }
                 };
@@ -90,7 +90,7 @@ impl TryFrom<k8s::policy::HttpLocalRateLimitPolicy> for Spec {
                     "True" => true,
                     "False" => false,
                     condition_status => {
-                        tracing::error!(%status.target_ref.name, %type_, %condition_status, "Unexpected condition status found in status");
+                        tracing::warn!(%status.target_ref.name, %type_, %condition_status, "Unexpected condition status found in status");
                         return None
                     },
                 };

--- a/policy-controller/k8s/index/src/inbound/routes.rs
+++ b/policy-controller/k8s/index/src/inbound/routes.rs
@@ -137,7 +137,7 @@ impl Status {
                 let type_ = match condition.type_.as_ref() {
                     "Accepted" => ConditionType::Accepted,
                     condition_type => {
-                        tracing::error!(%status.parent_ref.name, %condition_type, "Unexpected condition type found in parent status");
+                        tracing::warn!(%status.parent_ref.name, %condition_type, "Unexpected condition type found in parent status");
                         return None;
                     }
                 };
@@ -145,7 +145,7 @@ impl Status {
                     "True" => true,
                     "False" => false,
                     condition_status => {
-                        tracing::error!(%status.parent_ref.name, %type_, %condition_status, "Unexpected condition status found in parent status");
+                        tracing::warn!(%status.parent_ref.name, %type_, %condition_status, "Unexpected condition status found in parent status");
                         return None
                     },
                 };

--- a/policy-controller/k8s/index/src/inbound/workload.rs
+++ b/policy-controller/k8s/index/src/inbound/workload.rs
@@ -103,7 +103,7 @@ fn container_http_probe_paths(
             match http::Uri::try_from(path) {
                 Ok(uri) => Some((port, uri.path().to_string())),
                 Err(error) => {
-                    tracing::warn!(%error, path, "invalid probe path");
+                    tracing::warn!(%error, path, "Invalid probe path");
                     None
                 }
             }
@@ -161,7 +161,7 @@ impl Settings {
         };
 
         let default_policy = default_policy(anns).unwrap_or_else(|error| {
-            tracing::warn!(%error, "invalid default policy annotation value");
+            tracing::warn!(%error, "Invalid default policy annotation value");
             None
         });
 

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -216,21 +216,21 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         let ns = service.namespace().expect("Service must have a namespace");
         tracing::debug!(name, ns, "indexing service");
         let accrual = parse_accrual_config(service.annotations())
-            .map_err(|error| tracing::error!(%error, service=name, namespace=ns, "failed to parse accrual config"))
+            .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();
         let opaque_ports =
             ports_annotation(service.annotations(), "config.linkerd.io/opaque-ports")
                 .unwrap_or_else(|| self.namespaces.cluster_info.default_opaque_ports.clone());
 
         let timeouts = parse_timeouts(service.annotations())
-            .map_err(|error| tracing::error!(%error, service=name, namespace=ns, "failed to parse timeouts"))
+            .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))
             .unwrap_or_default();
 
         let http_retry = http::parse_http_retry(service.annotations()).map_err(|error| {
-            tracing::error!(%error, service=name, namespace=ns, "failed to parse http retry")
+            tracing::warn!(%error, service=name, namespace=ns, "Failed to parse http retry")
         }).unwrap_or_default();
         let grpc_retry = grpc::parse_grpc_retry(service.annotations()).map_err(|error| {
-            tracing::error!(%error, service=name, namespace=ns, "failed to parse grpc retry")
+            tracing::warn!(%error, service=name, namespace=ns, "Failed to parse grpc retry")
         }).unwrap_or_default();
 
         if let Some(cluster_ips) = service
@@ -252,7 +252,7 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
                         self.services_by_ip.insert(addr, service_ref);
                     }
                     Err(error) => {
-                        tracing::error!(%error, service=name, cluster_ip, "invalid cluster ip");
+                        tracing::warn!(%error, service=name, cluster_ip, "Invalid cluster ip");
                     }
                 }
             }
@@ -318,7 +318,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             .expect("EgressNetwork must have a namespace");
         tracing::debug!(name, ns, "indexing EgressNetwork");
         let accrual = parse_accrual_config(egress_network.annotations())
-            .map_err(|error| tracing::error!(%error, service=name, namespace=ns, "failed to parse accrual config"))
+            .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();
         let opaque_ports = ports_annotation(
             egress_network.annotations(),
@@ -327,14 +327,14 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
         .unwrap_or_else(|| self.namespaces.cluster_info.default_opaque_ports.clone());
 
         let timeouts = parse_timeouts(egress_network.annotations())
-            .map_err(|error| tracing::error!(%error, service=name, namespace=ns, "failed to parse timeouts"))
+            .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))
             .unwrap_or_default();
 
         let http_retry = http::parse_http_retry(egress_network.annotations()).map_err(|error| {
-            tracing::error!(%error, service=name, namespace=ns, "failed to parse http retry")
+            tracing::warn!(%error, service=name, namespace=ns, "Failed to parse http retry")
         }).unwrap_or_default();
         let grpc_retry = grpc::parse_grpc_retry(egress_network.annotations()).map_err(|error| {
-            tracing::error!(%error, service=name, namespace=ns, "failed to parse grpc retry")
+            tracing::warn!(%error, service=name, namespace=ns, "Failed to parse grpc retry")
         }).unwrap_or_default();
 
         let egress_net_ref = ResourceRef {
@@ -678,7 +678,7 @@ impl Namespace {
         ) {
             Ok(route) => route,
             Err(error) => {
-                tracing::error!(%error, "failed to convert route");
+                tracing::warn!(%error, "Failed to convert route");
                 return;
             }
         };
@@ -773,7 +773,7 @@ impl Namespace {
         ) {
             Ok(route) => route,
             Err(error) => {
-                tracing::error!(%error, "failed to convert route");
+                tracing::warn!(%error, "Failed to convert route");
                 return;
             }
         };
@@ -868,7 +868,7 @@ impl Namespace {
             match tls::convert_route(&self.namespace, route.clone(), cluster_info, resource_info) {
                 Ok(route) => route,
                 Err(error) => {
-                    tracing::error!(%error, "failed to convert route");
+                    tracing::warn!(%error, "Failed to convert route");
                     return;
                 }
             };
@@ -964,7 +964,7 @@ impl Namespace {
             match tcp::convert_route(&self.namespace, route.clone(), cluster_info, resource_info) {
                 Ok(route) => route,
                 Err(error) => {
-                    tracing::error!(%error, "failed to convert route");
+                    tracing::warn!(%error, "Failed to convert route");
                     return;
                 }
             };

--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -107,21 +107,21 @@ pub struct IndexMetrics {
     patch_channel_full: Counter,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 struct RouteRef {
     parents: Vec<routes::ParentReference>,
     backends: Vec<routes::BackendReference>,
     statuses: Vec<k8s_gateway_api::RouteParentStatus>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 struct HttpLocalRateLimitPolicyRef {
     creation_timestamp: Option<DateTime<Utc>>,
     target_ref: ratelimit::TargetReference,
     status_conditions: Vec<k8s_core_api::Condition>,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 struct EgressNetworkRef {
     networks: Vec<Network>,
     status_conditions: Vec<k8s_core_api::Condition>,
@@ -259,7 +259,7 @@ impl Controller {
                     let was_leader = self.leader;
                     self.leader = claim.is_current_for(&self.name);
                     if was_leader != self.leader {
-                        tracing::debug!(leader = %self.leader, "Leadership changed");
+                        tracing::info!(leader=%self.leader, "Status controller");
                     }
                 }
 
@@ -270,21 +270,22 @@ impl Controller {
                     // any resources.
                     if self.leader {
                         if id.gkn.group == linkerd_k8s_api::HttpRoute::group(&()) && id.gkn.kind == linkerd_k8s_api::HttpRoute::kind(&()){
-                            self.patch_status::<linkerd_k8s_api::HttpRoute>(&id.gkn.name, &id.namespace, patch).await;
+                            self.patch::<linkerd_k8s_api::HttpRoute>(&id.gkn.name, &id.namespace, patch).await;
                         } else if id.gkn.group == k8s_gateway_api::HttpRoute::group(&()) && id.gkn.kind == k8s_gateway_api::HttpRoute::kind(&()) {
-                            self.patch_status::<k8s_gateway_api::HttpRoute>(&id.gkn.name, &id.namespace, patch).await;
+                            self.patch::<k8s_gateway_api::HttpRoute>(&id.gkn.name, &id.namespace, patch).await;
                         } else if id.gkn.group == k8s_gateway_api::GrpcRoute::group(&()) && id.gkn.kind == k8s_gateway_api::GrpcRoute::kind(&()) {
-                            self.patch_status::<k8s_gateway_api::GrpcRoute>(&id.gkn.name, &id.namespace, patch).await;
+                            self.patch::<k8s_gateway_api::GrpcRoute>(&id.gkn.name, &id.namespace, patch).await;
                         } else if id.gkn.group == k8s_gateway_api::TcpRoute::group(&()) && id.gkn.kind == k8s_gateway_api::TcpRoute::kind(&()) {
-                            self.patch_status::<k8s_gateway_api::TcpRoute>(&id.gkn.name, &id.namespace, patch).await;
+                            self.patch::<k8s_gateway_api::TcpRoute>(&id.gkn.name, &id.namespace, patch).await;
                         } else if id.gkn.group == k8s_gateway_api::TlsRoute::group(&()) && id.gkn.kind == k8s_gateway_api::TlsRoute::kind(&()) {
-                            self.patch_status::<k8s_gateway_api::TlsRoute>(&id.gkn.name, &id.namespace, patch).await;
+                            self.patch::<k8s_gateway_api::TlsRoute>(&id.gkn.name, &id.namespace, patch).await;
                         } else if id.gkn.group == linkerd_k8s_api::HttpLocalRateLimitPolicy::group(&()) && id.gkn.kind == linkerd_k8s_api::HttpLocalRateLimitPolicy::kind(&()) {
-                            self.patch_status::<linkerd_k8s_api::HttpLocalRateLimitPolicy>(&id.gkn.name, &id.namespace, patch).await;
+                            self.patch::<linkerd_k8s_api::HttpLocalRateLimitPolicy>(&id.gkn.name, &id.namespace, patch).await;
                         } else if id.gkn.group == linkerd_k8s_api::EgressNetwork::group(&()) && id.gkn.kind == linkerd_k8s_api::EgressNetwork::kind(&()) {
-                            self.patch_status::<linkerd_k8s_api::EgressNetwork>(&id.gkn.name, &id.namespace, patch).await;
+                            self.patch::<linkerd_k8s_api::EgressNetwork>(&id.gkn.name, &id.namespace, patch).await;
                         }
                     } else {
+                        tracing::debug!(?id, "Dropping patch because we are not the leader");
                         self.metrics.patch_drops.inc();
                     }
                 }
@@ -292,7 +293,15 @@ impl Controller {
         }
     }
 
-    async fn patch_status<K>(
+    #[tracing::instrument(
+        level = tracing::Level::ERROR,
+        skip(self, patch),
+        fields(
+            group=%K::group(&Default::default()),
+            kind=%K::kind(&Default::default()),
+        ),
+    )]
+    async fn patch<K>(
         &self,
         name: &str,
         namespace: &str,
@@ -302,32 +311,31 @@ impl Controller {
         <K as Resource>::DynamicType: Default,
         K: DeserializeOwned,
     {
-        let patch_params = k8s_core_api::PatchParams::apply(K::group(&Default::default()).as_ref());
+        tracing::trace!(?patch);
         let api = k8s_core_api::Api::<K>::namespaced(self.client.clone(), namespace);
+        let patch_params = k8s_core_api::PatchParams::apply(&K::group(&Default::default()));
         let start = time::Instant::now();
-
-        match time::timeout(
+        let result = time::timeout(
             self.patch_timeout,
             api.patch_status(name, &patch_params, &patch),
         )
-        .await
-        {
+        .await;
+        let elapsed = start.elapsed();
+        tracing::trace!(?elapsed);
+        match result {
             Ok(Ok(_)) => {
                 self.metrics.patch_succeeded.inc();
-                self.metrics
-                    .patch_duration
-                    .observe(start.elapsed().as_secs_f64());
+                self.metrics.patch_duration.observe(elapsed.as_secs_f64());
+                tracing::info!("Patched status");
             }
             Ok(Err(error)) => {
                 self.metrics.patch_failed.inc();
-                self.metrics
-                    .patch_duration
-                    .observe(start.elapsed().as_secs_f64());
-                tracing::error!(%namespace, %name, kind = %K::kind(&Default::default()), %error, "Patch failed");
+                self.metrics.patch_duration.observe(elapsed.as_secs_f64());
+                tracing::error!(%error);
             }
             Err(_) => {
                 self.metrics.patch_timeout.inc();
-                tracing::error!(%namespace, %name, kind = %K::kind(&Default::default()), "Patch timed out");
+                tracing::error!("Timed out");
             }
         }
     }
@@ -372,7 +380,7 @@ impl Index {
             tokio::select! {
                 res = claims.changed() => {
                     res.expect("Claims watch must not be dropped");
-                    tracing::debug!("Lease holder has changed");
+                    tracing::trace!("Lease updated");
                 }
                 _ = time::sleep(reconciliation_period) => {}
             }
@@ -386,7 +394,6 @@ impl Index {
             if !claims.is_current_for(&index.name) {
                 continue;
             }
-            tracing::debug!(%index.name, "Lease holder reconciling cluster");
             index.reconcile();
         }
     }
@@ -777,8 +784,33 @@ impl Index {
         make_patch(id, status)
     }
 
+    fn reconcile_if_leader(&self) {
+        let lease = self.claims.borrow();
+        if !lease.is_current_for(&self.name) {
+            tracing::trace!(%lease.holder, "Reconcilation skipped");
+            return;
+        }
+        self.reconcile();
+    }
+
     fn reconcile(&self) {
-        // first update all egress networks and their statuses
+        tracing::trace!(
+            egressnetworks = self.egress_networks.len(),
+            routes = self.route_refs.len(),
+            httplocalratelimits = self.ratelimits.len(),
+            "Reconciling"
+        );
+        let egressnetworks = self.reconcile_egress_networks();
+        let routes = self.reconcile_routes();
+        let ratelimits = self.reconcile_ratelimits();
+
+        if egressnetworks + routes + ratelimits > 0 {
+            tracing::debug!(egressnetworks, routes, ratelimits, "Reconciled");
+        }
+    }
+
+    fn reconcile_egress_networks(&self) -> usize {
+        let mut patches = 0;
         for (id, net) in self.egress_networks.iter() {
             let id = NamespaceGroupKindName {
                 namespace: id.namespace.clone(),
@@ -795,6 +827,7 @@ impl Index {
                     patch,
                 }) {
                     Ok(()) => {
+                        patches += 1;
                         self.metrics.patch_enqueues.inc();
                     }
                     Err(error) => {
@@ -804,8 +837,11 @@ impl Index {
                 }
             }
         }
+        patches
+    }
 
-        // then update all route refs
+    fn reconcile_routes(&self) -> usize {
+        let mut patches = 0;
         for (id, route) in self.route_refs.iter() {
             if let Some(patch) = self.make_route_patch(id, route) {
                 match self.updates.try_send(Update {
@@ -813,6 +849,7 @@ impl Index {
                     patch,
                 }) {
                     Ok(()) => {
+                        patches += 1;
                         self.metrics.patch_enqueues.inc();
                     }
                     Err(error) => {
@@ -822,8 +859,11 @@ impl Index {
                 }
             }
         }
+        patches
+    }
 
-        // then update all ratelimit policies and their statuses
+    fn reconcile_ratelimits(&self) -> usize {
+        let mut patches = 0;
         for (id, rl) in self.ratelimits.iter() {
             let id = NamespaceGroupKindName {
                 namespace: id.namespace.clone(),
@@ -840,6 +880,7 @@ impl Index {
                     patch,
                 }) {
                     Ok(()) => {
+                        patches += 1;
                         self.metrics.patch_enqueues.inc();
                     }
                     Err(error) => {
@@ -849,6 +890,43 @@ impl Index {
                 }
             }
         }
+        patches
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, net))]
+    fn index_egress_network(&mut self, id: ResourceId, net: EgressNetworkRef) {
+        tracing::trace!(?net);
+        // Insert into the index; if the network is already in the index, and it hasn't
+        // changed, skip creating a patch.
+        if !self.update_egress_net(id, &net) {
+            return;
+        }
+
+        self.reconcile_if_leader();
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, route))]
+    fn index_route(&mut self, id: NamespaceGroupKindName, route: RouteRef) {
+        tracing::trace!(?route);
+        // Insert into the index; if the route is already in the index, and it hasn't
+        // changed, skip creating a patch.
+        if !self.update_route(id.clone(), &route) {
+            return;
+        }
+
+        self.reconcile_if_leader();
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, ratelimit))]
+    fn index_ratelimit(&mut self, id: ResourceId, ratelimit: HttpLocalRateLimitPolicyRef) {
+        tracing::trace!(?ratelimit);
+        // Insert into the index; if the route is already in the index, and it hasn't
+        // changed, skip creating a patch.
+        if !self.update_ratelimit(id.clone(), &ratelimit) {
+            return;
+        }
+
+        self.reconcile_if_leader();
     }
 }
 
@@ -1158,29 +1236,13 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::Server> for Index {
     fn apply(&mut self, resource: linkerd_k8s_api::Server) {
         let namespace = resource.namespace().expect("Server must have a namespace");
         let name = resource.name_unchecked();
-        let id = ResourceId::new(namespace, name);
-
-        self.servers.insert(id);
-
-        // If we're not the leader, skip reconciling the cluster.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-        self.reconcile();
+        self.servers.insert(ResourceId::new(namespace, name));
+        self.reconcile_if_leader();
     }
 
     fn delete(&mut self, namespace: String, name: String) {
-        let id = ResourceId::new(namespace, name);
-
-        self.servers.remove(&id);
-
-        // If we're not the leader, skip reconciling the cluster.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-        self.reconcile();
+        self.servers.remove(&ResourceId::new(namespace, name));
+        self.reconcile_if_leader();
     }
 
     // Since apply only reindexes a single Server at a time, there's no need
@@ -1191,29 +1253,14 @@ impl kubert::index::IndexNamespacedResource<k8s_core_api::Service> for Index {
     fn apply(&mut self, resource: k8s_core_api::Service) {
         let namespace = resource.namespace().expect("Service must have a namespace");
         let name = resource.name_unchecked();
-        let id = ResourceId::new(namespace, name);
-
-        self.services.insert(id, resource.into());
-
-        // If we're not the leader, skip reconciling the cluster.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-        self.reconcile();
+        self.services
+            .insert(ResourceId::new(namespace, name), resource.into());
+        self.reconcile_if_leader();
     }
 
     fn delete(&mut self, namespace: String, name: String) {
-        let id = ResourceId::new(namespace, name);
-
-        self.services.remove(&id);
-
-        // If we're not the leader, skip reconciling the cluster.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-        self.reconcile();
+        self.services.remove(&ResourceId::new(namespace, name));
+        self.reconcile_if_leader();
     }
 
     // Since apply only reindexes a single Service at a time, there's no need
@@ -1249,13 +1296,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::HttpLocalRateLimitP
     fn delete(&mut self, namespace: String, name: String) {
         let id = ResourceId::new(namespace, name);
         self.ratelimits.remove(&id);
-
-        // If we're not the leader, skip reconciling the cluster.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-        self.reconcile();
+        self.reconcile_if_leader();
     }
 }
 
@@ -1304,66 +1345,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
     fn delete(&mut self, namespace: String, name: String) {
         let id = ResourceId::new(namespace, name);
         self.egress_networks.remove(&id);
-
-        // If we're not the leader, skip reconciling the cluster.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-        self.reconcile();
-    }
-}
-
-impl Index {
-    fn index_egress_network(&mut self, id: ResourceId, net: EgressNetworkRef) {
-        // Insert into the index; if the network is already in the index, and it hasn't
-        // changed, skip creating a patch.
-        if !self.update_egress_net(id, &net) {
-            return;
-        }
-
-        // If we're not the leader, skip creating a patch and sending an
-        // update to the Controller.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-
-        self.reconcile()
-    }
-
-    fn index_route(&mut self, id: NamespaceGroupKindName, route: RouteRef) {
-        // Insert into the index; if the route is already in the index, and it hasn't
-        // changed, skip creating a patch.
-        if !self.update_route(id.clone(), &route) {
-            return;
-        }
-
-        // If we're not the leader, skip creating a patch and sending an
-        // update to the Controller.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-
-        self.reconcile()
-    }
-
-    fn index_ratelimit(&mut self, id: ResourceId, ratelimit: HttpLocalRateLimitPolicyRef) {
-        // Insert into the index; if the route is already in the index, and it hasn't
-        // changed, skip creating a patch.
-        if !self.update_ratelimit(id.clone(), &ratelimit) {
-            return;
-        }
-
-        // If we're not the leader, skip creating a patch and sending an
-        // update to the Controller.
-        if !self.claims.borrow().is_current_for(&self.name) {
-            tracing::debug!(%self.name, "Lease non-holder skipping controller update");
-            return;
-        }
-
-        self.reconcile()
+        self.reconcile_if_leader();
     }
 }
 
@@ -1376,7 +1358,7 @@ where
 {
     match resource_id.api_version() {
         Err(error) => {
-            tracing::error!(error = %error, "failed to create patch for resource");
+            tracing::error!(error = %error, "Failed to create patch for resource");
             None
         }
         Ok(api_version) => {

--- a/policy-controller/k8s/status/src/ratelimit.rs
+++ b/policy-controller/k8s/status/src/ratelimit.rs
@@ -1,7 +1,7 @@
 use crate::resource_id::ResourceId;
 use linkerd_policy_controller_k8s_api::policy as linkerd_k8s_api;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum TargetReference {
     Server(ResourceId),
     UnknownKind,

--- a/policy-controller/k8s/status/src/routes.rs
+++ b/policy-controller/k8s/status/src/routes.rs
@@ -18,7 +18,7 @@ pub(crate) mod tls;
 /// namespace. This is something that should be relaxed in the future in the
 /// policy controller's index, and we could then consider consolidating these
 /// types into a single shared lib.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum ParentReference {
     Server(ResourceId),
     Service(ResourceId, Option<u16>),
@@ -26,7 +26,7 @@ pub enum ParentReference {
     UnknownKind,
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum BackendReference {
     Service(ResourceId),
     EgressNetwork(ResourceId),

--- a/policy-controller/src/admission.rs
+++ b/policy-controller/src/admission.rs
@@ -77,7 +77,7 @@ impl hyper::service::Service<Request<Body>> for Admission {
             let review: Review = match serde_json::from_reader(bytes.reader()) {
                 Ok(review) => review,
                 Err(error) => {
-                    warn!(%error, "failed to parse request body");
+                    warn!(%error, "Failed to parse request body");
                     return json_response(AdmissionResponse::invalid(error).into_review());
                 }
             };
@@ -89,7 +89,7 @@ impl hyper::service::Service<Request<Body>> for Admission {
                     admission.admit(req).await
                 }
                 Err(error) => {
-                    warn!(%error, "invalid admission request");
+                    warn!(%error, "Invalid admission request");
                     AdmissionResponse::invalid(error)
                 }
             };

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -94,7 +94,7 @@ impl DiscoverOutboundPolicy<ResourceTarget, OutboundDiscoverTarget> for Outbound
         let rx = match self.0.write().outbound_policy_rx(resource.clone()) {
             Ok(rx) => rx,
             Err(error) => {
-                tracing::error!(%error, "failed to get outbound policy rx");
+                tracing::error!(%error, "Failed to get outbound policy rx");
                 return Ok(None);
             }
         };

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -360,7 +360,7 @@ async fn main() -> Result<()> {
     // Spawn the status Controller reconciliation.
     tokio::spawn(
         status::Index::run(status_index.clone(), RECONCILIATION_PERIOD)
-            .instrument(info_span!("status::Index")),
+            .instrument(info_span!("status_index")),
     );
 
     // Run the gRPC server, serving results by looking up against the index handle.
@@ -386,7 +386,7 @@ async fn main() -> Result<()> {
     tokio::spawn(
         status_controller
             .run()
-            .instrument(info_span!("status::Controller")),
+            .instrument(info_span!("status_controller")),
     );
 
     let client = runtime.client();
@@ -495,10 +495,10 @@ async fn init_lease(client: Client, ns: &str, deployment_name: &str) -> Result<L
         )
         .await
     {
-        Ok(lease) => tracing::info!(?lease, "created Lease resource"),
-        Err(k8s::Error::Api(_)) => tracing::info!("Lease already exists, no need to create it"),
+        Ok(lease) => tracing::info!(?lease, "Created Lease resource"),
+        Err(k8s::Error::Api(_)) => tracing::debug!("Lease already exists, no need to create it"),
         Err(error) => {
-            tracing::error!(%error, "error creating Lease resource");
+            tracing::error!(%error, "Failed to create Lease resource");
             return Err(error.into());
         }
     };

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -393,7 +393,7 @@ impl Execable {
         let mut stderr_buf = String::new();
         match stderr.read_to_string(&mut stderr_buf).await {
             Ok(_) => tracing::debug!("curl stderr:\n{stderr_buf}"),
-            Err(error) => tracing::warn!("failed to read curl stderr: {error}"),
+            Err(error) => tracing::warn!("Failed to read curl stderr: {error}"),
         }
         Ok(stdout_buf)
     }


### PR DESCRIPTION
There are a few things about the policy controller logging that can be cleaned
up for consistency and clarity:

* We frequently log ERROR messages when processing resources with unexpected values. These messages are more appropriately emitted at WARN--we want to surface these situations, but they are not really exceptional.
* The leadership status of the status controller is not logged at INFO level, so it's not possible to know about status changes without DEBUG logging.
* We generally use Sentence-cased log messages when emitting user-facing messages. There are a few situations where we are not consistent.
* The status controller reconciliation logging is somewhat noisy and misleading.

```
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder has changed
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder has changed
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder has changed
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
DEBUG status::Index: linkerd_policy_controller_k8s_status::index: Lease holder reconciling cluster index.name=linkerd-destination-74d7fdc45d-xfb8l
```

The "Lease holder has changed" message actually indicates that the _lease_ has changed, though the holder may be unchanged.

To improve logging clarity, this change does the following:

* Adds an INFO level log when the leadership status of the controller changes.
* Adds an INFO level log when the status controller patches resources.
* Reconciliation logging is moved to TRACE level.
* Consistently uses sentence capitalization in user-facing log messages
* Reduces ERROR messages to WARN when handling invalid user-provided data
  (including cluster resources). This ensures that ERRORs are reserved for
  exceptional policy controller states.