### PR TITLE
feat(multicluster): have linkerd-multicluster chart be responsible for service mirror controllers - CLI

### DIFF
--- a/multicluster/cmd/install.go
+++ b/multicluster/cmd/install.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/linkerd/linkerd2/multicluster/static"
@@ -189,6 +190,18 @@ func render(w io.Writer, values *multicluster.Values, valuesOverrides map[string
 		return err
 	}
 
+	if reg := os.Getenv(flags.EnvOverrideDockerRegistry); reg != "" {
+		overrideRegistry(chart.Values, "localServiceMirror.image.name", reg, "cr.l5d.io/linkerd/controller")
+
+		if controllers, ok := valuesOverrides["controllers"].([]any); ok {
+			for _, c := range controllers {
+				if controller, ok := c.(map[string]any); ok {
+					overrideRegistry(controller, "image.name", reg, "cr.l5d.io/linkerd/controller")
+				}
+			}
+		}
+	}
+
 	vals, err := chartutil.CoalesceValues(chart, valuesOverrides)
 	if err != nil {
 		return err
@@ -238,10 +251,6 @@ func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInsta
 		return nil, err
 	}
 
-	if reg := os.Getenv(flags.EnvOverrideDockerRegistry); reg != "" {
-		defaults.LocalServiceMirror.Image.Name = pkgcmd.RegistryOverride(defaults.LocalServiceMirror.Image.Name, reg)
-	}
-
 	defaults.LocalServiceMirror.Image.Version = version.Version
 	defaults.Gateway.Enabled = opts.gateway.Enabled
 	defaults.Gateway.Port = opts.gateway.Port
@@ -267,4 +276,32 @@ func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInsta
 	defaults.IdentityTrustDomain = values.IdentityTrustDomain
 
 	return defaults, nil
+}
+
+// overrideRegistry overrides the image name in the values map at the given
+// keyPath with the given registry. If the keyPath does not exist, it is
+// created.
+func overrideRegistry(values map[string]any, keyPath, reg, defaultImage string) {
+	keys := strings.Split(keyPath, ".")
+	m := values
+
+	// Traverse map using keys, except for the last key
+	for _, key := range keys[:len(keys)-1] {
+		if next, ok := m[key].(map[string]any); ok {
+			m = next
+		} else {
+			newMap := make(map[string]any)
+			m[key] = newMap
+			m = newMap
+		}
+	}
+
+	// Override the last key if it exists and is a string
+	lastKey := keys[len(keys)-1]
+	if val, ok := m[lastKey].(string); ok {
+		m[lastKey] = pkgcmd.RegistryOverride(val, reg)
+	} else {
+		// If the key is missing, initialize it with an empty string before overriding
+		m[lastKey] = pkgcmd.RegistryOverride(defaultImage, reg)
+	}
 }

--- a/multicluster/cmd/install.go
+++ b/multicluster/cmd/install.go
@@ -252,6 +252,7 @@ func buildMulticlusterInstallValues(ctx context.Context, opts *multiclusterInsta
 	}
 
 	defaults.LocalServiceMirror.Image.Version = version.Version
+	defaults.ControllerDefaults.Image.Version = version.Version
 	defaults.Gateway.Enabled = opts.gateway.Enabled
 	defaults.Gateway.Port = opts.gateway.Port
 	defaults.Gateway.Probe.Seconds = opts.gateway.Probe.Seconds

--- a/multicluster/cmd/install.go
+++ b/multicluster/cmd/install.go
@@ -46,6 +46,11 @@ var TemplatesMulticluster = []string{
 	"templates/link-crd.yaml",
 	"templates/service-mirror-policy.yaml",
 	"templates/local-service-mirror.yaml",
+	"templates/controller-clusterrole.yaml",
+	"templates/controller/deployment.yaml",
+	"templates/controller/pdb.yaml",
+	"templates/controller/probe-svc.yaml",
+	"templates/controller/rbac.yaml",
 }
 
 func newMulticlusterInstallCommand() *cobra.Command {

--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -60,6 +60,7 @@ type (
 		gatewayPort              uint32
 		ha                       bool
 		enableGateway            bool
+		enableServiceMirror      bool
 		output                   string
 	}
 )
@@ -372,8 +373,10 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 			stdout.Write(separator)
 			stdout.Write(linkOut)
 			stdout.Write(separator)
-			stdout.Write(serviceMirrorOut)
-			stdout.Write(separator)
+			if opts.enableServiceMirror {
+				stdout.Write(serviceMirrorOut)
+				stdout.Write(separator)
+			}
 
 			return nil
 		},
@@ -399,6 +402,7 @@ A full list of configurable values can be found at https://github.com/linkerd/li
 	cmd.Flags().Uint32Var(&opts.gatewayPort, "gateway-port", opts.gatewayPort, "If specified, overwrites gateway port when gateway service is not type LoadBalancer")
 	cmd.Flags().BoolVar(&opts.ha, "ha", opts.ha, "Enable HA configuration for the service-mirror deployment (default false)")
 	cmd.Flags().BoolVar(&opts.enableGateway, "gateway", opts.enableGateway, "If false, allows a link to be created against a cluster that does not have a gateway service")
