### PR TITLE
feat(policy): enable kubert runtime metrics

### DIFF
--- a/policy-controller/runtime/src/args.rs
+++ b/policy-controller/runtime/src/args.rs
@@ -168,9 +168,11 @@ impl Args {
             prom.sub_registry_with_prefix("inbound_index"),
             inbound_index.clone(),
         );
+        let rt_metrics = kubert::RuntimeMetrics::register(prom.sub_registry_with_prefix("kube"));
 
         let mut runtime = kubert::Runtime::builder()
             .with_log(log_level, log_format)
+            .with_metrics(rt_metrics)
             .with_admin(admin.into_builder().with_prometheus(prom))
             .with_client(client)
             .with_optional_server(server)


### PR DESCRIPTION
Kubert's runtime can provide metrics for watches. This change configures the runtime to enable these default metrics.

In an upcoming kubert release, these metrics are expanded to include Kubernetes client metrics. Future enhancements may be added without additional policy controller changes.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
