### PR TITLE
build(deps): enable tracing feature in hyper-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "hyper",
+ "hyper-util",
  "ipnet",
  "k8s-openapi",
  "kube",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ lto = "thin"
 gateway-api = "0.15"
 http = "1"
 hyper = "1"
+hyper-util = { version = "0.1", default-features = false, features = ["tracing"] }
 k8s-openapi = { version = "0.24", features = ["v1_32"] }
 kube = { version = "0.99", default-features = false }
 kubert = { version = "0.24", default-features = false }

--- a/policy-controller/runtime/Cargo.toml
+++ b/policy-controller/runtime/Cargo.toml
@@ -22,6 +22,7 @@ futures = { version = "0.3", default-features = false }
 k8s-openapi = { workspace = true }
 http-body-util = "0.1"
 hyper = { workspace = true, features = ["http1", "http2", "server"] }
+hyper-util = { workspace = true }
 ipnet = { version = "2", default-features = false }
 openssl = { version = "0.10.71", optional = true }
 parking_lot = "0.12"

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 bytes = "1"
 http-body-util = "0.1"
 hyper = { workspace = true, features = ["client", "http2"] }
-hyper-util = { version = "0.1" }
+hyper-util = { workspace = true }
 futures = { version = "0.3", default-features = false }
 ipnet = "2"
 k8s-openapi = { workspace = true }


### PR DESCRIPTION
This enables the `tracing` feature in the hyper-util dependency, allowing for the span context to properly propagate and avoiding having entries like this in the log, deprived from all the labels:

```log
2025-04-01T18:02:28.180957Z DEBUG hyper_util::client::legacy::pool: pooling idle connection for ("https", 10.43.0.1)
```

An entry with full context conserved should look something like this instead:

```log
2025-04-01T18:28:45.647991Z DEBUG serverauthorizations:HTTP{http.method=GET http.url=https://10.43.0.1/apis/policy.linkerd.io/v1beta1/serverauthorizations?&watch=true&timeoutSeconds=290&allowWatchBookmarks=true&resourceVersion=2684 otel.name="watch" otel.kind="client" http.status_code=200}: hyper_util::client::legacy::pool: pooling idle connection for ("https", 10.43.0.1)
```

See hyperium/hyper-util#166