### PR TITLE
feat(multicluster): have linkerd-multicluster chart be responsible for service mirror controllers

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/controller-clusterrole.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller-clusterrole.yaml
@@ -1,0 +1,20 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-multicluster-controller-access-local-resources
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+    {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+rules:
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["list", "get", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+{{- if .Values.enableNamespaceCreation }}
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["create"]
+{{- end}}

--- a/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
@@ -1,0 +1,105 @@
+{{- range .Values.controllers }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+    mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+    {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+  name: controller-{{.link.ref.name}}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  replicas: {{ dig "replicas" $.Values.controllerDefaults.replicas . }}
+  revisionHistoryLimit: {{$.Values.revisionHistoryLimit}}
+  selector:
+    matchLabels:
+      component: controller
+      mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+  {{- if dig "enablePodAntiAffinity" $.Values.controllerDefaults.enablePodAntiAffinity . }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: "0"
+        {{- with $.Values.podAnnotations }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+      labels:
+        linkerd.io/extension: multicluster
+        component: controller
+        mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+        {{- with $.Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
+    spec:
+    {{- if dig "enablePodAntiAffinity" $.Values.controllerDefaults.enablePodAntiAffinity . }}
+    {{- with $tree := deepCopy $ }}
+    {{- $_ := set $tree "component" .link.ref.name -}}
+    {{- $_ := set $tree "label" "mirror.linkerd.io/cluster-name" -}}
+    {{- include "linkerd.affinity" $tree | nindent 6 }}
+    {{- end }}
+    {{- end }}
+      automountServiceAccountToken: false
+      containers:
+      - args:
+        - service-mirror
+        - -log-level={{ dig "logLevel" $.Values.controllerDefaults.logLevel . }}
+        - -log-format={{ dig "logFormat" $.Values.controllerDefaults.logFormat . }}
+        - -event-requeue-limit={{ dig "retryLimit" $.Values.controllerDefaults.retryLimit . }}
+        - -namespace={{$.Release.Namespace}}
+        {{- if dig "enableHeadlessServices" $.Values.controllerDefaults.enableHeadlessServices . }}
+        - -enable-headless-services
+        {{- end }}
+        {{- if $.Values.enableNamespaceCreation }}
+        - -enable-namespace-creation
+        {{- end }}
+        - -enable-pprof={{ dig "enablePprof" $.Values.controllerDefaults.enablePprof . }}
+        - {{.link.ref.name}}
+        {{- if or $.Values.serviceMirrorAdditionalEnv $.Values.serviceMirrorExperimentalEnv }}
+        env:
+        {{- with $.Values.serviceMirrorAdditionalEnv }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- with $.Values.serviceMirrorExperimentalEnv }}
+        {{- toYaml . | nindent 8 -}}
+        {{- end }}
+        {{- end }}
+        image: {{ dig "image" "name" $.Values.controllerDefaults.image.name . }}:{{ dig "image" "version" $.Values.controllerDefaults.image.version . }}
+        name: controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: {{ dig "UID" $.Values.controllerDefaults.UID . }}
+          runAsGroup: {{ dig "GID" $.Values.controllerDefaults.GID . }}
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access
+          readOnly: true
+        ports:
+        - containerPort: 9999
+          name: admin-http
+        {{- with dig "resources" $.Values.controllerDefaults.resources . }}
+        resources: {{ toYaml . | nindent 10 }}
+        {{- end }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: controller-{{.link.ref.name}}
+      volumes:
+      - {{- include "partials.volumes.manual-mount-service-account-token" $ | indent 8 | trimPrefix (repeat 7 " ") }}
+      {{- with dig "nodeSelector" $.Values.controllerDefaults.nodeSelector . }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with dig "tolerations" $.Values.controllerDefaults.tolerations . }}
+      tolerations: {{ toYaml . | nindent 6 }}
+      {{- end }}
+{{- end}}

--- a/multicluster/charts/linkerd-multicluster/templates/controller/pdb.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/pdb.yaml
@@ -1,0 +1,20 @@
+{{- range .Values.controllers }}
+{{- if dig "enablePodAntiAffinity" $.Values.enablePodAntiAffinity . }}
+---
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: controller-{{.link.ref.name}}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    component: controller
+  annotations:
+    {{ include "partials.annotations.created-by" . }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: controller
+      mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+{{- end}}
+{{- end}}

--- a/multicluster/charts/linkerd-multicluster/templates/controller/probe-svc.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/probe-svc.yaml
@@ -1,0 +1,21 @@
+{{- range .Values.controllers }}
+{{- if dig "gateway" "enabled" $.Values.controllerDefaults.gateway.enabled . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: probe-{{.link.ref.name}}
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+  labels:
+    linkerd.io/extension: multicluster
+    mirror.linkerd.io/mirrored-gateway: "true"
+    mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+    {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+spec:
+  ports:
+  - name: mc-probe
+    port: {{ dig "gateway" "probe" "port" $.Values.controllerDefaults.gateway.probe.port . }}
+    protocol: TCP
+{{ end -}}
+{{ end -}}

--- a/multicluster/charts/linkerd-multicluster/templates/controller/rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/rbac.yaml
@@ -1,0 +1,79 @@
+{{- range .Values.controllers }}
+{{- if empty ((.link).ref).name -}}
+{{- fail "the value link.ref.name is required" -}}
+{{- end -}}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: controller-{{.link.ref.name}}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+    mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+    {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+{{- include "partials.image-pull-secrets" $.Values.imagePullSecrets }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-multicluster-controller-access-local-resources-{{.link.ref.name}}
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+    mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+    {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd-multicluster-controller-access-local-resources
+subjects:
+- kind: ServiceAccount
+  name: controller-{{.link.ref.name}}
+  namespace: {{$.Release.Namespace}}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: controller-read-remote-creds-{{.link.ref.name}}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+    mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+    {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["cluster-credentials-{{.link.ref.name}}"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["multicluster.linkerd.io"]
+    resources: ["links"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["multicluster.linkerd.io"]
+    resources: ["links/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: controller-read-remote-creds-{{.link.ref.name}}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+    mirror.linkerd.io/cluster-name: {{.link.ref.name}}
+    {{- with $.Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-read-remote-creds-{{.link.ref.name}}
+subjects:
+  - kind: ServiceAccount
+    name: controller-{{.link.ref.name}}
+    namespace: {{$.Release.Namespace}}
+{{- end}}

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -98,6 +98,9 @@ namespaceMetadata:
 # deprecated since k8s v1.21
 enablePSP: false
 
+# -- Toggle support for creating namespaces for mirror services when necessary
+enableNamespaceCreation: false
+
 # -- Enables Pod Anti Affinity logic to balance the placement of replicas
 # across hosts and zones for High Availability.
 # Enable this only when you have multiple replicas of components.
@@ -154,3 +157,52 @@ localServiceMirror:
 
   # -- Resources for the Service mirror container
   resources: {}
+
+# -- List of service mirror controllers.
+# References to the Links deployed in the cluster, each of which will have a
+# corresponding service mirror controller deployed.
+# Only `link.ref.name` is required for each entry.
+# Example (all the missing values take their values from controllerDefaults):
+# controllers:
+# - link:
+#     ref:
+#       name: target1
+# - link:
+#     ref:
+#       name: target2
+controllers: []
+
+controllerDefaults:
+  # -- Number of service mirror replicas for a given Link
+  replicas: 1
+  image:
+    name: cr.l5d.io/linkerd/controller
+    # @default -- imagePullPolicy
+    pullPolicy: ""
+    # @default -- linkerdVersion
+    version: linkerdVersionValue
+  gateway:
+    # -- Enables a probe service for the gateway
+    enabled: true
+    probe:
+      # -- Port used for liveliness probing
+      port: 4191
+  # -- Log level (`error`, `warn`, `info`, `debug` or `trace`)
+  logLevel: info
+  # -- Log format (`plain` or `json`)
+  logFormat: plain
+  # -- Toggle support for mirroring headless services
+  enableHeadlessServices: false
+  # -- Enables the use of pprof endpoints for the controller
+  enablePprof: false
+  UID: 2103
+  GID: 2103
+  # -- Number of times service mirror updates are allowed to be requeued (retried)
+  retryLimit: 3
+  # -- Resources to assign to the controller.
+  # See `policyController.resources` in the linkerd-control-plane chart for the expected format
+  resources: {}
+  nodeSelector: {}
+  tolerations: {}
+  enablePodAntiAffinity: false
+  nodeAffinity: {}


### PR DESCRIPTION
First task of #13768

- Additions to the values.yaml file for the `linkerd-multicluster` chart:
  - `controllers`: users should refer the list of links, for the chart to manage their controllers and configuration.
  - `controllersDefaults`: all the defaults to apply when not specified in the `controllers` list (applied using the `dig` function in the templates). These entries are basically a copy of what we have in the values.yaml file for the `linkerd-multicluster-link` chart.
  - `enableNamespaceCreation`: also copied from the `linkerd-multicluster-link` chart, but promoted as a root entry.
- All the template files from the `linkerd-multicluster-link` chart were copied and adapted to the `linkerd-multicluster` chart:
  - `controller-clusterrole.yaml`: formerly we were needlessly adding a separate instance of this cluster role per link. Now it's just one.
  - `controller` directory: contains the same manifests from the other chart with the following changes:
    - the name of the deployment is now "controller-<targetName>". The renaming was necessary to allow coexistence of workloads created by both the old method and this one. Not using "linkerd" nor "multicluster" in the name given it's already contained in the namespace, and "controller" feels more standard than "service-mirror".
    - the name of the container and the `component` label have also been renamed to simply "controller"
    - the probe service has been renamed from `probe-gateway-<targetName>` to just `probe-<targetName>` also to allow coexistence with the old method.

## How to test

The following is the detailed setup for a source and target clusters with emojivoto installed:

```console
# Build
TAG=$(bin/root-tag)
sed -i "s/linkerdVersionValue/$TAG/" multicluster/charts/linkerd-multicluster/values.yaml
bin/helm-build
bin/docker-build

# Create certs
step certificate create root.linkerd.cluster.local ca.crt ca.key --profile root-ca --no-password --insecure -f
step cli certificate create identity.linkerd.cluster.local issuer.crt issuer.key --profile intermediate-ca --not-after 8760h --no-password --insecure --ca ca.crt --ca-key ca.key -f

# Create clusters
k3d cluster create source --k3s-arg '--disable=local-storage,metrics-server@server:0' --network multicluster-test --wait
bin/image-load --k3d --cluster source
k3d cluster create target1 --k3s-arg '--disable=local-storage,metrics-server@server:0' --network multicluster-test --wait
bin/image-load --k3d --cluster target1

# Install linkerd and multicluster in target1
bin/linkerd install --crds --identity-trust-anchors-file ca.crt --identity-issuer-certificate-file issuer.crt --identity-issuer-key-file issuer.key | kubectl apply -f -
bin/linkerd install --identity-trust-anchors-file ca.crt --identity-issuer-certificate-file issuer.crt --identity-issuer-key-file issuer.key | kubectl apply -f -
bin/linkerd check
helm installlinkerd-multicluster -n linkerd-multicluster --create-namespace multicluster/charts/linkerd-multicluster

# Install emojivoto exporting the web service
bin/linkerd inject https://run.linkerd.io/emojivoto.yml | kubectl apply -f -
kubectl -n emojivoto label svc/web-svc mirror.linkerd.io/exported=true

# Generate Link CR and credentials secrets
ip=$(kubectl get node -ojson | jq -r '.items[0].status.addresses[] | select(.type=="InternalIP").address')
linkerd mc link --cluster-name=target1 --api-server-address=https://$ip:6443 | yq 'select(.kind == "Link")' > link.yml
linkerd mc link --cluster-name=target1 --api-server-address=https://$ip:6443 | yq 'select(.kind == "Secret")' > creds.yml

# Install linkerd source
kubectl config use-context k3d-source
bin/linkerd install --crds --identity-trust-anchors-file ca.crt --identity-issuer-certificate-file issuer.crt --identity-issuer-key-file issuer.key | kubectl apply -f -
bin/linkerd install --identity-trust-anchors-file ca.crt --identity-issuer-certificate-file issuer.crt --identity-issuer-key-file issuer.key | kubectl apply -f -
bin/linkerd check

# Install emojivoto's vote-bot pointing to target1
bin/linkerd inject https://run.linkerd.io/emojivoto.yml | yq 'select(.kind == "Deployment" and .metadata.name == "vote-bot").spec.template.spec.containers[0].env[] |= (select(.name == "WEB_HOST").value = "web-svc-target1.emojivoto:80")' | kubectl apply -f -
```

Now install linkerd-multicluster with a config referring the link:

```console
cat <<EOF > values.yaml
controllers:
- link:
    ref:
      name: target1
EOF
helm installlinkerd-multicluster -n linkerd-multicluster --create-namespace -f values.yaml multicluster/charts/linkerd-multicluster
```

This should have deployed a `controller-target1-xxx` pod.

Finally, apply the Link CR and the credentials. This will trigger the creation of the web-svc-target1 service, and you'll be able to verify that vote-bot is sending traffic to the other cluster:

```console
kubectl apply -f creds.yml
kubectl apply -f link.yml
```