### PR TITLE
Add newlines to port-forward error output

### DIFF
--- a/cli/cmd/identity.go
+++ b/cli/cmd/identity.go
@@ -183,7 +183,7 @@ func getContainerCertificate(k8sAPI *k8s.KubernetesAPI, pod corev1.Pod, containe
 
 	defer portForward.Stop()
 	if err = portForward.Init(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+		fmt.Fprintf(os.Stderr, "Error running port-forward: %s\n", err)
 		return nil, err
 	}
 

--- a/pkg/k8s/metrics.go
+++ b/pkg/k8s/metrics.go
@@ -27,7 +27,7 @@ func GetContainerMetrics(
 
 	defer portForward.Stop()
 	if err = portForward.Init(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error running port-forward: %s", err)
+		fmt.Fprintf(os.Stderr, "Error running port-forward: %s\n", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Some of the port-forward errors print to stderr without a newline. This can cause callers to inadvertently concatenate their own outputs to the lower-level error message.

Add a `\n` to port-forward error outputs.
