### PR TITLE
bin: shellscript housekeeping

### DIFF
--- a/bin/_docker.sh
+++ b/bin/_docker.sh
@@ -65,17 +65,17 @@ docker_build() {
     shift
 
     rootdir=${ROOTDIR:-$( cd "$bindir"/.. && pwd )}
-    cache_params=""
+    cache_params=''
 
     if [ "$ACTIONS_CACHE_URL" ]; then
       cache_params="--cache-from type=gha,scope=$name-$DOCKER_TARGET --cache-to type=gha,scope=$name-$DOCKER_TARGET,mode=max"
     fi
 
-    output_params="--load"
+    output_params='--load'
     if [ "$DOCKER_TARGET" = 'multi-arch' ]; then
       output_params="--platform $SUPPORTED_ARCHS"
       if [ "$DOCKER_PUSH" ]; then
-        output_params+=" --push"
+        output_params+=' --push'
       else
         echo 'Error: env DOCKER_PUSH=1 is missing
 When building the multi-arch images it is required to push the images to the registry

--- a/bin/_os.sh
+++ b/bin/_os.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eu
 
-export OS_ARCH_ALL="linux-amd64 linux-arm64 linux-arm darwin darwin-arm64 windows"
+export OS_ARCH_ALL='linux-amd64 linux-arm64 linux-arm darwin darwin-arm64 windows'
 
 architecture() {
   arch=$(uname -m)
@@ -32,7 +32,7 @@ architecture() {
 
 os() {
   os=$(uname -s)
-  arch=""
+  arch=''
   case $os in
     CYGWIN* | MINGW64*)
       os=windows

--- a/bin/_tag.sh
+++ b/bin/_tag.sh
@@ -11,7 +11,7 @@ clean_head() {
 }
 
 named_tag() {
-    tag="$(git name-rev --tags --name-only "$(git_sha_head)")"
+    tag=$(git name-rev --tags --name-only "$(git_sha_head)")
     tag=${tag%"^0"}
     echo "${tag}"
 }

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -8,7 +8,7 @@ k8s_version_min='+v1.22'
 k8s_version_max='docker.io/rancher/k3s:v1.29.6-k3s2'
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
-testdir="$bindir"/../test/integration
+testdir=$bindir/../test/integration
 
 ##### Test setup helpers #####
 
@@ -20,7 +20,7 @@ export all_test_names=(cluster-domain cni-calico-deep multicluster "${default_te
 images_load_default=(proxy controller policy-controller web metrics-api tap)
 
 tests_usage() {
-  progname="${0##*/}"
+  progname=${0##*/}
   echo "Run Linkerd integration tests.
 
 Optionally specify a test with the --name flag: [${all_test_names[*]}]
@@ -56,7 +56,7 @@ Available Commands:
 }
 
 cleanup_usage() {
-  progname="${0##*/}"
+  progname=${0##*/}
   echo "Cleanup Linkerd integration tests.
 
 Usage:
@@ -76,7 +76,7 @@ handle_tests_input() {
   export skip_cluster_create=''
   export skip_cluster_delete=''
   export cleanup_docker=''
-  export linkerd_path=""
+  export linkerd_path=''
 
   while  [ $# -ne 0 ]; do
     case $1 in
@@ -227,7 +227,7 @@ cleanup_cluster() {
 
 setup_min_cluster() {
   local name=$1
-  export helm_path="$bindir"/helm
+  export helm_path=$bindir/helm
 
   check_linkerd_binary
   if [ -z "$skip_cluster_create" ]; then
@@ -239,7 +239,7 @@ setup_min_cluster() {
 
 setup_cluster() {
   local name=$1
-  export helm_path="$bindir"/helm
+  export helm_path=$bindir/helm
 
   check_linkerd_binary
   if [ -z "$skip_cluster_create" ]; then
@@ -428,7 +428,7 @@ run_helm-upgrade_test() {
   fi
 
   setup_helm
-  helm_viz_chart="$( cd "$bindir"/.. && pwd )"/viz/charts/linkerd-viz
+  helm_viz_chart=$( cd "$bindir"/.. && pwd )/viz/charts/linkerd-viz
   run_test "$testdir/install/install_test.go" --helm-path="$helm_path" --helm-charts="$helm_charts" \
   --viz-helm-chart="$helm_viz_chart" --viz-helm-stable-chart="linkerd/linkerd-viz" --helm-release="$helm_release_name" --upgrade-helm-from-version="$edge_version"
   helm_cleanup

--- a/bin/certs-openssl
+++ b/bin/certs-openssl
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-#
+
 set -eu
 
 # Creates the root and issuer (intermediary) self-signed certificates for the control plane using openssl.

--- a/bin/docker
+++ b/bin/docker
@@ -9,12 +9,11 @@ targetbin=$( cd "$bindir"/.. && pwd )/target/bin
 dockerbin=$targetbin/.docker-$dockerversion
 
 if [ ! -f "$dockerbin" ]; then
+  filename=docker-$dockerversion.tgz
   if [ "$(uname -s)" = Darwin ]; then
     os=mac
-    filename=docker-$dockerversion.tgz
   else
     os=linux
-    filename=docker-$dockerversion.tgz
   fi
 
   url=https://download.docker.com/$os/static/stable/x86_64/$filename

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -3,7 +3,7 @@
 set -eu
 
 if [ $# -eq 1 ]; then
-    tag="${1:-}"
+    tag=${1:-}
 else
     echo "usage: ${0##*/} tag" >&2
     exit 64

--- a/bin/fetch-proxy
+++ b/bin/fetch-proxy
@@ -9,16 +9,16 @@ set -eu
 
 bindir=$( cd "${0%/*}" && pwd )
 rootdir=$( cd "$bindir"/.. && pwd )
-builddir="$rootdir/target/proxy"
+builddir=$rootdir/target/proxy
 
-proxy_repo="${LINKERD2_PROXY_REPO:-}"
+proxy_repo=${LINKERD2_PROXY_REPO:-}
 if [ -z "$proxy_repo" ]; then
   proxy_repo=linkerd/linkerd2-proxy
 fi
 
 releases_url=https://api.github.com/repos/"$proxy_repo"/releases
 
-github_token="${GITHUB_TOKEN:-}"
+github_token=${GITHUB_TOKEN:-}
 if [ -z "$github_token" ] && [ -n "${GITHUB_TOKEN_FILE:-}" ] && [ -f "$GITHUB_TOKEN_FILE" ]; then
   github_token=$(cat "$GITHUB_TOKEN_FILE")
 fi
@@ -42,16 +42,16 @@ if ! ghcurl "$releases_url" | jq '.[] | select(.name == "'"$version"'")' > relea
   exit 1
 fi
 
-pkgname="linkerd2-proxy-${version}-${arch}"
+pkgname=linkerd2-proxy-${version}-${arch}
 
-pkgfile="${pkgname}.tar.gz"
+pkgfile=${pkgname}.tar.gz
 pkgurl=$(jq -r '.assets[] | select(.name == "'"$pkgfile"'") | .url' release.json)
 if ! ghcurl -H 'Accept: application/octet-stream' -o "$pkgfile" "$pkgurl" ; then
   echo "Failed to fetch $pkgurl" >&2
   exit 1
 fi
 
-shafile="${pkgname}.txt"
+shafile=${pkgname}.txt
 shaurl=$(jq -r '.assets[] | select(.name == "'"$shafile"'") | .url' release.json)
 if ! ghcurl -H 'Accept: application/octet-stream' -o "$shafile" "$shaurl" ; then
   echo "Failed to fetch $shaurl" >&2

--- a/bin/go-mod-tree
+++ b/bin/go-mod-tree
@@ -8,7 +8,7 @@ if [ $# -gt 1 ]; then
     echo "Usage: $0 [root]" >&2
     exit 64
 fi
-declare -r MODULE="${1:-github.com/linkerd/linkerd2}"
+declare -r MODULE=${1:-github.com/linkerd/linkerd2}
 
 GRAPH=$(go mod graph)
 declare -r GRAPH

--- a/bin/go-mod-versions
+++ b/bin/go-mod-versions
@@ -8,7 +8,7 @@ if [ $# -ne 1 ]; then
     echo "Usage: $0 <module>" >&2
     exit 64
 fi
-declare -r MODULE="$1"
+declare -r MODULE=$1
 
 if [[ "$MODULE" == *@* ]]; then
     echo 'The dependency must not specify an exact version.' >&2

--- a/bin/go-mod-why
+++ b/bin/go-mod-why
@@ -8,7 +8,7 @@ if [ $# -ne 1 ]; then
     echo "Usage: $0 <module>" >&2
     exit 64
 fi
-declare -r MODULE="$1"
+declare -r MODULE=$1
 
 GRAPH=$(go mod graph)
 declare -r GRAPH

--- a/bin/helm
+++ b/bin/helm
@@ -22,7 +22,7 @@ if [ ! -f "$helmbin" ]; then
             arm) dpkg --print-architecture | grep -q arm64 && arch=arm64 || arch=arm ;;
         esac
     fi
-    helmcurl="https://get.helm.sh/helm-$helmversion-$os-$arch.tar.gz"
+    helmcurl=https://get.helm.sh/helm-$helmversion-$os-$arch.tar.gz
     targetdir=$os-$arch
     tmp=$(mktemp -d -t helm.XXX)
     mkdir -p "$targetbin"

--- a/bin/helm-bump-edge
+++ b/bin/helm-bump-edge
@@ -11,7 +11,7 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 . "$bindir"/_tag.sh
 tag=$(named_tag)
 
-edge_tag_regex="edge-([0-9][0-9])\.([0-9]|[0-9][0-9])\.([0-9]+)"
+edge_tag_regex='edge-([0-9][0-9])\.([0-9]|[0-9][0-9])\.([0-9]+)'
 
 # Get the current edge version.
 url=https://run.linkerd.io/install-edge
@@ -24,7 +24,7 @@ yyyy=$(date +"%Y")
 new_mm=$(date +"%-m")
 
 # If this is a new month, `new_xx` should be 1; otherwise increment it.
-if [[ "$new_mm" != "$current_mm" ]]; then
+if [ "$new_mm" != "$current_mm" ]; then
     new_xx=1
 else
     new_xx=$((current_xx+1))
@@ -32,7 +32,7 @@ fi
 
 expected_tag="edge-$yy.$new_mm.$new_xx"
 
-if [[ "$tag" != "$expected_tag" ]]; then
+if [ "$tag" != "$expected_tag" ]; then
     echo "Tag ($tag) doesn't match computed edge version ($expected_tag)"
     exit 1
 fi

--- a/bin/helm-docs
+++ b/bin/helm-docs
@@ -10,8 +10,8 @@ helmdocsv=1.12.0
 bindir=$( cd "${0%/*}" && pwd ) # Change to script dir and set bin dir to this
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin
 helmdocsbin=$targetbin/helm-docs-$helmdocsv
-os=""
-arch=""
+os=''
+arch=''
 
 if [ ! -f "$helmdocsbin" ]; then
     case $(uname | tr '[:upper:]' '[:lower:]') in

--- a/bin/image-load
+++ b/bin/image-load
@@ -91,11 +91,11 @@ if [ "$k3d" ]; then
   if [ -z "$cluster" ]; then
     cluster=k3s-default
   fi
-  bin="$bindir"/k3d
+  bin=$bindir/k3d
   image_sub_cmd=(image import -c "$cluster")
 else
   kind=1
-  bin="$bindir"/kind
+  bin=$bindir/kind
   if [ -z "$cluster" ]; then
     cluster=kind
   fi
@@ -106,8 +106,7 @@ else
   fi
 fi
 
-if [ -z "$archive" ]
-then
+if [ -z "$archive" ]; then
   # shellcheck source=_tag.sh
   . "$bindir"/_tag.sh
   # shellcheck source=_docker.sh
@@ -122,9 +121,9 @@ fi
 rm -f load_fail
 for i in "${!images[@]}"; do
   if [ $archive ]; then
-    param="image-archives/${images[$i]}.tar"
+    param=image-archives/${images[$i]}.tar
   else
-    param="$DOCKER_REGISTRY/${images[$i]}:$TAG"
+    param=$DOCKER_REGISTRY/${images[$i]}:$TAG
     if [ $preload ]; then
       docker pull -q "$param" || (echo "Error pulling image $param"; touch load_fail) &
     fi

--- a/bin/install-pr
+++ b/bin/install-pr
@@ -60,16 +60,14 @@ done
 
 pr=$1
 
-if [ -z "$pr" ]
-then
+if [ -z "$pr" ]; then
   echo "Error: ${0##*/} accepts 1 argument
 Usage:
     ${0##*/} ####" >&2
   exit 1
 fi
 
-if [ -z "$GITHUB_TOKEN" ]
-then
+if [ -z "$GITHUB_TOKEN" ]; then
   # shellcheck disable=SC2016
   echo 'Error: Generate a personal access token at https://github.com/settings/tokens and set it in the $GITHUB_TOKEN env var'
   exit 1
@@ -108,18 +106,16 @@ do
   docker load -i "image-archives/$image.tar"
 done
 
-if [ "$is_kind" = true ] || [ "$is_k3d" = true ]
-then
+if [ "$is_kind" = true ] || [ "$is_k3d" = true ]; then
   # When importing into k3d or kind, the images must be renamed to use the
   # proper registry so that users don't have to change the default install
   # output.
   docker_rename_registry "$tag" 'ghcr.io/linkerd' 'cr.l5d.io/linkerd'
   distro=k3d
-  if [ "$is_kind" = true ]
-  then
+  if [ "$is_kind" = true ]; then
     distro=kind
   fi
-  export TAG="$tag"
+  export TAG=$tag
   "$bindir"/image-load --"$distro" --cluster "$cluster"
 else
   # The images were built with the ghcr.io registry so when pushing to a

--- a/bin/k3d
+++ b/bin/k3d
@@ -10,7 +10,7 @@ bindir=$( cd "${0%/*}" && pwd )
 . "$bindir"/_os.sh
 
 targetbin=$( cd "$bindir"/.. && pwd )/target/bin
-k3dbin="$targetbin/k3d-${K3D_VERSION}"
+k3dbin=$targetbin/k3d-${K3D_VERSION}
 
 if [ ! -f "$k3dbin" ]; then
   arch=$(architecture)

--- a/bin/rust-toolchain-version
+++ b/bin/rust-toolchain-version
@@ -15,10 +15,10 @@ if [[ $toolchain =~ $version_regex ]]; then
 fi
 
 # Otherwise, no matching line was found, so print an error.
-if [[ "${GITHUB_ACTIONS:-false}" ==  "true" ]]; then
-    echo "::error file=rust-toolchain.toml::failed to parse rust-toolchain.toml"
+if [ "${GITHUB_ACTIONS:-false}" =  'true' ]; then
+    echo '::error file=rust-toolchain.toml::failed to parse rust-toolchain.toml'
 else
-    echo "failed to parse rust-toolchain.toml"
+    echo 'failed to parse rust-toolchain.toml'
 fi
 
 exit 1

--- a/bin/test-scale
+++ b/bin/test-scale
@@ -98,13 +98,13 @@ done
 BOOKS_APP=$("$bindir"/scurl https://raw.githubusercontent.com/BuoyantIO/booksapp/main/k8s/mysql-app.yml)
 
 # add "-sleep=10ms" param to the traffic app (~100rps)
-traffic_param="        - \"webapp:7000\""
+traffic_param='        - "webapp:7000"'
 sleep_param=$(cat <<-END
         - "-sleep=10ms"
         - "webapp:7000"
 END
 )
-BOOKS_APP="${BOOKS_APP/$traffic_param/$sleep_param}"
+BOOKS_APP=${BOOKS_APP/$traffic_param/$sleep_param}
 
 # inject
 BOOKS_APP=$(echo "$BOOKS_APP" | "$linkerd_path" -l "$linkerd_namespace" inject -)
@@ -128,10 +128,10 @@ EMOJIVOTO=$("$bindir"/scurl https://run.linkerd.io/emojivoto.yml)
 # delete namespace
 EMOJIVOTO=$(echo "$EMOJIVOTO" | tail -n +6)
 emojins='namespace: emojivoto'
-EMOJIVOTO="${EMOJIVOTO//$emojins/}"
+EMOJIVOTO=${EMOJIVOTO//$emojins/}
 emojins=.emojivoto:
 newns=:
-EMOJIVOTO="${EMOJIVOTO//$emojins/$newns}"
+EMOJIVOTO=${EMOJIVOTO//$emojins/$newns}
 
 # inject
 EMOJIVOTO=$(echo "$EMOJIVOTO" | "$linkerd_path" -l "$linkerd_namespace" inject -)

--- a/bin/update-codegen.sh
+++ b/bin/update-codegen.sh
@@ -4,8 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-SCRIPT_ROOT="$(dirname "${SCRIPT_DIR}")"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+SCRIPT_ROOT=$(dirname "${SCRIPT_DIR}")
 GEN_VER=$( awk '/k8s.io\/code-generator/ { print $2 }' "${SCRIPT_ROOT}/go.mod" )
 KUBE_OPEN_API_VER=$( awk '/k8s.io\/kube-openapi/ { print $2 }' "${SCRIPT_ROOT}/go.mod" )
 CODEGEN_PKG=$(mktemp -d -t "code-generator-${GEN_VER}.XXX")/code-generator
@@ -38,10 +38,10 @@ kube::codegen::gen_helpers \
     --boilerplate "${SCRIPT_ROOT}/controller/gen/boilerplate.go.txt" \
     github.com/linkerd/linkerd2/controller/gen/apis
 
-if [[ -n "${API_KNOWN_VIOLATIONS_DIR:-}" ]]; then
-    report_filename="${API_KNOWN_VIOLATIONS_DIR}/codegen_violation_exceptions.list"
-    if [[ "${UPDATE_API_KNOWN_VIOLATIONS:-}" == "true" ]]; then
-        update_report="--update-report"
+if [ -n "${API_KNOWN_VIOLATIONS_DIR:-}" ]; then
+    report_filename=${API_KNOWN_VIOLATIONS_DIR}/codegen_violation_exceptions.list
+    if [ "${UPDATE_API_KNOWN_VIOLATIONS:-}" = 'true' ]; then
+        update_report='--update-report'
     fi
 fi
 

--- a/bin/web
+++ b/bin/web
@@ -27,7 +27,7 @@ USAGE
 check-for-linkerd-and-viz() {
   metrics_api_pod=$(get-pod linkerd-viz metrics-api)
 
-  if [[ -z "${metrics_api_pod// }" ]]; then
+  if [ -z "${metrics_api_pod// }" ]; then
     err 'Metrics-api is not running. Have you installed Linkerd-Viz?'
     exit 1
   fi
@@ -57,7 +57,7 @@ get-pod() {
   fi
 
 
-  selector="linkerd.io/control-plane-component=$2"
+  selector=linkerd.io/control-plane-component=$2
   if [ "$1" = 'linkerd-viz' ]; then
     selector="component=$2"
   fi
@@ -123,7 +123,8 @@ msg() { out "$*" >&2 ;}
 err() { local x=$? ; msg "$*" ; return $(( x == 0 ? 1 : x )) ;}
 out() { printf '%s\n' "$*" ;}
 
-if [[ ${1:-} ]] && declare -F | cut -d' ' -f3 | grep -Fqx -- "${1:-}"
-then "$@"
-else main "$@"
+if [ ${1:-} ] && declare -F | cut -d' ' -f3 | grep -Fqx -- "${1:-}"; then
+  "$@"
+else
+  main "$@"
 fi


### PR DESCRIPTION
- Use single quotes for static strings, not double
- Use sh and not bash for _os.sh that has no bash-specific content
- Remove superfluous double quotes on variable assignments
- Only use bash-specific [[ ]] if statements for bash-specific content
- Consistently use style with if; then on same line

Signed-off-by: Joakim Roubert <joakimr@axis.com>