### PR TITLE
build(deps): bump cni-plugin to v1.6.3, proxy-init to v2.4.3, validator to v0.1.3

### DIFF
--- a/Dockerfile-proxy
+++ b/Dockerfile-proxy
@@ -27,9 +27,9 @@ RUN --mount=type=secret,id=github \
 RUN echo "$LINKERD2_PROXY_VERSION" > proxy-version
 ARG LINKERD_AWAIT_VERSION=v0.2.9
 RUN bin/scurl -o linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
-ARG LINKERD_VALIDATOR_VERSION=v0.1.2
-RUN bin/scurl -O https://github.com/linkerd/linkerd2-proxy-init/releases/download/validator%2F${LINKERD_VALIDATOR_VERSION}/linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}.tgz
-RUN tar -zxvf linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}.tgz && mv linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}/linkerd-network-validator .
+ARG LINKERD_VALIDATOR_VERSION=v0.1.3
+RUN bin/scurl -O https://github.com/linkerd/linkerd2-proxy-init/releases/download/validator%2F${LINKERD_VALIDATOR_VERSION}/linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}-linux.tgz
+RUN tar -zxvf linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}-linux.tgz && mv linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}-linux/linkerd-network-validator .
 
 ## compile proxy-identity agent
 FROM go-deps AS golang

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -342,7 +342,7 @@ proxyInit:
     # @default -- imagePullPolicy
     pullPolicy: ""
     # -- Tag for the proxy-init container image
-    version: v2.4.2
+    version: v2.4.3
   # -- Changes the default value for the nf_conntrack_tcp_timeout_close_wait
   # kernel parameter. If used, runAsRoot needs to be true.
   closeWaitTimeoutSecs: 0

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -69,7 +69,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.6.2"
+  version: "v1.6.3"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx.yaml
@@ -214,7 +214,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_nginx_redis.yaml
@@ -214,7 +214,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -464,7 +464,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
+++ b/cli/cmd/testdata/inject-filepath/expected/injected_redis.yaml
@@ -214,7 +214,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_contour.golden.yml
+++ b/cli/cmd/testdata/inject_contour.golden.yml
@@ -254,7 +254,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_already_injected.golden.yml
@@ -225,7 +225,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -486,7 +486,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -747,7 +747,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -1008,7 +1008,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment.golden.yml
@@ -225,7 +225,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_access_log.golden.yml
@@ -228,7 +228,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_automountServiceAccountToken_false.golden.yml
@@ -217,7 +217,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_capabilities.golden.yml
@@ -239,7 +239,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_config_overrides.golden.yml
@@ -242,7 +242,7 @@ spec:
         - 4190,9998,7777,8888
         - --outbound-ports-to-ignore
         - "9999"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_controller_name.golden.yml
@@ -225,7 +225,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -486,7 +486,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_debug.golden.yml
@@ -238,7 +238,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_empty_resources.golden.yml
@@ -225,7 +225,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_hostNetwork_false.golden.yml
@@ -226,7 +226,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
@@ -49,7 +49,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_opaque_ports.golden.yml
@@ -226,7 +226,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_overridden.golden.yml
@@ -226,7 +226,7 @@ spec:
         - 4190,1234,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_params.golden.yml
@@ -225,7 +225,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_proxyignores.golden.yml
@@ -227,7 +227,7 @@ spec:
         - 4190,4191,22,8100-8102
         - --outbound-ports-to-ignore
         - "5432"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_udp.golden.yml
@@ -227,7 +227,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_list.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list.golden.yml
@@ -227,7 +227,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.3
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:
@@ -482,7 +482,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.3
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_list_empty_resources.golden.yml
@@ -227,7 +227,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.3
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:
@@ -482,7 +482,7 @@ items:
           - 4190,4191,4567,4568
           - --outbound-ports-to-ignore
           - 4567,4568
-          image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+          image: cr.l5d.io/linkerd/proxy-init:v2.4.3
           imagePullPolicy: IfNotPresent
           name: linkerd-init
           securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod.golden.yml
@@ -209,7 +209,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.3
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_ingress.golden.yml
@@ -212,7 +212,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.3
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_proxyignores.golden.yml
@@ -211,7 +211,7 @@ spec:
     - 4190,4191,22,8100-8102
     - --outbound-ports-to-ignore
     - "5432"
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.3
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     securityContext:

