### PR TITLE
feat!(tracing): Change default trace protocol to OpenTelemetry

### DIFF
--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -294,8 +294,8 @@ webhook:
   # Points by default to the linkerd-jaeger collector
   collectorSvcAddr: collector.linkerd-jaeger:55678
   # -- protocol proxies should use to send trace data.
-  # Can be `opencensus` (default) or `opentelemetry`
-  collectorTraceProtocol: opencensus
+  # Can be `opencensus` or `opentelemetry` (default)
+  collectorTraceProtocol: opentelemetry
   # -- name of the service proxies should use for exported traces
   collectorTraceSvcName: linkerd-proxy
   # -- service account associated with the collector instance

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -47,7 +47,7 @@ spec:
       containers:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
-        - -collector-trace-protocol=opencensus
+        - -collector-trace-protocol=opentelemetry
         - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector
         - -log-level=info

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -47,7 +47,7 @@ spec:
       containers:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
-        - -collector-trace-protocol=opencensus
+        - -collector-trace-protocol=opentelemetry
         - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector
         - -log-level=info

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -47,7 +47,7 @@ spec:
       containers:
       - args:
         - -collector-svc-addr=collector.linkerd-jaeger:55678
-        - -collector-trace-protocol=opencensus
+        - -collector-trace-protocol=opentelemetry
         - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector
         - -log-level=info


### PR DESCRIPTION
Now that OpenTelemetry support has been available for a few releases, this changes the default protocol so we can begin the migration away from OpenCensus.
