### PR TITLE
fix(test): fix policy-test e2e_appprotocol

### DIFF
--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -27,7 +27,9 @@ pub struct Execable {
 }
 
 impl Runner {
-    const CURL_IMAGE: &'static str = "docker.io/curlimages/curl:latest";
+    // @TODO(alpeb): point to `latest` once the fix for this bug is released:
+    // https://github.com/curl/curl/issues/17554
+    const CURL_IMAGE: &'static str = "docker.io/curlimages/curl:8.13.0";
 
     pub async fn init(client: &kube::Client, ns: &str) -> Runner {
         let runner = Runner {


### PR DESCRIPTION
Due to curl/curl#17554 curl is not returning an error code on a failed call that was invoked with the `--retry` flag.

We temporarily revert to curl `v8.13.0` until the fix gets released.