--- a/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_pod_with_requests.golden.yml
@@ -220,7 +220,7 @@ spec:
     - 4190,4191,4567,4568
     - --outbound-ports-to-ignore
     - 4567,4568
-    image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+    image: cr.l5d.io/linkerd/proxy-init:v2.4.3
     imagePullPolicy: IfNotPresent
     name: linkerd-init
     resources:

--- a/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_statefulset.golden.yml
@@ -226,7 +226,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
+++ b/cli/cmd/testdata/inject_gettest_deployment.good.golden.yml
@@ -227,7 +227,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:
@@ -490,7 +490,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
+++ b/cli/cmd/testdata/inject_tap_deployment_debug.golden.yml
@@ -288,7 +288,7 @@ spec:
         - 4190,4191,4567,4568
         - --outbound-ports-to-ignore
         - 4567,4568
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         securityContext:

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -90,7 +90,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: linkerd-cni
-  updateStrategy: 
+  updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate
@@ -117,7 +117,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -91,7 +91,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: linkerd-cni
-  updateStrategy: 
+  updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate
@@ -118,7 +118,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -83,7 +83,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: linkerd-cni
-  updateStrategy: 
+  updateStrategy:
     rollingUpdate:
       maxUnavailable: 1
     type: RollingUpdate
@@ -110,7 +110,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1096,6 +1096,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1186,7 +1187,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1248,6 +1249,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1390,7 +1392,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1481,6 +1483,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1722,7 +1725,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1784,6 +1787,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1915,7 +1919,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2006,6 +2010,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2148,7 +2153,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2213,7 +2218,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1185,7 +1186,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1247,6 +1248,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1389,7 +1391,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1480,6 +1482,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1720,7 +1723,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1782,6 +1785,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1913,7 +1917,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2004,6 +2008,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2146,7 +2151,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2211,7 +2216,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: my.custom.registry/linkerd-io/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1185,7 +1186,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.4.2
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1247,6 +1248,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1389,7 +1391,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1480,6 +1482,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1720,7 +1723,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.4.2
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1782,6 +1785,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1913,7 +1917,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2004,6 +2008,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2146,7 +2151,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: my.custom.registry/linkerd-io/proxy-init:v2.4.2
+        image: my.custom.registry/linkerd-io/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2211,7 +2216,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1185,7 +1186,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1247,6 +1248,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1389,7 +1391,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1480,6 +1482,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1720,7 +1723,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1782,6 +1785,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1913,7 +1917,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2004,6 +2008,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2146,7 +2151,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2211,7 +2216,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1185,7 +1186,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1247,6 +1248,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1389,7 +1391,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1480,6 +1482,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1720,7 +1723,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1782,6 +1785,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1913,7 +1917,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2004,6 +2008,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2146,7 +2151,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2211,7 +2216,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1183,7 +1184,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1238,6 +1239,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1380,7 +1382,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1471,6 +1473,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1709,7 +1712,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1764,6 +1767,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1895,7 +1899,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1986,6 +1990,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2126,7 +2131,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2184,7 +2189,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1096,6 +1096,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1189,7 +1190,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1251,6 +1252,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1393,7 +1395,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1484,6 +1486,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1730,7 +1733,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1792,6 +1795,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1924,7 +1928,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2015,6 +2019,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2161,7 +2166,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2226,7 +2231,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -794,7 +794,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1172,6 +1172,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1267,7 +1268,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1334,6 +1335,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1602,6 +1604,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1853,7 +1856,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1920,6 +1923,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -2167,6 +2171,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2320,7 +2325,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2390,7 +2395,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -794,7 +794,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -1172,6 +1172,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1267,7 +1268,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1334,6 +1335,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1602,6 +1604,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1853,7 +1856,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1920,6 +1923,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -2167,6 +2171,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2320,7 +2325,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2390,7 +2395,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -698,7 +698,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -882,7 +882,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1026,6 +1026,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1116,7 +1117,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1178,6 +1179,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1320,7 +1322,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1411,6 +1413,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1651,7 +1654,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1713,6 +1716,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 
 ---
 ###
