### PR TITLE
fix(destination): skip servers with invalid selectors

### DIFF
--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -367,7 +367,7 @@ func (ww *WorkloadWatcher) updateServers(servers ...*v1beta3.Server) {
 		} else if wp.addr.ExternalWorkload != nil {
 			name = wp.addr.ExternalWorkload.GetName()
 		}
-		if err := SetToServerProtocol(wp.k8sAPI, &wp.addr); err != nil {
+		if err := SetToServerProtocol(wp.k8sAPI, &wp.addr, wp.log); err != nil {
 			wp.log.Errorf("Error computing opaque protocol for %s: %q", name, err)
 		}
 		if wp.addr.OpaqueProtocol == opaque {
@@ -701,7 +701,7 @@ func (wp *workloadPublisher) updatePod(pod *corev1.Pod) {
 		}
 
 		// Compute opaque protocol.
-		if err := SetToServerProtocol(wp.k8sAPI, &wp.addr); err != nil {
+		if err := SetToServerProtocol(wp.k8sAPI, &wp.addr, wp.log); err != nil {
 			wp.log.Errorf("Error computing opaque protocol for pod %s: %q", wp.addr.Pod.GetName(), err)
 		}
 


### PR DESCRIPTION
Fixes #14176 

When a Server resource has an invalid podSelector, it triggers an error in the destination controller's `SetToServerProtocol` and aborts processing any further Servers and aborts setting addresses on destination controller responses, leading to failures across the mesh.

One invalid Server should not bring down the mesh.  Instead, when encountering an invalid Server, we log an error message and then continue processing any other Servers and continue to set addresses as usual.

As a more comprehensive solution, we should also update the Server resource validation so that invalid Servers cannot be created and add a Status subresource to Server to reflect the current validity of the Server.  These followups are tracked in #14194

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
