### PR TITLE
feat(helm)!: abandon gateway api CRDs after install

### DIFF
--- a/charts/linkerd-crds/templates/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/charts/linkerd-crds/templates/gateway.networking.k8s.io_grpcroutes.yaml
@@ -8,6 +8,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     {{ include "partials.annotations.created-by" . }}
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/charts/linkerd-crds/templates/gateway.networking.k8s.io_httproutes.yaml
+++ b/charts/linkerd-crds/templates/gateway.networking.k8s.io_httproutes.yaml
@@ -8,6 +8,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     {{ include "partials.annotations.created-by" . }}
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/charts/linkerd-crds/templates/gateway.networking.k8s.io_tcproutes.yaml
+++ b/charts/linkerd-crds/templates/gateway.networking.k8s.io_tcproutes.yaml
@@ -8,6 +8,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     {{ include "partials.annotations.created-by" . }}
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/charts/linkerd-crds/templates/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/charts/linkerd-crds/templates/gateway.networking.k8s.io_tlsroutes.yaml
@@ -8,6 +8,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     {{ include "partials.annotations.created-by" . }}
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     linkerd.io/control-plane-ns: {{.Release.Namespace}}

--- a/cli/cmd/testdata/install_crds.golden
+++ b/cli/cmd/testdata/install_crds.golden
@@ -6772,6 +6772,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/cli dev-undefined
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-0.0.0-undefined
     linkerd.io/control-plane-ns: linkerd
@@ -13255,6 +13256,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/cli dev-undefined
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-0.0.0-undefined
     linkerd.io/control-plane-ns: linkerd
@@ -17952,6 +17954,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/cli dev-undefined
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-0.0.0-undefined
     linkerd.io/control-plane-ns: linkerd
@@ -18852,6 +18855,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/cli dev-undefined
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-0.0.0-undefined
     linkerd.io/control-plane-ns: linkerd

--- a/cli/cmd/testdata/install_helm_crds_output.golden
+++ b/cli/cmd/testdata/install_helm_crds_output.golden
@@ -6792,6 +6792,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev
@@ -13277,6 +13278,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev
@@ -17976,6 +17978,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev
@@ -18878,6 +18881,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev

--- a/cli/cmd/testdata/install_helm_crds_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_crds_output_ha.golden
@@ -6792,6 +6792,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev
@@ -13277,6 +13278,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev
@@ -17976,6 +17978,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev
@@ -18878,6 +18881,7 @@ metadata:
     gateway.networking.k8s.io/bundle-version: v1.1.1
     gateway.networking.k8s.io/channel: experimental
     linkerd.io/created-by: linkerd/helm linkerd-version
+    helm.sh/resource-policy: keep
   labels:
     helm.sh/chart: linkerd-crds-
     linkerd.io/control-plane-ns: linkerd-dev


### PR DESCRIPTION
We add the `helm.sh/resource-policy: keep` annotation to Gateway API CRDs installed by Linkerd.  This is to enable Linkerd to stop managing these CRDs in the future without deleting them and causing downtime during upgrades.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
