### PR TITLE
fix(CLI): streamline error output when gateway api is missing

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -158,10 +158,9 @@ A full list of configurable values can be found at https://artifacthub.io/packag
 			}
 
 			if crds {
-				// The CRD chart is not configurable.
-				// TODO(ver): Error if values have been configured?
 				if err = installCRDs(cmd.Context(), k8sAPI, os.Stdout, options, output); err != nil {
-					return err
+					fmt.Fprintf(os.Stderr, "%s\n", err)
+					os.Exit(1)
 				}
 
 				fmt.Fprintln(os.Stderr, "Rendering Linkerd CRDs...")


### PR DESCRIPTION
When running `linkerd install --crds` on a cluster without the Gateway API installed, Linkerd will return an error prompting the user to install the Gateway API first.  However, Linkerd will also print the `linkerd install` command usage along with the error message.  This is confusing because the usage includes example commands which are not relevant to the error and can mislead the user about what action they need to take.

We print only the error message in this case and not the usage help.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
