### PR TITLE
refactor(inject): group resource requests/limits by type

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -372,24 +372,6 @@ func applyAnnotationOverrides(values *l5dcharts.Values, annotations map[string]s
 		}
 	}
 
-	if override, ok := annotations[k8s.ProxyMemoryRequestAnnotation]; ok {
-		_, err := k8sResource.ParseQuantity(override)
-		if err != nil {
-			log.Warnf("%s (%s)", err, k8s.ProxyMemoryRequestAnnotation)
-		} else {
-			values.Proxy.Resources.Memory.Request = override
-		}
-	}
-
-	if override, ok := annotations[k8s.ProxyEphemeralStorageRequestAnnotation]; ok {
-		_, err := k8sResource.ParseQuantity(override)
-		if err != nil {
-			log.Warnf("%s (%s)", err, k8s.ProxyEphemeralStorageRequestAnnotation)
-		} else {
-			values.Proxy.Resources.EphemeralStorage.Request = override
-		}
-	}
-
 	if override, ok := annotations[k8s.ProxyCPULimitAnnotation]; ok {
 		q, err := k8sResource.ParseQuantity(override)
 		if err != nil {
@@ -405,12 +387,34 @@ func applyAnnotationOverrides(values *l5dcharts.Values, annotations map[string]s
 		}
 	}
 
+	// Proxy memory resources
+
+	if override, ok := annotations[k8s.ProxyMemoryRequestAnnotation]; ok {
+		_, err := k8sResource.ParseQuantity(override)
+		if err != nil {
+			log.Warnf("%s (%s)", err, k8s.ProxyMemoryRequestAnnotation)
+		} else {
+			values.Proxy.Resources.Memory.Request = override
+		}
+	}
+
 	if override, ok := annotations[k8s.ProxyMemoryLimitAnnotation]; ok {
 		_, err := k8sResource.ParseQuantity(override)
 		if err != nil {
 			log.Warnf("%s (%s)", err, k8s.ProxyMemoryLimitAnnotation)
 		} else {
 			values.Proxy.Resources.Memory.Limit = override
+		}
+	}
+
+	// Proxy ephemeral storage resources
+
+	if override, ok := annotations[k8s.ProxyEphemeralStorageRequestAnnotation]; ok {
+		_, err := k8sResource.ParseQuantity(override)
+		if err != nil {
+			log.Warnf("%s (%s)", err, k8s.ProxyEphemeralStorageRequestAnnotation)
+		} else {
+			values.Proxy.Resources.EphemeralStorage.Request = override
 		}
 	}
 


### PR DESCRIPTION
In preparation for changes to CPU resource configuration, this commit reorders the internals of the annotation overriding logic to group resource requests and limits by type.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
