### PR TITLE
fix(injector): use annotated values for debug container

### DIFF
--- a/controller/proxy-injector/fake/data/pod-with-custom-debug-tag.yaml
+++ b/controller/proxy-injector/fake/data/pod-with-custom-debug-tag.yaml
@@ -1,0 +1,19 @@
+kind: Pod
+apiVersion: apps/v1
+metadata:
+  name: nginx
+  namespace: kube-public
+  annotations:
+    config.linkerd.io/debug-image: cr.l5d.io/linkerd/debug
+    config.linkerd.io/debug-image-version: edge-24.2.4
+    config.linkerd.io/enable-debug-sidecar: true
+    linkerd.io/inject: enabled
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - name: http
+      containerPort: 80

--- a/controller/proxy-injector/fake/data/pod-with-custom-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-custom-debug.patch.json
@@ -1,0 +1,437 @@
+[
+  {
+    "op": "add",
+    "path": "/metadata/annotations/linkerd.io~1proxy-version",
+    "value": "dev-undefined"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/annotations/linkerd.io~1trust-root-sha256",
+    "value": "5090806bcf2daff5d54739ba02a8e7b919f7e62b2a46757e11089c916ec97fc2"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/linkerd.io~1control-plane-ns",
+    "value": "linkerd"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/linkerd.io~1proxy-deployment",
+    "value": "owner-deployment"
+  },
+  {
+    "op": "add",
+    "path": "/metadata/labels/linkerd.io~1workload-ns",
+    "value": "kube-public"
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes",
+    "value": []
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers",
+    "value": []
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "emptyDir": {},
+      "name": "linkerd-proxy-init-xtables-lock"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/initContainers/-",
+    "value": {
+      "args": [
+        "--ipv6=false",
+        "--incoming-proxy-port",
+        "4143",
+        "--outgoing-proxy-port",
+        "4140",
+        "--proxy-uid",
+        "2102",
+        "--inbound-ports-to-ignore",
+        "4190,4191,4567,4568",
+        "--outbound-ports-to-ignore",
+        "4567,4568"
+      ],
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
+      "imagePullPolicy": "IfNotPresent",
+      "name": "linkerd-init",
+      "resources": null,
+      "securityContext": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "add": [
+            "NET_ADMIN",
+            "NET_RAW"
+          ]
+        },
+        "privileged": false,
+        "readOnlyRootFilesystem": true,
+        "runAsGroup": 65534,
+        "runAsNonRoot": true,
+        "runAsUser": 65534,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        }
+      },
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/run",
+          "name": "linkerd-proxy-init-xtables-lock"
+        }
+      ]
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/-",
+    "value": {
+      "image": "cr.l5d.io/linkerd/debug:edge-24.2.4",
+      "imagePullPolicy": "IfNotPresent",
+      "name": "linkerd-debug",
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "livenessProbe": {
+        "exec": {
+          "command": [
+            "true"
+          ]
+        }
+      },
+      "readinessProbe": {
+        "exec": {
+          "command": [
+            "true"
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "linkerd-identity-end-entity",
+      "emptyDir": {
+        "medium": "Memory"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/volumes/-",
+    "value": {
+      "name": "linkerd-identity-token",
+      "projected": {
+        "sources": [
+          {
+            "serviceAccountToken": {
+              "audience": "identity.l5d.io",
+              "expirationSeconds": 86400,
+              "path": "linkerd-identity-token"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/containers/0",
+    "value": {
+      "env": [
+        {
+          "name": "_pod_name",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.name"
+            }
+          }
+        },
+        {
+          "name": "_pod_ns",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.namespace"
+            }
+          }
+        },
+        {
+          "name": "_pod_uid",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "metadata.uid"
+            }
+          }
+        },
+        {
+          "name": "_pod_nodeName",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "spec.nodeName"
+            }
+          }
+        },
+        {
+          "name": "_pod_containerName",
+          "value": "linkerd-proxy"
+        },
+        {
+          "name": "LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED",
+          "value": "false"
+        },
+        {
+          "name": "LINKERD2_PROXY_LOG",
+          "value": "warn,linkerd=info,hickory=error,[{headers}]=off,[{request}]=off"
+        },
+        {
+          "name": "LINKERD2_PROXY_LOG_FORMAT",
+          "value": "plain"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_SVC_ADDR",
+          "value": "linkerd-dst-headless.linkerd.svc.cluster.local.:8086"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_PROFILE_NETWORKS",
+          "value": "10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16,fd00::/8"
+        },
+        {
+          "name": "LINKERD2_PROXY_POLICY_SVC_ADDR",
+          "value": "linkerd-policy.linkerd.svc.cluster.local.:8090"
+        },
+        {
+          "name": "LINKERD2_PROXY_POLICY_WORKLOAD",
+          "value": "{\"ns\":\"$(_pod_ns)\", \"pod\":\"$(_pod_name)\"}\n"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_DEFAULT_POLICY",
+          "value": "all-unauthenticated"
+        },
+        {
+          "name": "LINKERD2_PROXY_POLICY_CLUSTER_NETWORKS",
+          "value": "10.0.0.0/8,100.64.0.0/10,172.16.0.0/12,192.168.0.0/16,fd00::/8"
+        },
+        {
+          "name": "LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT",
+          "value": "3s"
+        },
+        {
+          "name": "LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT",
+          "value": "5m"
+        },
+        {
+          "name": "LINKERD2_PROXY_CONTROL_STREAM_LIFETIME",
+          "value": "1h"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT",
+          "value": "100ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT",
+          "value": "1000ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_DISCOVERY_IDLE_TIMEOUT",
+          "value": "5s"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_DISCOVERY_IDLE_TIMEOUT",
+          "value": "90s"
+        },
+        {
+          "name": "LINKERD2_PROXY_CONTROL_LISTEN_ADDR",
+          "value": "0.0.0.0:4190"
+        },
+        {
+          "name": "LINKERD2_PROXY_ADMIN_LISTEN_ADDR",
+          "value": "0.0.0.0:4191"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR",
+          "value": "127.0.0.1:4140"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_LISTEN_ADDRS",
+          "value": "127.0.0.1:4140"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_LISTEN_ADDR",
+          "value": "0.0.0.0:4143"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_IPS",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "status.podIPs"
+            }
+          }
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_PORTS",
+          "value": "80"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES",
+          "value": "svc.cluster.local."
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE",
+          "value": "10000ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE",
+          "value": "10000ms"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_ACCEPT_USER_TIMEOUT",
+          "value": "30s"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_CONNECT_USER_TIMEOUT",
+          "value": "30s"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL",
+          "value": "10s"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT",
+          "value": "3s"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL",
+          "value": "10s"
+        },
+        {
+          "name": "LINKERD2_PROXY_OUTBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT",
+          "value": "3s"
+        },
+        {
+          "name": "LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION",
+          "value": "25,587,3306,4444,5432,6379,9300,11211"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_CONTEXT",
+          "value": "{\"ns\":\"$(_pod_ns)\", \"nodeName\":\"$(_pod_nodeName)\", \"pod\":\"$(_pod_name)\"}\n"
+        },
+        {
+          "name": "_pod_sa",
+          "valueFrom": {
+            "fieldRef": {
+              "fieldPath": "spec.serviceAccountName"
+            }
+          }
+        },
+        {
+          "name": "_l5d_ns",
+          "value": "linkerd"
+        },
+        {
+          "name": "_l5d_trustdomain",
+          "value": "cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_DIR",
+          "value": "/var/run/linkerd/identity/end-entity"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS",
+          "value": "IdentityTrustAnchorsPEM\n"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_TOKEN_FILE",
+          "value": "/var/run/secrets/tokens/linkerd-identity-token"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_ADDR",
+          "value": "linkerd-identity-headless.linkerd.svc.cluster.local.:8080"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_LOCAL_NAME",
+          "value": "$(_pod_sa).$(_pod_ns).serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_IDENTITY_SVC_NAME",
+          "value": "linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_DESTINATION_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        },
+        {
+          "name": "LINKERD2_PROXY_POLICY_SVC_NAME",
+          "value": "linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local"
+        }
+      ],
+      "image": "cr.l5d.io/linkerd/proxy:dev-undefined",
+      "imagePullPolicy": "IfNotPresent",
+      "lifecycle": {
+        "postStart": {
+          "exec": {
+            "command": [
+              "/usr/lib/linkerd/linkerd-await",
+              "--timeout=2m",
+              "--port=4191"
+            ]
+          }
+        }
+      },
+      "livenessProbe": {
+        "httpGet": {
+          "path": "/live",
+          "port": 4191
+        },
+        "initialDelaySeconds": 10,
+        "timeoutSeconds": 1
+      },
+      "name": "linkerd-proxy",
+      "ports": [
+        {
+          "containerPort": 4143,
+          "name": "linkerd-proxy"
+        },
+        {
+          "containerPort": 4191,
+          "name": "linkerd-admin"
+        }
+      ],
+      "readinessProbe": {
+        "httpGet": {
+          "path": "/ready",
+          "port": 4191
+        },
+        "initialDelaySeconds": 2,
+        "timeoutSeconds": 1
+      },
+      "resources": null,
+      "securityContext": {
+        "allowPrivilegeEscalation": false,
+        "readOnlyRootFilesystem": true,
+        "runAsNonRoot": true,
+        "runAsUser": 2102,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        }
+      },
+      "terminationMessagePolicy": "FallbackToLogsOnError",
+      "volumeMounts": [
+        {
+          "mountPath": "/var/run/linkerd/identity/end-entity",
+          "name": "linkerd-identity-end-entity"
+        },
+        {
+          "mountPath": "/var/run/secrets/tokens",
+          "name": "linkerd-identity-token"
+        }
+      ]
+    }
+  }
+]

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -157,6 +157,27 @@ func TestGetPodPatch(t *testing.T) {
 		}
 	})
 
