### PR TITLE
feat(multicluster): add link-gen command, deprecate link and unlink commands

### DIFF
--- a/multicluster/cmd/link-deprecated.go
+++ b/multicluster/cmd/link-deprecated.go
@@ -1,18 +1,29 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
+	"path"
 	"strings"
-	"time"
 
 	"github.com/linkerd/linkerd2/controller/gen/apis/link/v1alpha3"
+	"github.com/linkerd/linkerd2/multicluster/static"
+	multicluster "github.com/linkerd/linkerd2/multicluster/values"
+	"github.com/linkerd/linkerd2/pkg/charts"
+	partials "github.com/linkerd/linkerd2/pkg/charts/static"
 	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
+	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/k8s"
+	"github.com/linkerd/linkerd2/pkg/version"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	chartloader "helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	valuespkg "helm.sh/helm/v3/pkg/cli/values"
+	"helm.sh/helm/v3/pkg/engine"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,25 +33,39 @@ import (
 )
 
 type (
-	linkGenOptions struct {
+	linkOptions struct {
 		namespace                string
 		clusterName              string
 		apiServerAddress         string
 		serviceAccountName       string
 		gatewayName              string
 		gatewayNamespace         string
+		serviceMirrorRetryLimit  uint32
+		logLevel                 string
+		logFormat                string
+		controlPlaneVersion      string
+		dockerRegistry           string
 		selector                 string
 		remoteDiscoverySelector  string
 		federatedServiceSelector string
 		gatewayAddresses         string
 		gatewayPort              uint32
+		ha                       bool
 		enableGateway            bool
 		output                   string
 	}
 )
 
-func newGenCommand() *cobra.Command {
-	opts, err := newLinkGenOptionsWithDefault()
+func newLinkCommand() *cobra.Command {
+	opts, err := newLinkOptionsWithDefault()
+
+	// Override the default value with env registry path.
+	// If cli cmd contains --registry flag, it will override env variable.
+	if registry := os.Getenv(flags.EnvOverrideDockerRegistry); registry != "" {
+		opts.dockerRegistry = registry
+	}
+
+	var valuesOptions valuespkg.Options
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -48,16 +73,20 @@ func newGenCommand() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "link-gen",
-		Short: "Outputs a Link manifest and credentials for another cluster to mirror services from this one",
-		Long: `Outputs a Link manifest and credentials for another cluster to mirror services from this one.
+		Use:        "link",
+		Deprecated: "please use `multicluster link-gen` instead.",
+		Short:      "Outputs resources that allow another cluster to mirror services from this one",
+		Long: `Outputs resources that allow another cluster to mirror services from this one.
 
 Note that the Link resource applies only in one direction. In order for two
 clusters to mirror each other, a Link resource will have to be generated for
 each cluster and applied to the other.`,
 		Args: cobra.NoArgs,
 		Example: `  # To link the west cluster to east
-  linkerd --context=east multicluster link-gen --cluster-name east | kubectl --context=west apply -f -
+  linkerd --context=east multicluster link --cluster-name east | kubectl --context=west apply -f -
+
+The command can be configured by using the --set, --values, --set-string and --set-file flags.
+A full list of configurable values can be found at https://github.com/linkerd/linkerd2/blob/main/multicluster/charts/linkerd-multicluster-link/README.md
   `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -300,6 +329,32 @@ each cluster and applied to the other.`,
 				return fmt.Errorf("output format %s not supported", opts.output)
 			}
 
+			values, err := buildServiceMirrorValues(opts)
+			if err != nil {
+				return err
+			}
+
+			// Create values override
+			valuesOverrides, err := valuesOptions.MergeValues(nil)
+			if err != nil {
+				return err
+			}
+
+			if opts.ha {
+				if valuesOverrides, err = charts.OverrideFromFile(
+					valuesOverrides,
+					static.Templates,
+					helmMulticlusterLinkDefaultChartName,
+					"values-ha.yaml",
+				); err != nil {
+					return err
+				}
+			}
+			serviceMirrorOut, err := renderServiceMirror(values, valuesOverrides, opts.namespace, opts.output)
+			if err != nil {
+				return err
+			}
+
 			separator := []byte("---\n")
 			if opts.output == "json" {
 				separator = []byte("\n")
@@ -310,22 +365,32 @@ each cluster and applied to the other.`,
 			stdout.Write(separator)
 			stdout.Write(linkOut)
 			stdout.Write(separator)
+			stdout.Write(serviceMirrorOut)
+			stdout.Write(separator)
 
 			return nil
 		},
 	}
 
+	flags.AddValueOptionsFlags(cmd.Flags(), &valuesOptions)
 	cmd.Flags().StringVar(&opts.namespace, "namespace", defaultMulticlusterNamespace, "The namespace for the service account")
 	cmd.Flags().StringVar(&opts.clusterName, "cluster-name", "", "Cluster name")
 	cmd.Flags().StringVar(&opts.apiServerAddress, "api-server-address", "", "The api server address of the target cluster")
 	cmd.Flags().StringVar(&opts.serviceAccountName, "service-account-name", defaultServiceAccountName, "The name of the service account associated with the credentials")
+	cmd.Flags().StringVar(&opts.controlPlaneVersion, "control-plane-version", opts.controlPlaneVersion, "(Development) Tag to be used for the service mirror controller image")
 	cmd.Flags().StringVar(&opts.gatewayName, "gateway-name", defaultGatewayName, "The name of the gateway service")
 	cmd.Flags().StringVar(&opts.gatewayNamespace, "gateway-namespace", defaultMulticlusterNamespace, "The namespace of the gateway service")
+	cmd.Flags().Uint32Var(&opts.serviceMirrorRetryLimit, "service-mirror-retry-limit", opts.serviceMirrorRetryLimit, "The number of times a failed update from the target cluster is allowed to be retried")
+	cmd.Flags().StringVar(&opts.logLevel, "log-level", opts.logLevel, "Log level for the Multicluster components")
+	cmd.Flags().StringVar(&opts.logFormat, "log-format", opts.logFormat, "Log format for the Multicluster components")
+	cmd.Flags().StringVar(&opts.dockerRegistry, "registry", opts.dockerRegistry,
+		fmt.Sprintf("Docker registry to pull service mirror controller image from ($%s)", flags.EnvOverrideDockerRegistry))
 	cmd.Flags().StringVarP(&opts.selector, "selector", "l", opts.selector, "Selector (label query) to filter which services in the target cluster to mirror")
 	cmd.Flags().StringVar(&opts.remoteDiscoverySelector, "remote-discovery-selector", opts.remoteDiscoverySelector, "Selector (label query) to filter which services in the target cluster to mirror in remote discovery mode")
 	cmd.Flags().StringVar(&opts.federatedServiceSelector, "federated-service-selector", opts.federatedServiceSelector, "Selector (label query) for federated service members in the target cluster")
 	cmd.Flags().StringVar(&opts.gatewayAddresses, "gateway-addresses", opts.gatewayAddresses, "If specified, overwrites gateway addresses when gateway service is not type LoadBalancer (comma separated list)")
 	cmd.Flags().Uint32Var(&opts.gatewayPort, "gateway-port", opts.gatewayPort, "If specified, overwrites gateway port when gateway service is not type LoadBalancer")
+	cmd.Flags().BoolVar(&opts.ha, "ha", opts.ha, "Enable HA configuration for the service-mirror deployment (default false)")
 	cmd.Flags().BoolVar(&opts.enableGateway, "gateway", opts.enableGateway, "If false, allows a link to be created against a cluster that does not have a gateway service")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "yaml", "Output format. One of: json|yaml")
 
@@ -335,87 +400,152 @@ each cluster and applied to the other.`,
 	return cmd
 }
 
-func newLinkGenOptionsWithDefault() (*linkGenOptions, error) {
-	return &linkGenOptions{
+func renderServiceMirror(values *multicluster.Values, valuesOverrides map[string]interface{}, namespace string, format string) ([]byte, error) {
+	files := []*chartloader.BufferedFile{
+		{Name: chartutil.ChartfileName},
+		{Name: "templates/service-mirror.yaml"},
+		{Name: "templates/psp.yaml"},
+		{Name: "templates/gateway-mirror.yaml"},
+	}
+
+	var partialFiles []*chartloader.BufferedFile
+	for _, template := range charts.L5dPartials {
+		partialFiles = append(partialFiles,
+			&chartloader.BufferedFile{Name: template},
+		)
+	}
+
+	// Load all multicluster link chart files into buffer
+	if err := charts.FilesReader(static.Templates, helmMulticlusterLinkDefaultChartName+"/", files); err != nil {
+		return nil, err
+	}
+
+	// Load all partial chart files into buffer
+	if err := charts.FilesReader(partials.Templates, "", partialFiles); err != nil {
+		return nil, err
+	}
+
+	// Create a Chart obj from the files
+	chart, err := chartloader.LoadFiles(append(files, partialFiles...))
+	if err != nil {
+		return nil, err
+	}
+
+	// Render raw values and create chart config
+	rawValues, err := yaml.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store final Values generated from values.yaml and CLI flags
+	err = yaml.Unmarshal(rawValues, &chart.Values)
+	if err != nil {
+		return nil, err
+	}
+
+	vals, err := chartutil.CoalesceValues(chart, valuesOverrides)
+	if err != nil {
+		return nil, err
+	}
+
+	fullValues := map[string]interface{}{
+		"Values": vals,
+		"Release": map[string]interface{}{
+			"Namespace": namespace,
+			"Service":   "CLI",
+		},
+	}
+
+	// Attach the final values into the `Values` field for rendering to work
+	renderedTemplates, err := engine.Render(chart, fullValues)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge templates and inject
+	var yamlBytes bytes.Buffer
+	for _, tmpl := range chart.Templates {
+		t := path.Join(chart.Metadata.Name, tmpl.Name)
+		if _, err := yamlBytes.WriteString(renderedTemplates[t]); err != nil {
+			return nil, err
+		}
+	}
+
+	var out bytes.Buffer
+	err = pkgcmd.RenderYAMLAs(&yamlBytes, &out, format)
+	if err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func newLinkOptionsWithDefault() (*linkOptions, error) {
+	defaults, err := multicluster.NewLinkValues()
+	if err != nil {
+		return nil, err
+	}
+
+	return &linkOptions{
+		controlPlaneVersion:      version.Version,
 		namespace:                defaultMulticlusterNamespace,
+		dockerRegistry:           pkgcmd.DefaultDockerRegistry,
+		serviceMirrorRetryLimit:  defaults.ServiceMirrorRetryLimit,
+		logLevel:                 defaults.LogLevel,
+		logFormat:                defaults.LogFormat,
 		selector:                 fmt.Sprintf("%s=%s", k8s.DefaultExportedServiceSelector, "true"),
 		remoteDiscoverySelector:  fmt.Sprintf("%s=%s", k8s.DefaultExportedServiceSelector, "remote-discovery"),
 		federatedServiceSelector: fmt.Sprintf("%s=%s", k8s.DefaultFederatedServiceSelector, "member"),
 		gatewayAddresses:         "",
 		gatewayPort:              0,
+		ha:                       false,
 		enableGateway:            true,
 	}, nil
 }
 
-func extractGatewayPort(gateway *corev1.Service) (uint32, error) {
-	for _, port := range gateway.Spec.Ports {
-		if port.Name == k8s.GatewayPortName {
-			if gateway.Spec.Type == "NodePort" {
-				return uint32(port.NodePort), nil
-			}
-			return uint32(port.Port), nil
+func buildServiceMirrorValues(opts *linkOptions) (*multicluster.Values, error) {
+
+	if !alphaNumDashDot.MatchString(opts.controlPlaneVersion) {
+		return nil, fmt.Errorf("%s is not a valid version", opts.controlPlaneVersion)
+	}
+
+	if opts.namespace == "" {
+		return nil, errors.New("you need to specify a namespace")
+	}
+
+	if _, err := log.ParseLevel(opts.logLevel); err != nil {
+		return nil, fmt.Errorf("--log-level must be one of: panic, fatal, error, warn, info, debug, trace")
+	}
+
+	if opts.logFormat != "plain" && opts.logFormat != "json" {
+		return nil, fmt.Errorf("--log-format must be one of: plain, json")
+	}
+
+	if opts.selector != "" && opts.selector != fmt.Sprintf("%s=%s", k8s.DefaultExportedServiceSelector, "true") {
+		if !opts.enableGateway {
+			return nil, fmt.Errorf("--selector and --gateway=false are mutually exclusive")
 		}
 	}
-	return 0, fmt.Errorf("gateway service %s has no gateway port named %s", gateway.Name, k8s.GatewayPortName)
-}
 
-func extractSAToken(secrets []corev1.Secret, saName string) (string, error) {
-	for _, secret := range secrets {
-		boundSA := secret.Annotations[saNameAnnotationKey]
-		if saName == boundSA {
-			token, ok := secret.Data[tokenKey]
-			if !ok {
-				return "", fmt.Errorf("could not find the token data in service account secret %s", secret.Name)
-			}
-
-			return string(token), nil
-		}
+	if opts.gatewayAddresses != "" && !opts.enableGateway {
+		return nil, fmt.Errorf("--gateway-addresses and --gateway=false are mutually exclusive")
 	}
 
-	return "", fmt.Errorf("could not find service account token secret for %s", saName)
-}
-
-// ExtractProbeSpec parses the ProbSpec from a gateway service's annotations.
-// For now we're not including the failureThreshold and timeout fields which
-// are new since edge-24.9.3, to avoid errors when attempting to apply them in
-// clusters with an older Link CRD.
-func extractProbeSpec(gateway *corev1.Service) (v1alpha3.ProbeSpec, error) {
-	path := gateway.Annotations[k8s.GatewayProbePath]
-	if path == "" {
-		return v1alpha3.ProbeSpec{}, errors.New("probe path is empty")
+	if opts.gatewayPort != 0 && !opts.enableGateway {
+		return nil, fmt.Errorf("--gateway-port and --gateway=false are mutually exclusive")
 	}
 
-	port, err := extractPort(gateway.Spec, k8s.ProbePortName)
+	defaults, err := multicluster.NewLinkValues()
 	if err != nil {
-		return v1alpha3.ProbeSpec{}, err
+		return nil, err
 	}
 
-	// the `mirror.linkerd.io/probe-period` annotation is initialized with a
-	// default value of "3", but we require a duration-formatted string. So we
-	// perform the conversion, if required.
-	period := gateway.Annotations[k8s.GatewayProbePeriod]
-	if secs, err := strconv.ParseInt(period, 10, 64); err == nil {
-		dur := time.Duration(secs) * time.Second
-		period = dur.String()
-	} else if _, err := time.ParseDuration(period); err != nil {
-		return v1alpha3.ProbeSpec{}, fmt.Errorf("could not parse probe period: %w", err)
-	}
+	defaults.Gateway.Enabled = opts.enableGateway
+	defaults.TargetClusterName = opts.clusterName
+	defaults.ServiceMirrorRetryLimit = opts.serviceMirrorRetryLimit
+	defaults.LogLevel = opts.logLevel
+	defaults.LogFormat = opts.logFormat
+	defaults.ControllerImageVersion = opts.controlPlaneVersion
+	defaults.ControllerImage = fmt.Sprintf("%s/controller", opts.dockerRegistry)
 
-	return v1alpha3.ProbeSpec{
-		Path:   path,
-		Port:   fmt.Sprintf("%d", port),
-		Period: period,
-	}, nil
-}
-
-func extractPort(spec corev1.ServiceSpec, portName string) (uint32, error) {
-	for _, p := range spec.Ports {
-		if p.Name == portName {
-			if spec.Type == "NodePort" {
-				return uint32(p.NodePort), nil
-			}
-			return uint32(p.Port), nil
-		}
-	}
-	return 0, fmt.Errorf("could not find port with name %s", portName)
+	return defaults, nil
 }

--- a/multicluster/cmd/root.go
+++ b/multicluster/cmd/root.go
@@ -23,6 +23,10 @@ const (
 
 	saNameAnnotationKey       = "kubernetes.io/service-account.name"
 	defaultServiceAccountName = "linkerd-service-mirror-remote-access-default"
+
+	clusterNameLabel        = "multicluster.linkerd.io/cluster-name"
+	trustDomainAnnotation   = "multicluster.linkerd.io/trust-domain"
+	clusterDomainAnnotation = "multicluster.linkerd.io/cluster-domain"
 )
 
 var (
@@ -81,6 +85,7 @@ components on a cluster, manage credentials and link clusters together.`,
 	multiclusterCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Turn on debug logging")
 	multiclusterCmd.AddCommand(newLinkCommand())
 	multiclusterCmd.AddCommand(newUnlinkCommand())
+	multiclusterCmd.AddCommand(newGenCommand())
 	multiclusterCmd.AddCommand(newMulticlusterInstallCommand())
 	multiclusterCmd.AddCommand(NewCmdCheck())
 	multiclusterCmd.AddCommand(newMulticlusterUninstallCommand())

--- a/multicluster/cmd/unlink.go
+++ b/multicluster/cmd/unlink.go
@@ -27,9 +27,10 @@ func newUnlinkCommand() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "unlink",
-		Short: "Outputs link resources for deletion",
-		Args:  cobra.NoArgs,
+		Use:        "unlink",
+		Deprecated: "only use for removing service mirror resources created by the (also deprecated) 'linkerd multicluster link' command (Linkerd 2.17 and earlier).",
+		Short:      "Outputs link resources for deletion",
+		Args:       cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if opts.clusterName == "" {

--- a/test/integration/multicluster/install_test.go
+++ b/test/integration/multicluster/install_test.go
@@ -221,16 +221,17 @@ func TestLinkClusters(t *testing.T) {
 		"--context=" + contexts[testutil.TargetContextKey],
 		"--cluster-name", linkName,
 		"--api-server-address", fmt.Sprintf("https://%s:6443", lbIP),
-		"multicluster", "link",
+		"multicluster",
 	}
 	if TestHelper.GetMulticlusterManageControllers() {
 		linkCmd = append(
 			linkCmd,
-			"--service-mirror=false",
+			"link-gen",
 		)
 	} else {
 		linkCmd = append(
 			linkCmd,
+			"link",
 			"--set", "enableHeadlessServices=true",
 			"--log-format", "json",
 			"--log-level", "debug",
@@ -261,16 +262,17 @@ func TestLinkClusters(t *testing.T) {
 		"--context=" + contexts[testutil.SourceContextKey],
 		"--cluster-name", linkName, "--gateway=false",
 		"--api-server-address", fmt.Sprintf("https://%s:6443", lbIP),
-		"multicluster", "link",
+		"multicluster",
 	}
 	if TestHelper.GetMulticlusterManageControllers() {
 		linkCmd = append(
 			linkCmd,
-			"--service-mirror=false",
+			"link-gen",
 		)
 	} else {
 		linkCmd = append(
 			linkCmd,
+			"link",
 			"--log-format", "json",
 			"--log-level", "debug",
 		)


### PR DESCRIPTION
As of version 2.18 the golden path for establishing links will be by setting the `controllers` entry in the helm values, and applying the Link resource along with the credential secrets (see #13770).

This change deprecates the `linkerd multicluster link` command and puts in its place `linkerd multicluster link-gen` which only generates the Link resource and the credentials secrets. This is what the recently introduced flag `linkerd multicluster link --service-mirror=false` flag was accomplishing, but now we'd rather revert the introduction of that flag and instead deprecate the whole subcommand and introduce a new one.

We copied here the old `link.go` file to `link-deprecated.go` (which should be removed at some point in the future) and introduced the new sub-command on top of `link.go` to preserve git history.

Likewise, `linkerd mc unlink` is deprecated as well.