### PR TITLE
fix(CLI): Check that the Gateway API version includes v1 resources

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -231,7 +231,7 @@ func checkGatewayAPICRDs(ctx context.Context, k8sAPI *k8s.KubernetesAPI) (Gatewa
 			}
 			result = External
 			if !crdIncludesV1(crd) {
-				return result, fmt.Errorf("the %s CRD is missing the v1 version, please upgrade to Gateway API v1.0.0 or later", name)
+				return result, fmt.Errorf("the %s CRD is missing the v1 version, please upgrade to Gateway API v1.1.1 or later", name)
 			}
 		} else if kerrors.IsNotFound(err) {
 			// No action if CRD is not found.

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -300,6 +300,19 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: httproutes.gateway.networking.k8s.io
+spec:
+  versions:
+    - name: v1
+`
+
+	unsupportedGatewayAPIVersionManifest := `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httproutes.gateway.networking.k8s.io
+spec:
+  versions:
+    - name: v1alpha1
 `
 
 	linkerdGatewayAPIManifest := `---
@@ -324,6 +337,13 @@ metadata:
 			values.Options{},
 			false,
 			"install_crds.golden",
+		},
+		{
+			"error with unsupported external GW API",
+			unsupportedGatewayAPIVersionManifest,
+			values.Options{},
+			true,
+			"",
 		},
 		{
 			"render with missing GW API",


### PR DESCRIPTION
When Linkerd is installed with an externally managed Gateway API, those externally managed CRDs must include the v1 resources versions of the HTTPRoute and GRPCRoute resources.  These resource versions are present in gateway API versions v1.0.0 and onward.

During install and upgrade, if using an externally managed Gateway API, we add a check to verify that the Gateway API includes v1 resource versions of HTTPRoute and GRPCRoute.  We return an error if these resource versions are not present.

```
> linkerd install --crds
the httproutes.gateway.networking.k8s.io CRD is missing the v1 version, please upgrade to Gateway API v1.0.0 or later
```

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
