### PR TITLE
test(deps): bump k8s to v1.32

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ env:
   CARGO_NET_RETRY: 10
   DOCKER_REGISTRY: ghcr.io/linkerd
   GH_ANNOTATION: true
-  K3D_VERSION: v5.7.5
+  K3D_VERSION: v5.8.1
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
   YQ_VERSION: v4.44.5
@@ -164,7 +164,7 @@ jobs:
       matrix:
         k8s:
           - v1.22
-          - v1.31
+          - v1.32
     steps:
       - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6
         env:
@@ -316,7 +316,7 @@ jobs:
       matrix:
         k8s:
           - v1.22
-          - v1.31
+          - v1.32
     steps:
       - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6
         env:

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -5,7 +5,7 @@
 set +e
 
 k8s_version_min='+v1.22'
-k8s_version_max='docker.io/rancher/k3s:v1.29.6-k3s2'
+k8s_version_max='docker.io/rancher/k3s:v1.31.5-k3s1'
 
 bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 testdir=$bindir/../test/integration

--- a/bin/k3d
+++ b/bin/k3d
@@ -2,7 +2,7 @@
 
 set -eu
 
-K3D_VERSION=v5.7.5
+K3D_VERSION=v5.8.1
 
 bindir=$( cd "${0%/*}" && pwd )
 


### PR DESCRIPTION
- Bump k3d to v5.8.1
- Bump max k8s version tested to v1.32 in test-policy and test-multicluster suites (driven by justfile)
- Bump max k8s version tested to v1.32 in all the other tests (driven by bin/tests)