### PR TITLE
fix(multicluster): affinities for controllers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,6 +40,7 @@ jobs:
             **/*.rs
             **/Dockerfile*
             charts/**
+            multicluster/charts/**
             justfile
             bin/fetch-proxy
             bin/_test-helper.sh

--- a/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
@@ -35,13 +35,12 @@ spec:
         mirror.linkerd.io/cluster-name: {{.link.ref.name}}
         {{- with $.Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
-    {{- if dig "enablePodAntiAffinity" $.Values.controllerDefaults.enablePodAntiAffinity . }}
-    {{- with $tree := deepCopy $ }}
+    {{- $tree := deepCopy $ }}
+    {{- $_ := set $tree.Values "enablePodAntiAffinity" (dig "enablePodAntiAffinity" $.Values.controllerDefaults.enablePodAntiAffinity .) -}}
+    {{- $_ := set $tree.Values "nodeAffinity" (dig "nodeAffinity" $.Values.controllerDefaults.nodeAffinity .) -}}
     {{- $_ := set $tree "component" .link.ref.name -}}
     {{- $_ := set $tree "label" "mirror.linkerd.io/cluster-name" -}}
     {{- include "linkerd.affinity" $tree | nindent 6 }}
-    {{- end }}
-    {{- end }}
       automountServiceAccountToken: false
       containers:
       - args:

--- a/multicluster/charts/linkerd-multicluster/templates/controller/pdb.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/pdb.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     component: controller
   annotations:
-    {{ include "partials.annotations.created-by" . }}
+    {{ include "partials.annotations.created-by" $ }}
 spec:
   maxUnavailable: 1
   selector:

--- a/multicluster/charts/linkerd-multicluster/templates/controller/probe-svc.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/probe-svc.yaml
@@ -7,6 +7,7 @@ metadata:
   name: probe-{{.link.ref.name}}
   namespace: {{ $.Release.Namespace }}
   annotations:
+    {{ include "partials.annotations.created-by" $ }}
   labels:
     linkerd.io/extension: multicluster
     mirror.linkerd.io/mirrored-gateway: "true"


### PR DESCRIPTION
Fixes #14008

In the linkerd-multicluster chart (or via `linkerd mc install|upgrade`), setting `enablePodAntiAffinity: true` for specific multicluster controllers or globally was causing the following error:

```
Error: template: linkerd-multicluster/templates/controller/pdb.yaml:12:7: executing "linkerd-multicluster/templates/controller/pdb.yaml" at <include "partials.annotations.created-by" .>: error calling include: template: linkerd-multicluster/charts/partials/templates/_metadata.tpl:2:33: executing "partials.annotations.created-by" at <.Values.cliVersion>: nil pointer evaluating interface {}.cliVersion
```

The problem was with the PodDisruptionBudget manifest not passing the proper context to the `annotations.created-by` partials.

Also, the `nodeAffinity` setting wasn't being taken into account for such controllers.

The output can be tested with `bin/linkerd mc install -f values.yaml`, using this as `values.yaml` (put something that makes sense for nodeAffinity, if you want to apply this to the cluster):

```yaml
controllers:
- link:
    ref:
      name: target1
  enablePodAntiAffinity: true
  nodeAffinity:
    foo: bar
```