### PR TITLE
build(policy): fix kubert TLS features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "futures-util",
  "http-body-util",
  "hyper",
+ "hyper-openssl",
  "hyper-util",
  "k8s-openapi",
  "kube-client",
@@ -1269,6 +1270,8 @@ dependencies = [
  "kube-runtime",
  "kubert-prometheus-process",
  "kubert-prometheus-tokio",
+ "once_cell",
+ "openssl",
  "parking_lot",
  "pin-project-lite",
  "prometheus-client",
@@ -1277,6 +1280,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-openssl",
  "tokio-rustls",
  "tower 0.5.2",
  "tower-http",
@@ -2501,6 +2505,17 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio",
 ]
 
 [[package]]

--- a/policy-controller/runtime/Cargo.toml
+++ b/policy-controller/runtime/Cargo.toml
@@ -7,11 +7,11 @@ license = "Apache-2.0"
 publish = false
 
 [features]
-default = ["openssl-tls", "openssl-vendored"]
-openssl-tls = ["kube/openssl-tls"]
+default = ["rustls-tls"]
+openssl-tls = ["kube/openssl-tls", "kubert/openssl-tls"]
 # Vendor openssl to statically link lib
-openssl-vendored = ["openssl/vendored"]
-rustls-tls = ["kube/rustls-tls"]
+openssl-vendored = ["openssl-tls", "openssl/vendored"]
+rustls-tls = ["kube/rustls-tls", "kubert/rustls-tls"]
 
 [dependencies]
 anyhow = "1"
@@ -60,7 +60,6 @@ features = [
     "prometheus-client",
     "runtime",
     "server",
-    "rustls-tls",
 ]
 
 [dependencies.tokio]


### PR DESCRIPTION
The policy controller runtime crate incorrectly set the 'rustls-tls' feature on the kubert dependency, even though the crate takes top-level feature flags to control its crypto implementation.

This change updates the runtime crate's feature flagging to properly alternate between rustls and openssl.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
