### PR TITLE
feat: add basic outbound protocol detection

### DIFF
--- a/policy-controller/core/src/outbound/policy.rs
+++ b/policy-controller/core/src/outbound/policy.rs
@@ -1,6 +1,6 @@
 use super::{
-    FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute, RouteRetry,
-    RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+    AppProtocol, FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute,
+    RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
 };
 
 use std::num::NonZeroU16;
@@ -30,6 +30,7 @@ pub struct OutboundPolicy {
     pub tcp_routes: RouteSet<TcpRoute>,
     pub port: NonZeroU16,
     pub opaque: bool,
+    pub app_protocol: Option<AppProtocol>,
     pub accrual: Option<FailureAccrual>,
     pub http_retry: Option<RouteRetry<HttpRetryCondition>>,
     pub grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,

--- a/policy-controller/grpc/src/outbound/http.rs
+++ b/policy-controller/grpc/src/outbound/http.rs
@@ -85,6 +85,110 @@ pub(crate) fn protocol(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub(crate) fn http1_only_protocol(
+    default_backend: outbound::Backend,
+    routes: impl Iterator<Item = (GroupKindNamespaceName, HttpRoute)>,
+    accrual: Option<outbound::FailureAccrual>,
+    service_retry: Option<RouteRetry<HttpRetryCondition>>,
+    service_timeouts: RouteTimeouts,
+    allow_l5d_request_headers: bool,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
+) -> outbound::proxy_protocol::Kind {
+    let mut routes = routes
+        .map(|(gknn, route)| {
+            convert_outbound_route(
+                gknn,
+                route,
+                default_backend.clone(),
+                service_retry.clone(),
+                service_timeouts.clone(),
+                allow_l5d_request_headers,
+                parent_info,
+                original_dst,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    match parent_info {
+        ParentInfo::Service { .. } => {
+            if routes.is_empty() {
+                routes.push(default_outbound_service_route(
+                    default_backend,
+                    service_retry.clone(),
+                    service_timeouts.clone(),
+                ));
+            }
+        }
+        ParentInfo::EgressNetwork { traffic_policy, .. } => {
+            routes.push(default_outbound_egress_route(
+                default_backend,
+                service_retry.clone(),
+                service_timeouts.clone(),
+                traffic_policy,
+            ));
+        }
+    }
+
+    outbound::proxy_protocol::Kind::Http1(outbound::proxy_protocol::Http1 {
+        routes: routes.clone(),
+        failure_accrual: accrual.clone(),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn http2_only_protocol(
+    default_backend: outbound::Backend,
+    routes: impl Iterator<Item = (GroupKindNamespaceName, HttpRoute)>,
+    accrual: Option<outbound::FailureAccrual>,
+    service_retry: Option<RouteRetry<HttpRetryCondition>>,
+    service_timeouts: RouteTimeouts,
+    allow_l5d_request_headers: bool,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
+) -> outbound::proxy_protocol::Kind {
+    let mut routes = routes
+        .map(|(gknn, route)| {
+            convert_outbound_route(
+                gknn,
+                route,
+                default_backend.clone(),
+                service_retry.clone(),
+                service_timeouts.clone(),
+                allow_l5d_request_headers,
+                parent_info,
+                original_dst,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    match parent_info {
+        ParentInfo::Service { .. } => {
+            if routes.is_empty() {
+                routes.push(default_outbound_service_route(
+                    default_backend,
+                    service_retry.clone(),
+                    service_timeouts.clone(),
+                ));
+            }
+        }
+        ParentInfo::EgressNetwork { traffic_policy, .. } => {
+            routes.push(default_outbound_egress_route(
+                default_backend,
+                service_retry.clone(),
+                service_timeouts.clone(),
+                traffic_policy,
+            ));
+        }
+    }
+
+    outbound::proxy_protocol::Kind::Http2(outbound::proxy_protocol::Http2 {
+        routes: routes.clone(),
+        failure_accrual: accrual.clone(),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
 fn convert_outbound_route(
     gknn: GroupKindNamespaceName,
     HttpRoute {

--- a/policy-controller/k8s/index/src/outbound/index/http.rs
+++ b/policy-controller/k8s/index/src/outbound/index/http.rs
@@ -196,7 +196,7 @@ pub(super) fn convert_backend<BackendRef: Into<gateway::HttpBackendRef>>(
     cluster: &ClusterInfo,
     resources: &HashMap<ResourceRef, ResourceInfo>,
 ) -> Option<Backend> {
-    let backend = backend.into();
+    let backend: gateway::HttpBackendRef = backend.into();
     let filters = backend.filters;
     let backend = backend.backend_ref?;
 

--- a/policy-test/src/outbound_api.rs
+++ b/policy-test/src/outbound_api.rs
@@ -59,6 +59,46 @@ where
 }
 
 #[track_caller]
+pub fn http1_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::HttpRoute] {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+    if let grpc::outbound::proxy_protocol::Kind::Http1(grpc::outbound::proxy_protocol::Http1 {
+        routes,
+        failure_accrual: _,
+    }) = kind
+    {
+        routes
+    } else {
+        panic!("proxy protocol must be Http1; actually got:\n{kind:#?}")
+    }
+}
+
+#[track_caller]
+pub fn http2_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::HttpRoute] {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+    if let grpc::outbound::proxy_protocol::Kind::Http2(grpc::outbound::proxy_protocol::Http2 {
+        routes,
+        failure_accrual: _,
+    }) = kind
+    {
+        routes
+    } else {
+        panic!("proxy protocol must be Http2; actually got:\n{kind:#?}")
+    }
+}
+
+#[track_caller]
 pub fn grpc_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::GrpcRoute] {
     let kind = config
         .protocol

--- a/policy-test/src/test_route.rs
+++ b/policy-test/src/test_route.rs
@@ -61,7 +61,10 @@ pub trait TestParent:
     + Send
     + Sync
 {
-    fn make_parent(ns: impl ToString) -> Self;
+    fn make_parent(ns: impl ToString) -> Self {
+        Self::make_parent_with_protocol(ns, None)
+    }
+    fn make_parent_with_protocol(ns: impl ToString, protocol: Option<String>) -> Self;
     fn make_backend(ns: impl ToString) -> Option<Self>;
     fn conditions(&self) -> Vec<&Condition>;
     fn obj_ref(&self) -> ParentReference;
@@ -721,7 +724,7 @@ impl TestRoute for gateway::TcpRoute {
 }
 
 impl TestParent for k8s::Service {
-    fn make_parent(ns: impl ToString) -> Self {
+    fn make_parent_with_protocol(ns: impl ToString, protocol: Option<String>) -> Self {
         k8s::Service {
             metadata: k8s::ObjectMeta {
                 namespace: Some(ns.to_string()),
@@ -731,6 +734,8 @@ impl TestParent for k8s::Service {
             spec: Some(k8s::ServiceSpec {
                 ports: Some(vec![k8s::ServicePort {
                     port: 4191,
+                    app_protocol: protocol,
+
                     ..Default::default()
                 }]),
                 ..Default::default()
@@ -786,7 +791,12 @@ impl TestParent for k8s::Service {
 }
 
 impl TestParent for policy::EgressNetwork {
-    fn make_parent(ns: impl ToString) -> Self {
+    fn make_parent_with_protocol(ns: impl ToString, protocol: Option<String>) -> Self {
+        assert!(
+            protocol.is_none(),
+            "appProtocol not supported for EgressNetwork"
+        );
+
         policy::EgressNetwork {
             metadata: k8s::ObjectMeta {
                 namespace: Some(ns.to_string()),

--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -1,0 +1,84 @@
+use futures::StreamExt;
+use k8s_gateway_api::{self as gateway};
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_test::{
+    assert_resource_meta, create,
+    outbound_api::{
+        assert_route_is_default, assert_singleton, http1_routes, http2_routes,
+        retry_watch_outbound_policy,
+    },
+    test_route::TestParent,
+    with_temp_ns,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn http1_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("http".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http1_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::HttpRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http2_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http2_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::HttpRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}

--- a/test/integration/deep/appprotocol/appprotocol_test.go
+++ b/test/integration/deep/appprotocol/appprotocol_test.go
@@ -1,0 +1,314 @@
+package appprotocol
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/linkerd/linkerd2/testutil"
+	v1 "k8s.io/api/core/v1"
+)
+
+var TestHelper *testutil.TestHelper
+
+var opaquePortsClientTemplate = template.Must(template.New("appprotocol_ports_client.yaml").ParseFiles("testdata/appprotocol_ports_client.yaml"))
+
+var (
+	http1PodApp  = "http1-pod"
+	http1PodSC   = "slow-cooker-http1"
+	http2PodApp  = "http2-pod"
+	http2PodSC   = "slow-cooker-http2"
+	opaquePodApp = "opaque-pod"
+	opaquePodSC  = "slow-cooker-opaque-pod"
+)
+
+type testCase struct {
+	name      string
+	appName   string
+	appChecks []check
+	scName    string
+	scChecks  []check
+}
+
+type check func(metrics, ns string) error
+
+func checks(c ...check) []check { return c }
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	// Block test execution until control plane is running
+	TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasEdge)
+	os.Exit(m.Run())
+}
+
+// clientTemplateArgs is a struct that contains the arguments to be supplied
+// to the deployment template opaque_ports_client.yaml.
+type clientTemplateArgs struct {
+	ServiceCookerHttp1TargetHost  string
+	ServiceCookerHttp2TargetHost  string
+	ServiceCookerOpaqueTargetHost string
+}
+
+func serviceName(n string) string {
+	return fmt.Sprintf("svc-%s", n)
+}
+
+//////////////////////
+/// TEST EXECUTION ///
+//////////////////////
+
+func TestOpaquePortsCalledByServiceTarget(t *testing.T) {
+	ctx := context.Background()
+	TestHelper.WithDataPlaneNamespace(ctx, "opaque-ports-called-by-service-name-test", map[string]string{}, t, func(t *testing.T, opaquePortsNs string) {
+		checks := func(c ...check) []check { return c }
+
+		if err := deployApplications(opaquePortsNs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy applications", err)
+		}
+		waitForAppDeploymentReady(t, opaquePortsNs)
+
+		tmplArgs := clientTemplateArgs{
+			ServiceCookerHttp1TargetHost:  serviceName(http1PodApp),
+			ServiceCookerHttp2TargetHost:  serviceName(http2PodApp),
+			ServiceCookerOpaqueTargetHost: serviceName(opaquePodApp),
+		}
+		if err := deployTemplate(opaquePortsNs, opaquePortsClientTemplate, tmplArgs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy client pods", err)
+		}
+		waitForClientDeploymentReady(t, opaquePortsNs)
+
+		runTests(ctx, t, opaquePortsNs, []testCase{
+			{
+				name:   "calling a meshed service when appProtocol is http on receiving service",
+				scName: http1PodSC,
+				scChecks: checks(
+					hasNoOutboundHTTPRequest,
+					hasOutboundTCPWithTLSAndNoAuthority,
+				),
+				appName:   http1PodApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+			{
+				name:   "calling a meshed service when appProtocol is kubernetes.io/h2c on receiving service",
+				scName: http2PodSC,
+				scChecks: checks(
+					hasNoOutboundHTTPRequest,
+					hasOutboundTCPWithTLSAndAuthority,
+				),
+				appName:   http2PodApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+			{
+				name:   "calling a meshed service when appProtocol is linkerd.io/opaque on receiving service",
+				scName: opaquePodSC,
+				scChecks: checks(
+					hasNoOutboundHTTPRequest,
+					hasOutboundTCPWithTLSAndAuthority,
+				),
+				appName:   opaquePodApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+		})
+	})
+}
+
+func TestOpaquePortsCalledByPodTarget(t *testing.T) {
+	ctx := context.Background()
+	TestHelper.WithDataPlaneNamespace(ctx, "opaque-ports-called-by-pod-ip-test", map[string]string{}, t, func(t *testing.T, opaquePortsNs string) {
+
+		if err := deployApplications(opaquePortsNs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy applications", err)
+		}
+		waitForAppDeploymentReady(t, opaquePortsNs)
+
+		tmplArgs, err := templateArgsPodIP(ctx, opaquePortsNs)
+		if err != nil {
+			testutil.AnnotatedFatal(t, "failed to fetch pod IPs", err)
+		}
+
+		if err := deployTemplate(opaquePortsNs, opaquePortsClientTemplate, tmplArgs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy client pods", err)
+		}
+		waitForClientDeploymentReady(t, opaquePortsNs)
+
+		runTests(ctx, t, opaquePortsNs, []testCase{
+			{
+				name:   "calling a meshed service when appProtocol is http on receiving service",
+				scName: http1PodSC,
+				scChecks: checks(
+					hasNoOutboundHTTPRequest,
+					hasOutboundTCPWithTLSAndNoAuthority,
+				),
+				appName:   http1PodApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+			{
+				name:   "calling a meshed service when appProtocol is kubernetes.io/h2c on receiving service",
+				scName: http2PodSC,
+				scChecks: checks(
+					// We call pods directly, so annotation on a service is ignored.
+					hasOutboundHTTPRequestWithTLS,
+					// No authority here, because we are calling the pod directly.
+					hasOutboundTCPWithTLSAndNoAuthority,
+				),
+				appName:   http2PodApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+			{
+				name:   "calling a meshed service when appProtocol is linkerd.io/opaque on receiving service",
+				scName: opaquePodSC,
+				scChecks: checks(
+					// We call pods directly, so annotation on a service is ignored.
+					hasOutboundHTTPRequestWithTLS,
+					// No authority here, because we are calling the pod directly.
+					hasOutboundTCPWithTLSAndNoAuthority,
+				),
+				appName:   opaquePodApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+		})
+	})
+}
+
+func waitForAppDeploymentReady(t *testing.T, appProtocolNs string) {
+	TestHelper.WaitRollout(t, map[string]testutil.DeploySpec{
+		http1PodApp: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+		http2PodApp: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+		opaquePodApp: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+	})
+}
+
+func waitForClientDeploymentReady(t *testing.T, appProtocolNs string) {
+	TestHelper.WaitRollout(t, map[string]testutil.DeploySpec{
+		http1PodSC: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+		http2PodSC: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+		opaquePodSC: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+	})
+}
+
+func templateArgsPodIP(ctx context.Context, ns string) (clientTemplateArgs, error) {
+	http1SCPodIP, err := getPodIPByAppLabel(ctx, ns, http1PodApp)
+	if err != nil {
+		return clientTemplateArgs{}, fmt.Errorf("failed to fetch pod IP for %q: %w", http1PodApp, err)
+	}
+	http2SCPodIP, err := getPodIPByAppLabel(ctx, ns, http2PodApp)
+	if err != nil {
+		return clientTemplateArgs{}, fmt.Errorf("failed to fetch pod IP for %q: %w", http2PodApp, err)
+	}
+	opaquePodIP, err := getPodIPByAppLabel(ctx, ns, opaquePodApp)
+	if err != nil {
+		return clientTemplateArgs{}, fmt.Errorf("failed to fetch pod IP for %q: %w", opaquePodApp, err)
+	}
+	return clientTemplateArgs{
+		ServiceCookerHttp1TargetHost:  http1SCPodIP,
+		ServiceCookerHttp2TargetHost:  http2SCPodIP,
+		ServiceCookerOpaqueTargetHost: opaquePodIP,
+	}, nil
+}
+
+func runTests(ctx context.Context, t *testing.T, ns string, tcs []testCase) {
+	t.Helper()
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := testutil.RetryFor(30*time.Second, func() error {
+				if err := checkPodMetrics(ctx, ns, tc.scName, tc.scChecks); err != nil {
+					return fmt.Errorf("failed to check metrics for client pod: %w", err)
+				}
+				if tc.appName == "" {
+					return nil
+				}
+				if err := checkPodMetrics(ctx, ns, tc.appName, tc.appChecks); err != nil {
+					return fmt.Errorf("failed to check metrics for app pod: %w", err)
+				}
+				return nil
+			})
+			if err != nil {
+				testutil.AnnotatedFatalf(t, "unexpected metric for pod", "unexpected metric for pod: %s", err)
+			}
+		})
+	}
+}
+
+func checkPodMetrics(ctx context.Context, opaquePortsNs string, podAppLabel string, checks []check) error {
+	pods, err := TestHelper.GetPods(ctx, opaquePortsNs, map[string]string{"app": podAppLabel})
+	if err != nil {
+		return fmt.Errorf("error getting pods for label 'app: %q': %w", podAppLabel, err)
+	}
+	if len(pods) == 0 {
+		return fmt.Errorf("no pods found for label 'app: %q'", podAppLabel)
+	}
+	metrics, err := getPodMetrics(pods[0], opaquePortsNs)
+	if err != nil {
+		return fmt.Errorf("error getting metrics for pod %q: %w", pods[0].Name, err)
+	}
+	for _, check := range checks {
+		if err := check(metrics, opaquePortsNs); err != nil {
+			return fmt.Errorf("validation of pod metrics failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func deployApplications(ns string) error {
+	out, err := TestHelper.Kubectl("", "apply", "-f", "testdata/appprotocol_ports_application.yaml", "-n", ns)
+	if err != nil {
+		return fmt.Errorf("failed apply deployment file %q: %w", out, err)
+	}
+	return nil
+}
+
+func deployTemplate(ns string, tmpl *template.Template, templateArgs interface{}) error {
+	bb := &bytes.Buffer{}
+	if err := tmpl.Execute(bb, templateArgs); err != nil {
+		return fmt.Errorf("failed to write deployment template: %w", err)
+	}
+	out, err := TestHelper.KubectlApply(bb.String(), ns)
+	if err != nil {
+		return fmt.Errorf("failed apply deployment file %q: %w", out, err)
+	}
+	return nil
+}
+
+func getPodMetrics(pod v1.Pod, ns string) (string, error) {
+	podName := fmt.Sprintf("pod/%s", pod.Name)
+	cmd := []string{"diagnostics", "proxy-metrics", "--namespace", ns, podName}
+	metrics, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		return "", err
+	}
+	return metrics, nil
+}
+
+func getPodIPByAppLabel(ctx context.Context, ns string, app string) (string, error) {
+	labels := map[string]string{"app": app}
+	pods, err := TestHelper.GetPods(ctx, ns, labels)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod by labels %v: %w", labels, err)
+	}
+	if len(pods) == 0 {
+		return "", fmt.Errorf("no pods found for labels %v", labels)
+	}
+	return pods[0].Status.PodIP, nil
+}

--- a/test/integration/deep/appprotocol/assertions.go
+++ b/test/integration/deep/appprotocol/assertions.go
@@ -1,0 +1,243 @@
+package appprotocol
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/linkerd/linkerd2/testutil/prommatch"
+)
+
+var (
+	authorityRE = regexp.MustCompile(`[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+`)
+)
+
+// hasNoOutboundHTTPRequest returns error if there is any
+// series matching request_total{direction="outbound"}
+func hasNoOutboundHTTPRequest(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+		})
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if ok {
+		return fmt.Errorf("expected not to find HTTP outbound requests \n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundHTTPRequestWithTLS checks there is a series matching:
+//
+//	request_total{
+//	  direction="outbound",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9.]+",
+//	  tls="true",
+//	  dst_namespace="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  dst_serviceaccount="default"
+//	}
+func hasOutboundHTTPRequestWithTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":          prommatch.Equals("outbound"),
+			"tls":                prommatch.Equals("true"),
+			"server_id":          prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"dst_namespace":      prommatch.Equals(ns),
+			"dst_serviceaccount": prommatch.Equals("default"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("expected to find HTTP TLS outbound requests \n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundHTTPRequestNoTLS checks there is a series matching:
+//
+//	request_total{
+//	  direction="outbound",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9.]+",
+//	  tls="no_identity",
+//	  no_tls_reason="not_provided_by_service_discovery",
+//	  dst_namespace="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  dst_serviceaccount="default"
+//	}
+func hasOutboundHTTPRequestNoTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":          prommatch.Equals("outbound"),
+			"tls":                prommatch.Equals("no_identity"),
+			"no_tls_reason":      prommatch.Equals("not_provided_by_service_discovery"),
+			"dst_namespace":      prommatch.Equals(ns),
+			"dst_serviceaccount": prommatch.Equals("default"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("expected to find HTTP non-TLS outbound requests\n%s", metrics)
+	}
+	return nil
+}
+
+// hasInboundTCPTrafficWithTLS checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="inbound",
+//	  peer="src",
+//	  tls="true",
+//	  client_id="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  srv_kind="default",
+//	  srv_name="all-unauthenticated",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9\.]+"
+//	}
+func hasInboundTCPTrafficWithTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher(
+		"tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("inbound"),
+			"peer":      prommatch.Equals("src"),
+			"tls":       prommatch.Equals("true"),
+			"client_id": prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"srv_kind":  prommatch.Equals("default"),
+			"srv_name":  prommatch.Equals("all-unauthenticated"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue(),
+	)
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for inbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithAuthorityAndNoTLS checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="no_identity",
+//	  no_tls_reason="not_provided_by_service_discovery",
+//	  authority=~"[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+"
+//	}
+func hasOutboundTCPWithAuthorityAndNoTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction":     prommatch.Equals("outbound"),
+			"peer":          prommatch.Equals("dst"),
+			"tls":           prommatch.Equals("no_identity"),
+			"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
+			"authority":     prommatch.Like(authorityRE),
+		},
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound non-TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithNoTLSAndNoAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="no_identity",
+//	  no_tls_reason="not_provided_by_service_discovery",
+//	  authority=""
+//	}
+func hasOutboundTCPWithNoTLSAndNoAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction":     prommatch.Equals("outbound"),
+			"peer":          prommatch.Equals("dst"),
+			"tls":           prommatch.Equals("no_identity"),
+			"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
+			"authority":     prommatch.Absent(),
+		})
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound non-TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithTLSAndAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="true",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  authority=~"[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+"
+//	}
+func hasOutboundTCPWithTLSAndAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Like(authorityRE),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithTLSAndNoAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="true",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  authority=""
+//	}
+func hasOutboundTCPWithTLSAndNoAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Absent(),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}

--- a/test/integration/deep/appprotocol/testdata/appprotocol_ports_application.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_ports_application.yaml
@@ -1,0 +1,123 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http1-pod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http1-pod
+  template:
+    metadata:
+      labels:
+        app: http1-pod
+      annotations:
+        linkerd.io/inject: "enabled"
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=http1-pod"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-http1-pod
+  labels:
+    app: svc-http1-pod
+spec:
+  selector:
+    app: http1-pod
+  clusterIP: None
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http2-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http2-service
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: http2-service
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h2-server-port=8080"
+        - "--response-text=http2-service"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-http2-service
+  labels:
+    app: svc-http2-service
+spec:
+  selector:
+    app: http2-service
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: kubernetes.io/h2c
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opaque-pod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opaque-pod
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: opaque-pod
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=opaque-pod"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-opaque-pod
+  labels:
+    app: svc-opaque-pod
+spec:
+  selector:
+    app: opaque-pod
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: linkerd.io/opaque

--- a/test/integration/deep/appprotocol/testdata/appprotocol_ports_client.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_ports_client.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-http1
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-http1
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-http1
+    spec:
+      containers:
+      - name: slow-cooker-http1
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerHttp1TargetHost}}:8080
+        ports:
+        - containerPort: 9999
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-http2
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-http2
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-http2
+    spec:
+      containers:
+      - name: slow-cooker-http2
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerHttp2TargetHost}}:8080
+        ports:
+        - containerPort: 9999
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-opaque-pod
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-opaque-pod
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-opaque-pod
+    spec:
+      containers:
+      - name: slow-cooker-opaque-pod
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerOpaqueTargetHost}}:8080
+        ports:
+        - containerPort: 9999


### PR DESCRIPTION
This looks for the `appProtocol` field on the ports in a service, and limits the set of outbound routes to that protocol if found.

Tested on a local cluster and with `linkerd diagnose` to inspect the generated routes.