### PR TITLE
feat(viz): make window parameter dynamic

### DIFF
--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -57,7 +57,7 @@ export const apiErrorPropType = PropTypes.shape({
 });
 
 const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
-  let metricsWindow = defaultMetricsWindow;
+  let metricsWindow = sessionStorage.getItem('metricsWindow') || defaultMetricsWindow;
   const podsPath = '/api/pods';
   const servicesPath = '/api/services';
   const edgesPath = '/api/edges';

--- a/web/app/js/components/util/ApiHelpers.jsx
+++ b/web/app/js/components/util/ApiHelpers.jsx
@@ -57,7 +57,8 @@ export const apiErrorPropType = PropTypes.shape({
 });
 
 const ApiHelpers = (pathPrefix, defaultMetricsWindow = '1m') => {
-  let metricsWindow = sessionStorage.getItem('metricsWindow') || defaultMetricsWindow;
+  const sessionMetricsWindow = sessionStorage.getItem('metricsWindow');
+  let metricsWindow = (storedValue && validMetricsWindows[sessionMetricsWindow]) ? sessionMetricsWindow : defaultMetricsWindow;
   const podsPath = '/api/pods';
   const servicesPath = '/api/services';
   const edgesPath = '/api/edges';

--- a/web/app/js/components/util/ApiHelpers.test.jsx
+++ b/web/app/js/components/util/ApiHelpers.test.jsx
@@ -57,6 +57,41 @@ describe('ApiHelpers', () => {
     });
   });
 
+  describe('getMetricsWindow and setMetricsWindow (with session storage)', () => {
+    beforeEach(() => {
+      sessionStorage.removeItem('metricsWindow');
+    });
+  
+    it('should return the default metricsWindow when no session value exists', () => {
+      expect(sessionStorage.getItem('metricsWindow')).to.be.null;
+      expect(api.getMetricsWindow()).to.equal('1m');
+    });
+
+    it('should update the metricsWindow on valid window inputs', () => {
+      sessionStorage.setItem('metricsWindow', '10s');
+      expect(sessionStorage.getItem('metricsWindow')).to.equal('10s');
+      expect(api.getMetricsWindow()).to.equal('10s');
+  
+      sessionStorage.setItem('metricsWindow', '1m');
+      expect(sessionStorage.getItem('metricsWindow')).to.equal('1m');
+      expect(api.getMetricsWindow()).to.equal('1m');
+  
+      sessionStorage.setItem('metricsWindow', '10m');
+      expect(sessionStorage.getItem('metricsWindow')).to.equal('10m');
+      expect(api.getMetricsWindow()).to.equal('10m');
+  
+      sessionStorage.setItem('metricsWindow', '1h');
+      expect(sessionStorage.getItem('metricsWindow')).to.equal('1h');
+      expect(api.getMetricsWindow()).to.equal('1h');
+    });
+  
+    it('should not change metricsWindow on invalid window values', () => {
+      sessionStorage.setItem('metricsWindow', '1s');
+      expect(sessionStorage.getItem('metricsWindow')).to.equal('1s');
+      expect(api.getMetricsWindow()).to.equal('1m');
+    });
+  });
+
   describe('PrefixedLink', () => {
     it('respects default values', () => {
       api = ApiHelpers('/my/path/prefix/linkerd-web:/foo');


### PR DESCRIPTION
### Subject
Linkerd Viz: Make window Parameter Dynamic

### Problem
While we already have a list of acceptable values for the window parameter, it is currently hard-coded to `1m`. In some edge cases, users may need to increase the scrape interval beyond one minute. This limitation causes the `irate()` functions to lack two data points within the one-minute window, resulting in an empty array.

### Solution
Allow users to dynamically change the window parameter without needing to create local overrides in their browser. This is accomplished by checking the session storage for a value under the key `metricsWindow`. If a value exists, it is validated against the existing `validMetricsWindows` array. If the stored value is valid, it is used; otherwise, the default value is applied.

### Validation
- N/D