### PR TITLE
test(multicluster): don't retry the "extension is managing controllers" test

### DIFF
--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -226,8 +226,6 @@ func multiclusterCategory(hc *healthChecker, wait time.Duration) *healthcheck.Ca
 	checkers = append(checkers,
 		*healthcheck.NewChecker("extension is managing controllers").
 			WithHintAnchor("l5d-multicluster-managed-controllers").
-			WithRetryDeadline(hc.RetryDeadline).
-			SurfaceErrorOnRetry().
 			Warning().
 			WithCheck(func(ctx context.Context) error {
 				return hc.checkLegacyController(ctx)


### PR DESCRIPTION
This is just a warning, and there's no waiting for some eventual convergence here, so the test should not be retried. Plus it's unnecessarily delaying the integration tests.

