### PR TITLE
feat(multicluster): have linkerd-multicluster chart be responsible for service mirror controllers - tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -318,9 +318,10 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        k8s:
-          - v1.23
-          - v1.32
+        cases:
+        - {k8s: "v1.23", manage-controllers: false}
+        - {k8s: "v1.32", manage-controllers: false}
+        - {k8s: "v1.32", manage-controllers: true}
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff
         env:
@@ -351,13 +352,13 @@ jobs:
       - name: Run just mc-test-load
         run: |
           just linkerd-tag='${{ needs.meta.outputs.tag }}' \
-              k3d-k8s='${{ matrix.k8s }}' \
+              k3d-k8s='${{ matrix.cases.k8s }}' \
               mc-test-load
       - name: Run just mc-test-run
         run: |
           just linkerd-tag='${{ needs.meta.outputs.tag }}' \
-              k3d-k8s='${{ matrix.k8s }}' \
-              mc-test-run
+              k3d-k8s='${{ matrix.cases.k8s }}' \
+              mc-test-run -multicluster-manage-controllers=${{ matrix.cases.manage-controllers }}
 
   build-ok:
     needs: [build-cli, build-core, build-ext]

--- a/justfile
+++ b/justfile
@@ -532,14 +532,15 @@ mc-flat-network-init:
 
 
 # Run the multicluster tests without any setup
-mc-test-run:
+mc-test-run *flags:
     LINKERD_DOCKER_REGISTRY='{{ DOCKER_REGISTRY }}' \
         go test -v -test.timeout=20m --failfast --mod=readonly \
             ./test/integration/multicluster/... \
                 -integration-tests \
                 -linkerd='{{ justfile_directory() }}/bin/linkerd' \
                 -multicluster-source-context='k3d-{{ k3d-name }}' \
-                -multicluster-target-context='k3d-{{ k3d-name }}-target'
+                -multicluster-target-context='k3d-{{ k3d-name }}-target' \
+                {{ flags }}
 
 ##
 ## GitHub Actions

--- a/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
+++ b/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
@@ -65,7 +65,15 @@ func TestMain(m *testing.M) {
 	}
 	// Block until gateway & service mirror deploys are running successfully in
 	// source cluster.
-	TestHelper.WaitUntilDeployReady(testutil.MulticlusterSourceReplicas)
+	if TestHelper.GetMulticlusterManageControllers() {
+		TestHelper.WaitUntilDeployReady(map[string]testutil.DeploySpec{
+			"controller-target": {Namespace: "linkerd-multicluster", Replicas: 1},
+		})
+	} else {
+		TestHelper.WaitUntilDeployReady(map[string]testutil.DeploySpec{
+			"linkerd-service-mirror-target": {Namespace: "linkerd-multicluster", Replicas: 1},
+		})
+	}
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Followup to #13770, #13781 and #13782, based off of branch alpeb/multicluster-chart-manage-smc-cli-install

Addresses test task in #13768

This introduces a new boolean flag `multicluster-target-context` to the multicluster tests, that when set to true:

- the multicluster extension is installed in both clusters passing a config for a `controllers` entry.
- the `linkerd mc link` command is run with `--service-mirror=false` so it only outputs the Link CR and the credentials secrets.

This is used in a new test triggered in parallel in the test-multicluster integration test job.