### PR TITLE
feat(policy): Add http protocol configuration

### DIFF
--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -44,6 +44,8 @@ pub type RouteSet<T> = HashMap<GroupKindNamespaceName, T>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AppProtocol {
+    Http1,
+    Http2,
     Opaque,
     Unknown(Arc<str>),
 }
@@ -53,6 +55,8 @@ impl FromStr for AppProtocol {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let protocol = match s.to_ascii_lowercase().as_str() {
+            "http" => AppProtocol::Http1,
+            "kubernetes.io/h2c" => AppProtocol::Http2,
             "linkerd.io/tcp" | "linkerd.io/opaque" => AppProtocol::Opaque,
             protocol => AppProtocol::Unknown(Arc::from(protocol)),
         };

--- a/policy-controller/core/src/outbound/policy.rs
+++ b/policy-controller/core/src/outbound/policy.rs
@@ -1,6 +1,6 @@
 use super::{
-    FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute, RouteRetry,
-    RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+    AppProtocol, FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute,
+    RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
 };
 
 use std::num::NonZeroU16;
@@ -29,7 +29,7 @@ pub struct OutboundPolicy {
     pub tls_routes: RouteSet<TlsRoute>,
     pub tcp_routes: RouteSet<TcpRoute>,
     pub port: NonZeroU16,
-    pub opaque: bool,
+    pub app_protocol: Option<AppProtocol>,
     pub accrual: Option<FailureAccrual>,
     pub http_retry: Option<RouteRetry<HttpRetryCondition>>,
     pub grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,

--- a/policy-controller/grpc/src/outbound/http.rs
+++ b/policy-controller/grpc/src/outbound/http.rs
@@ -85,6 +85,103 @@ pub(crate) fn protocol(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub(crate) fn http1_only_protocol(
+    default_backend: outbound::Backend,
+    routes: impl Iterator<Item = (GroupKindNamespaceName, HttpRoute)>,
+    accrual: Option<outbound::FailureAccrual>,
+    service_retry: Option<RouteRetry<HttpRetryCondition>>,
+    service_timeouts: RouteTimeouts,
+    allow_l5d_request_headers: bool,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
+) -> outbound::proxy_protocol::Kind {
+    outbound::proxy_protocol::Kind::Http1(outbound::proxy_protocol::Http1 {
+        routes: base_http_routes(
+            default_backend,
+            routes,
+            service_retry,
+            service_timeouts,
+            allow_l5d_request_headers,
+            parent_info,
+            original_dst,
+        ),
+        failure_accrual: accrual.clone(),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn http2_only_protocol(
+    default_backend: outbound::Backend,
+    routes: impl Iterator<Item = (GroupKindNamespaceName, HttpRoute)>,
+    accrual: Option<outbound::FailureAccrual>,
+    service_retry: Option<RouteRetry<HttpRetryCondition>>,
+    service_timeouts: RouteTimeouts,
+    allow_l5d_request_headers: bool,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
+) -> outbound::proxy_protocol::Kind {
+    outbound::proxy_protocol::Kind::Http2(outbound::proxy_protocol::Http2 {
+        routes: base_http_routes(
+            default_backend,
+            routes,
+            service_retry,
+            service_timeouts,
+            allow_l5d_request_headers,
+            parent_info,
+            original_dst,
+        ),
+        failure_accrual: accrual.clone(),
+    })
+}
+
+fn base_http_routes(
+    default_backend: outbound::Backend,
+    routes: impl Iterator<Item = (GroupKindNamespaceName, HttpRoute)>,
+    service_retry: Option<RouteRetry<HttpRetryCondition>>,
+    service_timeouts: RouteTimeouts,
+    allow_l5d_request_headers: bool,
+    parent_info: &ParentInfo,
+    original_dst: Option<SocketAddr>,
+) -> Vec<outbound::HttpRoute> {
+    let mut routes = routes
+        .map(|(gknn, route)| {
+            convert_outbound_route(
+                gknn,
+                route,
+                default_backend.clone(),
+                service_retry.clone(),
+                service_timeouts.clone(),
+                allow_l5d_request_headers,
+                parent_info,
+                original_dst,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    match parent_info {
+        ParentInfo::Service { .. } => {
+            if routes.is_empty() {
+                routes.push(default_outbound_service_route(
+                    default_backend,
+                    service_retry.clone(),
+                    service_timeouts.clone(),
+                ));
+            }
+        }
+        ParentInfo::EgressNetwork { traffic_policy, .. } => {
+            routes.push(default_outbound_egress_route(
+                default_backend,
+                service_retry.clone(),
+                service_timeouts.clone(),
+                traffic_policy,
+            ));
+        }
+    }
+
+    routes
+}
+
+#[allow(clippy::too_many_arguments)]
 fn convert_outbound_route(
     gknn: GroupKindNamespaceName,
     HttpRoute {

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -21,7 +21,9 @@ use linkerd_policy_controller_k8s_api::{
     ResourceExt, Service,
 };
 use parking_lot::RwLock;
-use std::{hash::Hash, net::IpAddr, num::NonZeroU16, sync::Arc, time};
+use std::{
+    collections::hash_map::Entry, hash::Hash, net::IpAddr, num::NonZeroU16, sync::Arc, time,
+};
 use tokio::sync::watch;
 
 #[allow(dead_code)]
@@ -218,13 +220,45 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         let accrual = parse_accrual_config(service.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();
+
+        let mut app_protocols = service
+            .spec
+            .as_ref()
+            .and_then(|spec| {
+                spec.ports.as_ref().map(|ports| {
+                    ports
+                        .iter()
+                        .filter_map(|port| {
+                            port.app_protocol.as_ref().and_then(|p| {
+                                Some((
+                                    NonZeroU16::new(port.port as u16)?,
+                                    AppProtocol::from(p.as_str()),
+                                ))
+                            })
+                        })
+                        .collect::<PortMap<AppProtocol>>()
+                })
+            })
+            .unwrap_or_default();
         let opaque_ports =
             ports_annotation(service.annotations(), "config.linkerd.io/opaque-ports")
                 .unwrap_or_else(|| self.namespaces.cluster_info.default_opaque_ports.clone());
-        let app_protocols = opaque_ports
-            .into_iter()
-            .map(|port| (port, AppProtocol::Opaque))
-            .collect();
+        for opaque_port in opaque_ports {
+            match app_protocols.entry(opaque_port) {
+                Entry::Occupied(occupied) => {
+                    tracing::warn!(
+                        appProtocol = ?occupied.get(),
+                        port = opaque_port.get(),
+                        ns,
+                        name,
+                        "`appProtocol` set on service port, ignoring opaque port setting"
+                    );
+                }
+                Entry::Vacant(vacant) => {
+                    vacant.insert(AppProtocol::Opaque);
+                }
+            }
+        }
 
         let timeouts = parse_timeouts(service.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ports::{ports_annotation, PortSet},
+    ports::{ports_annotation, PortMap},
     routes::{ExplicitGKN, HttpRouteResource, ImpliedGKN},
     ClusterInfo,
 };
@@ -9,9 +9,9 @@ use egress_network::EgressNetwork;
 use kube::Resource;
 use linkerd_policy_controller_core::{
     outbound::{
-        Backend, Backoff, FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition,
-        HttpRoute, Kind, OutboundPolicy, ParentInfo, ResourceTarget, RouteRetry, RouteSet,
-        RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+        AppProtocol, Backend, Backoff, FailureAccrual, GrpcRetryCondition, GrpcRoute,
+        HttpRetryCondition, HttpRoute, Kind, OutboundPolicy, ParentInfo, ResourceTarget,
+        RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
     },
     routes::GroupKindNamespaceName,
 };
@@ -91,7 +91,7 @@ struct Namespace {
 
 #[derive(Debug)]
 struct ResourceInfo {
-    opaque_ports: PortSet,
+    app_protocols: PortMap<AppProtocol>,
     accrual: Option<FailureAccrual>,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
@@ -112,7 +112,7 @@ struct ResourceRoutes {
     namespace: Arc<String>,
     port: NonZeroU16,
     watches_by_ns: HashMap<String, RoutesWatch>,
-    opaque: bool,
+    app_protocol: Option<AppProtocol>,
     accrual: Option<FailureAccrual>,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
@@ -122,7 +122,7 @@ struct ResourceRoutes {
 #[derive(Debug)]
 struct RoutesWatch {
     parent_info: ParentInfo,
-    opaque: bool,
+    app_protocol: Option<AppProtocol>,
     accrual: Option<FailureAccrual>,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
@@ -221,6 +221,10 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         let opaque_ports =
             ports_annotation(service.annotations(), "config.linkerd.io/opaque-ports")
                 .unwrap_or_else(|| self.namespaces.cluster_info.default_opaque_ports.clone());
+        let app_protocols = opaque_ports
+            .into_iter()
+            .map(|port| (port, AppProtocol::Opaque))
+            .collect();
 
         let timeouts = parse_timeouts(service.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))
@@ -259,7 +263,7 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         }
 
         let service_info = ResourceInfo {
-            opaque_ports,
+            app_protocols,
             accrual,
             http_retry,
             grpc_retry,
@@ -325,6 +329,10 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             "config.linkerd.io/opaque-ports",
         )
         .unwrap_or_else(|| self.namespaces.cluster_info.default_opaque_ports.clone());
+        let app_protocols = opaque_ports
+            .into_iter()
+            .map(|port| (port, AppProtocol::Opaque))
+            .collect();
 
         let timeouts = parse_timeouts(egress_network.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))
@@ -355,7 +363,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             .insert(egress_net_ref.clone(), egress_net);
 
         let egress_network_info = ResourceInfo {
-            opaque_ports,
+            app_protocols,
             accrual,
             http_retry,
             grpc_retry,
@@ -1150,10 +1158,10 @@ impl Namespace {
                 continue;
             }
 
-            let opaque = resource.opaque_ports.contains(&resource_port.port);
+            let app_protocol = resource.app_protocols.get(&resource_port.port).cloned();
 
             resource_routes.update_resource(
-                opaque,
+                app_protocol,
                 resource.accrual,
                 resource.http_retry.clone(),
                 resource.grpc_retry.clone(),
@@ -1238,13 +1246,13 @@ impl Namespace {
                         }
                     }
                 };
-                let mut opaque = false;
+                let mut app_protocol = None;
                 let mut accrual = None;
                 let mut http_retry = None;
                 let mut grpc_retry = None;
                 let mut timeouts = Default::default();
                 if let Some(resource) = resource_info.get(&resource_ref) {
-                    opaque = resource.opaque_ports.contains(&rp.port);
+                    app_protocol = resource.app_protocols.get(&rp.port).cloned();
                     accrual = resource.accrual;
                     http_retry = resource.http_retry.clone();
                     grpc_retry = resource.grpc_retry.clone();
@@ -1284,7 +1292,7 @@ impl Namespace {
 
                 let mut resource_routes = ResourceRoutes {
                     parent_info,
-                    opaque,
+                    app_protocol,
                     accrual,
                     http_retry,
                     grpc_retry,
@@ -1577,7 +1585,7 @@ impl ResourceRoutes {
             let (sender, _) = watch::channel(OutboundPolicy {
                 parent_info: self.parent_info.clone(),
                 port: self.port,
-                opaque: self.opaque,
+                app_protocol: self.app_protocol.clone(),
                 accrual: self.accrual,
                 http_retry: self.http_retry.clone(),
                 grpc_retry: self.grpc_retry.clone(),
@@ -1595,7 +1603,7 @@ impl ResourceRoutes {
                 tls_routes,
                 tcp_routes,
                 watch: sender,
-                opaque: self.opaque,
+                app_protocol: self.app_protocol.clone(),
                 accrual: self.accrual,
                 http_retry: self.http_retry.clone(),
                 grpc_retry: self.grpc_retry.clone(),
@@ -1694,21 +1702,21 @@ impl ResourceRoutes {
 
     fn update_resource(
         &mut self,
-        opaque: bool,
+        app_protocol: Option<AppProtocol>,
         accrual: Option<FailureAccrual>,
         http_retry: Option<RouteRetry<HttpRetryCondition>>,
         grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
         timeouts: RouteTimeouts,
         traffic_policy: Option<TrafficPolicy>,
     ) {
-        self.opaque = opaque;
+        self.app_protocol = app_protocol.clone();
         self.accrual = accrual;
         self.http_retry = http_retry.clone();
         self.grpc_retry = grpc_retry.clone();
         self.timeouts = timeouts.clone();
         self.update_traffic_policy(traffic_policy);
         for watch in self.watches_by_ns.values_mut() {
-            watch.opaque = opaque;
+            watch.app_protocol = app_protocol.clone();
             watch.accrual = accrual;
             watch.http_retry = http_retry.clone();
             watch.grpc_retry = grpc_retry.clone();
@@ -1799,8 +1807,8 @@ impl RoutesWatch {
                 modified = true;
             }
 
-            if self.opaque != policy.opaque {
-                policy.opaque = self.opaque;
+            if self.app_protocol != policy.app_protocol {
+                policy.app_protocol = self.app_protocol.clone();
                 modified = true;
             }
 

--- a/policy-test/src/outbound_api.rs
+++ b/policy-test/src/outbound_api.rs
@@ -59,6 +59,46 @@ where
 }
 
 #[track_caller]
+pub fn http1_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::HttpRoute] {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+    if let grpc::outbound::proxy_protocol::Kind::Http1(grpc::outbound::proxy_protocol::Http1 {
+        routes,
+        failure_accrual: _,
+    }) = kind
+    {
+        routes
+    } else {
+        panic!("proxy protocol must be Grpc; actually got:\n{kind:#?}")
+    }
+}
+
+#[track_caller]
+pub fn http2_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::HttpRoute] {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+    if let grpc::outbound::proxy_protocol::Kind::Http2(grpc::outbound::proxy_protocol::Http2 {
+        routes,
+        failure_accrual: _,
+    }) = kind
+    {
+        routes
+    } else {
+        panic!("proxy protocol must be Grpc; actually got:\n{kind:#?}")
+    }
+}
+
+#[track_caller]
 pub fn grpc_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::GrpcRoute] {
     let kind = config
         .protocol

--- a/policy-test/src/test_route.rs
+++ b/policy-test/src/test_route.rs
@@ -61,7 +61,10 @@ pub trait TestParent:
     + Send
     + Sync
 {
-    fn make_parent(ns: impl ToString) -> Self;
+    fn make_parent(ns: impl ToString) -> Self {
+        Self::make_parent_with_protocol(ns, None)
+    }
+    fn make_parent_with_protocol(ns: impl ToString, app_protocol: Option<String>) -> Self;
     fn make_backend(ns: impl ToString) -> Option<Self>;
     fn conditions(&self) -> Vec<&Condition>;
     fn obj_ref(&self) -> ParentReference;
@@ -721,7 +724,7 @@ impl TestRoute for gateway::TcpRoute {
 }
 
 impl TestParent for k8s::Service {
-    fn make_parent(ns: impl ToString) -> Self {
+    fn make_parent_with_protocol(ns: impl ToString, app_protocol: Option<String>) -> Self {
         k8s::Service {
             metadata: k8s::ObjectMeta {
                 namespace: Some(ns.to_string()),
@@ -731,6 +734,7 @@ impl TestParent for k8s::Service {
             spec: Some(k8s::ServiceSpec {
                 ports: Some(vec![k8s::ServicePort {
                     port: 4191,
+                    app_protocol,
                     ..Default::default()
                 }]),
                 ..Default::default()
@@ -786,7 +790,12 @@ impl TestParent for k8s::Service {
 }
 
 impl TestParent for policy::EgressNetwork {
-    fn make_parent(ns: impl ToString) -> Self {
+    fn make_parent_with_protocol(ns: impl ToString, app_protocol: Option<String>) -> Self {
+        assert!(
+            app_protocol.is_none(),
+            "`appProtocol` is not supported by EgressNetwork"
+        );
+
         policy::EgressNetwork {
             metadata: k8s::ObjectMeta {
                 namespace: Some(ns.to_string()),

--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -1,0 +1,47 @@
+use futures::StreamExt;
+use k8s_gateway_api::{self as gateway};
+use linkerd_policy_controller_k8s_api as k8s;
+use linkerd_policy_test::{
+    assert_resource_meta, create,
+    outbound_api::{
+        assert_route_is_default, assert_singleton, retry_watch_outbound_policy, tcp_routes,
+    },
+    test_route::TestParent,
+    with_temp_ns,
+};
+
+#[tokio::test(flavor = "current_thread")]
+async fn opaque_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("linkerd.io/opaque".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = tcp_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::TcpRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}

--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -4,7 +4,8 @@ use linkerd_policy_controller_k8s_api as k8s;
 use linkerd_policy_test::{
     assert_resource_meta, create,
     outbound_api::{
-        assert_route_is_default, assert_singleton, retry_watch_outbound_policy, tcp_routes,
+        assert_route_is_default, assert_singleton, http1_routes, http2_routes,
+        retry_watch_outbound_policy, tcp_routes,
     },
     test_route::TestParent,
     with_temp_ns,
@@ -39,6 +40,78 @@ async fn opaque_parent() {
             let routes = tcp_routes(&config);
             let route = assert_singleton(routes);
             assert_route_is_default::<gateway::TcpRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http1_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("http".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http1_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::HttpRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http2_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http2_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::HttpRoute>(route, &parent.obj_ref(), port);
         })
         .await;
     }

--- a/test/integration/deep/appprotocol/appprotocol_test.go
+++ b/test/integration/deep/appprotocol/appprotocol_test.go
@@ -1,0 +1,238 @@
+package appprotocol
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/linkerd/linkerd2/testutil"
+	v1 "k8s.io/api/core/v1"
+)
+
+var TestHelper *testutil.TestHelper
+
+var opaquePortsClientTemplate = template.Must(template.New("appprotocol_client.yaml").ParseFiles("testdata/appprotocol_client.yaml"))
+
+var (
+	opaqueApp = "opaque"
+	opaqueSC  = "slow-cooker-opaque"
+)
+
+type testCase struct {
+	name      string
+	appName   string
+	appChecks []check
+	scName    string
+	scChecks  []check
+}
+
+type check func(metrics, ns string) error
+
+func checks(c ...check) []check { return c }
+
+func TestMain(m *testing.M) {
+	TestHelper = testutil.NewTestHelper()
+	// Block test execution until control plane is running
+	TestHelper.WaitUntilDeployReady(testutil.LinkerdDeployReplicasEdge)
+	os.Exit(m.Run())
+}
+
+// clientTemplateArgs is a struct that contains the arguments to be supplied
+// to the deployment template opaque_ports_client.yaml.
+type clientTemplateArgs struct {
+	ServiceCookerOpaqueTargetHost string
+}
+
+func serviceName(n string) string {
+	return fmt.Sprintf("svc-%s", n)
+}
+
+//////////////////////
+/// TEST EXECUTION ///
+//////////////////////
+
+func TestOpaquePortsCalledByServiceTarget(t *testing.T) {
+	ctx := context.Background()
+	TestHelper.WithDataPlaneNamespace(ctx, "opaque-ports-called-by-service-name-test", map[string]string{}, t, func(t *testing.T, opaquePortsNs string) {
+		checks := func(c ...check) []check { return c }
+
+		if err := deployApplications(opaquePortsNs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy applications", err)
+		}
+		waitForAppDeploymentReady(t, opaquePortsNs)
+
+		tmplArgs := clientTemplateArgs{
+			ServiceCookerOpaqueTargetHost: serviceName(opaqueApp),
+		}
+		if err := deployTemplate(opaquePortsNs, opaquePortsClientTemplate, tmplArgs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy client pods", err)
+		}
+		waitForClientDeploymentReady(t, opaquePortsNs)
+
+		runTests(ctx, t, opaquePortsNs, []testCase{
+			{
+				name:   "calling a meshed service when appProtocol is linkerd.io/opaque on receiving service",
+				scName: opaqueSC,
+				scChecks: checks(
+					hasNoOutboundHTTPRequest,
+					hasOutboundTCPWithTLSAndAuthority,
+				),
+				appName:   opaqueApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+		})
+	})
+}
+
+func TestOpaquePortsCalledByPodTarget(t *testing.T) {
+	ctx := context.Background()
+	TestHelper.WithDataPlaneNamespace(ctx, "opaque-ports-called-by-pod-ip-test", map[string]string{}, t, func(t *testing.T, opaquePortsNs string) {
+
+		if err := deployApplications(opaquePortsNs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy applications", err)
+		}
+		waitForAppDeploymentReady(t, opaquePortsNs)
+
+		tmplArgs, err := templateArgsPodIP(ctx, opaquePortsNs)
+		if err != nil {
+			testutil.AnnotatedFatal(t, "failed to fetch pod IPs", err)
+		}
+
+		if err := deployTemplate(opaquePortsNs, opaquePortsClientTemplate, tmplArgs); err != nil {
+			testutil.AnnotatedFatal(t, "failed to deploy client pods", err)
+		}
+		waitForClientDeploymentReady(t, opaquePortsNs)
+
+		runTests(ctx, t, opaquePortsNs, []testCase{
+			{
+				name:   "calling a meshed service when appProtocol is linkerd.io/opaque on receiving service",
+				scName: opaqueSC,
+				scChecks: checks(
+					// We call pods directly, so annotation on a service is ignored.
+					hasOutboundHTTPRequestWithTLS,
+					// No authority here, because we are calling the pod directly.
+					hasOutboundTCPWithTLSAndNoAuthority,
+				),
+				appName:   opaqueApp,
+				appChecks: checks(hasInboundTCPTrafficWithTLS),
+			},
+		})
+	})
+}
+
+func waitForAppDeploymentReady(t *testing.T, appProtocolNs string) {
+	TestHelper.WaitRollout(t, map[string]testutil.DeploySpec{
+		opaqueApp: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+	})
+}
+
+func waitForClientDeploymentReady(t *testing.T, appProtocolNs string) {
+	TestHelper.WaitRollout(t, map[string]testutil.DeploySpec{
+		opaqueSC: {
+			Namespace: appProtocolNs,
+			Replicas:  1,
+		},
+	})
+}
+
+func templateArgsPodIP(ctx context.Context, ns string) (clientTemplateArgs, error) {
+	opaquePodIP, err := getPodIPByAppLabel(ctx, ns, opaqueApp)
+	if err != nil {
+		return clientTemplateArgs{}, fmt.Errorf("failed to fetch pod IP for %q: %w", opaqueApp, err)
+	}
+	return clientTemplateArgs{
+		ServiceCookerOpaqueTargetHost: opaquePodIP,
+	}, nil
+}
+
+func runTests(ctx context.Context, t *testing.T, ns string, tcs []testCase) {
+	t.Helper()
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := testutil.RetryFor(30*time.Second, func() error {
+				if err := checkPodMetrics(ctx, ns, tc.scName, tc.scChecks); err != nil {
+					return fmt.Errorf("failed to check metrics for client pod: %w", err)
+				}
+				if tc.appName == "" {
+					return nil
+				}
+				if err := checkPodMetrics(ctx, ns, tc.appName, tc.appChecks); err != nil {
+					return fmt.Errorf("failed to check metrics for app pod: %w", err)
+				}
+				return nil
+			})
+			if err != nil {
+				testutil.AnnotatedFatalf(t, "unexpected metric for pod", "unexpected metric for pod: %s", err)
+			}
+		})
+	}
+}
+
+func checkPodMetrics(ctx context.Context, opaquePortsNs string, podAppLabel string, checks []check) error {
+	pods, err := TestHelper.GetPods(ctx, opaquePortsNs, map[string]string{"app": podAppLabel})
+	if err != nil {
+		return fmt.Errorf("error getting pods for label 'app: %q': %w", podAppLabel, err)
+	}
+	if len(pods) == 0 {
+		return fmt.Errorf("no pods found for label 'app: %q'", podAppLabel)
+	}
+	metrics, err := getPodMetrics(pods[0], opaquePortsNs)
+	if err != nil {
+		return fmt.Errorf("error getting metrics for pod %q: %w", pods[0].Name, err)
+	}
+	for _, check := range checks {
+		if err := check(metrics, opaquePortsNs); err != nil {
+			return fmt.Errorf("validation of pod metrics failed: %w", err)
+		}
+	}
+	return nil
+}
+
+func deployApplications(ns string) error {
+	out, err := TestHelper.Kubectl("", "apply", "-f", "testdata/appprotocol_application.yaml", "-n", ns)
+	if err != nil {
+		return fmt.Errorf("failed apply deployment file %q: %w", out, err)
+	}
+	return nil
+}
+
+func deployTemplate(ns string, tmpl *template.Template, templateArgs interface{}) error {
+	bb := &bytes.Buffer{}
+	if err := tmpl.Execute(bb, templateArgs); err != nil {
+		return fmt.Errorf("failed to write deployment template: %w", err)
+	}
+	out, err := TestHelper.KubectlApply(bb.String(), ns)
+	if err != nil {
+		return fmt.Errorf("failed apply deployment file %q: %w", out, err)
+	}
+	return nil
+}
+
+func getPodMetrics(pod v1.Pod, ns string) (string, error) {
+	podName := fmt.Sprintf("pod/%s", pod.Name)
+	cmd := []string{"diagnostics", "proxy-metrics", "--namespace", ns, podName}
+	metrics, err := TestHelper.LinkerdRun(cmd...)
+	if err != nil {
+		return "", err
+	}
+	return metrics, nil
+}
+
+func getPodIPByAppLabel(ctx context.Context, ns string, app string) (string, error) {
+	labels := map[string]string{"app": app}
+	pods, err := TestHelper.GetPods(ctx, ns, labels)
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod by labels %v: %w", labels, err)
+	}
+	if len(pods) == 0 {
+		return "", fmt.Errorf("no pods found for labels %v", labels)
+	}
+	return pods[0].Status.PodIP, nil
+}

--- a/test/integration/deep/appprotocol/assertions.go
+++ b/test/integration/deep/appprotocol/assertions.go
@@ -1,0 +1,243 @@
+package appprotocol
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/linkerd/linkerd2/testutil/prommatch"
+)
+
+var (
+	authorityRE = regexp.MustCompile(`[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+`)
+)
+
+// hasNoOutboundHTTPRequest returns error if there is any
+// series matching request_total{direction="outbound"}
+func hasNoOutboundHTTPRequest(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+		})
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if ok {
+		return fmt.Errorf("expected not to find HTTP outbound requests \n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundHTTPRequestWithTLS checks there is a series matching:
+//
+//	request_total{
+//	  direction="outbound",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9.]+",
+//	  tls="true",
+//	  dst_namespace="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  dst_serviceaccount="default"
+//	}
+func hasOutboundHTTPRequestWithTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":          prommatch.Equals("outbound"),
+			"tls":                prommatch.Equals("true"),
+			"server_id":          prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"dst_namespace":      prommatch.Equals(ns),
+			"dst_serviceaccount": prommatch.Equals("default"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("expected to find HTTP TLS outbound requests \n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundHTTPRequestNoTLS checks there is a series matching:
+//
+//	request_total{
+//	  direction="outbound",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9.]+",
+//	  tls="no_identity",
+//	  no_tls_reason="not_provided_by_service_discovery",
+//	  dst_namespace="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  dst_serviceaccount="default"
+//	}
+func hasOutboundHTTPRequestNoTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher("request_total",
+		prommatch.Labels{
+			"direction":          prommatch.Equals("outbound"),
+			"tls":                prommatch.Equals("no_identity"),
+			"no_tls_reason":      prommatch.Equals("not_provided_by_service_discovery"),
+			"dst_namespace":      prommatch.Equals(ns),
+			"dst_serviceaccount": prommatch.Equals("default"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("expected to find HTTP non-TLS outbound requests\n%s", metrics)
+	}
+	return nil
+}
+
+// hasInboundTCPTrafficWithTLS checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="inbound",
+//	  peer="src",
+//	  tls="true",
+//	  client_id="default.${ns}.serviceaccount.identity.linkerd.cluster.local",
+//	  srv_kind="default",
+//	  srv_name="all-unauthenticated",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  target_ip=~"[0-9\.]+"
+//	}
+func hasInboundTCPTrafficWithTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher(
+		"tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("inbound"),
+			"peer":      prommatch.Equals("src"),
+			"tls":       prommatch.Equals("true"),
+			"client_id": prommatch.Equals(fmt.Sprintf("default.%s.serviceaccount.identity.linkerd.cluster.local", ns)),
+			"srv_kind":  prommatch.Equals("default"),
+			"srv_name":  prommatch.Equals("all-unauthenticated"),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue(),
+	)
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for inbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithAuthorityAndNoTLS checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="no_identity",
+//	  no_tls_reason="not_provided_by_service_discovery",
+//	  authority=~"[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+"
+//	}
+func hasOutboundTCPWithAuthorityAndNoTLS(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction":     prommatch.Equals("outbound"),
+			"peer":          prommatch.Equals("dst"),
+			"tls":           prommatch.Equals("no_identity"),
+			"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
+			"authority":     prommatch.Like(authorityRE),
+		},
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound non-TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithNoTLSAndNoAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="no_identity",
+//	  no_tls_reason="not_provided_by_service_discovery",
+//	  authority=""
+//	}
+func hasOutboundTCPWithNoTLSAndNoAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction":     prommatch.Equals("outbound"),
+			"peer":          prommatch.Equals("dst"),
+			"tls":           prommatch.Equals("no_identity"),
+			"no_tls_reason": prommatch.Equals("not_provided_by_service_discovery"),
+			"authority":     prommatch.Absent(),
+		})
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound non-TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithTLSAndAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="true",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  authority=~"[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+"
+//	}
+func hasOutboundTCPWithTLSAndAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Like(authorityRE),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}
+
+// hasOutboundTCPWithTLSAndNoAuthority checks there is a series matching:
+//
+//	tcp_open_total{
+//	  direction="outbound",
+//	  peer="dst",
+//	  tls="true",
+//	  target_addr=~"[0-9\.]+:[0-9]+",
+//	  authority=""
+//	}
+func hasOutboundTCPWithTLSAndNoAuthority(metrics, ns string) error {
+	m := prommatch.NewMatcher("tcp_open_total",
+		prommatch.Labels{
+			"direction": prommatch.Equals("outbound"),
+			"peer":      prommatch.Equals("dst"),
+			"tls":       prommatch.Equals("true"),
+			"authority": prommatch.Absent(),
+		},
+		prommatch.TargetAddrLabels(),
+		prommatch.HasPositiveValue())
+	ok, err := m.HasMatchInString(metrics)
+	if err != nil {
+		return fmt.Errorf("failed to run a check of against the provided metrics: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("failed to find expected metric for outbound TLS TCP traffic\n%s", metrics)
+	}
+	return nil
+}

--- a/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opaque
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opaque
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: opaque
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=opaque"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-opaque
+  labels:
+    app: svc-opaque
+spec:
+  selector:
+    app: opaque
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: linkerd.io/opaque

--- a/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
@@ -39,3 +39,85 @@ spec:
     port: 8080
     targetPort: 8080
     appProtocol: linkerd.io/opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http1
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: http1
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=http1"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-http1
+  labels:
+    app: svc-http1
+spec:
+  selector:
+    app: http1
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http2
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: http2
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.6
+        args:
+        - terminus
+        - "--h2-server-port=8080"
+        - "--response-text=http2"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-http2
+  labels:
+    app: svc-http2
+spec:
+  selector:
+    app: http2
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: kubernetes.io/h2c

--- a/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
@@ -23,3 +23,53 @@ spec:
         - http://{{ .ServiceCookerOpaqueTargetHost}}:8080
         ports:
         - containerPort: 9999
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-http1
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-http1
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-http1
+    spec:
+      containers:
+      - name: slow-cooker-opaque
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerHttp1TargetHost}}:8080
+        ports:
+        - containerPort: 9999
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-http2
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-http2
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-http2
+    spec:
+      containers:
+      - name: slow-cooker-http2
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerHttp2TargetHost}}:8080
+        ports:
+        - containerPort: 9999

--- a/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-opaque
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-opaque
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-opaque
+    spec:
+      containers:
+      - name: slow-cooker-opaque
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerOpaqueTargetHost}}:8080
+        ports:
+        - containerPort: 9999


### PR DESCRIPTION
This adds "http" and "kubernetes.io/h2c" as a valid values for service port appProtocol. Continuation of https://github.com/linkerd/linkerd2/pull/13660.