### PR TITLE
chore: group cargo dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,13 @@ updates:
         update-types: [version-update:semver-major, version-update:semver-minor]
       - dependency-name: k8s-openapi
         update-types: [version-update:semver-major, version-update:semver-minor]
+      # These dependencies are updated via linkerd2-proxy-api, so only accept patch updates.
+      - dependency-name: prost
+        update-types: [version-update:semver-major, version-update:semver-minor]
+      - dependency-name: prost-*
+        update-types: [version-update:semver-major, version-update:semver-minor]
+      - dependency-name: tonic
+        update-types: [version-update:semver-major, version-update:semver-minor]
     groups:
       clap:
         patterns:
@@ -52,6 +59,12 @@ updates:
           - k8s-openapi
           - kube
           - kube-*
+        update-types: [patch]
+      grpc:
+        patterns:
+          - prost
+          - prost-*
+          - tonic
         update-types: [patch]
       tracing:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,51 +5,65 @@
 # JS updates are run weekly.
 version: 2
 updates:
-  - package-ecosystem: "gomod"
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: daily
       time: "03:00"
-      timezone: "UTC"
+      timezone: Etc/UTC
 
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: daily
       time: "03:30"
-      timezone: "UTC"
+      timezone: Etc/UTC
     allow:
-      - dependency-type: "all"
+      - dependency-type: all
     ignore:
-      # These dependencies will be updated via higher-level aggregator dependencies like `clap`,
-      # `futures`, `kube`, `prost`, and `tracing`:
-      - dependency-name: "clap_derive"
-      - dependency-name: "futures-channel"
-      - dependency-name: "futures-core"
-      - dependency-name: "futures-io"
-      - dependency-name: "futures-sink"
-      - dependency-name: "futures-task"
-      - dependency-name: "futures-util"
-      - dependency-name: "kube-client"
-      - dependency-name: "kube-core"
-      - dependency-name: "kube-derive"
-      - dependency-name: "kube-runtime"
-      - dependency-name: "prost-derive"
-      - dependency-name: "tracing-attributes"
-      - dependency-name: "tracing-core"
-      - dependency-name: "tracing-serde"
       # These dependencies are for platforms that we don't support:
-      - dependency-name: "redox_syscall"
-      - dependency-name: "js-sys"
-      - dependency-name: "wasm-bindgen"
-      - dependency-name: "web-sys"
+      - dependency-name: redox*
+      - dependency-name: js-sys
+      - dependency-name: wasm-bindgen
+      - dependency-name: web-sys
+      # These dependencies are updated via kubert, so only accept patch updates.
+      - dependency-name: clap
+        update-types: [version-update:semver-major, version-update:semver-minor]
+      - dependency-name: clap_*
+        update-types: [version-update:semver-major, version-update:semver-minor]
+      - dependency-name: kube
+        update-types: [version-update:semver-major, version-update:semver-minor]
+      - dependency-name: kube-*
+        update-types: [version-update:semver-major, version-update:semver-minor]
+      - dependency-name: k8s-openapi
+        update-types: [version-update:semver-major, version-update:semver-minor]
+    groups:
+      clap:
+        patterns:
+          - clap
+          - clap_*
+        update-types: [minor, patch]
+      futures:
+        patterns:
+          - futures
+          - futures-*
+      kube:
+        patterns:
+          - k8s-openapi
+          - kube
+          - kube-*
+        update-types: [patch]
+      tracing:
+        patterns:
+          - tracing
+          - tracing-*
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
       time: "04:00"
-      timezone: "UTC"
+      timezone: Etc/UTC
 
   - package-ecosystem: "npm"
     directory: "/web/app"


### PR DESCRIPTION
There are some groups of Rust dependencies that are updated together, so we can group them in the dependabot configuration file.

This update also disables updates for dependencies that we must upgrade via kubert.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
