### PR TITLE
feat(multicluster): add --only-controller flag to `linkerd mc unlink`

### DIFF
--- a/multicluster/cmd/link.go
+++ b/multicluster/cmd/link.go
@@ -54,6 +54,7 @@ type (
 		excludedLabels           []string
 		ha                       bool
 		enableGateway            bool
+		onlyController           bool
 		output                   string
 	}
 )

--- a/multicluster/cmd/unlink.go
+++ b/multicluster/cmd/unlink.go
@@ -97,16 +97,15 @@ func newUnlinkCommand() *cobra.Command {
 			}
 
 			for _, r := range resources {
-				switch opts.output {
-				case "yaml":
+				if opts.output == "yaml" {
 					if err := r.RenderResource(stdout); err != nil {
 						log.Errorf("failed to render resource %s: %s", r.Name, err)
 					}
-				case "json":
+				} else if opts.output == "json" {
 					if err := r.RenderResourceJSON(stdout); err != nil {
 						log.Errorf("failed to render resource %s: %s", r.Name, err)
 					}
-				default:
+				} else {
 					return fmt.Errorf("unsupported format: %s", opts.output)
 				}
 			}


### PR DESCRIPTION
This flag allows removing the service-mirror controller deployment and all the associated resources for a given target cluster. It doesn't output entries for the link CR, credential secrets, lease object or mirror services. It can be used to migrate from controllers generated by `linkerd mc link`, to the controllers managed by the multicluster extension introduced in 2.18.