### PR TITLE
feat(multicluster): have linkerd-multicluster chart be responsible for service mirror controllers - probes

### DIFF
--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -151,6 +151,7 @@ spec:
         - -enable-namespace-creation
         {{- end }}
         - -enable-pprof={{.Values.enablePprof | default false}}
+        - -probe-service=probe-gateway-{{.Values.targetClusterName}}
         - {{.Values.targetClusterName}}
         {{- if or .Values.serviceMirrorAdditionalEnv .Values.serviceMirrorExperimentalEnv }}
         env:

--- a/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
@@ -57,6 +57,7 @@ spec:
         - -enable-namespace-creation
         {{- end }}
         - -enable-pprof={{ dig "enablePprof" $.Values.controllerDefaults.enablePprof . }}
+        - -probe-service=probe-{{.link.ref.name}}
         - {{.link.ref.name}}
         {{- if or $.Values.serviceMirrorAdditionalEnv $.Values.serviceMirrorExperimentalEnv }}
         env:

--- a/multicluster/cmd/gateways.go
+++ b/multicluster/cmd/gateways.go
@@ -68,7 +68,7 @@ func newGatewaysCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("make sure the linkerd-multicluster extension is installed, using 'linkerd multicluster install' (%w)", err)
 			}
-			selector := fmt.Sprintf("component=%s", "linkerd-service-mirror")
+			selector := "component in (linkerd-service-mirror, controller)"
 			if opts.clusterName != "" {
 				selector = fmt.Sprintf("%s,mirror.linkerd.io/cluster-name=%s", selector, opts.clusterName)
 			}
@@ -255,7 +255,9 @@ func getServiceMirrorContainer(pod corev1.Pod) (corev1.Container, error) {
 		return corev1.Container{}, fmt.Errorf("pod not running: %s", pod.GetName())
 	}
 	for _, c := range pod.Spec.Containers {
-		if c.Name == "service-mirror" {
+		// "controller" is for the service mirror controllers managed by the
+		// linkerd-multicluster chart
+		if c.Name == "service-mirror" || c.Name == "controller" {
 			return c, nil
 		}
 	}

--- a/multicluster/cmd/testdata/service_mirror_default.golden
+++ b/multicluster/cmd/testdata/service_mirror_default.golden
@@ -119,6 +119,7 @@ spec:
         - -event-requeue-limit=3
         - -namespace=test
         - -enable-pprof=false
+        - -probe-service=probe-gateway-test-cluster
         - test-cluster
         image: cr.l5d.io/linkerd/controller:dev-undefined
         name: service-mirror

--- a/multicluster/cmd/testdata/service_mirror_ha.golden
+++ b/multicluster/cmd/testdata/service_mirror_ha.golden
@@ -142,6 +142,7 @@ spec:
         - -event-requeue-limit=3
         - -namespace=test
         - -enable-pprof=false
+        - -probe-service=probe-gateway-test-cluster
         - test-cluster
         image: cr.l5d.io/linkerd/controller:dev-undefined
         name: service-mirror


### PR DESCRIPTION
Followup to #13770, based off of branch `alpeb/multicluster-chart-manage-smc`

Third task of #13768

#13770 properly sets up the linkerd-multicluster chart to manage controllers, but the probes are still looking for the old `probe-gateway-<clusterName>` service.

This change updates `cluster_watcher.go` to have that name be a parameter, that is passed as a controller argument.

Likewise, the `linkerd mc gateways` command has been updated to select over old and new controllers.