### PR TITLE
fix(policy): Fix policy controller panic when gateway api is not installed

### DIFF
--- a/policy-controller/runtime/src/args.rs
+++ b/policy-controller/runtime/src/args.rs
@@ -458,9 +458,9 @@ where
     T::DynamicType: Default,
 {
     let dt = Default::default();
-    let resources = client
-        .list_api_group_resources(&T::api_version(&dt))
-        .await
-        .expect("Failed to list API group resources");
-    resources.resources.iter().any(|r| r.kind == T::kind(&dt))
+    if let Ok(resources) = client.list_api_group_resources(&T::api_version(&dt)).await {
+        resources.resources.iter().any(|r| r.kind == T::kind(&dt))
+    } else {
+        false
+    }
 }

--- a/policy-controller/runtime/src/args.rs
+++ b/policy-controller/runtime/src/args.rs
@@ -458,9 +458,11 @@ where
     T::DynamicType: Default,
 {
     let dt = Default::default();
-    if let Ok(resources) = client.list_api_group_resources(&T::api_version(&dt)).await {
-        resources.resources.iter().any(|r| r.kind == T::kind(&dt))
-    } else {
-        false
-    }
+    client
+        .list_api_group_resources(&T::api_version(&dt))
+        .await
+        .ok()
+        .iter()
+        .flat_map(|r| r.resources.iter())
+        .any(|r| r.kind == T::kind(&dt))
 }


### PR DESCRIPTION
When the policy controller starts up, it attempts to detect if each of the Gateway API CRDs are installed on the cluster and starts a watch on that resource if the CRD exists.  However, if no CRDs in the Gateway API resource group are installed, then the call to find CRDs in that resource group will fail with a 404.  This causes a panic in the policy controller.

We fix this behavior to handle a Not Found API Group as the CRD not existing.  This causes us to skip the watch as desired instead of panicking.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
