### PR TITLE
chore(multicluster): update Prometheus configs and access policy to scrape new multicluster controllers

### DIFF
--- a/charts/linkerd-control-plane/templates/podmonitor.yaml
+++ b/charts/linkerd-control-plane/templates/podmonitor.yaml
@@ -40,7 +40,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: "linkerd-service-mirror"
+  name: "linkerd-multicluster-controller"
   namespace: {{ .Release.Namespace }}
   labels:
     linkerd.io/control-plane-ns: {{ .Release.Namespace }}
@@ -61,7 +61,7 @@ spec:
             - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
             - __meta_kubernetes_pod_container_port_name
           action: keep
-          regex: linkerd-service-mirror;admin-http$
+          regex: (linkerd-service-mirror|controller);admin-http$
         - sourceLabels:
             - __meta_kubernetes_pod_container_name
           action: replace

--- a/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
@@ -10,8 +10,12 @@ metadata:
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 spec:
   podSelector:
-    matchLabels:
-      component: linkerd-service-mirror
+    matchExpressions:
+    - key: component
+      operator: In
+      values:
+      - linkerd-service-mirror
+      - controller
   port: admin-http
   proxyProtocol: HTTP/1
 ---

--- a/multicluster/cmd/gateways.go
+++ b/multicluster/cmd/gateways.go
@@ -261,7 +261,7 @@ func getServiceMirrorContainer(pod corev1.Pod) (corev1.Container, error) {
 			return c, nil
 		}
 	}
-	return corev1.Container{}, fmt.Errorf("pod %s did not have 'service-mirror' container", pod.GetName())
+	return corev1.Container{}, fmt.Errorf("pod %s did not have a 'service-mirror' nor a 'controller' container", pod.GetName())
 }
 
 func isTargetClusterMetric(metric *io_prometheus_client.Metric, targetClusterName string) bool {

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -1247,8 +1247,12 @@ metadata:
     component: linkerd-service-mirror
 spec:
   podSelector:
-    matchLabels:
-      component: linkerd-service-mirror
+    matchExpressions:
+    - key: component
+      operator: In
+      values:
+      - linkerd-service-mirror
+      - controller
   port: admin-http
   proxyProtocol: HTTP/1
 ---

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -1319,8 +1319,12 @@ metadata:
     component: linkerd-service-mirror
 spec:
   podSelector:
-    matchLabels:
-      component: linkerd-service-mirror
+    matchExpressions:
+    - key: component
+      operator: In
+      values:
+      - linkerd-service-mirror
+      - controller
   port: admin-http
   proxyProtocol: HTTP/1
 ---

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -1281,8 +1281,12 @@ metadata:
     component: linkerd-service-mirror
 spec:
   podSelector:
-    matchLabels:
-      component: linkerd-service-mirror
+    matchExpressions:
+    - key: component
+      operator: In
+      values:
+      - linkerd-service-mirror
+      - controller
   port: admin-http
   proxyProtocol: HTTP/1
 ---

--- a/viz/charts/linkerd-viz/templates/prometheus.yaml
+++ b/viz/charts/linkerd-viz/templates/prometheus.yaml
@@ -73,7 +73,7 @@ data:
         action: replace
         target_label: component
 
-    - job_name: 'linkerd-service-mirror'
+    - job_name: 'linkerd-multicluster-controller'
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
@@ -81,7 +81,7 @@ data:
         - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
-        regex: linkerd-service-mirror;admin-http$
+        regex: (linkerd-service-mirror|controller);admin-http$
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: component

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -628,7 +628,7 @@ data:
         action: replace
         target_label: component
 
-    - job_name: 'linkerd-service-mirror'
+    - job_name: 'linkerd-multicluster-controller'
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
@@ -636,7 +636,7 @@ data:
         - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
-        regex: linkerd-service-mirror;admin-http$
+        regex: (linkerd-service-mirror|controller);admin-http$
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: component

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -628,7 +628,7 @@ data:
         action: replace
         target_label: component
 
-    - job_name: 'linkerd-service-mirror'
+    - job_name: 'linkerd-multicluster-controller'
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
@@ -636,7 +636,7 @@ data:
         - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
-        regex: linkerd-service-mirror;admin-http$
+        regex: (linkerd-service-mirror|controller);admin-http$
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: component

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -628,7 +628,7 @@ data:
         action: replace
         target_label: component
 
-    - job_name: 'linkerd-service-mirror'
+    - job_name: 'linkerd-multicluster-controller'
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
@@ -636,7 +636,7 @@ data:
         - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
-        regex: linkerd-service-mirror;admin-http$
+        regex: (linkerd-service-mirror|controller);admin-http$
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: component

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -628,7 +628,7 @@ data:
         action: replace
         target_label: component
 
-    - job_name: 'linkerd-service-mirror'
+    - job_name: 'linkerd-multicluster-controller'
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
@@ -636,7 +636,7 @@ data:
         - __meta_kubernetes_pod_label_component
         - __meta_kubernetes_pod_container_port_name
         action: keep
-        regex: linkerd-service-mirror;admin-http$
+        regex: (linkerd-service-mirror|controller);admin-http$
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: component


### PR DESCRIPTION
This updates the Prometheus ConfigMap to scrape the new multicluster-managed link controllers. The analogous PodMonitor resource in the linkerd-control-plane chart is updated as well.

Also, the default Server provided by the linkerd-multicluster chart for granting access to the controller's metrics has been updated.