### PR TITLE
Steering committee membership change

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,9 +19,10 @@ The Linkerd directors are:
 
 The Linkerd Steering Committee members are:
 
-* Christian Hüning (BWI) @christianhuening
-* Dan Williams (LoveHolidays) @dwilliams782
 * Steve Gray (ZeroFlucs) @steve-gray
+* Priya Namasivayam (Earnin) @priyanamasivayam
+* Christian Hüning (BWI) @christianhuening
+* Dimple Thoomkuzhy (CompareTheMarket) @dimpledalby07
 
 ## Emeriti
 


### PR DESCRIPTION
Linkerd maintainers and steering committee members, I'd like your vote on some changes to steering committee membership.

Dan Williams has changed jobs and has asked to step down from the committee. Dan, thank you for your service.

I'd like to nominate two new steering committee members, Dimple Thoomkuzhy and Priya Namasivayam. Both have been long-time Linkerd users in production, Dimple at Compare the Market and Priya at Earnin, and I'm grateful to both of them for their willingness to spend time guiding the project.

Maintainers, directors, and steering committee members, please vote by either leaving a comment or a thumbs-up emoji.