### PR TITLE
deps(test): fetch latest helm version in integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -287,6 +287,8 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: "1.23"
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112
+        if: matrix.integration_test == 'helm-upgrade'
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: image-archives-*


### PR DESCRIPTION
We were relying on the helm CLI version available in the runner. Currently that's 3.18.0 which has a few issues that are causing the helm-upgrade integration test to fail.

This change retrieves the latest helm CLI version via the `azure/setup-helm` github action, before triggering the test.