### PR TITLE
fix(test): add missing env var to debug annotation test

### DIFF
--- a/controller/proxy-injector/fake/data/pod-with-custom-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-custom-debug.patch.json
@@ -183,6 +183,14 @@
           "value": "linkerd-proxy"
         },
         {
+          "name": "LINKERD2_PROXY_CORES",
+          "value": "1"
+        },
+        {
+          "name": "LINKERD2_PROXY_CORES_MIN",
+          "value": "1"
+        },
+        {
           "name": "LINKERD2_PROXY_SHUTDOWN_ENDPOINT_ENABLED",
           "value": "false"
         },


### PR DESCRIPTION
Followup to #13778, where a new test case was introduced for testing the debug container annotation, but didn't account for the new LINKERD2_PROXY_CORES_MIN environment variable.