### PR TITLE
test(policy): update postman tests to expect 200 response code

### DIFF
--- a/policy-test/tests/e2e_egress_network.rs
+++ b/policy-test/tests/e2e_egress_network.rs
@@ -38,7 +38,11 @@ async fn default_traffic_policy_http_allow() {
             .await;
 
         let allowed_status = allowed.http_status_code().await;
-        assert_eq!(allowed_status, 200, "traffic should be allowed");
+        assert!(
+            allowed_status.is_success() || allowed_status.is_redirection(),
+            "traffic should be allowed but got HTTP status code {}",
+            allowed_status
+        );
     })
     .await;
 }
@@ -112,7 +116,11 @@ async fn default_traffic_policy_opaque_allow() {
             .await;
 
         let allowed_status = allowed.http_status_code().await;
-        assert_eq!(allowed_status, 200, "traffic should be allowed");
+        assert!(
+            allowed_status.is_success() || allowed_status.is_redirection(),
+            "traffic should be allowed but got HTTP status code {}",
+            allowed_status
+        );
     })
     .await;
 }
@@ -237,7 +245,11 @@ async fn explicit_allow_http_route() {
             .await;
 
         let allowed_get_status = allowed_get.http_status_code().await;
-        assert_eq!(allowed_get_status, 200, "traffic should be allowed");
+        assert!(
+            allowed_get_status.is_success() || allowed_get_status.is_redirection(),
+            "traffic should be allowed but got HTTP status code {}",
+            allowed_get_status
+        );
 
         // traffic should not be allowed for /ip request
         let not_allowed_ip = curl
@@ -339,7 +351,11 @@ async fn explicit_allow_tls_route() {
             .await;
 
         let allowed_external_status = allowed_external.http_status_code().await;
-        assert_eq!(allowed_external_status, 200, "traffic should be allowed");
+        assert!(
+            allowed_external_status.is_success() || allowed_external_status.is_redirection(),
+            "traffic should be allowed but got HTTP status code {}",
+            allowed_external_status
+        );
 
         // traffic should not be allowed for google.com
         let not_allowed_google = curl
@@ -443,7 +459,11 @@ async fn explicit_allow_tcp_route() {
             .await;
 
         let allowed_external_status = allowed_external.http_status_code().await;
-        assert_eq!(allowed_external_status, 200, "traffic should be allowed");
+        assert!(
+            allowed_external_status.is_success() || allowed_external_status.is_redirection(),
+            "traffic should be allowed but got HTTP status code {}",
+            allowed_external_status
+        );
 
         // External traffic should not be allowed on 80.
         let not_allowed_google = curl
@@ -562,7 +582,11 @@ async fn routing_back_to_cluster_http_route() {
         );
 
         assert_eq!(in_cluster_status, 204); // in-cluster service returns 204
-        assert_eq!(out_of_cluster_status, 200); // external service returns 200
+        assert!(
+            out_of_cluster_status.is_success() || out_of_cluster_status.is_redirection(),
+            "external service should be allowed but got HTTP status code {}",
+            out_of_cluster_status
+        );
     })
     .await;
 }

--- a/policy-test/tests/e2e_egress_network.rs
+++ b/policy-test/tests/e2e_egress_network.rs
@@ -40,8 +40,7 @@ async fn default_traffic_policy_http_allow() {
         let allowed_status = allowed.http_status_code().await;
         assert!(
             allowed_status.is_success() || allowed_status.is_redirection(),
-            "traffic should be allowed but got HTTP status code {}",
-            allowed_status
+            "traffic should be allowed but got HTTP status code {allowed_status}"
         );
     })
     .await;
@@ -118,8 +117,7 @@ async fn default_traffic_policy_opaque_allow() {
         let allowed_status = allowed.http_status_code().await;
         assert!(
             allowed_status.is_success() || allowed_status.is_redirection(),
-            "traffic should be allowed but got HTTP status code {}",
-            allowed_status
+            "traffic should be allowed but got HTTP status code {allowed_status}"
         );
     })
     .await;
@@ -247,8 +245,7 @@ async fn explicit_allow_http_route() {
         let allowed_get_status = allowed_get.http_status_code().await;
         assert!(
             allowed_get_status.is_success() || allowed_get_status.is_redirection(),
-            "traffic should be allowed but got HTTP status code {}",
-            allowed_get_status
+            "traffic should be allowed but got HTTP status code {allowed_get_status}"
         );
 
         // traffic should not be allowed for /ip request
@@ -353,8 +350,7 @@ async fn explicit_allow_tls_route() {
         let allowed_external_status = allowed_external.http_status_code().await;
         assert!(
             allowed_external_status.is_success() || allowed_external_status.is_redirection(),
-            "traffic should be allowed but got HTTP status code {}",
-            allowed_external_status
+            "traffic should be allowed but got HTTP status code {allowed_external_status}"
         );
 
         // traffic should not be allowed for google.com
@@ -461,8 +457,7 @@ async fn explicit_allow_tcp_route() {
         let allowed_external_status = allowed_external.http_status_code().await;
         assert!(
             allowed_external_status.is_success() || allowed_external_status.is_redirection(),
-            "traffic should be allowed but got HTTP status code {}",
-            allowed_external_status
+            "traffic should be allowed but got HTTP status code {allowed_external_status}"
         );
 
         // External traffic should not be allowed on 80.
@@ -584,8 +579,7 @@ async fn routing_back_to_cluster_http_route() {
         assert_eq!(in_cluster_status, 204); // in-cluster service returns 204
         assert!(
             out_of_cluster_status.is_success() || out_of_cluster_status.is_redirection(),
-            "external service should be allowed but got HTTP status code {}",
-            out_of_cluster_status
+            "external service should be allowed but got HTTP status code {out_of_cluster_status}"
         );
     })
     .await;

--- a/policy-test/tests/e2e_egress_network.rs
+++ b/policy-test/tests/e2e_egress_network.rs
@@ -38,7 +38,7 @@ async fn default_traffic_policy_http_allow() {
             .await;
 
         let allowed_status = allowed.http_status_code().await;
-        assert_eq!(allowed_status, 301, "traffic should be allowed");
+        assert_eq!(allowed_status, 200, "traffic should be allowed");
     })
     .await;
 }
@@ -237,7 +237,7 @@ async fn explicit_allow_http_route() {
             .await;
 
         let allowed_get_status = allowed_get.http_status_code().await;
-        assert_eq!(allowed_get_status, 301, "traffic should be allowed");
+        assert_eq!(allowed_get_status, 200, "traffic should be allowed");
 
         // traffic should not be allowed for /ip request
         let not_allowed_ip = curl
@@ -562,7 +562,7 @@ async fn routing_back_to_cluster_http_route() {
         );
 
         assert_eq!(in_cluster_status, 204); // in-cluster service returns 204
-        assert_eq!(out_of_cluster_status, 301); // external service returns 301
+        assert_eq!(out_of_cluster_status, 200); // external service returns 200
     })
     .await;
 }


### PR DESCRIPTION
It seems the behavior of `http://postman-echo.com/get` has changed to return a 200 here instead of a 301

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
