### PR TITLE
chore(docs): fix proxy update instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,25 +4,17 @@ This document contains instructions for releasing Linkerd2.
 
 ## 1. Bump the proxy version
 
-Determine the commit SHA of the `linkerd2-proxy` repo to be included in the
-release. If
-[proxy-version](https://github.com/linkerd/linkerd2/blob/main/.proxy-version)
-is already at the desired SHA, skip to step 2.
+Determine the commit SHA or tag of the `linkerd2-proxy` repo to be included in
+the release.
+
+The [proxy-version](https://github.com/linkerd/linkerd2/blob/main/.proxy-version)
+file is kept in sync automatically by the
+[`sync-proxy`](https://github.com/linkerd/linkerd2/actions/workflows/sync-proxy.yml)
+workflow. If the file is already at the desired SHA or tag, skip to step 2.
 
 If updating to `linkerd-proxy` HEAD, note the commit SHA at
 [latest.txt](https://build.l5d.io/linkerd2-proxy/latest.txt) (Look for
 `linkerd2-proxy-<linkerd2-proxy-sha>.tar.gz`).
-
-Create a new branch in the `linkerd2` repo, `username/proxy-version-bump`.
-
-Then run:
-
-```bash
-bin/git-commit-proxy-version <linkerd2-proxy-sha>
-```
-
-The script will update the `.proxy-version` file. Submit a PR to obtain reviews
-and approval.
 
 ## 2. Bump the proxy-init or CNI plugin version
 


### PR DESCRIPTION
these instructions are no longer accurate.

this commit removes reference to `bin/git-commit-proxy-version`, which no longer exists, and adds mention of the automated `sync-proxy` workflow that does this automatically when new proxy versions are released.
