### PR TITLE
fix(policy): ensure runtime default features are correct

### DIFF
--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -15,7 +15,7 @@ openssl-vendored = ["linkerd-policy-controller-runtime/openssl-vendored"]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 
-linkerd-policy-controller-runtime = { path = "./runtime" }
+linkerd-policy-controller-runtime = { path = "./runtime", default-features = false }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.5"


### PR DESCRIPTION
We unintentionally use the default feautres of the runtime crate in the policy controller. This commit fixes that by setting the default features to false.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
