### PR TITLE
include TCPRoute policy on opaque appProtocol services

### DIFF
--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -2,12 +2,12 @@ use futures::StreamExt;
 use linkerd_policy_controller_k8s_api as k8s;
 use linkerd_policy_controller_k8s_api::gateway;
 use linkerd_policy_test::{
-    assert_resource_meta, create,
+    assert_resource_meta, await_route_accepted, create,
     outbound_api::{
-        assert_route_is_default, assert_singleton, http1_routes, http2_routes,
+        assert_route_is_default, assert_singleton, grpc_routes, http1_routes, http2_routes,
         retry_watch_outbound_policy,
     },
-    test_route::TestParent,
+    test_route::{TestParent, TestRoute},
     with_temp_ns,
 };
 
@@ -41,6 +41,93 @@ async fn opaque_parent() {
             let routes = linkerd_policy_test::outbound_api::tcp_routes(&config);
             let route = assert_singleton(routes);
             assert_route_is_default::<gateway::TCPRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[cfg(feature = "gateway-api-experimental")]
+#[tokio::test(flavor = "current_thread")]
+async fn unknown_app_protocol_parent() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("XMPP".to_string())),
+            )
+            .await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = linkerd_policy_test::outbound_api::tcp_routes(&config);
+            let route = assert_singleton(routes);
+            assert_route_is_default::<gateway::TCPRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[cfg(feature = "gateway-api-experimental")]
+#[tokio::test(flavor = "current_thread")]
+async fn opaque_parent_with_tcp_route() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("linkerd.io/opaque".to_string())),
+            )
+            .await;
+
+            let route = create(
+                &client,
+                gateway::TCPRoute::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![parent.backend_ref(port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            gateway::TCPRoute::routes(&config, |routes| {
+                // Only the first TCPRoute should be returned in the config.
+                assert!(route.meta_eq(gateway::TCPRoute::extract_meta(&routes[0])));
+                assert_eq!(routes.len(), 1);
+            });
         })
         .await;
     }
@@ -85,6 +172,53 @@ async fn http1_parent() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn http1_parent_with_http_route() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("http".to_string())),
+            )
+            .await;
+
+            let route = create(
+                &client,
+                gateway::HTTPRoute::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![parent.backend_ref(port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http1_routes(&config);
+            let outbound_route = assert_singleton(routes);
+            assert!(route.meta_eq(gateway::HTTPRoute::extract_meta(outbound_route)));
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn http2_parent() {
     async fn test<P: TestParent>() {
         tracing::debug!(
@@ -113,6 +247,100 @@ async fn http2_parent() {
             let routes = http2_routes(&config);
             let route = assert_singleton(routes);
             assert_route_is_default::<gateway::HTTPRoute>(route, &parent.obj_ref(), port);
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http2_parent_with_http_route() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
+            )
+            .await;
+
+            let route = create(
+                &client,
+                gateway::HTTPRoute::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![parent.backend_ref(port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = http2_routes(&config);
+            let outbound_route = assert_singleton(routes);
+            assert!(route.meta_eq(gateway::HTTPRoute::extract_meta(outbound_route)));
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http2_parent_with_grpc_route() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            // Create a parent with no routes.
+            // let parent = P::create_parent(&client.clone(), &ns).await;
+            let parent = create(
+                &client,
+                P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
+            )
+            .await;
+
+            let route = create(
+                &client,
+                gateway::GRPCRoute::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![parent.backend_ref(port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let routes = grpc_routes(&config);
+            let outbound_route = assert_singleton(routes);
+            assert!(route.meta_eq(gateway::GRPCRoute::extract_meta(outbound_route)));
         })
         .await;
     }

--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -21,7 +21,6 @@ async fn opaque_parent() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("linkerd.io/opaque".to_string())),
@@ -58,7 +57,6 @@ async fn unknown_app_protocol_parent() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("XMPP".to_string())),
@@ -95,7 +93,6 @@ async fn opaque_parent_with_tcp_route() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("linkerd.io/opaque".to_string())),
@@ -144,7 +141,6 @@ async fn http1_parent() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("http".to_string())),
@@ -180,7 +176,6 @@ async fn http1_parent_with_http_route() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("http".to_string())),
@@ -227,7 +222,6 @@ async fn http2_parent() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
@@ -263,7 +257,6 @@ async fn http2_parent_with_http_route() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
@@ -310,7 +303,6 @@ async fn http2_parent_with_grpc_route() {
         with_temp_ns(|client, ns| async move {
             let port = 4191;
             // Create a parent with no routes.
-            // let parent = P::create_parent(&client.clone(), &ns).await;
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),

--- a/policy-test/tests/outbound_api_app_protocol.rs
+++ b/policy-test/tests/outbound_api_app_protocol.rs
@@ -92,7 +92,7 @@ async fn opaque_parent_with_tcp_route() {
         );
         with_temp_ns(|client, ns| async move {
             let port = 4191;
-            // Create a parent with no routes.
+            // Create a parent with TCPRoute.
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("linkerd.io/opaque".to_string())),
@@ -175,7 +175,7 @@ async fn http1_parent_with_http_route() {
         );
         with_temp_ns(|client, ns| async move {
             let port = 4191;
-            // Create a parent with no routes.
+            // Create a parent with HTTPRoute.
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("http".to_string())),
@@ -256,7 +256,7 @@ async fn http2_parent_with_http_route() {
         );
         with_temp_ns(|client, ns| async move {
             let port = 4191;
-            // Create a parent with no routes.
+            // Create a parent with HTTPRoute.
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),
@@ -302,7 +302,7 @@ async fn http2_parent_with_grpc_route() {
         );
         with_temp_ns(|client, ns| async move {
             let port = 4191;
-            // Create a parent with no routes.
+            // Create a parent with GRPCRoute.
             let parent = create(
                 &client,
                 P::make_parent_with_protocol(&ns, Some("kubernetes.io/h2c".to_string())),


### PR DESCRIPTION
When a Service has a port marked with `appProtocol: linkerd.io/opaque`, the policy controller returns only the default opaque route and any TCPRoutes attached to that service and port are ignored.

We include any TCPRoute in the outbound policy when the `appProtocol` is marked as opaque.  

Furthermore, we update the logic to treat any unknown value for `appProtocol` as opaque (when previously, an unknown value was ignored, allowing any route type to be attached).  The consequence of this is TCPRoute is the only route type that can be attached to a pork with an unknown value for `appProtocol`.

Yet furthermore, we updated the logic to allow GRPCRoutes to be attached to ports marked with `appProtocol: kubernetes.io/h2c`.  This means that either GRPCRoutes or HTTPRoutes may be attached to such ports and the more specific type (GRPCRoute) will take higher precedence.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
