### PR TITLE
Add pod UID and container name to proxy env

### DIFF
--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -15,10 +15,16 @@ env:
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
+- name: _pod_uid
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.uid
 - name: _pod_nodeName
   valueFrom:
     fieldRef:
       fieldPath: spec.nodeName
+- name: _pod_containerName
+  value: &containerName linkerd-proxy
 {{- if .Values.proxy.cores }}
 - name: LINKERD2_PROXY_CORES
   value: {{.Values.proxy.cores | quote}}
@@ -197,7 +203,7 @@ livenessProbe:
     port: {{.Values.proxy.ports.admin}}
   initialDelaySeconds: {{.Values.proxy.livenessProbe.initialDelaySeconds }}
   timeoutSeconds: {{.Values.proxy.livenessProbe.timeoutSeconds }}
-name: linkerd-proxy
+name: *containerName
 ports:
 - containerPort: {{.Values.proxy.ports.inbound}}
   name: linkerd-proxy

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -28,10 +28,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -28,10 +28,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -262,10 +268,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -28,10 +28,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -36,10 +36,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -275,10 +281,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -520,10 +532,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -765,10 +783,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -31,10 +31,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -31,10 +31,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -38,10 +38,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_CORES
           value: "1"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -275,10 +281,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -31,10 +31,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
@@ -78,10 +78,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_no_init_container.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -31,10 +31,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -31,10 +31,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -32,10 +32,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -30,10 +30,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -32,10 +32,16 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: _pod_uid
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: _pod_nodeName
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: _pod_containerName
+            value: linkerd-proxy
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG
@@ -276,10 +282,16 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: _pod_uid
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: _pod_nodeName
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: _pod_containerName
+            value: linkerd-proxy
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -32,10 +32,16 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: _pod_uid
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: _pod_nodeName
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: _pod_containerName
+            value: linkerd-proxy
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG
@@ -276,10 +282,16 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: _pod_uid
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: _pod_nodeName
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: _pod_containerName
+            value: linkerd-proxy
           - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
             value: "false"
           - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -22,10 +22,16 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: _pod_uid
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     - name: _pod_nodeName
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: _pod_containerName
+      value: linkerd-proxy
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -23,10 +23,16 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: _pod_uid
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     - name: _pod_nodeName
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: _pod_containerName
+      value: linkerd-proxy
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_pod_nativesidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_nativesidecar.golden.yml
@@ -67,10 +67,16 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: _pod_uid
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     - name: _pod_nodeName
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: _pod_containerName
+      value: linkerd-proxy
     - name: LINKERD2_PROXY_LOG
       value: warn,linkerd=info,trust_dns=error
     - name: LINKERD2_PROXY_LOG_FORMAT

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -24,10 +24,16 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: _pod_uid
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     - name: _pod_nodeName
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: _pod_containerName
+      value: linkerd-proxy
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -26,10 +26,16 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: _pod_uid
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
     - name: _pod_nodeName
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: _pod_containerName
+      value: linkerd-proxy
     - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
       value: "false"
     - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -31,10 +31,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -26,10 +26,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -273,10 +279,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -47,10 +47,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1001,10 +1001,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1372,10 +1378,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1880,10 +1892,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1371,10 +1377,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1878,10 +1890,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1371,10 +1377,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1878,10 +1890,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1371,10 +1377,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1878,10 +1890,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1371,10 +1377,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1878,10 +1890,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1362,10 +1368,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1860,10 +1872,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -1001,10 +1001,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1375,10 +1381,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1889,10 +1901,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1077,10 +1077,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1493,10 +1499,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -2041,10 +2053,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1077,10 +1077,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1493,10 +1499,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -2041,10 +2053,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -931,10 +931,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1302,10 +1308,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1725,10 +1737,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -973,10 +973,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1346,10 +1352,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1857,10 +1869,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -1050,10 +1050,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1468,10 +1474,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -2020,10 +2032,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -1051,10 +1051,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1472,10 +1478,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -2031,10 +2043,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1058,10 +1058,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1480,10 +1486,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -2040,10 +2052,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1040,10 +1040,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1458,10 +1464,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -2010,10 +2022,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1364,10 +1370,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1864,10 +1876,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -953,10 +953,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1321,10 +1327,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1834,10 +1846,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1371,10 +1377,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1878,10 +1890,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1000,10 +1000,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS
           value: "8080"
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
@@ -1371,10 +1377,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG
@@ -1878,10 +1890,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: _pod_uid
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: _pod_nodeName
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: _pod_containerName
+          value: linkerd-proxy
         - name: LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED
           value: "false"
         - name: LINKERD2_PROXY_LOG

--- a/controller/proxy-injector/fake/data/pod-log-level.json
+++ b/controller/proxy-injector/fake/data/pod-log-level.json
@@ -139,12 +139,24 @@
           }
         },
         {
+          "name": "_pod_uid",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.uid"
+            }
+          }
+        },
+        {
           "name": "_pod_nodeName",
           "valueFrom": {
             "fieldRef": {
               "fieldPath": "spec.nodeName"
             }
           }
+        },
+        {
+          "name": "_pod_containerName",
+          "value": "linkerd-proxy"
         },
         {
           "name": "LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED",

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -163,12 +163,24 @@
           }
         },
         {
+          "name": "_pod_uid",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.uid"
+            }
+          }
+        },
+        {
           "name": "_pod_nodeName",
           "valueFrom": {
             "fieldRef": {
               "fieldPath": "spec.nodeName"
             }
           }
+        },
+        {
+          "name": "_pod_containerName",
+          "value": "linkerd-proxy"
         },
         {
           "name": "LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED",

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -149,12 +149,24 @@
           }
         },
         {
+          "name": "_pod_uid",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.uid"
+            }
+          }
+        },
+        {
           "name": "_pod_nodeName",
           "valueFrom": {
             "fieldRef": {
               "fieldPath": "spec.nodeName"
             }
           }
+        },
+        {
+          "name": "_pod_containerName",
+          "value": "linkerd-proxy"
         },
         {
           "name": "LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED",

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -139,12 +139,24 @@
           }
         },
         {
+          "name": "_pod_uid",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.uid"
+            }
+          }
+        },
+        {
           "name": "_pod_nodeName",
           "valueFrom": {
             "fieldRef": {
               "fieldPath": "spec.nodeName"
             }
           }
+        },
+        {
+          "name": "_pod_containerName",
+          "value": "linkerd-proxy"
         },
         {
           "name": "LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED",


### PR DESCRIPTION
These values are useful as fields for correlating OpenTelemetry traces. A corresponding proxy change will be needed to emit these fields in said traces.