### PR TITLE
chore(policy): use rustls-tls instead of openssl-tls

### DIFF
--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -6,11 +6,10 @@ license = "Apache-2.0"
 publish = false
 
 [features]
-default = ["openssl-tls", "openssl-vendored"]
+default = ["linkerd-policy-controller-runtime/rustls-tls"]
 openssl-tls = ["linkerd-policy-controller-runtime/openssl-tls"]
 # Vendor openssl to statically link lib
 openssl-vendored = ["linkerd-policy-controller-runtime/openssl-vendored"]
-rustls-tls = ["linkerd-policy-controller-runtime/rustls-tls"]
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
This switches the policy-controller build back to using rustls-tls instead of openssl-tls.

We have been using rustls-tls in kubert anyways since at least #11255 (included since edge-23.8.3 and stable-2.14.0) and that didn't seem to have caused any issues.