### PR TITLE
Bump Prometheus to `v2.55.1`

### DIFF
--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -451,7 +451,7 @@ prometheus:
     # -- Docker image name for the prometheus instance
     name: prometheus
     # -- Docker image tag for the prometheus instance
-    tag: v2.48.1
+    tag: v2.55.1
     # -- Pull policy for the prometheus instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -760,7 +760,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.1
+        image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -760,7 +760,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.1
+        image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -760,7 +760,7 @@ spec:
         - --log.level=debug
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.1
+        image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -764,7 +764,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
         - --storage.tsdb.retention.time=6h
-        image: prom/prometheus:v2.48.1
+        image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Bump Prometheus from `v2.48.1` to `v2.55.1`, to resolve CVEs.

We bump to `v2.55.1` rather than the latest `v3.2.1` because there is a TSDB backwards compatibility issue that recommends upgrading to 2.55 first:
https://prometheus.io/docs/prometheus/latest/migration/#tsdb-format-and-downgrade

```bash
$ grype -q prom/prometheus:v2.48.1
NAME                                              INSTALLED             FIXED-IN                      TYPE       VULNERABILITY        SEVERITY
busybox                                           1.36.1                                              binary     CVE-2023-42363       Medium
busybox                                           1.36.1                                              binary     CVE-2023-42364       Medium
busybox                                           1.36.1                                              binary     CVE-2023-42365       Medium
busybox                                           1.36.1                                              binary     CVE-2023-42366       Medium
github.com/Azure/azure-sdk-for-go/sdk/azidentity  v1.4.0                1.6.0                         go-module  GHSA-m5vv-6r4h-3vj9  Medium
github.com/docker/docker                          v24.0.6+incompatible  25.0.6                        go-module  GHSA-v23v-6jw2-98fq  Critical
github.com/docker/docker                          v24.0.6+incompatible  24.0.7                        go-module  GHSA-jq35-85cj-fj4p  Medium
github.com/docker/docker                          v24.0.6+incompatible  24.0.9                        go-module  GHSA-xw73-rw38-6vjc  Medium
github.com/golang-jwt/jwt/v5                      v5.0.0                5.2.2                         go-module  GHSA-mh63-6h87-95cp  High
github.com/hashicorp/go-retryablehttp             v0.7.4                0.7.7                         go-module  GHSA-v6v8-xj6m-xwqh  Medium
golang.org/x/crypto                               v0.14.0               0.31.0                        go-module  GHSA-v778-237x-gjrc  Critical
golang.org/x/crypto                               v0.14.0               0.17.0                        go-module  GHSA-45x7-px36-x8w8  Medium
golang.org/x/net                                  v0.17.0               0.23.0                        go-module  GHSA-4v7x-pqxf-cx7m  Medium
golang.org/x/net                                  v0.17.0               0.36.0                        go-module  GHSA-qxp5-gwg8-xv66  Medium
google.golang.org/protobuf                        v1.31.0               1.33.0                        go-module  GHSA-8r3f-844c-mc37  Medium
stdlib                                            go1.21.5              1.21.11, 1.22.4               go-module  CVE-2024-24790       Critical
stdlib                                            go1.21.5              1.21.9, 1.22.2                go-module  CVE-2023-45288       High
stdlib                                            go1.21.5              1.21.8, 1.22.1                go-module  CVE-2024-24784       High
stdlib                                            go1.21.5              1.21.12, 1.22.5               go-module  CVE-2024-24791       High
stdlib                                            go1.21.5              1.22.7, 1.23.1                go-module  CVE-2024-34156       High
stdlib                                            go1.21.5              1.22.7, 1.23.1                go-module  CVE-2024-34158       High
stdlib                                            go1.21.5              1.21.8, 1.22.1                go-module  CVE-2023-45289       Medium
stdlib                                            go1.21.5              1.21.8, 1.22.1                go-module  CVE-2023-45290       Medium
stdlib                                            go1.21.5              1.21.8, 1.22.1                go-module  CVE-2024-24783       Medium
stdlib                                            go1.21.5              1.21.8, 1.22.1                go-module  CVE-2024-24785       Medium
stdlib                                            go1.21.5              1.21.10, 1.22.3               go-module  CVE-2024-24787       Medium
stdlib                                            go1.21.5              1.21.11, 1.22.4               go-module  CVE-2024-24789       Medium
stdlib                                            go1.21.5              1.22.7, 1.23.1                go-module  CVE-2024-34155       Medium
stdlib                                            go1.21.5              1.22.11, 1.23.5, 1.24.0-rc.2  go-module  CVE-2024-45336       Medium
stdlib                                            go1.21.5              1.22.11, 1.23.5, 1.24.0-rc.2  go-module  CVE-2024-45341       Medium
stdlib                                            go1.21.5              1.22.12, 1.23.6, 1.24.0-rc.3  go-module  CVE-2025-22866       Medium

$ grype -q prom/prometheus:v2.55.1
NAME                          INSTALLED  FIXED-IN                      TYPE       VULNERABILITY        SEVERITY
busybox                       1.36.1                                   binary     CVE-2023-42363       Medium
busybox                       1.36.1                                   binary     CVE-2023-42364       Medium
busybox                       1.36.1                                   binary     CVE-2023-42365       Medium
busybox                       1.36.1                                   binary     CVE-2023-42366       Medium
github.com/golang-jwt/jwt/v5  v5.2.1     5.2.2                         go-module  GHSA-mh63-6h87-95cp  High
golang.org/x/crypto           v0.26.0    0.31.0                        go-module  GHSA-v778-237x-gjrc  Critical
golang.org/x/net              v0.28.0    0.36.0                        go-module  GHSA-qxp5-gwg8-xv66  Medium
stdlib                        go1.23.2   1.22.11, 1.23.5, 1.24.0-rc.2  go-module  CVE-2024-45336       Medium
stdlib                        go1.23.2   1.22.11, 1.23.5, 1.24.0-rc.2  go-module  CVE-2024-45341       Medium
stdlib                        go1.23.2   1.22.12, 1.23.6, 1.24.0-rc.3  go-module  CVE-2025-22866       Medium
```

Signed-off-by: Andrew Seigner <siggy@buoyant.io>