### PR TITLE
refactor(proxy-injector): make injection code take a value overrider as a parameter

### DIFF
--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/linkerd/linkerd2/pkg/charts/linkerd2"
 	"github.com/linkerd/linkerd2/pkg/cmd"
+	"github.com/linkerd/linkerd2/pkg/inject"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/testutil"
 )
@@ -50,6 +51,7 @@ func testUninjectAndInject(t *testing.T, tc testCase) {
 		overrideAnnotations: getOverrideAnnotations(tc.testInjectConfig, defaultConfig()),
 		enableDebugSidecar:  tc.enableDebugSidecarFlag,
 		allowNsInject:       true,
+		overrider:           inject.GetOverriddenValues,
 	}
 
 	if exitCode := uninjectAndInject([]io.Reader{read}, report, output, transformer, "yaml"); exitCode != 0 {
@@ -431,6 +433,7 @@ func testInjectCmd(t *testing.T, tc injectCmd) {
 	transformer := &resourceTransformerInject{
 		injectProxy: tc.injectProxy,
 		values:      testConfig,
+		overrider:   inject.GetOverriddenValues,
 	}
 	exitCode := runInjectCmd([]io.Reader{in}, errBuffer, outBuffer, transformer, "yaml")
 	if exitCode != tc.exitCode {
@@ -537,6 +540,7 @@ func testInjectFilePath(t *testing.T, tc injectFilePath) {
 	transformer := &resourceTransformerInject{
 		injectProxy: true,
 		values:      values,
+		overrider:   inject.GetOverriddenValues,
 	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer, "yaml"); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)
@@ -564,6 +568,7 @@ func testReadFromFolder(t *testing.T, resourceFolder string, expectedFolder stri
 	transformer := &resourceTransformerInject{
 		injectProxy: true,
 		values:      values,
+		overrider:   inject.GetOverriddenValues,
 	}
 	if exitCode := runInjectCmd(in, errBuf, actual, transformer, "yaml"); exitCode != 0 {
 		t.Fatal("Unexpected error. Exit code from runInjectCmd: ", exitCode)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	pkgcmd "github.com/linkerd/linkerd2/pkg/cmd"
 	"github.com/linkerd/linkerd2/pkg/flags"
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
+	"github.com/linkerd/linkerd2/pkg/inject"
 	viz "github.com/linkerd/linkerd2/viz/cmd"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -109,7 +110,7 @@ func init() {
 	RootCmd.AddCommand(newCmdDiagnostics())
 	RootCmd.AddCommand(newCmdDoc())
 	RootCmd.AddCommand(newCmdIdentity())
-	RootCmd.AddCommand(newCmdInject())
+	RootCmd.AddCommand(NewCmdInject(inject.GetOverriddenValues))
 	RootCmd.AddCommand(newCmdInstall())
 	RootCmd.AddCommand(newCmdInstallCNIPlugin())
 	RootCmd.AddCommand(newCmdProfile())

--- a/controller/cmd/proxy-injector/main.go
+++ b/controller/cmd/proxy-injector/main.go
@@ -9,6 +9,7 @@ import (
 	injector "github.com/linkerd/linkerd2/controller/proxy-injector"
 	"github.com/linkerd/linkerd2/controller/webhook"
 	"github.com/linkerd/linkerd2/pkg/flags"
+	"github.com/linkerd/linkerd2/pkg/inject"
 )
 
 // Main executes the proxy-injector subcommand
@@ -24,7 +25,7 @@ func Main(args []string) {
 	webhook.Launch(
 		context.Background(),
 		[]k8s.APIResource{k8s.NS, k8s.Deploy, k8s.RC, k8s.RS, k8s.Job, k8s.DS, k8s.SS, k8s.Pod, k8s.CJ},
-		injector.Inject(*linkerdNamespace),
+		injector.Inject(*linkerdNamespace, inject.GetOverriddenValues),
 		"linkerd-proxy-injector",
 		*metricsAddr,
 		*addr,

--- a/controller/proxy-injector/webhook.go
+++ b/controller/proxy-injector/webhook.go
@@ -28,7 +28,7 @@ const (
 // Inject returns the function that produces an AdmissionResponse containing
 // the patch, if any, to apply to the pod (proxy sidecar and eventually the
 // init container to set it up)
-func Inject(linkerdNamespace string) webhook.Handler {
+func Inject(linkerdNamespace string, overrider inject.ValueOverrider) webhook.Handler {
 	return func(
 		ctx context.Context,
 		api *k8s.MetadataAPI,
@@ -116,7 +116,7 @@ func Inject(linkerdNamespace string) webhook.Handler {
 				}
 			}
 
-			patchJSON, err := resourceConfig.GetPodPatch(true)
+			patchJSON, err := resourceConfig.GetPodPatch(true, overrider)
 			if err != nil {
 				return nil, err
 			}

--- a/controller/proxy-injector/webhook_test.go
+++ b/controller/proxy-injector/webhook_test.go
@@ -119,7 +119,7 @@ func TestGetPodPatch(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				patchJSON, err := fullConf.GetPodPatch(true)
+				patchJSON, err := fullConf.GetPodPatch(true, inject.GetOverriddenValues)
 				if err != nil {
 					t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 				}
@@ -142,7 +142,7 @@ func TestGetPodPatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		patchJSON, err := conf.GetPodPatch(true)
+		patchJSON, err := conf.GetPodPatch(true, inject.GetOverriddenValues)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}
@@ -163,7 +163,7 @@ func TestGetPodPatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		patchJSON, err := conf.GetPodPatch(true)
+		patchJSON, err := conf.GetPodPatch(true, inject.GetOverriddenValues)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}
@@ -186,7 +186,7 @@ func TestGetPodPatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		patchJSON, err := conf.GetPodPatch(true)
+		patchJSON, err := conf.GetPodPatch(true, inject.GetOverriddenValues)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}
@@ -210,7 +210,7 @@ func TestGetPodPatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		patchJSON, err := conf.GetPodPatch(true)
+		patchJSON, err := conf.GetPodPatch(true, inject.GetOverriddenValues)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}
@@ -240,7 +240,7 @@ func TestGetPodPatch(t *testing.T) {
 		// The namespace has two config annotations: one valid and one invalid
 		// the pod patch should only contain the valid annotation.
 		inject.AppendNamespaceAnnotations(conf.GetOverrideAnnotations(), conf.GetNsAnnotations(), conf.GetWorkloadAnnotations())
-		patchJSON, err := conf.GetPodPatch(true)
+		patchJSON, err := conf.GetPodPatch(true, inject.GetOverriddenValues)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}
@@ -254,7 +254,7 @@ func TestGetPodPatch(t *testing.T) {
 		deployment := fileContents(factory, t, "deployment-with-injected-proxy.yaml")
 		fakeReq := getFakePodReq(deployment)
 		conf := confNsDisabled().WithKind(fakeReq.Kind.Kind)
-		patchJSON, err := conf.GetPodPatch(true)
+		patchJSON, err := conf.GetPodPatch(true, inject.GetOverriddenValues)
 		if err != nil {
 			t.Fatalf("Unexpected PatchForAdmissionRequest error: %s", err)
 		}

--- a/pkg/inject/inject_fuzzer.go
+++ b/pkg/inject/inject_fuzzer.go
@@ -25,7 +25,7 @@ func FuzzInject(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	_, _ = conf.GetPodPatch(injectProxy)
+	_, _ = conf.GetPodPatch(injectProxy, GetOverriddenValues)
 	_, _ = conf.CreateOpaquePortsPatch()
 
 	report := &Report{}


### PR DESCRIPTION
In order to make the way that proxy injector patches more flexible, we adjust the method signature of `ResourceConfig.GetPodPatch` to accept a `ValueOverrider`.  The type of `ValueOverrider` is:

```
func(values *l5dcharts.Values, overrides map[string]string, namedPorts map[string]int32) (*l5dcharts.Values, error)
``` 

and specifies how overrides (in the form of pod and namespace annotations) get translated into values for the proxy patch template.

The current override behavior, specified in `GetOverriddenValues`, is supplied in all cases, making this a refactor with no functional changes.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
