### PR TITLE
deps: bump proxy-init from v2.4.1 to v2.4.2

### DIFF
--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -299,7 +299,7 @@ proxyInit:
     # @default -- imagePullPolicy
     pullPolicy: ""
     # -- Tag for the proxy-init container image
-    version: v2.4.1
+    version: v2.4.2
   # -- Changes the default value for the nf_conntrack_tcp_timeout_close_wait
   # kernel parameter. If used, runAsRoot needs to be true.
   closeWaitTimeoutSecs: 0

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -198,7 +198,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -198,7 +198,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -432,7 +432,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -198,7 +198,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -238,7 +238,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -209,7 +209,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -454,7 +454,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -699,7 +699,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -944,7 +944,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -209,7 +209,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -212,7 +212,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -201,7 +201,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -223,7 +223,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -226,7 +226,7 @@ spec:
         - 4190,9998,7777,8888
         - --outbound-ports-to-ignore
         - "9999"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -209,7 +209,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -454,7 +454,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -222,7 +222,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -209,7 +209,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -210,7 +210,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
@@ -49,7 +49,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -210,7 +210,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -210,7 +210,7 @@ spec:
         - 4190,1234,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
@@ -209,7 +209,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -211,7 +211,7 @@ spec:
         - 4190,4191,22,8100-8102
         - --outbound-ports-to-ignore
         - "5432"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -211,7 +211,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -211,7 +211,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:
@@ -450,7 +450,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -211,7 +211,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:
@@ -450,7 +450,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -193,7 +193,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -196,7 +196,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -195,7 +195,7 @@ spec:
     - 4190,4191,22,8100-8102
     - --outbound-ports-to-ignore
     - "5432"
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -204,7 +204,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -210,7 +210,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -211,7 +211,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -458,7 +458,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -272,7 +272,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1156,7 +1156,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1675,7 +1675,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2085,7 +2085,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1155,7 +1155,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1673,7 +1673,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2083,7 +2083,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: my.custom.registry/linkerd-io/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1155,7 +1155,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.4.1
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1673,7 +1673,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.4.1
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2083,7 +2083,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.4.1
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1155,7 +1155,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1673,7 +1673,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2083,7 +2083,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1155,7 +1155,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1673,7 +1673,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2083,7 +2083,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1153,7 +1153,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1662,7 +1662,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2063,7 +2063,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1159,7 +1159,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1683,7 +1683,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2098,7 +2098,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -780,7 +780,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1237,7 +1237,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1806,7 +1806,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2257,7 +2257,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -780,7 +780,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1237,7 +1237,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1806,7 +1806,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2257,7 +2257,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -684,7 +684,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1086,7 +1086,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1604,7 +1604,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1930,7 +1930,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1155,7 +1155,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1673,7 +1673,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2083,7 +2083,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -753,7 +753,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.1
+        version: v2.4.2
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1155,7 +1155,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1673,7 +1673,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2083,7 +2083,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.1
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/controller/proxy-injector/fake/data/pod-log-level.json
+++ b/controller/proxy-injector/fake/data/pod-log-level.json
@@ -59,7 +59,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.1",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -59,7 +59,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.1",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -69,7 +69,7 @@
         "--outbound-ports-to-ignore",
         "34567"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.1",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -59,7 +59,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.1",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,7 +15,7 @@ var Version = undefinedVersion
 // ProxyInitVersion is the pinned version of the proxy-init, from
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
-var ProxyInitVersion = "v2.4.1"
+var ProxyInitVersion = "v2.4.2"
 var LinkerdCNIVersion = "v1.6.0"
 
 const (


### PR DESCRIPTION
https://github.com/linkerd/linkerd2-proxy-init/releases/tag/proxy-init%2Fv2.4.2

This only includes dependencies updates, notably the bump for the Alpine base image.