### PR TITLE
fix(multicluster)!: Link's probeSpec.period should be formatted as duration

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/link-crd.yaml
@@ -158,6 +158,7 @@ spec:
                     type: string
                   period:
                     description: Interval in between probe requests
+                    format: duration
                     type: string
                   port:
                     description: Port of remote gateway health endpoint

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -396,6 +396,7 @@ spec:
                     type: string
                   period:
                     description: Interval in between probe requests
+                    format: duration
                     type: string
                   port:
                     description: Port of remote gateway health endpoint

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -468,6 +468,7 @@ spec:
                     type: string
                   period:
                     description: Interval in between probe requests
+                    format: duration
                     type: string
                   port:
                     description: Port of remote gateway health endpoint

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -430,6 +430,7 @@ spec:
                     type: string
                   period:
                     description: Interval in between probe requests
+                    format: duration
                     type: string
                   port:
                     description: Port of remote gateway health endpoint

--- a/multicluster/service-mirror/probe_worker.go
+++ b/multicluster/service-mirror/probe_worker.go
@@ -70,12 +70,11 @@ func (pw *ProbeWorker) run() {
 		pw.log.Error("Probe spec is nil")
 		return
 	}
-	probeTickerPeriodSeconds, err := strconv.ParseInt(pw.probeSpec.Period, 10, 64)
+	probeTickerPeriod, err := time.ParseDuration(pw.probeSpec.Period)
 	if err != nil {
 		pw.log.Errorf("could not parse probe period: %s", err)
 		return
 	}
-	probeTickerPeriod := time.Duration(probeTickerPeriodSeconds) * time.Second
 	maxJitter := probeTickerPeriod / 10 // max jitter is 10% of period
 	probeTicker := NewTicker(probeTickerPeriod, maxJitter)
 	defer probeTicker.Stop()


### PR DESCRIPTION
Before the refactoring from #13420, `link mc link` would generate a Link resource with `probeSpec.period` formatted as duration. After that change, it was generated as an integer and the service mirror was refactored as well to consume that integer and convert it into a duration. If a Link with the old semantics is consumed by a service mirror controller containing that change (or vice-versa) it will error out with "could not parse probe period". This could happen for example when re-linking as part of a multicluster upgrade, when pending the rollout the old controller would consume the upgraded Link. Or for folks upgrading just by bumping the controller image tag and not re-linking (unwise as that may be).

This fix consists on:
- Updating the Link CRD, constraining `period` to be formatted as duration
- Having the `linkerd mc link` command produce a duration value for that period, being lenient to the gateway service annotation `mirror.linkerd.io/probe-period` either using an integer (which it does by default) or a duration
- Having the probe worker consume that value as a duration

BREAKING CHANGE: this realigns behavior with edge-24.11.8, but Links generated with edge-25.1.1 would be rejected.