### PR TITLE
fix(ci): replace tj-actions/changed-files action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+      - uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         id: changed
         with:
           files: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: tag
         run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> "$GITHUB_OUTPUT"
-      - uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+      - uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         id: core
         with:
           files: |


### PR DESCRIPTION
this commit replaces the `changed-files` github action, which has since been deleted due to a supply-chain attack. for more information, see the [report]. the report outlines an archived mirror of the original action under ["Recovery Steps"][recovery-steps]. this commit replaces the deleted action with this archive.

[report]: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
[recovery-steps]: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised#next-steps

see also, linkerd/linkerd2-proxy3762.