+	t.Run("by checking annotations with custom debug image version", func(t *testing.T) {
+		_, expectedPatch := loadPatch(factory, t, "pod-with-custom-debug.patch.json")
+
+		pod := fileContents(factory, t, "pod-with-custom-debug-tag.yaml")
+		fakeReq := getFakePodReq(pod)
+		conf := confNsEnabled().WithKind(fakeReq.Kind.Kind).WithOwnerRetriever(ownerRetrieverFake)
+		_, err = conf.ParseMetaAndYAML(fakeReq.Object.Raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		patchJSON, err := conf.GetPodPatch(true)
+		if err != nil {
+			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
+		}
+		actualPatch := unmarshalPatch(t, patchJSON)
+		if diff := deep.Equal(expectedPatch, actualPatch); diff != nil {
+			t.Fatalf("The actual patch didn't match what was expected.\n%+v", diff)
+		}
+	})
+
 	t.Run("by configuring log level", func(t *testing.T) {
 		_, expectedPatch := loadPatch(factory, t, "pod-log-level.json")
 

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -1096,9 +1096,9 @@ func (conf *ResourceConfig) injectPodSpec(values *podPatch) {
 			log.Infof("inject debug container")
 			values.DebugContainer = &l5dcharts.DebugContainer{
 				Image: &l5dcharts.Image{
-					Name:       conf.values.DebugContainer.Image.Name,
-					Version:    conf.values.DebugContainer.Image.Version,
-					PullPolicy: conf.values.DebugContainer.Image.PullPolicy,
+					Name:       values.Values.DebugContainer.Image.Name,
+					Version:    values.Values.DebugContainer.Image.Version,
+					PullPolicy: values.Values.DebugContainer.Image.PullPolicy,
 				},
 			}
 		}


### PR DESCRIPTION
Issue #13636 was opened stating that custom debug container annotations had no effect.

Quick investigation confirmed the issue and further debugging revealed a bug in code where the final values for helm chart were not using values processed by GetOverriddenValues function and that's why annotations had no effect for debug containers. This had been fixed now.

Added to unit test to test added code. Manual testing also done. The issue seems to be resolved.

Fixes #13636

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
