### PR TITLE
deps: have dependabot update composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,7 +90,9 @@ updates:
           - tracing-*
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+    - "/"
+    - ".github/actions/*"
     schedule:
       interval: "daily"
       time: "04:00"


### PR DESCRIPTION
This updates dependabot.yml to also look into ./github/actions/*

Support for this was recently introduced, see https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--