### PR TITLE
feat(destination): introduce transport-protocol outbound TLS mode

### DIFF
--- a/controller/api/destination/endpoint_profile_translator_test.go
+++ b/controller/api/destination/endpoint_profile_translator_test.go
@@ -40,7 +40,7 @@ func TestEndpointProfileTranslator(t *testing.T) {
 		}
 		log := logging.WithField("test", t.Name())
 		translator := newEndpointProfileTranslator(
-			true, "cluster", "identity", make(map[uint32]struct{}), nil,
+			false, true, "cluster", "identity", make(map[uint32]struct{}), nil,
 			mockGetProfileServer,
 			nil,
 			log,
@@ -84,7 +84,7 @@ func TestEndpointProfileTranslator(t *testing.T) {
 		log := logging.WithField("test", t.Name())
 		endStream := make(chan struct{})
 		translator := newEndpointProfileTranslator(
-			true, "cluster", "identity", make(map[uint32]struct{}), nil,
+			false, true, "cluster", "identity", make(map[uint32]struct{}), nil,
 			mockGetProfileServer,
 			endStream,
 			log,

--- a/controller/api/destination/federated_service_watcher.go
+++ b/controller/api/destination/federated_service_watcher.go
@@ -351,6 +351,7 @@ func (fs *federatedService) remoteDiscoverySubscribe(
 	translator := newEndpointTranslator(
 		fs.config.ControllerNS,
 		remoteConfig.TrustDomain,
+		fs.config.ForceOpaqueTransport,
 		fs.config.EnableH2Upgrade,
 		false, // Disable endpoint filtering for remote discovery.
 		fs.config.EnableIPv6,
@@ -399,6 +400,7 @@ func (fs *federatedService) localDiscoverySubscribe(
 	translator := newEndpointTranslator(
 		fs.config.ControllerNS,
 		fs.config.IdentityTrustDomain,
+		fs.config.ForceOpaqueTransport,
 		fs.config.EnableH2Upgrade,
 		true,
 		fs.config.EnableIPv6,

--- a/controller/api/destination/server.go
+++ b/controller/api/destination/server.go
@@ -30,6 +30,7 @@ type (
 		IdentityTrustDomain,
 		ClusterDomain string
 
+		ForceOpaqueTransport,
 		EnableH2Upgrade,
 		EnableEndpointSlices,
 		EnableIPv6,
@@ -205,6 +206,7 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 		translator := newEndpointTranslator(
 			s.config.ControllerNS,
 			remoteConfig.TrustDomain,
+			s.config.ForceOpaqueTransport,
 			s.config.EnableH2Upgrade,
 			false, // Disable endpoint filtering for remote discovery.
 			s.config.EnableIPv6,
@@ -239,6 +241,7 @@ func (s *server) Get(dest *pb.GetDestination, stream pb.Destination_GetServer) e
 		translator := newEndpointTranslator(
 			s.config.ControllerNS,
 			s.config.IdentityTrustDomain,
+			s.config.ForceOpaqueTransport,
 			s.config.EnableH2Upgrade,
 			true,
 			s.config.EnableIPv6,
@@ -531,6 +534,7 @@ func (s *server) subscribeToEndpointProfile(
 	canceled := stream.Context().Done()
 	streamEnd := make(chan struct{})
 	translator := newEndpointProfileTranslator(
+		s.config.ForceOpaqueTransport,
 		s.config.EnableH2Upgrade,
 		s.config.ControllerNS,
 		s.config.IdentityTrustDomain,

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -1045,6 +1045,10 @@ func (m *mockDestinationGetProfileServer) Send(profile *pb.DestinationProfile) e
 }
 
 func makeEndpointTranslator(t *testing.T) (*mockDestinationGetServer, *endpointTranslator) {
+	return makeEndpointTranslatorWithOpaqueTransport(t, false)
+}
+
+func makeEndpointTranslatorWithOpaqueTransport(t *testing.T, forceOpaqueTransport bool) (*mockDestinationGetServer, *endpointTranslator) {
 	t.Helper()
 	node := `apiVersion: v1
 kind: Node
@@ -1072,9 +1076,10 @@ metadata:
 	translator := newEndpointTranslator(
 		"linkerd",
 		"trust.domain",
-		true,
-		true,
+		forceOpaqueTransport,
+		true,  // enableH2Upgrade
 		true,  // enableEndpointFiltering
+		true,  // enableIPv6
 		false, // extEndpointZoneWeights
 		nil,   // meshedHttp2ClientParams
 		"service-name.service-ns",


### PR DESCRIPTION
Non-opaque meshed traffic currently flows over the original destination port, which requires the inbound proxy to do protocol detection.

This adds an option to the destination controller that configures all meshed traffic to flow to the inbound proxy's inbound port. This will allow us to include more session protocol information in the future, obviating the need for inbound protocol detection.

This doesn't do much in the way of testing, since the default behavior should be unchanged. When this default changes, more validation will be done on the behavior here.