### PR TITLE
fix(multicluster): correct Helm manifest whitespacing

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/controller/rbac.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/rbac.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.controllers }}
 {{- if empty ((.link).ref).name -}}
 {{- fail "the value link.ref.name is required" -}}
-{{- end -}}
+{{ end -}}
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -76,4 +76,4 @@ subjects:
   - kind: ServiceAccount
     name: controller-{{.link.ref.name}}
     namespace: {{$.Release.Namespace}}
-{{- end}}
+{{ end -}}


### PR DESCRIPTION
This fixes a bug recently introduced by #13770, where installing the multicluster extension with more than one controller would result in invalid yaml:

```
$ bin/helm-build
$ helm template linkerd-multicluster multicluster/charts/linkerd-multicluster \
  --set controllers[0].link.ref.name=target1 --set controllers[1].link.ref.name=target2 | \
  sed -n '27,32p'

subjects:
  - kind: ServiceAccount
    name: controller-target1
    namespace: default---
kind: ServiceAccount
apiVersion: v1
```

The fix consists on properly tunning the whitespace handling in the rbac.yaml template.