### PR TITLE
fix(test): mark TestResourcesPostInstall as a helper

### DIFF
--- a/testutil/install.go
+++ b/testutil/install.go
@@ -8,6 +8,7 @@ import (
 
 // TestResourcesPostInstall tests resources post control plane installation
 func TestResourcesPostInstall(namespace string, services []Service, deploys map[string]DeploySpec, h *TestHelper, t *testing.T) {
+	t.Helper()
 	ctx := context.Background()
 	// Tests Namespace
 	err := h.CheckIfNamespaceExists(ctx, namespace)


### PR DESCRIPTION
TestResourcesPostInstall is a test helper, but it does not use t.Helper() so it hides the proper line number for test failures.

This change fixes this.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
