### PR TITLE
fix(multicluster): fix stale service resources during event requeue

### DIFF
--- a/controller/gen/apis/link/v1alpha3/types.go
+++ b/controller/gen/apis/link/v1alpha3/types.go
@@ -91,7 +91,7 @@ type LinkCondition struct {
 	// +optional
 	Message string `json:"message"`
 	// LocalRef is a reference to the local mirror or federated service.
-	LocalRef ObjectRef `json:"localRef,omitempty"`
+	LocalRef *ObjectRef `json:"localRef,omitempty"`
 }
 
 type ObjectRef struct {

--- a/controller/gen/apis/link/v1alpha3/zz_generated.deepcopy.go
+++ b/controller/gen/apis/link/v1alpha3/zz_generated.deepcopy.go
@@ -59,7 +59,11 @@ func (in *LinkCondition) DeepCopyInto(out *LinkCondition) {
 	*out = *in
 	in.LastProbeTime.DeepCopyInto(&out.LastProbeTime)
 	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
-	out.LocalRef = in.LocalRef
+	if in.LocalRef != nil {
+		in, out := &in.LocalRef, &out.LocalRef
+		*out = new(ObjectRef)
+		**out = **in
+	}
 	return
 }
 

--- a/multicluster/service-mirror/cluster_watcher_mirroring_test.go
+++ b/multicluster/service-mirror/cluster_watcher_mirroring_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 	"github.com/linkerd/linkerd2/controller/gen/apis/link/v1alpha3"
@@ -592,8 +593,6 @@ func TestServiceCreatedGatewayAlive(t *testing.T) {
 	// update svc-remote; the gateway is still not alive though so we expect
 	// the Endpoints of svc-remote to still have no ready addresses.
 	events.Add(&RemoteExportedServiceUpdated{
-		localService:   remoteService("svc-remote", "ns", "2", nil, nil),
-		localEndpoints: endpoints,
 		remoteUpdate: remoteService("svc", "ns", "2", map[string]string{
 			consts.DefaultExportedServiceSelector: "true",
 			"new-label":                           "hi",
@@ -605,6 +604,13 @@ func TestServiceCreatedGatewayAlive(t *testing.T) {
 			},
 		}),
 	})
+
+	// Processing the RemoteExportedServiceUpdated involves reading from the
+	// localAPI informer cache. Since this cache is updated asyncronously, we
+	// pause briefly here to give a chance for updates to the localAPI to be
+	// reflected in the cache.
+	time.Sleep(100 * time.Millisecond)
+
 	for events.Len() > 0 {
 		watcher.processNextEvent(context.Background())
 	}
@@ -1011,8 +1017,6 @@ func onAddOrUpdateTestCases(isAdd bool) []mirroringTestCase {
 			description: fmt.Sprintf("enqueue a RemoteServiceUpdated event if this is a service that we have already mirrored and its res version is different (%s)", testType),
 			environment: onAddOrUpdateRemoteServiceUpdated(isAdd),
 			expectedEventsInQueue: []interface{}{&RemoteExportedServiceUpdated{
-				localService:   mirrorService("test-service-remote", "test-namespace", "pastResourceVersion", nil, nil),
-				localEndpoints: endpoints("test-service-remote", "test-namespace", nil, "0.0.0.0", "", nil),
 				remoteUpdate: remoteService("test-service", "test-namespace", "currentResVersion", map[string]string{
 					consts.DefaultExportedServiceSelector: "true",
 				}, nil),

--- a/multicluster/service-mirror/cluster_watcher_test_util.go
+++ b/multicluster/service-mirror/cluster_watcher_test_util.go
@@ -216,7 +216,6 @@ func joinFederatedService() *testEnvironment {
 	return &testEnvironment{
 		events: []interface{}{
 			&RemoteServiceJoinsFederatedService{
-				localService: fedSvc,
 				remoteUpdate: remoteService("service-one", "ns1", "111", map[string]string{
 					consts.DefaultFederatedServiceSelector: "member",
 				}, []corev1.ServicePort{
@@ -349,7 +348,6 @@ func joinLocalFederatedService() *testEnvironment {
 	return &testEnvironment{
 		events: []interface{}{
 			&RemoteServiceJoinsFederatedService{
-				localService: fedSvc,
 				remoteUpdate: remoteService("service-one", "ns1", "111", map[string]string{
 					consts.DefaultFederatedServiceSelector: "member",
 				}, []corev1.ServicePort{
@@ -550,30 +548,6 @@ var updateServiceWithChangedPorts = &testEnvironment{
 					Name:     "port3",
 					Protocol: "TCP",
 					Port:     333,
-				},
-			}),
-			localService: mirrorService("test-service-remote", "test-namespace", "pastServiceResVersion", nil, []corev1.ServicePort{
-				{
-					Name:     "port1",
-					Protocol: "TCP",
-					Port:     111,
-				},
-				{
-					Name:     "port2",
-					Protocol: "TCP",
-					Port:     222,
-				},
-			}),
-			localEndpoints: endpoints("test-service-remote", "test-namespace", nil, "192.0.2.127", "", []corev1.EndpointPort{
-				{
-					Name:     "port1",
-					Port:     888,
-					Protocol: "TCP",
-				},
-				{
-					Name:     "port2",
-					Port:     888,
-					Protocol: "TCP",
 				},
 			}),
 		},

--- a/multicluster/service-mirror/events_formatting.go
+++ b/multicluster/service-mirror/events_formatting.go
@@ -8,15 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func formatAddresses(addresses []corev1.EndpointAddress) string {
-	var addrs []string
-
-	for _, a := range addresses {
-		addrs = append(addrs, a.IP)
-	}
-	return fmt.Sprintf("[%s]", strings.Join(addrs, ","))
-}
-
 func formatMetadata(meta map[string]string) string {
 	var metadata []string
 
@@ -28,33 +19,11 @@ func formatMetadata(meta map[string]string) string {
 	return fmt.Sprintf("[%s]", strings.Join(metadata, ","))
 }
 
-func formatPorts(ports []corev1.EndpointPort) string {
-	var formattedPorts []string
-
-	for _, p := range ports {
-		formattedPorts = append(formattedPorts, fmt.Sprintf("Port: {name: %s, port: %d}", p.Name, p.Port))
-	}
-	return fmt.Sprintf("[%s]", strings.Join(formattedPorts, ","))
-}
-
 func formatService(svc *corev1.Service) string {
 	if svc == nil {
 		return "Service: nil"
 	}
 	return fmt.Sprintf("Service: {name: %s, namespace: %s, annotations: [%s], labels [%s]}", svc.Name, svc.Namespace, formatMetadata(svc.Annotations), formatMetadata(svc.Labels))
-}
-
-func formatEndpoints(endpoints *corev1.Endpoints) string {
-	if endpoints == nil {
-		return "Endpoints: nil"
-	}
-	var subsets []string
-
-	for _, ss := range endpoints.Subsets {
-		subsets = append(subsets, fmt.Sprintf("%s:%s", formatAddresses(ss.Addresses), formatPorts(ss.Ports)))
-	}
-
-	return fmt.Sprintf("Endpoints: {name: %s, namespace: %s, annotations: [%s], labels: [%s], subsets: [%s]}", endpoints.Name, endpoints.Namespace, formatMetadata(endpoints.Annotations), formatMetadata(endpoints.Labels), strings.Join(subsets, ","))
 }
 
 // Events for cluster watcher
@@ -63,7 +32,7 @@ func (rsc RemoteServiceExported) String() string {
 }
 
 func (rsu RemoteExportedServiceUpdated) String() string {
-	return fmt.Sprintf("RemoteExportedServiceUpdated: {localService: %s, localEndpoints: %s, remoteUpdate: %s}", formatService(rsu.localService), formatEndpoints(rsu.localEndpoints), formatService(rsu.remoteUpdate))
+	return fmt.Sprintf("RemoteExportedServiceUpdated: {remoteUpdate: %s}", formatService(rsu.remoteUpdate))
 }
 
 func (rsd RemoteServiceUnexported) String() string {
@@ -75,7 +44,7 @@ func (cfs CreateFederatedService) String() string {
 }
 
 func (jfs RemoteServiceJoinsFederatedService) String() string {
-	return fmt.Sprintf("RemoteServiceJoinsFederatedService: {localService: %s, remoteUpdate: %s}", formatService(jfs.localService), formatService(jfs.remoteUpdate))
+	return fmt.Sprintf("RemoteServiceJoinsFederatedService: {remoteUpdate: %s}", formatService(jfs.remoteUpdate))
 }
 
 func (lfs RemoteServiceLeavesFederatedService) String() string {


### PR DESCRIPTION
When the service mirror controller encounters an error during processing an event, it requeues that event to be processed again up to a certain number of tries.  These events can store Service and Endpoint resources.

When two events which each cause updates to a mirror service happen in quick succession, one of these updates may fail because the other one has incremented the mirror service's resource version.  This manifests as a "Failed Precondition" during the update.  This update failure causes the event to be requeued; however the requeued event still holds the out-of-date service resource.  This means that when the requeued event is processed again, it will fail again because the service it holds is still out-of-date.  These failures will continue until the maximum number of requeue tries is reached and then we give up on the event and miss out on the update, leaving the mirror service in an incorrect state.

To fix this, we stop storing these resources in the event, and instead re-fetch them when processing the event.  This way, if an update fails due to a conflict and the event is requeued, then when the requeued event is processed, the mirror service will be fetched again and will be an up-to-date base for updates to be applied to.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
