### PR TITLE
fix(cli): Don't require gateway CRDs in linkerd install

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -138,7 +138,14 @@ A full list of configurable values can be found at https://artifacthub.io/packag
 
 				if !crds {
 					crds := bytes.Buffer{}
-					err := renderCRDs(&crds, options, "yaml")
+					err = renderCRDs(&crds, valuespkg.Options{
+						// GatewayAPI CRDs are optional so don't check for them.
+						Values: []string{
+							"enableHttpRoutes=false",
+							"enableTcpRoutes=false",
+							"enableTlsRoutes=false",
+						},
+					}, "yaml")
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "%q", err)
 						os.Exit(1)


### PR DESCRIPTION
In https://github.com/linkerd/linkerd2/pull/12917 we made the Gateway API CRDs optional in Linkerd and updated the `linkerd check` command to no longer error if these CRDs were not present.  However, we missing making the corresponding change in `linkerd install`.  As a result, `linkerd install` returns an error if the Gateway API CRDs are not installed on the cluster.

We add the corresponding change to `linkerd install` so that it no longer returns an error if the Gateway API CRDs are not installed.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
