### PR TITLE
fix(policy): order Server resources deterministically

### DIFF
--- a/policy-controller/k8s/index/src/inbound/index.rs
+++ b/policy-controller/k8s/index/src/inbound/index.rs
@@ -1240,7 +1240,15 @@ impl Pod {
             std::hash::BuildHasherDefault::<PortHasher>::default(),
         );
 
-        for (srvname, server) in policy.servers.iter() {
+        // Sort by creation and then name, similarly to HTTPRoutes, to enforce
+        // precedence.
+        let mut servers = policy.servers.iter().collect::<Vec<_>>();
+        servers.sort_by(|(aname, asrv), (bname, bsrv)| {
+            asrv.created_at
+                .cmp(&bsrv.created_at)
+                .then_with(|| aname.cmp(bname))
+        });
+        for (srvname, server) in servers {
             if let Selector::Pod(pod_selector) = &server.selector {
                 if pod_selector.matches(&self.meta.labels) {
                     for port in self.select_ports(&server.port_ref).into_iter() {
@@ -1489,7 +1497,15 @@ impl ExternalWorkload {
             std::hash::BuildHasherDefault::<PortHasher>::default(),
         );
 
-        for (srvname, server) in policy.servers.iter() {
+        // Sort by creation and then name, similarly to HTTPRoutes, to enforce
+        // precedence.
+        let mut servers = policy.servers.iter().collect::<Vec<_>>();
+        servers.sort_by(|(aname, asrv), (bname, bsrv)| {
+            asrv.created_at
+                .cmp(&bsrv.created_at)
+                .then_with(|| aname.cmp(bname))
+        });
+        for (srvname, server) in servers {
             if let Selector::ExternalWorkload(selector) = &server.selector {
                 if selector.matches(&self.meta.labels) {
                     // Each server selects exactly one port on an

--- a/policy-controller/k8s/index/src/inbound/server.rs
+++ b/policy-controller/k8s/index/src/inbound/server.rs
@@ -12,6 +12,7 @@ pub(crate) struct Server {
     pub port_ref: Port,
     pub protocol: ProxyProtocol,
     pub access_policy: Option<DefaultPolicy>,
+    pub created_at: Option<k8s::Time>,
 }
 
 impl Server {
@@ -22,6 +23,7 @@ impl Server {
             port_ref: srv.spec.port,
             protocol: proxy_protocol(srv.spec.proxy_protocol, cluster),
             access_policy: srv.spec.access_policy.and_then(|p| p.parse().ok()),
+            created_at: srv.metadata.creation_timestamp,
         }
     }
 }

--- a/policy-controller/runtime/src/args.rs
+++ b/policy-controller/runtime/src/args.rs
@@ -387,8 +387,7 @@ impl Args {
                 .instrument(info_span!("status_controller")),
         );
 
-        let client = runtime.client();
-        let runtime = runtime.spawn_server(|| Admission::new(client));
+        let runtime = runtime.spawn_server(Admission::new);
 
         // Block the main thread on the shutdown signal. Once it fires, wait for the background tasks to
         // complete before exiting.


### PR DESCRIPTION
The policy controller iterates over a map of Server resources when associating a
Server with a Pod. The map iteration order is non-deterministic. We currently
attempt to prevent multiple server resources from selecting a single pod-port,
however, this logic is imperfect and unreliable, so the policy controller must
handle overlapping Servers in any case...

To resolve this, the inbound policy index now sorts Server resources by their
creation timestamp (and then name) before iterating over them. This mimics our
handling of Route resources...

Furthermore, this change relaxes the policy controller's admission logic,
avoiding the rejection of overlapping Server resources. This avoids an
unnecessary API call (that may timeout, etc).

An integration test is added to confirm the API response behavior.