### PR TITLE
test(CI): move go test timeout to justfile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,6 @@ jobs:
   go-test:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
-    timeout-minutes: 10
     runs-on: ubuntu-24.04
     container: ghcr.io/linkerd/dev:v45-go
     steps:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,6 +49,7 @@ jobs:
   go-test:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     container: ghcr.io/linkerd/dev:v45-go
     steps:

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ go-lint *flags:
     golangci-lint run {{ flags }}
 
 go-test:
-    LINKERD_TEST_PRETTY_DIFF=1 gotestsum -- -race -v -mod=readonly ./...
+    LINKERD_TEST_PRETTY_DIFF=1 gotestsum -- -race -v -mod=readonly --timeout 10m ./...
 
 ##
 ## Rust


### PR DESCRIPTION
The go-test CI workflow specifies at 10m timeout.  However, if a test exceeds this timeout (for example if it is deadlocked) then CI terminates the job and the go test output doesn't give us any clues about which test specifically was running.  This makes it hard to identify what caused the failure.

We move the 10m timeout from the CI workflow into the `go-test` justfile recipe.  This causes `go test` to exit with a more informative error message once the timeout is reached, instead of being terminated by CI.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
