### PR TITLE
feat(proto-detect): Convert opaque ports to app protocol

### DIFF
--- a/policy-controller/core/src/outbound/policy.rs
+++ b/policy-controller/core/src/outbound/policy.rs
@@ -1,6 +1,6 @@
 use super::{
-    FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute, RouteRetry,
-    RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+    AppProtocol, FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute,
+    RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
 };
 
 use std::num::NonZeroU16;
@@ -29,7 +29,7 @@ pub struct OutboundPolicy {
     pub tls_routes: RouteSet<TlsRoute>,
     pub tcp_routes: RouteSet<TcpRoute>,
     pub port: NonZeroU16,
-    pub opaque: bool,
+    pub app_protocol: Option<AppProtocol>,
     pub accrual: Option<FailureAccrual>,
     pub http_retry: Option<RouteRetry<HttpRetryCondition>>,
     pub grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ports::{ports_annotation, PortSet},
+    ports::{ports_annotation, PortMap},
     routes::{ExplicitGKN, HttpRouteResource, ImpliedGKN},
     ClusterInfo,
 };
@@ -8,9 +8,9 @@ use anyhow::{bail, ensure, Result};
 use egress_network::EgressNetwork;
 use linkerd_policy_controller_core::{
     outbound::{
-        Backend, Backoff, FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition,
-        HttpRoute, Kind, OutboundPolicy, ParentInfo, ResourceTarget, RouteRetry, RouteSet,
-        RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+        AppProtocol, Backend, Backoff, FailureAccrual, GrpcRetryCondition, GrpcRoute,
+        HttpRetryCondition, HttpRoute, Kind, OutboundPolicy, ParentInfo, ResourceTarget,
+        RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
     },
     routes::GroupKindNamespaceName,
 };
@@ -90,7 +90,7 @@ struct Namespace {
 
 #[derive(Debug)]
 struct ResourceInfo {
-    opaque_ports: PortSet,
+    app_protocols: PortMap<AppProtocol>,
     accrual: Option<FailureAccrual>,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
@@ -111,7 +111,7 @@ struct ResourceRoutes {
     namespace: Arc<String>,
     port: NonZeroU16,
     watches_by_ns: HashMap<String, RoutesWatch>,
-    opaque: bool,
+    app_protocol: Option<AppProtocol>,
     accrual: Option<FailureAccrual>,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
@@ -121,7 +121,7 @@ struct ResourceRoutes {
 #[derive(Debug)]
 struct RoutesWatch {
     parent_info: ParentInfo,
-    opaque: bool,
+    app_protocol: Option<AppProtocol>,
     accrual: Option<FailureAccrual>,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
@@ -212,6 +212,10 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         let opaque_ports =
             ports_annotation(service.annotations(), "config.linkerd.io/opaque-ports")
                 .unwrap_or_else(|| self.namespaces.cluster_info.default_opaque_ports.clone());
+        let app_protocols = opaque_ports
+            .into_iter()
+            .map(|port| (port, AppProtocol::Opaque))
+            .collect();
 
         let timeouts = parse_timeouts(service.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))
@@ -250,7 +254,7 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         }
 
         let service_info = ResourceInfo {
-            opaque_ports,
+            app_protocols,
             accrual,
             http_retry,
             grpc_retry,
@@ -316,6 +320,10 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             "config.linkerd.io/opaque-ports",
         )
         .unwrap_or_else(|| self.namespaces.cluster_info.default_opaque_ports.clone());
+        let app_protocols = opaque_ports
+            .into_iter()
+            .map(|port| (port, AppProtocol::Opaque))
+            .collect();
 
         let timeouts = parse_timeouts(egress_network.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))
@@ -346,7 +354,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             .insert(egress_net_ref.clone(), egress_net);
 
         let egress_network_info = ResourceInfo {
-            opaque_ports,
+            app_protocols,
             accrual,
             http_retry,
             grpc_retry,
@@ -1140,10 +1148,10 @@ impl Namespace {
                 continue;
             }
 
-            let opaque = resource.opaque_ports.contains(&resource_port.port);
+            let app_protocol = resource.app_protocols.get(&resource_port.port).cloned();
 
             resource_routes.update_resource(
-                opaque,
+                app_protocol,
                 resource.accrual,
                 resource.http_retry.clone(),
                 resource.grpc_retry.clone(),
@@ -1228,13 +1236,13 @@ impl Namespace {
                         }
                     }
                 };
-                let mut opaque = false;
+                let mut app_protocol = None;
                 let mut accrual = None;
                 let mut http_retry = None;
                 let mut grpc_retry = None;
                 let mut timeouts = Default::default();
                 if let Some(resource) = resource_info.get(&resource_ref) {
-                    opaque = resource.opaque_ports.contains(&rp.port);
+                    app_protocol = resource.app_protocols.get(&rp.port).cloned();
                     accrual = resource.accrual;
                     http_retry = resource.http_retry.clone();
                     grpc_retry = resource.grpc_retry.clone();
@@ -1274,7 +1282,7 @@ impl Namespace {
 
                 let mut resource_routes = ResourceRoutes {
                     parent_info,
-                    opaque,
+                    app_protocol,
                     accrual,
                     http_retry,
                     grpc_retry,
@@ -1495,7 +1503,7 @@ impl ResourceRoutes {
             let (sender, _) = watch::channel(OutboundPolicy {
                 parent_info: self.parent_info.clone(),
                 port: self.port,
-                opaque: self.opaque,
+                app_protocol: self.app_protocol.clone(),
                 accrual: self.accrual,
                 http_retry: self.http_retry.clone(),
                 grpc_retry: self.grpc_retry.clone(),
@@ -1513,7 +1521,7 @@ impl ResourceRoutes {
                 tls_routes,
                 tcp_routes,
                 watch: sender,
-                opaque: self.opaque,
+                app_protocol: self.app_protocol.clone(),
                 accrual: self.accrual,
                 http_retry: self.http_retry.clone(),
                 grpc_retry: self.grpc_retry.clone(),
@@ -1612,21 +1620,21 @@ impl ResourceRoutes {
 
     fn update_resource(
         &mut self,
-        opaque: bool,
+        app_protocol: Option<AppProtocol>,
         accrual: Option<FailureAccrual>,
         http_retry: Option<RouteRetry<HttpRetryCondition>>,
         grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
         timeouts: RouteTimeouts,
         traffic_policy: Option<TrafficPolicy>,
     ) {
-        self.opaque = opaque;
+        self.app_protocol = app_protocol.clone();
         self.accrual = accrual;
         self.http_retry = http_retry.clone();
         self.grpc_retry = grpc_retry.clone();
         self.timeouts = timeouts.clone();
         self.update_traffic_policy(traffic_policy);
         for watch in self.watches_by_ns.values_mut() {
-            watch.opaque = opaque;
+            watch.app_protocol = app_protocol.clone();
             watch.accrual = accrual;
             watch.http_retry = http_retry.clone();
             watch.grpc_retry = grpc_retry.clone();
@@ -1717,8 +1725,8 @@ impl RoutesWatch {
                 modified = true;
             }
 
-            if self.opaque != policy.opaque {
-                policy.opaque = self.opaque;
+            if self.app_protocol != policy.app_protocol {
+                policy.app_protocol = self.app_protocol.clone();
                 modified = true;
             }
 


### PR DESCRIPTION
Currently, we store whether or not a port in a parent is opaque with a simple boolean. This works, but is somewhat restrictive if we want to specifiy different port protocols in the resource definition.

This converts it to a proper `AppProtocol` enum, which will allow us to use different protocol specifications for ports in the future.