### PR TITLE
build: validate edge version in release workflow

### DIFF
--- a/.github/actions/helm-publish/action.yml
+++ b/.github/actions/helm-publish/action.yml
@@ -10,7 +10,7 @@ runs:
     run: |
       mkdir -p target/helm
       gsutil cp gs://helm.linkerd.io/edge/index.yaml target/helm/index-pre.yaml
-      bin/helm-bump-edge
+      bin/compute-edge-version update-charts
       helm-docs
       bin/helm-build package
       cp charts/artifacthub-repo-edge.yml target/helm/artifacthub-repo.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> "$GITHUB_OUTPUT"
         id: tag
+      - name: Validate edge version
+        run: bin/compute-edge-version
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
 

--- a/bin/compute-edge-version
+++ b/bin/compute-edge-version
@@ -11,7 +11,7 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 . "$bindir"/_tag.sh
 tag=$(named_tag)
 
-edge_tag_regex='edge-([0-9][0-9])\.([0-9]|[0-9][0-9])\.([0-9]+)'
+edge_tag_regex='edge-([0-9][0-9]).([0-9]|[0-9][0-9]).([0-9]+)'
 
 # Get the current edge version.
 url=https://run.linkerd.io/install-edge
@@ -36,6 +36,8 @@ if [ "$tag" != "$expected_tag" ]; then
     echo "Tag ($tag) doesn't match computed edge version ($expected_tag)"
     exit 1
 fi
+
+[[ "${1:-}" == "update-charts" ]] || exit 0
 
 new_version="$yyyy.$new_mm.$new_xx"
 


### PR DESCRIPTION
Currently when an edge version is tagged, it gets validated only until the chart_deploy job. If it fails, the release CLI gets published but the chart not, leaving things in a mixed bad state.

This change validates the version early on in the release.yml workflow.

It repurposes the script bin/helm-bump-edge as bin/compute-edge-version which performs the validation, and optionally mutates the version in the helm charts (the latter being used only in the chart_deploy job).

The following tests the functionality, assuming the tip of the repo is tagged as `edge-25.5.1` and a new tag is expected to be `edge-25.5.2`:

```bash
# Remove current tag
$ git tag -d edge-25.5.1

# Test with invalid tag
$ git tag edge-25.5.3
$ bin/compute-edge-version
Tag (edge-25.5.3) doesnt match computed edge version (edge-25.5.2)

# Test with valid tag
$ git tag -d edge-25.5.3
Deleted tag 'edge-25.5.3' (was 4823b7af3)
$ git tag edge-25.5.2
# Empty results means success
$ bin/compute-edge-version

# Mutate charts
$ bin/compute-edge-version update-charts
Bumping charts/linkerd2-cni/Chart.yaml to 2025.5.2
Bumping charts/linkerd-control-plane/Chart.yaml to 2025.5.2
Bumping charts/linkerd-crds/Chart.yaml to 2025.5.2
Bumping jaeger/charts/linkerd-jaeger/Chart.yaml to 2025.5.2
Bumping multicluster/charts/linkerd-multicluster/Chart.yaml to 2025.5.2
Bumping viz/charts/linkerd-viz/Chart.yaml to 2025.5.2
```