### PR TITLE
fix(policy): Update outbound policy routes even when parent ref has no port

### DIFF
--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -1103,6 +1103,35 @@ impl Namespace {
                 watch.send_if_modified();
             }
         }
+
+        let http_backends = self
+            .service_http_routes
+            .values_mut()
+            .flat_map(|routes| routes.values_mut())
+            .flat_map(|route| route.rules.iter_mut())
+            .flat_map(|rule| rule.backends.iter_mut());
+        let grpc_backends = self
+            .service_grpc_routes
+            .values_mut()
+            .flat_map(|routes| routes.values_mut())
+            .flat_map(|route| route.rules.iter_mut())
+            .flat_map(|rule| rule.backends.iter_mut());
+        let tls_backends = self
+            .service_tls_routes
+            .values_mut()
+            .flat_map(|routes| routes.values_mut())
+            .flat_map(|route| route.rule.backends.iter_mut());
+        let tcp_backends = self
+            .service_tcp_routes
+            .values_mut()
+            .flat_map(|routes| routes.values_mut())
+            .flat_map(|route| route.rule.backends.iter_mut());
+
+        http_backends
+            .chain(grpc_backends)
+            .chain(tls_backends)
+            .chain(tcp_backends)
+            .for_each(update_backend);
     }
 
     fn reinitialize_egress_watches(&mut self) {

--- a/policy-controller/k8s/index/src/outbound/tests.rs
+++ b/policy-controller/k8s/index/src/outbound/tests.rs
@@ -341,8 +341,8 @@ fn update_backend_on_route_with_no_port() {
     let (gknn, outbound_route) = policy.http_routes.iter().next().unwrap();
     assert_eq!(gknn.name, "foo-route");
     assert_eq!(gknn.namespace, ns);
-    let rule = outbound_route.rules.get(0).unwrap();
-    let backend = rule.backends.get(0).unwrap();
+    let rule = outbound_route.rules.first().unwrap();
+    let backend = rule.backends.first().unwrap();
     if let outbound::Backend::Service(outbound::WeightedService {
         weight: _,
         authority: _,

--- a/policy-controller/k8s/index/src/outbound/tests.rs
+++ b/policy-controller/k8s/index/src/outbound/tests.rs
@@ -7,10 +7,13 @@ use crate::{
 };
 use k8s_openapi::chrono::Utc;
 use kubert::index::IndexNamespacedResource;
-use linkerd_policy_controller_core::outbound::{Kind, ResourceTarget};
-use linkerd_policy_controller_core::IpNet;
+use linkerd_policy_controller_core::{outbound, IpNet};
+use linkerd_policy_controller_core::{
+    outbound::{Kind, ResourceTarget},
+    POLICY_CONTROLLER_NAME,
+};
 use linkerd_policy_controller_k8s_api::{
-    self as k8s,
+    self as k8s, gateway,
     policy::{self, EgressNetwork},
 };
 use tokio::time;
@@ -214,4 +217,147 @@ fn fallback_rx_closed_when_egress_net_deleted() {
     );
 
     assert!(fallback_rx.has_changed().is_err());
+}
+
+#[test]
+fn update_backend_on_route_with_no_port() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .try_init()
+        .ok();
+
+    let test = TestConfig::default();
+    let ns = "ns";
+
+    let parent = k8s::Service {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some("parent-svc".to_string()),
+            ..Default::default()
+        },
+        spec: Some(k8s::ServiceSpec {
+            cluster_ip: Some("1.1.1.1".to_string()),
+            cluster_ips: Some(vec!["1.1.1.1".to_string()]),
+            type_: Some("ClusterIP".to_string()),
+            ..Default::default()
+        }),
+        status: None,
+    };
+
+    test.index.write().apply(parent);
+
+    let parent_ref = gateway::ParentReference {
+        name: "parent-svc".to_string(),
+        namespace: Some(ns.to_string()),
+        kind: Some("Service".to_string()),
+        group: Some("core".to_string()),
+        section_name: None,
+        port: None, // Route is attached to parent without specifying port.
+    };
+
+    let route = gateway::HttpRoute {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some("foo-route".to_string()),
+            ..Default::default()
+        },
+        spec: gateway::HttpRouteSpec {
+            inner: gateway::CommonRouteSpec {
+                parent_refs: Some(vec![parent_ref.clone()]),
+            },
+            hostnames: None,
+            rules: Some(vec![gateway::HttpRouteRule {
+                matches: None,
+                filters: None,
+                // Reference to a backend that doesn't exist yet.
+                backend_refs: Some(vec![gateway::HttpBackendRef {
+                    backend_ref: Some(gateway::BackendRef {
+                        weight: Some(1),
+                        inner: gateway::BackendObjectReference {
+                            group: Some("core".to_string()),
+                            kind: Some("Service".to_string()),
+                            name: "backend-svc".to_string(),
+                            namespace: Some(ns.to_string()),
+                            port: Some(8080),
+                        },
+                    }),
+                    filters: None,
+                }]),
+            }]),
+        },
+        status: Some(gateway::HttpRouteStatus {
+            inner: gateway::RouteStatus {
+                parents: vec![gateway::RouteParentStatus {
+                    parent_ref,
+                    controller_name: POLICY_CONTROLLER_NAME.to_string(),
+                    conditions: vec![k8s::Condition {
+                        last_transition_time: k8s::Time(Utc::now()),
+                        message: "".to_string(),
+                        observed_generation: None,
+                        reason: "Accepted".to_string(),
+                        status: "True".to_string(),
+                        type_: "Accepted".to_string(),
+                    }],
+                }],
+            },
+        }),
+    };
+
+    test.index.write().apply(route);
+
+    // Create the backend.
+    let backend = k8s::Service {
+        metadata: k8s::ObjectMeta {
+            namespace: Some(ns.to_string()),
+            name: Some("backend-svc".to_string()),
+            ..Default::default()
+        },
+        spec: Some(k8s::ServiceSpec {
+            cluster_ip: Some("1.1.1.2".to_string()),
+            cluster_ips: Some(vec!["1.1.1.2".to_string()]),
+            type_: Some("ClusterIP".to_string()),
+            ..Default::default()
+        }),
+        status: None,
+    };
+    test.index.write().apply(backend);
+
+    let mut rx = test
+        .index
+        .write()
+        .outbound_policy_rx(ResourceTarget {
+            name: "parent-svc".to_string(),
+            namespace: ns.to_string(),
+            port: 8080.try_into().unwrap(),
+            source_namespace: ns.to_string(),
+            kind: Kind::Service,
+        })
+        .expect("parent-svc should exist");
+
+    // Backend should be valid.
+    let policy = rx.borrow_and_update();
+    assert_eq!(policy.parent_namespace(), "ns");
+    assert_eq!(policy.parent_name(), "parent-svc");
+    let (gknn, outbound_route) = policy.http_routes.iter().next().unwrap();
+    assert_eq!(gknn.name, "foo-route");
+    assert_eq!(gknn.namespace, ns);
+    let rule = outbound_route.rules.get(0).unwrap();
+    let backend = rule.backends.get(0).unwrap();
+    if let outbound::Backend::Service(outbound::WeightedService {
+        weight: _,
+        authority: _,
+        name,
+        namespace,
+        port: _,
+        filters: _,
+        exists,
+    }) = backend
+    {
+        assert_eq!(name, "backend-svc");
+        assert_eq!(namespace, ns);
+        assert!(exists);
+    } else {
+        panic!("expected outbound::Backend::Service");
+    }
+    drop(policy);
 }


### PR DESCRIPTION
The `parent_ref` of an xRoute resource can optionally specify a port.  If no port is specified, the route applies to all ports.  These routes with `parent_ref` which do not specify a port are stored differently than routes which do, since these routes need to be applied for to all watches on any port on the parent.  When services are updated/created, we perform a reindex to ensure that all routes have the correct information about their backends.  However, routes which are stored in the separate way were not being updated in this case.  This means that routes with a `parent_ref` with no port can, depending on the sequence of operations, have stale information about their backend services.

We update these routes during the reindex operation to ensure they have up to date information about their backends and add a test for this behavior.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
