### PR TITLE
workflows/codeql - Reorder steps to cache dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,11 @@ jobs:
           - javascript
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
         with:
           go-version: "1.23"
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Initialize
         # Unpinned action version so that we automatically get analyzer updates.


### PR DESCRIPTION
Reordering the steps here to address a warning on runs e.g. https://github.com/linkerd/linkerd2/actions/runs/12931205390/job/36064522152#step:2:16

> Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/linkerd2/linkerd2. Supported file pattern: go.sum

as the code is not yet checked out, reference https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows
