### PR TITLE
feat(policy): Add http protocol configuration

### DIFF
--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -44,6 +44,8 @@ pub type RouteSet<T> = HashMap<GroupKindNamespaceName, T>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AppProtocol {
+    Http1,
+    Http2,
     Opaque,
     Unknown(Arc<str>),
 }
@@ -53,6 +55,8 @@ impl FromStr for AppProtocol {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let protocol = match s.to_ascii_lowercase().as_str() {
+            "http" => AppProtocol::Http1,
+            "kubernetes.io/h2c" => AppProtocol::Http2,
             "linkerd.io/tcp" | "linkerd.io/opaque" => AppProtocol::Opaque,
             protocol => AppProtocol::Unknown(Arc::from(protocol)),
         };

--- a/policy-test/src/outbound_api.rs
+++ b/policy-test/src/outbound_api.rs
@@ -59,6 +59,46 @@ where
 }
 
 #[track_caller]
+pub fn http1_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::HttpRoute] {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+    if let grpc::outbound::proxy_protocol::Kind::Http1(grpc::outbound::proxy_protocol::Http1 {
+        routes,
+        failure_accrual: _,
+    }) = kind
+    {
+        routes
+    } else {
+        panic!("proxy protocol must be Grpc; actually got:\n{kind:#?}")
+    }
+}
+
+#[track_caller]
+pub fn http2_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::HttpRoute] {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+    if let grpc::outbound::proxy_protocol::Kind::Http2(grpc::outbound::proxy_protocol::Http2 {
+        routes,
+        failure_accrual: _,
+    }) = kind
+    {
+        routes
+    } else {
+        panic!("proxy protocol must be Grpc; actually got:\n{kind:#?}")
+    }
+}
+
+#[track_caller]
 pub fn grpc_routes(config: &grpc::outbound::OutboundPolicy) -> &[grpc::outbound::GrpcRoute] {
     let kind = config
         .protocol

--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -4,7 +4,8 @@ use linkerd_policy_controller_k8s_api::gateway;
 use linkerd_policy_test::{
     assert_resource_meta, create,
     outbound_api::{
-        assert_route_is_default, assert_singleton, retry_watch_outbound_policy, tcp_routes,
+        assert_route_is_default, assert_singleton, http1_routes, http2_routes,
+        retry_watch_outbound_policy, tcp_routes,
     },
     test_route::TestParent,
     with_temp_ns,
@@ -39,6 +40,78 @@ async fn opaque_parent() {
             let routes = tcp_routes(&config);
             let route = assert_singleton(routes);
             assert_route_is_default::<gateway::TCPRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http1_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("http".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http1_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::HTTPRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http2_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http2_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::HTTPRoute>(route, &parent.obj_ref(), port);
         })
         .await;
     }

--- a/test/integration/deep/appprotocol/assertions.go
+++ b/test/integration/deep/appprotocol/assertions.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	authorityRE = regexp.MustCompile(`[a-zA-Z\-]+\.[a-zA-Z\-]+\.svc\.cluster\.local:[0-9]+`)
+	authorityRE = regexp.MustCompile(`[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-]+\.svc\.cluster\.local:[0-9]+`)
 )
 
 // hasNoOutboundHTTPRequest returns error if there is any

--- a/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_application.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: buoyantio/bb:v0.0.6
+        image: buoyantio/bb:v0.0.7
         args:
         - terminus
         - "--h1-server-port=8080"
@@ -39,3 +39,44 @@ spec:
     port: 8080
     targetPort: 8080
     appProtocol: linkerd.io/opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: http1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http1
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      labels:
+        app: http1
+    spec:
+      containers:
+      - name: app
+        image: buoyantio/bb:v0.0.7
+        args:
+        - terminus
+        - "--h1-server-port=8080"
+        - "--response-text=http1"
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-http1
+  labels:
+    app: svc-http1
+spec:
+  selector:
+    app: http1
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: http

--- a/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
+++ b/test/integration/deep/appprotocol/testdata/appprotocol_client.yaml
@@ -23,3 +23,28 @@ spec:
         - http://{{ .ServiceCookerOpaqueTargetHost}}:8080
         ports:
         - containerPort: 9999
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slow-cooker-http1
+spec:
+  selector:
+    matchLabels:
+      app: slow-cooker-http1
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: "enabled"
+      labels:
+        app: slow-cooker-http1
+    spec:
+      containers:
+      - name: slow-cooker-opaque
+        image: buoyantio/slow_cooker:1.3.0
+        args:
+        - -qps=1
+        - -metric-addr=0.0.0.0:9999
+        - http://{{ .ServiceCookerHttp1TargetHost}}:8080
+        ports:
+        - containerPort: 9999


### PR DESCRIPTION
This adds "http" and "kubernetes.io/h2c" as a valid values for service port appProtocol. Continuation of https://github.com/linkerd/linkerd2/pull/13660.