### PR TITLE
Set minimum TLS version to 1.3

### DIFF
--- a/controller/webhook/server.go
+++ b/controller/webhook/server.go
@@ -65,7 +65,7 @@ func NewServer(
 		Addr:              addr,
 		ReadHeaderTimeout: 15 * time.Second,
 		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
+			MinVersion: tls.VersionTLS13,
 		},
 	}
 

--- a/controller/webhook/server_test.go
+++ b/controller/webhook/server_test.go
@@ -18,7 +18,7 @@ var mockHTTPServer = &http.Server{
 	Addr:              ":0",
 	ReadHeaderTimeout: 15 * time.Second,
 	TLSConfig: &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: tls.VersionTLS13,
 	},
 }
 

--- a/viz/tap/api/server.go
+++ b/viz/tap/api/server.go
@@ -74,7 +74,7 @@ func NewServer(
 		TLSConfig: &tls.Config{
 			ClientAuth: tls.VerifyClientCertIfGiven,
 			ClientCAs:  clientCertPool,
-			MinVersion: tls.VersionTLS12,
+			MinVersion: tls.VersionTLS13,
 		},
 	}
 


### PR DESCRIPTION
This helps ensure a minimum level of security. The two places this affects is our controller webhook and linkerd-viz tap API.

The controller webhook requires that kube-api supports TLSv1.3, which it does as of 1.19 (our minimum is currently 1.22). The linkerd-viz tap API is mostly used internally, and is also deprecated. It may be worth revisiting if we want to keep it around at all.