### PR TITLE
build(deps): bump cni-plugin from v1.6.0 to v1.6.2

### DIFF
--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -69,7 +69,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.6.0"
+  version: "v1.6.2"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -90,10 +90,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: linkerd-cni
-  updateStrategy:
-    type: RollingUpdate
+  updateStrategy: 
     rollingUpdate:
       maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -117,7 +117,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -91,10 +91,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: linkerd-cni
-  updateStrategy:
-    type: RollingUpdate
+  updateStrategy: 
     rollingUpdate:
       maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -118,7 +118,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -83,10 +83,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: linkerd-cni
-  updateStrategy:
-    type: RollingUpdate
+  updateStrategy: 
     rollingUpdate:
       maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -110,7 +110,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2372,7 +2372,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.0
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var Version = undefinedVersion
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
 var ProxyInitVersion = "v2.4.2"
-var LinkerdCNIVersion = "v1.6.0"
+var LinkerdCNIVersion = "v1.6.2"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
https://github.com/linkerd/linkerd2-proxy-init/releases/tag/cni-plugin%2Fv1.6.2

> Fixed shutdown issue
>
> This release fixes an issue introduced in v1.6.0 where the linkerd-cni
> pod was failing to complete its cleanup tasks during shutdown, leaving
> the linkerd-cni active but potentially with revoked permissions, thus
> interfering with the proper startup of pods in the node.