### PR TITLE
chore(just): retry failures when loading pause container

### DIFF
--- a/justfile
+++ b/justfile
@@ -161,7 +161,7 @@ policy-test-deps-load: _k3d-init policy-test-deps-pull
         bitnami/kubectl:latest \
         curlimages/curl:latest \
         fortio/fortio:latest \
-        ghcr.io/olix0r/hokay:latest && exit ; sleep 1 ; done
+        ghcr.io/olix0r/hokay:latest && exit || sleep 1 ; done
 
 ##
 ## Test cluster
@@ -273,7 +273,7 @@ _pause-load: _k3d-init
     if [ -z "$(docker image ls -q "$img")" ]; then
        docker pull -q "$img"
     fi
-    k3d image import --mode=direct --cluster='{{ k3d-name }}' "$img"
+    for i in {1..3} ; do {{ _k3d-load }} "$img" && exit || sleep 1 ; done
 
 ##
 ## Linkerd CLI
@@ -331,7 +331,7 @@ linkerd-load: _linkerd-images _k3d-init
         '{{ controller-image }}:{{ linkerd-tag }}' \
         '{{ policy-controller-image }}:{{ linkerd-tag }}' \
         '{{ proxy-image }}:{{ linkerd-tag }}' \
-        $({{ _proxy-init-image-cmd }}) && exit ; sleep 1 ; done
+        $({{ _proxy-init-image-cmd }}) && exit || sleep 1 ; done
 
 linkerd-load-cni:
     docker pull -q $({{ _cni-plugin-image-cmd }})
@@ -437,7 +437,7 @@ linkerd-viz-load: _linkerd-viz-images _k3d-init
         {{ DOCKER_REGISTRY }}/metrics-api:{{ linkerd-tag }} \
         {{ DOCKER_REGISTRY }}/tap:{{ linkerd-tag }} \
         {{ DOCKER_REGISTRY }}/web:{{ linkerd-tag }} \
-        $({{ _prometheus-image-cmd }}) && exit ; sleep 1 ; done
+        $({{ _prometheus-image-cmd }}) && exit || sleep 1 ; done
 
 linkerd-viz-build:
     TAG={{ linkerd-tag }} bin/docker-build-metrics-api


### PR DESCRIPTION
The multicluster integration tests do not retry image import failures when loading the pause container. This change adds retries to the `_pause-load` target in `justfile`.

This change also ensures consistent usage of `|| sleep 1` in other load calls so that `set -e` cannot short-circuit the loop.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
