### PR TITLE
fix(test): avoid duplicate registry errors

### DIFF
--- a/controller/api/destination/federated_service_watcher_test.go
+++ b/controller/api/destination/federated_service_watcher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/linkerd/linkerd2/controller/api/destination/watcher"
 	"github.com/linkerd/linkerd2/controller/k8s"
 	"github.com/linkerd/linkerd2/pkg/addr"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestFederatedService(t *testing.T) {
@@ -135,11 +136,14 @@ func mockFederatedServiceWatcher(t *testing.T) (*federatedServiceWatcher, error)
 	if err != nil {
 		return nil, fmt.Errorf("NewEndpointsWatcher returned an error: %w", err)
 	}
+
+	prom := prometheus.NewRegistry()
 	clusterStore, err := watcher.NewClusterStoreWithDecoder(k8sAPI.Client, "linkerd", false,
 		watcher.CreateMulticlusterDecoder(map[string][]string{
 			"east":  eastConfigs,
 			"north": northConfigs,
 		}),
+		prom,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("NewClusterStoreWithDecoder returned an error: %w", err)

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/linkerd/linkerd2/controller/api/util"
 	l5dcrdclient "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned"
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/prometheus/client_golang/prometheus"
 	logging "github.com/sirupsen/logrus"
 )
 
@@ -998,7 +999,8 @@ spec:
 		t.Fatalf("can't create profile watcher: %s", err)
 	}
 
-	clusterStore, err := watcher.NewClusterStoreWithDecoder(k8sAPI.Client, "linkerd", true, watcher.CreateMockDecoder(exportedServiceResources...))
+	prom := prometheus.NewRegistry()
+	clusterStore, err := watcher.NewClusterStoreWithDecoder(k8sAPI.Client, "linkerd", true, watcher.CreateMockDecoder(exportedServiceResources...), prom)
 	if err != nil {
 		t.Fatalf("can't create cluster store: %s", err)
 	}

--- a/controller/api/destination/watcher/cluster_store.go
+++ b/controller/api/destination/watcher/cluster_store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/linkerd/linkerd2/controller/k8s"
 	pkgK8s "github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	logging "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -36,7 +35,7 @@ type (
 		// kubeconfig, it creates API Server clients
 		decodeFn configDecoder
 
-		size_gauge prometheus.GaugeFunc
+		sizeGauge prometheus.GaugeFunc
 	}
 
 	// remoteCluster is a helper struct that represents a store item
@@ -73,7 +72,7 @@ const (
 // Secret informer. The event handlers are responsible for driving the discovery
 // of remote clusters and their configuration
 func NewClusterStore(client kubernetes.Interface, namespace string, enableEndpointSlices bool) (*ClusterStore, error) {
-	return NewClusterStoreWithDecoder(client, namespace, enableEndpointSlices, decodeK8sConfigFromSecret)
+	return NewClusterStoreWithDecoder(client, namespace, enableEndpointSlices, decodeK8sConfigFromSecret, prometheus.DefaultRegisterer)
 }
 
 func (cs *ClusterStore) Sync(stopCh <-chan struct{}) {
@@ -81,12 +80,17 @@ func (cs *ClusterStore) Sync(stopCh <-chan struct{}) {
 }
 
 func (cs *ClusterStore) UnregisterGauges() {
-	prometheus.Unregister(cs.size_gauge)
+	prometheus.Unregister(cs.sizeGauge)
 }
 
 // newClusterStoreWithDecoder is a helper function that allows the creation of a
 // store with an arbitrary `configDecoder` function.
-func NewClusterStoreWithDecoder(client kubernetes.Interface, namespace string, enableEndpointSlices bool, decodeFn configDecoder) (*ClusterStore, error) {
+func NewClusterStoreWithDecoder(
+	client kubernetes.Interface,
+	namespace string, enableEndpointSlices bool,
+	decodeFn configDecoder,
+	prom prometheus.Registerer,
+) (*ClusterStore, error) {
 	api := k8s.NewNamespacedAPI(client, nil, nil, namespace, "local", k8s.Secret)
 
 	cs := &ClusterStore{
@@ -99,10 +103,17 @@ func NewClusterStoreWithDecoder(client kubernetes.Interface, namespace string, e
 		decodeFn:             decodeFn,
 	}
 
-	cs.size_gauge = promauto.NewGaugeFunc(prometheus.GaugeOpts{
+	sizeGauge := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "cluster_store_size",
 		Help: "The number of linked clusters in the remote discovery cluster store",
 	}, func() float64 { return (float64)(len(cs.store)) })
+	if prom != nil {
+		if err := prom.Register(sizeGauge); err != nil {
+			// If we can't register the metric, log the error but continue
+			cs.log.Warnf("Failed to register cluster_store_size metric: %v", err)
+		}
+	}
+	cs.sizeGauge = sizeGauge
 
 	_, err := cs.api.Secret().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {

--- a/controller/api/destination/watcher/cluster_store_test.go
+++ b/controller/api/destination/watcher/cluster_store_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestClusterStoreHandlers(t *testing.T) {
@@ -80,7 +81,8 @@ func TestClusterStoreHandlers(t *testing.T) {
 				t.Fatalf("NewFakeAPI returned an error: %s", err)
 			}
 
-			cs, err := NewClusterStoreWithDecoder(k8sAPI.Client, "linkerd", tt.enableEndpointSlices, CreateMockDecoder())
+			prom := prometheus.NewRegistry()
+			cs, err := NewClusterStoreWithDecoder(k8sAPI.Client, "linkerd", tt.enableEndpointSlices, CreateMockDecoder(), prom)
 			if err != nil {
 				t.Fatalf("Unexpected error when starting watcher cache: %s", err)
 			}


### PR DESCRIPTION
The destinaation controller's cluster store registers a gague in its constructor. When this constructor is called multiple times (i.e. in tests), this can lead to a panic.

To avoid this panic, this change updates NewClusterStoreWithDecoder to accept a prometheus registry). The NewClusterStore constructor (used by the application's main) continues to use the default registry, but tests now construct their own temporary registries to avoid duplicate registration errors.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
