### PR TITLE
chore(policy-controller): fix visibility clippy lint 

### DIFF
--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -1300,7 +1300,7 @@ impl Index {
     }
 
     #[tracing::instrument(level = "debug", skip(self, net))]
-    pub(crate) fn index_egress_network(&mut self, id: ResourceId, net: EgressNetworkRef) {
+    fn index_egress_network(&mut self, id: ResourceId, net: EgressNetworkRef) {
         tracing::trace!(?net);
         // Insert into the index; if the network is already in the index, and it hasn't
         // changed, skip creating a patch.


### PR DESCRIPTION
Clippy identified a lint warning because `EgressNetworkRef` is more private than a function where it is used `index_egress_network`.

We reduce the visibility of `index_egress_network` since it does not need to be `pub(crate)`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
