### PR TITLE
build(deps): bump kubert from 0.21.2 to 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023388cc940f58816aa0d758a3fd4c4b837474ccd356803b7ac738b8a2f26a66"
+checksum = "3ff4135c85607c3733cd52e3098df704994980a91cb14afabd967a60cb167433"
 dependencies = [
  "ahash",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ members = [
 
 [profile.release]
 lto = "thin"
+
+[workspace.dependencies]
+k8s-openapi = { version = "0.20", features = ["v1_22"] }
+kube = { version = "0.87.1", default-features = false }
+kubert = { version = "0.22", default-features = false }

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1"
 async-trait = "0.1"
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
-k8s-openapi = { version = "0.20", features = ["v1_22"] }
+k8s-openapi = { workspace = true }
 hyper = { version = "0.14", features = ["http1", "http2", "runtime", "server"] }
 ipnet = { version = "2", default-features = false }
 linkerd-policy-controller-core = { path = "./core" }
@@ -41,12 +41,12 @@ default-features = false
 features = ["derive", "env", "std"]
 
 [dependencies.kube]
-version = "0.87.1"
+workspace = true
 default-features = false
 features = ["admission", "derive"]
 
 [dependencies.kubert]
-version = "0.21.2"
+workspace = true
 default-features = false
 features = [
     "clap",

--- a/policy-controller/k8s/api/Cargo.toml
+++ b/policy-controller/k8s/api/Cargo.toml
@@ -6,11 +6,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-k8s-openapi = { version = "0.20", default-features = false, features = [
-    "v1_22",
-] }
+k8s-openapi = { workspace = true }
 k8s-gateway-api = { version = "0.16", features = ["experimental"] }
-kube = { version = "0.87.1", default-features = false, features = [
+kube = { workspace = true, default-features = false, features = [
     "client",
     "derive",
     "runtime",

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -11,12 +11,12 @@ anyhow = "1"
 chrono = { version = "0.4.38", default_features = false }
 futures = { version = "0.3", default-features = false }
 http = "0.2"
-kube = { version = "0.87.1", default-features = false, features = [
+kube = { workspace = true, default-features = false, features = [
     "client",
     "derive",
     "runtime",
 ] }
-kubert = { version = "0.21.2", default-features = false, features = ["index"] }
+kubert = { workspace = true, default-features = false, features = ["index"] }
 linkerd-policy-controller-core = { path = "../../core" }
 linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -10,7 +10,7 @@ ahash = "0.8"
 anyhow = "1"
 # Fix for https://github.com/chronotope/chrono/issues/602
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
-kubert = { version = "0.21.2", default-features = false, features = [
+kubert = { workspace = true, default-features = false, features = [
     "index",
     "lease",
 ] }

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -11,7 +11,7 @@ hyper = { version = "0.14", features = ["client", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2"
 k8s-gateway-api = "0.16"
-k8s-openapi = { version = "0.20", features = ["v1_22"] }
+k8s-openapi = { workspace = true }
 linkerd-policy-controller-core = { path = "../policy-controller/core" }
 linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
 linkerd-policy-controller-grpc = { path = "../policy-controller/grpc" }
@@ -26,7 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies.kube]
-version = "0.87.1"
+workspace = true
 default-features = false
 features = ["client", "openssl-tls", "runtime", "ws"]
 


### PR DESCRIPTION
This change introduces a timeout into the kubernetes lease logic so that patches may not get stuck indefinitely.

This change also modifies our Cargo.tomls so that kubert and its related dependencies (kube and k8s-openapi) are defined at the workspace-level.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
