### PR TITLE
fix(policy): retry lease creation errors

### DIFF
--- a/policy-controller/runtime/src/lease.rs
+++ b/policy-controller/runtime/src/lease.rs
@@ -18,9 +18,29 @@ pub async fn init<T>(
     // Fetch the policy-controller deployment so that we can use it as an owner
     // reference of the Lease.
     let api = k8s::Api::<Deployment>::namespaced(runtime.client(), ns);
-    let deployment = api.get(deployment_name).await?;
+    let mut tries = 3;
+    let deployment = loop {
+        tries -= 1;
+        let error = match api.get(deployment_name).await {
+            Ok(deploy) => {
+                tracing::debug!(?deploy, "Found Deployment");
+                break deploy;
+            }
+            Err(k8s::Error::Api(error)) => error.into(),
+            Err(k8s::Error::Service(error)) => error,
+            Err(k8s::Error::HyperError(error)) => error.into(),
+            Err(error) => {
+                return Err(error.into());
+            }
+        };
+        if tries == 0 {
+            anyhow::bail!(error);
+        }
+        tracing::warn!(?error, "Failed to fetch deployment, retrying in 1s...");
+        time::sleep(time::Duration::from_secs(1)).await;
+    };
 
-    let lease = coordv1::Lease {
+    let patch = kube::api::Patch::Apply(coordv1::Lease {
         metadata: ObjectMeta {
             name: Some(LEASE_NAME.to_string()),
             namespace: Some(ns.to_string()),
@@ -42,25 +62,39 @@ pub async fn init<T>(
             ..Default::default()
         },
         spec: None,
+    });
+    let patch_params = PatchParams {
+        field_manager: Some("policy-controller".to_string()),
+        ..Default::default()
     };
     let api = k8s::Api::<coordv1::Lease>::namespaced(runtime.client(), ns);
-    match api
-        .patch(
-            LEASE_NAME,
-            &PatchParams {
-                field_manager: Some("policy-controller".to_string()),
-                ..Default::default()
-            },
-            &kube::api::Patch::Apply(lease),
-        )
-        .await
-    {
-        Ok(lease) => tracing::info!(?lease, "Created Lease resource"),
-        Err(k8s::Error::Api(_)) => tracing::debug!("Lease already exists, no need to create it"),
-        Err(error) => {
-            return Err(error.into());
+
+    // An individual request may timeout or hit a transient error, so we try up to 3 times with a brief pause.
+    let mut tries = 3;
+    loop {
+        tries -= 1;
+        let error = match api.patch(LEASE_NAME, &patch_params, &patch).await {
+            Ok(lease) => {
+                tracing::info!(?lease, "Created Lease");
+                break;
+            }
+            Err(k8s::Error::Api(error)) if error.code >= 500 => error.into(),
+            Err(k8s::Error::Api(error)) => {
+                tracing::debug!(?error, "Lease already exists");
+                break;
+            }
+            Err(k8s::Error::Service(error)) => error,
+            Err(k8s::Error::HyperError(error)) => error.into(),
+            Err(error) => {
+                return Err(error.into());
+            }
+        };
+        if tries == 0 {
+            anyhow::bail!(error);
         }
-    };
+        tracing::warn!(?error, "Failed to create Lease, retrying in 1s...");
+        time::sleep(time::Duration::from_secs(1)).await;
+    }
 
     // Create the lease manager used for trying to claim the policy
     // controller write lease.


### PR DESCRIPTION
When the policy controller starts up, it attempts to create a Lease in the cluster. If this fails with an unexpected error, the error is considered fatal and the controller exits, causing the container to be restarted.

This can cause a substantial amount of CI flakiness (our CI checks for container restarts), and it's generally undesirable for users to see container restarts.

To avoid this problem, this change adds simple retry functionality to the lease creation.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
