### PR TITLE
chore: group k8s.io dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
       interval: daily
       time: "03:00"
       timezone: Etc/UTC
+    ignore:
+      # TODO(ver): Remove this once we update our Gateway API dependencies.
+      - dependency-name: sigs.k8s.io/gateway-api
+        update-types: [version-update:semver-major, version-update:semver-minor]
+    groups:
+      kube:
+        patterns:
+          - k8s.io/*
 
   - package-ecosystem: cargo
     directory: "/"


### PR DESCRIPTION
We get separate PRs for each k8s.io dependency update, which is needlessly noisy. This PR groups all k8s.io dependency updates into a single PR. It also disables sigs.k8s.io/gateway-api updates until we are ready to expclitly update it.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