@@ -1760,7 +1764,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1851,6 +1855,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1993,7 +1998,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2058,7 +2063,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1240,6 +1241,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1382,7 +1384,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1473,6 +1475,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1768,6 +1771,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1899,7 +1903,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1990,6 +1994,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2190,7 +2195,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1185,7 +1186,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1247,6 +1248,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1389,7 +1391,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1480,6 +1482,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1720,7 +1723,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1782,6 +1785,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1913,7 +1917,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2004,6 +2008,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2146,7 +2151,7 @@ spec:
         - "4190,4191,22,8100-8102"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2211,7 +2216,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -767,7 +767,7 @@ data:
       image:
         name: cr.l5d.io/linkerd/proxy-init
         pullPolicy: ""
-        version: v2.4.2
+        version: v2.4.3
       iptablesMode: legacy
       kubeAPIServerPorts: 443,6443
       logFormat: ""
@@ -951,7 +951,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - args:
@@ -1095,6 +1095,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1185,7 +1186,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1247,6 +1248,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Destination Controller Service
@@ -1389,7 +1391,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -1480,6 +1482,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -1720,7 +1723,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -1782,6 +1785,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      
 ---
 ###
 ### Heartbeat
@@ -1913,7 +1917,7 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-
+      
       automountServiceAccountToken: false
       containers:
       - env:
@@ -2004,6 +2008,7 @@ spec:
           value: 30s
         - name: LINKERD2_PROXY_OUTBOUND_METRICS_HOSTNAME_LABELS
           value: "false"
+        
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_INTERVAL
           value: "10s"
         - name: LINKERD2_PROXY_INBOUND_SERVER_HTTP2_KEEP_ALIVE_TIMEOUT
@@ -2146,7 +2151,7 @@ spec:
         - "4190,4191,4567,4568"
         - --outbound-ports-to-ignore
         - "443,6443"
-        image: cr.l5d.io/linkerd/proxy-init:v2.4.2
+        image: cr.l5d.io/linkerd/proxy-init:v2.4.3
         imagePullPolicy: IfNotPresent
         name: linkerd-init
         resources:
@@ -2211,7 +2216,7 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
-
+      
 ---
 kind: Service
 apiVersion: v1

--- a/controller/proxy-injector/fake/data/pod-cpu-ratio.json
+++ b/controller/proxy-injector/fake/data/pod-cpu-ratio.json
@@ -59,7 +59,7 @@
                 "--outbound-ports-to-ignore",
                 "4567,4568"
             ],
-            "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
+            "image": "cr.l5d.io/linkerd/proxy-init:v2.4.3",
             "imagePullPolicy": "IfNotPresent",
             "name": "linkerd-init",
             "resources": {

--- a/controller/proxy-injector/fake/data/pod-log-level.json
+++ b/controller/proxy-injector/fake/data/pod-log-level.json
@@ -59,7 +59,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.3",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/controller/proxy-injector/fake/data/pod-with-custom-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-custom-debug.patch.json
@@ -59,7 +59,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.3",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/controller/proxy-injector/fake/data/pod-with-debug.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-debug.patch.json
@@ -59,7 +59,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.3",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
+++ b/controller/proxy-injector/fake/data/pod-with-ns-annotations.patch.json
@@ -69,7 +69,7 @@
         "--outbound-ports-to-ignore",
         "34567"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.3",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/controller/proxy-injector/fake/data/pod.patch.json
+++ b/controller/proxy-injector/fake/data/pod.patch.json
@@ -59,7 +59,7 @@
         "--outbound-ports-to-ignore",
         "4567,4568"
       ],
-      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.2",
+      "image": "cr.l5d.io/linkerd/proxy-init:v2.4.3",
       "imagePullPolicy": "IfNotPresent",
       "name": "linkerd-init",
       "resources": null,

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2372,7 +2372,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.2
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,8 +15,8 @@ var Version = undefinedVersion
 // ProxyInitVersion is the pinned version of the proxy-init, from
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
-var ProxyInitVersion = "v2.4.2"
-var LinkerdCNIVersion = "v1.6.2"
+var ProxyInitVersion = "v2.4.3"
+var LinkerdCNIVersion = "v1.6.3"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
As of validator v0.1.3 the release assets have the `windows` or `linux` suffixes. This PR hard-codes `linux` for now.
