### PR TITLE
fix(helm): add validation for proxyInit.closeWaitTimeoutSecs

### DIFF
--- a/charts/linkerd-control-plane/README.md
+++ b/charts/linkerd-control-plane/README.md
@@ -287,7 +287,7 @@ Kubernetes: `>=1.22.0-0`
 | proxy.startupProbe.periodSeconds | int | `1` |  |
 | proxy.uid | int | `2102` | User id under which the proxy runs |
 | proxy.waitBeforeExitSeconds | int | `0` | If set the injected proxy sidecars in the data plane will stay alive for at least the given period before receiving the SIGTERM signal from Kubernetes but no longer than the pod's `terminationGracePeriodSeconds`. See [Lifecycle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) for more info on container lifecycle hooks. |
-| proxyInit.closeWaitTimeoutSecs | int | `0` |  |
+| proxyInit.closeWaitTimeoutSecs | int | `0` | Changes the default value for the nf_conntrack_tcp_timeout_close_wait kernel parameter. If used, runAsRoot needs to be true. |
 | proxyInit.ignoreInboundPorts | string | `"4567,4568"` | Default set of inbound ports to skip via iptables - Galera (4567,4568) |
 | proxyInit.ignoreOutboundPorts | string | `"4567,4568"` | Default set of outbound ports to skip via iptables - Galera (4567,4568) |
 | proxyInit.image.name | string | `"cr.l5d.io/linkerd/proxy-init"` | Docker image for the proxy-init container |

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -300,6 +300,8 @@ proxyInit:
     pullPolicy: ""
     # -- Tag for the proxy-init container image
     version: v2.4.1
+  # -- Changes the default value for the nf_conntrack_tcp_timeout_close_wait
+  # kernel parameter. If used, runAsRoot needs to be true.
   closeWaitTimeoutSecs: 0
   # -- Privileged mode allows the container processes to inherit all security
   # capabilities and bypass any security limitations enforced by the kubelet.

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -29,7 +29,7 @@ args:
 {{- end }}
 {{- if .Values.proxyInit.closeWaitTimeoutSecs }}
   {{- if not .Values.proxyInit.runAsRoot }}
-{{ fail "if proxyInit.closeWaitTimeoutSecs is modified, then proxyInit.runAsRoot must be true" }}
+{{ fail "proxyInit.runAsRoot must be set to use proxyInit.closeWaitTimeoutSecs" }}
   {{- end }}
 - --timeout-close-wait-secs
 - {{ .Values.proxyInit.closeWaitTimeoutSecs | quote}}

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -28,6 +28,9 @@ args:
 - {{.Values.proxyInit.ignoreOutboundPorts | quote}}
 {{- end }}
 {{- if .Values.proxyInit.closeWaitTimeoutSecs }}
+  {{- if not .Values.proxyInit.runAsRoot }}
+{{ fail "if proxyInit.closeWaitTimeoutSecs is modified, then proxyInit.runAsRoot must be true" }}
+  {{- end }}
 - --timeout-close-wait-secs
 - {{ .Values.proxyInit.closeWaitTimeoutSecs | quote}}
 {{- end }}


### PR DESCRIPTION
Fixes #13458

The `proxyInit.closeWaitTimeoutSecs` config triggers a call `sysctl -w net.netfilter.nf_conntrack_tcp_timeout_close_wait=x` by linkerd-init, which requires root access. So we add a validation such that when that config is used, `proxyInit.runAsRoot` should be true.