### PR TITLE
chore(ci): run policy tests against various Gateway API versions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -163,9 +163,24 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
+        # Test the latest Kubernetes version with the latest Gateway API
+        # version, as well as the vendored Gateway API CRDs.
         k8s:
-          - v1.23
           - v1.32
+        gateway-api:
+          - version: linkerd
+            channel: experimental
+          - version: v1.3.0-rc.1
+            channel: experimental
+        # Also test the Minimum Supported Kubernetes Version with the Minimum
+        # Supported Gateway API version.
+        include:
+          - k8s: v1.23
+            version: v1.1.1
+            channel: standard
+    env:
+      GATEWAY_API_VERSION: ${{ matrix.gateway-api.version }}
+      GATEWAY_API_CHANNEL: ${{ matrix.gateway-api.channel }}
     steps:
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -176,8 +176,9 @@ jobs:
         # Supported Gateway API version.
         include:
           - k8s: v1.23
-            version: v1.1.1
-            channel: standard
+            gateway-api:
+              version: v1.1.1
+              channel: standard
     env:
       GATEWAY_API_VERSION: ${{ matrix.gateway-api.version }}
       GATEWAY_API_CHANNEL: ${{ matrix.gateway-api.channel }}


### PR DESCRIPTION
This change expands the policy test matrix so that:

* The Minimum Supported Kubernetes Version is tested with the Minimum Supported
  Gateway API Version.
* The latest Kubernetes version is tested with the latest Gateway API version.
* The latest Kubernetes version is tested with the CLI's vendored Gateway API
  types. This is near the MSGV, though currently provides experimental types.