### PR TITLE
Fix duplicate port names

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -243,9 +243,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -303,7 +303,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -364,7 +364,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
           {{- with (.Values.policyController.livenessProbe).timeoutSeconds }}
           timeoutSeconds: {{ . }}
@@ -372,16 +372,16 @@ spec:
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
           {{- with (.Values.policyController.readinessProbe).timeoutSeconds }}
           timeoutSeconds: {{ . }}
           {{- end }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -191,9 +191,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -107,7 +107,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/charts/linkerd2-cni/templates/cni-plugin.yaml
+++ b/charts/linkerd2-cni/templates/cni-plugin.yaml
@@ -313,16 +313,16 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: repair-controller-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: repair-controller-admin-http
           initialDelaySeconds: 10
         ports:
         - containerPort: 9990
-          name: admin-http
+          name: repair-controller-admin-http
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/cli/cmd/metrics_diagnostics_util.go
+++ b/cli/cmd/metrics_diagnostics_util.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -46,7 +47,7 @@ func getAllContainersWithPort(
 	allContainers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
 	for _, c := range allContainers {
 		for _, p := range c.Ports {
-			if p.Name == portName {
+			if p.Name == portName || strings.HasSuffix(p.Name, portName) {
 				containers = append(containers, c)
 			}
 		}

--- a/cli/cmd/testdata/inject_tap_deployment.input.yml
+++ b/cli/cmd/testdata/inject_tap_deployment.input.yml
@@ -63,7 +63,7 @@ spec:
           name: apiserver
           protocol: TCP
         - containerPort: 9998
-          name: admin-http
+          name: tap-admin-http
           protocol: TCP
         readinessProbe:
           failureThreshold: 7

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -971,9 +971,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1581,9 +1581,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1621,7 +1621,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1666,21 +1666,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
         securityContext:
           capabilities:
@@ -2098,7 +2098,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -971,9 +971,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1581,9 +1581,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1621,7 +1621,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1666,21 +1666,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
         securityContext:
           capabilities:
@@ -2098,7 +2098,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1042,9 +1042,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1708,9 +1708,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1754,7 +1754,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1799,21 +1799,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
         securityContext:
           capabilities:
@@ -2266,7 +2266,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -902,9 +902,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1512,9 +1512,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1552,7 +1552,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1597,21 +1597,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
         securityContext:
           capabilities:
@@ -1945,7 +1945,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -944,9 +944,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1556,9 +1556,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1596,7 +1596,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1641,21 +1641,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
         securityContext:
           capabilities:
@@ -2077,7 +2077,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1005,9 +1005,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1673,9 +1673,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1719,7 +1719,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1764,21 +1764,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
         securityContext:
           capabilities:
@@ -2235,7 +2235,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -922,9 +922,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1517,9 +1517,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1557,7 +1557,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1602,21 +1602,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
           limits:
             cpu: "cpu-limit"
@@ -2036,7 +2036,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -971,9 +971,9 @@ spec:
         name: identity
         ports:
         - containerPort: 8080
-          name: grpc
+          name: identity-grpc
         - containerPort: 9990
-          name: admin-http
+          name: identity-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1581,9 +1581,9 @@ spec:
         name: destination
         ports:
         - containerPort: 8086
-          name: grpc
+          name: destination-grpc
         - containerPort: 9996
-          name: admin-http
+          name: destination-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1621,7 +1621,7 @@ spec:
         - containerPort: 8443
           name: sp-validator
         - containerPort: 9997
-          name: admin-http
+          name: sp-validator-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1666,21 +1666,21 @@ spec:
         livenessProbe:
           httpGet:
             path: /live
-            port: admin-http
+            port: policy-admin-http
           initialDelaySeconds: 10
         name: policy
         ports:
         - containerPort: 8090
-          name: grpc
+          name: policy-grpc
         - containerPort: 9990
-          name: admin-http
+          name: policy-admin-http
         - containerPort: 9443
           name: policy-https
         readinessProbe:
           failureThreshold: 7
           httpGet:
             path: /ready
-            port: admin-http
+            port: policy-admin-http
         resources:
         securityContext:
           capabilities:
@@ -2098,7 +2098,7 @@ spec:
         - containerPort: 8443
           name: proxy-injector
         - containerPort: 9995
-          name: admin-http
+          name: proxy-injector-admin-http
         readinessProbe:
           failureThreshold: 7
           httpGet:

--- a/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster-link/templates/service-mirror.yaml
@@ -181,7 +181,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: service-mirror-admin-http
         {{- with .Values.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/controller/deployment.yaml
@@ -86,7 +86,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: controller-admin-http
         {{- with dig "resources" $.Values.controllerDefaults.resources . }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/multicluster/charts/linkerd-multicluster/templates/local-service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/local-service-mirror.yaml
@@ -132,7 +132,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: local-service-mirror-admin-http
         {{- with .Values.localServiceMirror.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/service-mirror-policy.yaml
@@ -16,7 +16,7 @@ spec:
       values:
       - linkerd-service-mirror
       - controller
-  port: admin-http
+  port: service-mirror-admin-http
   proxyProtocol: HTTP/1
 ---
 apiVersion: policy.linkerd.io/v1alpha1

--- a/multicluster/cmd/testdata/install_default.golden
+++ b/multicluster/cmd/testdata/install_default.golden
@@ -1253,7 +1253,7 @@ spec:
       values:
       - linkerd-service-mirror
       - controller
-  port: admin-http
+  port: service-mirror-admin-http
   proxyProtocol: HTTP/1
 ---
 apiVersion: policy.linkerd.io/v1alpha1
@@ -1383,7 +1383,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: local-service-mirror-admin-http
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/multicluster/cmd/testdata/install_ha.golden
+++ b/multicluster/cmd/testdata/install_ha.golden
@@ -1325,7 +1325,7 @@ spec:
       values:
       - linkerd-service-mirror
       - controller
-  port: admin-http
+  port: service-mirror-admin-http
   proxyProtocol: HTTP/1
 ---
 apiVersion: policy.linkerd.io/v1alpha1
@@ -1478,7 +1478,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: local-service-mirror-admin-http
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/multicluster/cmd/testdata/install_psp.golden
+++ b/multicluster/cmd/testdata/install_psp.golden
@@ -1287,7 +1287,7 @@ spec:
       values:
       - linkerd-service-mirror
       - controller
-  port: admin-http
+  port: service-mirror-admin-http
   proxyProtocol: HTTP/1
 ---
 apiVersion: policy.linkerd.io/v1alpha1
@@ -1417,7 +1417,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: local-service-mirror-admin-http
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/multicluster/cmd/testdata/service_mirror_default.golden
+++ b/multicluster/cmd/testdata/service_mirror_default.golden
@@ -140,7 +140,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: service-mirror-admin-http
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/multicluster/cmd/testdata/service_mirror_ha.golden
+++ b/multicluster/cmd/testdata/service_mirror_ha.golden
@@ -163,7 +163,7 @@ spec:
           readOnly: true
         ports:
         - containerPort: 9999
-          name: admin-http
+          name: service-mirror-admin-http
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/pkg/k8s/metrics.go
+++ b/pkg/k8s/metrics.go
@@ -9,7 +9,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// AdminHTTPPortName is the name of the port used by the admin http server.
+// AdminHTTPPortName is the suffix for ports used by admin HTTP servers.
+// Ports may be named <container>-admin-http to avoid conflicts across multiple
+// containers.
 const AdminHTTPPortName string = "admin-http"
 
 // GetContainerMetrics returns the metrics exposed by a container on the passed in portName


### PR DESCRIPTION
## Summary
- rename `admin-http` and `grpc` port names in controller templates
- update metrics helper to match ports by suffix
- adjust CLI golden files and examples

## Testing
- `go test ./...` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_68431e8bc84883209e1781187cd0797b