+	cmd.Flags().BoolVar(&opts.enableServiceMirror, "service-mirror", opts.enableServiceMirror, "If false, only outputs link manifest and credentials secrets")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
 	pkgcmd.ConfigureNamespaceFlagCompletion(
@@ -506,7 +510,7 @@ func newLinkOptionsWithDefault() (*linkOptions, error) {
 		gatewayPort:              0,
 		ha:                       false,
 		enableGateway:            true,
-		output:                   "yaml",
+		enableServiceMirror:      true,
 	}, nil
 }
 

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -961,3 +961,21 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-multicluster-controller-access-local-resources
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+rules:
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["list", "get", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+
+
+

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -1071,3 +1071,21 @@ spec:
   selector:
     matchLabels:
       component: local-service-mirror
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-multicluster-controller-access-local-resources
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+rules:
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["list", "get", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+
+
+

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -995,3 +995,21 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
                 path: namespace
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linkerd-multicluster-controller-access-local-resources
+  labels:
+    linkerd.io/extension: multicluster
+    component: controller
+rules:
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["list", "get", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["list", "get", "watch"]
+
+
+

--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -86,15 +86,25 @@ type LocalServiceMirror struct {
 	GID                      int64           `json:"GID"`
 }
 
-// ControllerDefaults is used to unmarshal the default values.yaml file, so
-// only entries that are objects that are not empty by default are required.
+// ControllerDefaults contains all the entries for the controllerDefaults
+// section that are not empty by default
 type ControllerDefaults struct {
-	Gateway *ControllerDefaultsGateway `json:"gateway"`
-	Image   *linkerd2.Image            `json:"image"`
+	Replicas               uint32                     `json:"replicas"`
+	Image                  *linkerd2.Image            `json:"image"`
+	Gateway                *ControllerDefaultsGateway `json:"gateway"`
+	LogLevel               string                     `json:"logLevel"`
+	LogFormat              string                     `json:"logFormat"`
+	EnableHeadlessServices bool                       `json:"enableHeadlessServices"`
+	EnablePprof            bool                       `json:"enablePprof"`
+	UID                    int64                      `json:"UID"`
+	GID                    int64                      `json:"GID"`
+	RetryLimit             uint32                     `json:"retryLimit"`
+	EnablePodAntiAffinity  bool                       `json:"enablePodAntiAffinity"`
 }
 
 type ControllerDefaultsGateway struct {
-	Probe *ControllerDefaultsProbe `json:"probe"`
+	Enabled bool                     `json:"enabled"`
+	Probe   *ControllerDefaultsProbe `json:"probe"`
 }
 
 type ControllerDefaultsProbe struct {

--- a/multicluster/values/values.go
+++ b/multicluster/values/values.go
@@ -45,6 +45,7 @@ type Values struct {
 	ServiceMirrorExperimentalEnv []corev1.EnvVar `json:"serviceMirrorExperimentalEnv"`
 
 	LocalServiceMirror *LocalServiceMirror `json:"localServiceMirror"`
+	ControllerDefaults *ControllerDefaults `json:"controllerDefaults"`
 }
 
 // Gateway contains all options related to the Gateway Service
@@ -83,6 +84,21 @@ type LocalServiceMirror struct {
 	EnablePprof              bool            `json:"enablePprof"`
 	UID                      int64           `json:"UID"`
 	GID                      int64           `json:"GID"`
+}
+
+// ControllerDefaults is used to unmarshal the default values.yaml file, so
+// only entries that are objects that are not empty by default are required.
+type ControllerDefaults struct {
+	Gateway *ControllerDefaultsGateway `json:"gateway"`
+	Image   *linkerd2.Image            `json:"image"`
+}
+
+type ControllerDefaultsGateway struct {
+	Probe *ControllerDefaultsProbe `json:"probe"`
+}
+
+type ControllerDefaultsProbe struct {
+	Port uint32 `json:"port"`
 }
 
 // NewInstallValues returns a new instance of the Values type.


### PR DESCRIPTION
Followup to #13770 and #13781, based off of branch `alpeb/multicluster-chart-manage-smc-probes`

Addresses CLI tasks listed in #13768

- Refers in `multicluster/cmd/install.go` the new templates added in #13770, allowing `linkerd mc install` to also install the model that was implemented in #13770 just for helm.
- Adds a new flag `linkerd mc link --service-mirror`; if `false` then it only outputs the Link CR and the credentials secret. The default is `true` so the new model is opt-in.
- Refactors `linkerd mc check` in order to check for resources from both the old and new models.
- Extend the image registry overriding logic to cover the new controllers as well.