### PR TITLE
Simplify cni config

### DIFF
--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -158,11 +158,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "{{.Values.logLevel}}",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -59,11 +59,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "info",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured.golden
@@ -59,11 +59,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "debug",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_equal_dsts.golden
@@ -59,11 +59,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "debug",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },

--- a/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
+++ b/cli/cmd/testdata/install-cni-plugin_fully_configured_no_namespace.golden
@@ -59,11 +59,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "debug",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -59,11 +59,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "info",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -52,11 +52,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "info",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },

--- a/cli/cmd/testdata/install_cni_helm_override_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_override_output.golden
@@ -52,11 +52,6 @@ data:
       "name": "linkerd-cni",
       "type": "linkerd-cni",
       "log_level": "debug",
-      "policy": {
-          "type": "k8s",
-          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-      },
       "kubernetes": {
           "kubeconfig": "__KUBECONFIG_FILEPATH__"
       },


### PR DESCRIPTION
This change removes the `policy` entry from the cni config template, which isn't used. That contained a `__SERVICEACCOUNT_TOKEN__` placeholder, which was coupling this config file with the `ZZZ-linkerd-cni-kubeconfig` file generated by linkerd-cni. In linkerd/linkerd2-proxy-init#440 we add support for detecting changes in the mounted serviceaccount token file (see #12573), and the current change facilitates that effort.