### PR TITLE
Add extra trace attributes from downward API

### DIFF
--- a/jaeger/injector/mutator/patch.go
+++ b/jaeger/injector/mutator/patch.go
@@ -48,6 +48,14 @@ const tpl = `[
   },
   {
     "op": "add",
+    "path": "/spec/{{.ProxyPath}}/env/-",
+    "value": {
+      "name": "LINKERD2_PROXY_TRACE_EXTRA_ATTRIBUTES",
+      "value": "k8s.pod.uid=$(_pod_uid)\nk8s.container.name=$(_pod_containerName)"
+    }
+  },
+  {
+    "op": "add",
     "path": "/spec/{{.ProxyPath}}/volumeMounts/-",
     "value": {
       "mountPath": "var/run/linkerd/podinfo",


### PR DESCRIPTION
This allows us to specify extra trace attribute key-value pairs from the downward API without needing to pull from the pods annotations or labels. This lets us keep the proxy decoupled from k8s concepts.
