### PR TITLE
feat(tracing): Set correct default port for tracing

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -204,7 +204,7 @@ and their proxies by using the `--set controlPlaneTracing=true` installation
 flag.
 
 This will configure all the components to send the traces at
-`collector.{{.Values.controlPlaneTracingNamespace}}.svc.{{.Values.ClusterDomain}}:55678`
+`collector.{{.Values.controlPlaneTracingNamespace}}.svc.{{.Values.ClusterDomain}}:4317`
 
 ```bash
 

--- a/charts/partials/templates/_trace.tpl
+++ b/charts/partials/templates/_trace.tpl
@@ -1,5 +1,5 @@
 {{ define "partials.linkerd.trace" -}}
 {{ if .Values.controlPlaneTracing -}}
-- -trace-collector=collector.{{.Values.controlPlaneTracingNamespace}}.svc.{{.Values.clusterDomain}}:55678
+- -trace-collector=collector.{{.Values.controlPlaneTracingNamespace}}.svc.{{.Values.clusterDomain}}:4317
 {{ end -}}
 {{- end }}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -958,7 +958,7 @@ spec:
         - -enable-pprof=false
         - -kube-apiclient-qps=100
         - -kube-apiclient-burst=200
-        - -trace-collector=collector.linkerd-jaeger.svc.cluster.local:55678
+        - -trace-collector=collector.linkerd-jaeger.svc.cluster.local:4317
         env:
         - name: LINKERD_DISABLED
           value: "linkerd-await cannot block the identity controller"
@@ -1564,7 +1564,7 @@ spec:
         - -enable-ipv6=false
         - -enable-pprof=false
         - --meshed-http2-client-params={"keep_alive":{"interval":{"seconds":10},"timeout":{"seconds":3},"while_idle":true}}
-        - -trace-collector=collector.linkerd-jaeger.svc.cluster.local:55678
+        - -trace-collector=collector.linkerd-jaeger.svc.cluster.local:4317
         image: cr.l5d.io/linkerd/controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -292,7 +292,7 @@ webhook:
 
   # -- collector service address for the proxies to send trace data.
   # Points by default to the linkerd-jaeger collector
-  collectorSvcAddr: collector.linkerd-jaeger:55678
+  collectorSvcAddr: collector.linkerd-jaeger:4317
   # -- protocol proxies should use to send trace data.
   # Can be `opencensus` or `opentelemetry` (default)
   collectorTraceProtocol: opentelemetry

--- a/jaeger/cmd/testdata/install_collector_disabled.golden
+++ b/jaeger/cmd/testdata/install_collector_disabled.golden
@@ -46,7 +46,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - -collector-svc-addr=collector.linkerd-jaeger:55678
+        - -collector-svc-addr=collector.linkerd-jaeger:4317
         - -collector-trace-protocol=opentelemetry
         - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector

--- a/jaeger/cmd/testdata/install_default.golden
+++ b/jaeger/cmd/testdata/install_default.golden
@@ -46,7 +46,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - -collector-svc-addr=collector.linkerd-jaeger:55678
+        - -collector-svc-addr=collector.linkerd-jaeger:4317
         - -collector-trace-protocol=opentelemetry
         - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector

--- a/jaeger/cmd/testdata/install_jaeger_disabled.golden
+++ b/jaeger/cmd/testdata/install_jaeger_disabled.golden
@@ -46,7 +46,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - -collector-svc-addr=collector.linkerd-jaeger:55678
+        - -collector-svc-addr=collector.linkerd-jaeger:4317
         - -collector-trace-protocol=opentelemetry
         - -collector-trace-svc-name=linkerd-proxy
         - -collector-svc-account=collector


### PR DESCRIPTION
Now that the default tracing protocol is OpenTelemetry, this changes the default port for traces to the OpenTelemetry port on the collector instead of the OpenCensus one.

The current default port, matched with the current default trace protocol of OpenTelemetry, is currently broken as it causes traces to be sent to a collector port that expects OpenCensus traces. This is technically a breaking change, but it is less breaking than the change of the default protocol to OpenTelemetry.

More explicitly, if a user only used the defaults, this change brings them from a broken state to a working state. If a user brings their own tracing infrastructure with a custom collector address, this change doesn't affect them at all. The only users that may be broken by this are ones that explicitly set the protocol to OpenCensus, but we expect this to be rare as OpenCensus as a protocol has been sunset for a few years now.
