### PR TITLE
chore(controller)!: tune grpc handling time histogram buckets

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -119,7 +119,11 @@ func NewGrpcServer(opt ...grpc.ServerOption) *grpc.Server {
 		}, opt...)...,
 	)
 
-	grpc_prometheus.EnableHandlingTimeHistogram()
+	// Use custom buckets tuned for long-lived streaming RPCs. This configuration
+	// should be kept in sync with policy-controller/grpc's metrics.
+	grpc_prometheus.EnableHandlingTimeHistogram(
+		grpc_prometheus.WithHistogramBuckets([]float64{0.1, 1.0, 300.0, 3600.0}),
+	)
 	grpc_prometheus.Register(server)
 	return server
 }


### PR DESCRIPTION
The default histogram buckets for gRPC handling time are tuned for short-lived requests. Our controllers tend to serve long-lived response streams, which are counted at the maximum bucket.

This change adjusts the histogram buckets to better reflect the characteristics of our response streams, which have a default 5m idle timeout and 1h max lifetime.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
