### PR TITLE
chore(deps): sort and organize dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,33 @@ lto = "thin"
 gateway-api = "0.15"
 http = "1"
 hyper = "1"
-hyper-util = { version = "0.1", default-features = false, features = ["tracing"] }
 k8s-openapi = { version = "0.24", features = ["v1_32"] }
 kube = { version = "0.99", default-features = false }
 kubert = { version = "0.24", default-features = false }
 prometheus-client = { version = "0.23", default-features = false }
 tonic = { version = "0.12", default-features = false }
 tower = { version = "0.5", default-features = false }
+
+linkerd-policy-controller = { path = "./policy-controller" }
+linkerd-policy-controller-core = { path = "./policy-controller/core" }
+linkerd-policy-controller-grpc = { path = "./policy-controller/grpc" }
+linkerd-policy-controller-k8s-api = { path = "./policy-controller/k8s/api" }
+linkerd-policy-test = { path = "./policy-test" }
+
+[workspace.dependencies.hyper-util]
+version = "0.1"
+default-features = false
+features = ["tracing"]
+
+[workspace.dependencies.linkerd-policy-controller-k8s-index]
+path = "./policy-controller/k8s/index"
+
+[workspace.dependencies.linkerd-policy-controller-k8s-status]
+path = "./policy-controller/k8s/status"
+
+[workspace.dependencies.linkerd-policy-controller-runtime]
+path = "./policy-controller/runtime"
+default-features = false
 
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.16.0"

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -15,7 +15,9 @@ openssl-vendored = ["linkerd-policy-controller-runtime/openssl-vendored"]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 
-linkerd-policy-controller-runtime = { path = "./runtime", default-features = false }
+[dependencies.linkerd-policy-controller-runtime]
+workspace = true
+default-features = false
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.5"

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -8,18 +8,19 @@ publish = false
 [dependencies]
 async-stream = "0.3"
 async-trait = "0.1"
-http = { workspace = true }
 drain = "0.2"
 futures = { version = "0.3", default-features = false }
+http = { workspace = true }
 hyper = { workspace = true, features = ["http2", "server"] }
-linkerd-policy-controller-core = { path = "../core" }
 maplit = "1"
 prost-types = "0.13"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 tonic = { workspace = true }
 tracing = "0.1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+
+linkerd-policy-controller-core = { workspace = true }
 
 [dependencies.linkerd2-proxy-api]
 workspace = true

--- a/policy-controller/k8s/api/Cargo.toml
+++ b/policy-controller/k8s/api/Cargo.toml
@@ -6,14 +6,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-k8s-openapi = { workspace = true }
 gateway-api = { workspace = true }
-kube = { workspace = true, default-features = false, features = [
-    "client",
-    "derive",
-    "runtime",
-] }
 ipnet = { version = "2.11", features = ["json"] }
+k8s-openapi = { workspace = true }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -21,3 +16,12 @@ serde_yaml = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
+
+[dependencies.kube]
+workspace = true
+default-features = false
+features = [
+    "client",
+    "derive",
+    "runtime",
+]

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -11,19 +11,24 @@ anyhow = "1"
 chrono = { version = "0.4.41", default-features = false }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
-kube = { workspace = true, default-features = false, features = [
-    "client",
-    "derive",
-    "runtime",
-] }
 kubert = { workspace = true, default-features = false, features = ["index"] }
-linkerd-policy-controller-core = { path = "../../core" }
-linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"
 prometheus-client = { workspace = true, default-features = false }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tracing = "0.1"
+
+linkerd-policy-controller-core = { workspace = true }
+linkerd-policy-controller-k8s-api = { workspace = true }
+
+[dependencies.kube]
+workspace = true
+default-features = false
+features = [
+    "client",
+    "derive",
+    "runtime",
+]
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false }

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -10,12 +10,6 @@ ahash = "0.8"
 anyhow = "1"
 # Fix for https://github.com/chronotope/chrono/issues/602
 chrono = { version = "0.4.41", default-features = false, features = ["clock"] }
-kubert = { workspace = true, default-features = false, features = [
-    "index",
-    "lease",
-] }
-linkerd-policy-controller-core = { path = "../../core" }
-linkerd-policy-controller-k8s-api = { path = "../api" }
 parking_lot = "0.12"
 prometheus-client = { workspace = true }
 serde = "1"
@@ -23,6 +17,17 @@ serde_json = "1.0.140"
 thiserror = "2"
 tokio = { version = "1", features = ["macros"] }
 tracing = "0.1.41"
+
+linkerd-policy-controller-core = { workspace = true }
+linkerd-policy-controller-k8s-api = { workspace = true }
+
+[dependencies.kubert]
+workspace = true
+default-features = false
+features = [
+    "index",
+    "lease",
+]
 
 [dev-dependencies.tokio]
 version = "1"

--- a/policy-controller/runtime/Cargo.toml
+++ b/policy-controller/runtime/Cargo.toml
@@ -19,27 +19,27 @@ async-trait = "0.1"
 bytes = "1"
 drain = "0.2"
 futures = { version = "0.3", default-features = false }
-k8s-openapi = { workspace = true }
 http-body-util = "0.1"
 hyper = { workspace = true, features = ["http1", "http2", "server"] }
 hyper-util = { workspace = true }
 ipnet = { version = "2", default-features = false }
+k8s-openapi = { workspace = true }
 openssl = { version = "0.10.72", optional = true }
 parking_lot = "0.12"
 prometheus-client = { workspace = true }
+regex = "1"
 serde = "1"
 serde_json = "1"
 thiserror = "2"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower = { workspace = true }
 tracing = "0.1"
-regex = "1"
 
-linkerd-policy-controller-core = { path = "../core" }
-linkerd-policy-controller-grpc = { path = "../grpc" }
-linkerd-policy-controller-k8s-api = { path = "../k8s/api" }
-linkerd-policy-controller-k8s-index = { path = "../k8s/index" }
-linkerd-policy-controller-k8s-status = { path = "../k8s/status" }
+linkerd-policy-controller-core = { workspace = true }
+linkerd-policy-controller-grpc = { workspace = true }
+linkerd-policy-controller-k8s-api = { workspace = true }
+linkerd-policy-controller-k8s-index = { workspace = true }
+linkerd-policy-controller-k8s-status = { workspace = true }
 
 [dependencies.clap]
 version = "4"

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -18,9 +18,6 @@ hyper-util = { workspace = true }
 futures = { version = "0.3", default-features = false }
 ipnet = "2"
 k8s-openapi = { workspace = true }
-linkerd-policy-controller-core = { path = "../policy-controller/core" }
-linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
-linkerd-policy-controller-grpc = { path = "../policy-controller/grpc" }
 maplit = "1"
 rand = "0.9"
 serde = "1"
@@ -31,6 +28,10 @@ tokio = { version = "1", features = ["macros", "rt"] }
 tower = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+linkerd-policy-controller-core = { path = "../policy-controller/core" }
+linkerd-policy-controller-k8s-api = { path = "../policy-controller/k8s/api" }
+linkerd-policy-controller-grpc = { path = "../policy-controller/grpc" }
 
 [dependencies.kube]
 workspace = true


### PR DESCRIPTION
this commit tends to our package manifests.

dependencies are sorted, and dependencies whose metadata are longer than 80 characters are tweaked to be declared as tables. local dependencies are updated to consistently follow the convention that they be listed after other external crates.io dependencies.
