### PR TITLE
feat(policy): Add opaque protocol configuration

### DIFF
--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -1,0 +1,47 @@
+use futures::StreamExt;
+use k8s_gateway_api::{self as gateway};
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_test::{
+    assert_resource_meta, create,
+    outbound_api::{
+        assert_route_is_default, assert_singleton, retry_watch_outbound_policy, tcp_routes,
+    },
+    test_route::TestParent,
+    with_temp_ns,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn opaque_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("linkerd.io/opaque".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = tcp_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::TcpRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}

--- a/test/integration/deep/appprotocol/appprotocol_test.go
+++ b/test/integration/deep/appprotocol/appprotocol_test.go
@@ -1,0 +1,238 @@
+package appprotocol
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/linkerd/linkerd2/testutil"
+	v1 "k8s.io/api/core/v1"
+)
+
+var TestHelper *testutil.TestHelper
+
+var appProtocolClientTemplate = template.Must(template.New("appprotocol_client.yaml").ParseFiles("testdata/appprotocol_client.yaml"))
+
+var (
+	opaqueApp = "opaque"
+	opaqueSC  = "slow-cooker-opaque"
+)
+
+type testCase struct {
+	name      string
+	appName   string
+	appChecks []check
+	scName    string
+	scChecks  []check
+}
+
+type check func(metrics, ns string) error
+
+func checks(c ...check) []check { return c }
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	// Block test execution until control plane is running
+	TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasEdge)
+	os.Exit(m.Run())
+}
+
+// clientTemplateArgs is a struct that contains the arguments to be supplied
+// to the deployment template appprotocol_client.yaml.
+type clientTemplateArgs struct {
+	ServiceCookerOpaqueTargetHost string
+}
+
+func serviceName(n string) string {
+	return fmt.Sprintf("svc-%s", n)
+}
+
+//////////////////////
+/// TEST EXECUTION ///
+//////////////////////
+
+func TestAppProtocolCalledByServiceTarget(t *testing.T) {
+	ctx := context.Background()
+	TestHelper.WithDataPlaneNamespace(ctx, "appprotocol-called-by-service-name-test", map[string]string{}, t, func(t *testing.T, appProtocolNs string) {
+		checks := func(c ...check) []check { return c }
+
+		if err := deployApplications(appProtocolNs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy applications", err)
+		}
+		waitForAppDeploymentReady(t, appProtocolNs)
+
+		tmplArgs := clientTemplateArgs{
+			ServiceCookerOpaqueTargetHost: serviceName(opaqueApp),
+		}
+		if err := deployTemplate(appProtocolNs, appProtocolClientTemplate, tmplArgs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy client pods", err)
+		}
+		waitForClientDeploymentReady(t, appProtocolNs)
+
+		runTests(ctx, t, appProtocolNs, []testCase{
+			{
+				name:   "calling a meshed service when appProtocol is linkerd.io/opaque on receiving service",
+				scName: opaqueSC,
+				scChecks: checks(
+					hasNoOutboundHTTPRequest,
+					hasOutboundTCPWithTLSAndAuthority,
+				),
+				appName:   opaqueApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+		})
+	})
+}
+
+func TestAppProtocolCalledByPodTarget(t *testing.T) {
+	ctx := context.Background()
+	TestHelper.WithDataPlaneNamespace(ctx, "appprotocol-called-by-pod-ip-test", map[string]string{}, t, func(t *testing.T, appProtocolNs string) {
+
+		if err := deployApplications(appProtocolNs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy applications", err)
+		}
+		waitForAppDeploymentReady(t, appProtocolNs)
+
+		tmplArgs, err := templateArgsPodIP(ctx, appProtocolNs)
+		if err != nil {
+			testutil.AnnotatedFatal(t, "failed to fetch pod IPs", err)
+		}
+
+		if err := deployTemplate(appProtocolNs, appProtocolClientTemplate, tmplArgs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy client pods", err)
+		}
+		waitForClientDeploymentReady(t, appProtocolNs)
+
+		runTests(ctx, t, appProtocolNs, []testCase{
+			{
+				name:   "calling a meshed service when appProtocol is linkerd.io/opaque on receiving service",
+				scName: opaqueSC,
+				scChecks: checks(
+					// We call pods directly, so annotation on a service is ignored.
+					hasOutboundHTTPRequestWithTLS,
+					// No authority here, because we are calling the pod directly.
+					hasOutboundTCPWithTLSAndNoAuthority,
+				),
+				appName:   opaqueApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+		})
+	})
+}
+
+func waitForAppDeploymentReady(t *testing.T, appProtocolNs string) {
+	TestHelper.WaitRollout(t, map[string]testutil.DeploySpec{
+		opaqueApp: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+	})
+}
+
+func waitForClientDeploymentReady(t *testing.T, appProtocolNs string) {
+	TestHelper.WaitRollout(t, map[string]testutil.DeploySpec{
+		opaqueSC: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+	})
+}
+
+func templateArgsPodIP(ctx context.Context, ns string) (clientTemplateArgs, error) {
+	opaquePodIP, err := getPodIPByAppLabel(ctx, ns, opaqueApp)
+	if err != nil {
+		return clientTemplateArgs{}, fmt.Errorf("failed to fetch pod IP for %q: %w", opaqueApp, err)
+	}
+	return clientTemplateArgs{
+		ServiceCookerOpaqueTargetHost: opaquePodIP,
+	}, nil
+}
+
+func runTests(ctx context.Context, t *testing.T, ns string, tcs []testCase) {
+	t.Helper()
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := testutil.RetryFor(30*time.Second, func() error {
+				if err := checkPodMetrics(ctx, ns, tc.scName, tc.scChecks); err != nil {
+					return fmt.Errorf("failed to check metrics for client pod: %w", err)
+				}
+				if tc.appName == "" {
+					return nil
+				}
+				if err := checkPodMetrics(ctx, ns, tc.appName, tc.appChecks); err != nil {
+					return fmt.Errorf("failed to check metrics for app pod: %w", err)
+				}
+				return nil
+			})
+			if err != nil {
+				testutil.AnnotatedFatalf(t, "unexpected metric for pod", "unexpected metric for pod: %s", err)
+			}
+		})
+	}
+}
+
+func checkPodMetrics(ctx context.Context, appProtocolNs string, podAppLabel string, checks []check) error {
+	pods, err := TestHelper.GetPods(ctx, appProtocolNs, map[string]string{"app": podAppLabel})
+	if err != nil {
+		return fmt.Errorf("error getting pods for label 'app: %q': %w", podAppLabel, err)
+	}
+	if len(pods) == 0 {
+		return fmt.Errorf("no pods found for label 'app: %q'", podAppLabel)
+	}
+	metrics, err := getPodMetrics(pods[0], appProtocolNs)
+	if err != nil {
+		return fmt.Errorf("error getting metrics for pod %q: %w", pods[0].Name, err)
+	}
+	for _, check := range checks {
+		if err := check(metrics, appProtocolNs); err != nil {
+			return fmt.Errorf("validation of pod metrics failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func deployApplications(ns string) error {
+	out, err := TestHelper.Kubectl("", "apply", "-f", "testdata/appprotocol_application.yaml", "-n", ns)
+	if err != nil {
+		return fmt.Errorf("failed apply deployment file %q: %w", out, err)
+	}
+	return nil
+}
+
+func deployTemplate(ns string, tmpl *template.Template, templateArgs interface{}) error {
+	bb := &bytes.Buffer{}
+	if err := tmpl.Execute(bb, templateArgs); err != nil {
+		return fmt.Errorf("failed to write deployment template: %w", err)
+	}
+	out, err := TestHelper.KubectlApply(bb.String(), ns)
+	if err != nil {
+		return fmt.Errorf("failed apply deployment file %q: %w", out, err)
+	}
+	return nil
+}
+
+func getPodMetrics(pod v1.Pod, ns string) (string, error) {
+	podName := fmt.Sprintf("pod/%s", pod.Name)
+	cmd := []string{"diagnostics", "proxy-metrics", "--namespace", ns, podName}
+	metrics, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		return "", err
+	}
+	return metrics, nil
+}
+
+func getPodIPByAppLabel(ctx context.Context, ns string, app string) (string, error) {
+	labels := map[string]string{"app": app}
+	pods, err := TestHelper.GetPods(ctx, ns, labels)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod by labels %v: %w", labels, err)
+	}
+	if len(pods) == 0 {
+		return "", fmt.Errorf("no pods found for labels %v", labels)
+	}
+	return pods[0].Status.PodIP, nil
+}

--- a/test/integration/deep/appprotocol/assertions.go
+++ b/test/integration/deep/appprotocol/assertions.go
@@ -1,0 +1,154 @@
+package appprotocol
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/linkerd/linkerd2/testutil/prommatch"
+)
+
+var (
+	authorityRE = regexp.MustCompile(`[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+`)
+)
+
+// hasNoOutboundHTTPRequest returns error if there is any
+// series matching request_total{direction="outbound"}
+func hasNoOutboundHTTPRequest(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+		})
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if ok {
+		return fmt.Errorf("expected not to find HTTP outbound requests \n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundHTTPRequestWithTLS checks there is a series matching:
+//
+//	request_total{
+//	  direction="outbound",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9.]+",
+//	  tls="true",
+//	  dst_namespace="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  dst_serviceaccount="default"
+//	}
+func hasOutboundHTTPRequestWithTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":          prommatch.Equals("outbound"),
+			"tls":                prommatch.Equals("true"),
+			"server_id":          prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"dst_namespace":      prommatch.Equals(ns),
+			"dst_serviceaccount": prommatch.Equals("default"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("expected to find HTTP TLS outbound requests \n%s", metrics)
+	}
+	return nil
+}
+
+// hasInboundTCPTrafficWithTLS checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="inbound",
+//	  peer="src",
+//	  tls="true",
+//	  client_id="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  srv_kind="default",
+//	  srv_name="all-unauthenticated",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9\.]+"
+//	}
+func hasInboundTCPTrafficWithTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher(
+		"tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("inbound"),
+			"peer":      prommatch.Equals("src"),
+			"tls":       prommatch.Equals("true"),
+			"client_id": prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"srv_kind":  prommatch.Equals("default"),
+			"srv_name":  prommatch.Equals("all-unauthenticated"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue(),
+	)
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for inbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithTLSAndAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="true",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  authority=~"[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+"
+//	}
+func hasOutboundTCPWithTLSAndAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Like(authorityRE),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithTLSAndNoAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="true",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  authority=""
+//	}
+func hasOutboundTCPWithTLSAndNoAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Absent(),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}

--- a/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opaque
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opaque
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: opaque
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=opaque"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-opaque
+  labels:
+    app: svc-opaque
+spec:
+  selector:
+    app: opaque
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: linkerd.io/opaque

--- a/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-opaque
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-opaque
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-opaque
+    spec:
+      containers:
+      - name: slow-cooker-opaque
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerOpaqueTargetHost}}:8080
+        ports:
+        - containerPort: 9999


### PR DESCRIPTION
This allows specifying that a service port is opaque via "linkerd.io/opaque" in the appProtocol field.

This also includes a fair amount of tests and test infrastructure for future appProtocol values.
