### PR TITLE
ci(multicluster): increase federated test timeout

### DIFF
--- a/test/integration/multicluster/multicluster-traffic/federated_test.go
+++ b/test/integration/multicluster/multicluster-traffic/federated_test.go
@@ -81,7 +81,7 @@ func TestFederatedService(t *testing.T) {
 
 		})
 
-		timeout := time.Minute
+		timeout := 3 * time.Minute
 		t.Run("Ensure federated service exists and has no endpoints", func(t *testing.T) {
 			err := TestHelper.SwitchContext(contexts[testutil.SourceContextKey])
 			if err != nil {


### PR DESCRIPTION
The one minute timeout is too conservative in GitHub Actions. This change bumps it to 3 minutes.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
