### PR TITLE
test(destination): Replace sleeps with RetryFor in ClusterStoreTest

### DIFF
--- a/controller/api/destination/watcher/cluster_store_test.go
+++ b/controller/api/destination/watcher/cluster_store_test.go
@@ -1,10 +1,12 @@
 package watcher
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/linkerd/linkerd2/testutil"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -90,7 +92,20 @@ func TestClusterStoreHandlers(t *testing.T) {
 			cs.Sync(nil)
 
 			// Wait for the update to be processed because there is no blocking call currently in k8s that we can wait on
-			time.Sleep(50 * time.Millisecond)
+			err = testutil.RetryFor(time.Second*30, func() error {
+
+				cs.RLock()
+				actualLen := len(cs.store)
+				cs.RUnlock()
+
+				if actualLen != len(tt.expectedClusters) {
+					return fmt.Errorf("expected to see %d cache entries, got: %d", len(tt.expectedClusters), actualLen)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
 
 			cs.RLock()
 			actualLen := len(cs.store)
@@ -125,19 +140,24 @@ func TestClusterStoreHandlers(t *testing.T) {
 				// deletes, so we have to call remove directly.
 				cs.removeCluster(k)
 				// Leave it to do its thing and gracefully shutdown
-				time.Sleep(50 * time.Millisecond)
-				var hasStopped bool
-				if tt.enableEndpointSlices {
-					hasStopped = watcher.k8sAPI.ES().Informer().IsStopped()
-				} else {
-					hasStopped = watcher.k8sAPI.Endpoint().Informer().IsStopped()
-				}
-				if !hasStopped {
-					t.Fatalf("Unexpected error: informers for watcher %s should be stopped", k)
-				}
+				err = testutil.RetryFor(time.Second*30, func() error {
+					var hasStopped bool
+					if tt.enableEndpointSlices {
+						hasStopped = watcher.k8sAPI.ES().Informer().IsStopped()
+					} else {
+						hasStopped = watcher.k8sAPI.Endpoint().Informer().IsStopped()
+					}
+					if !hasStopped {
+						return fmt.Errorf("informers for watcher %s should be stopped", k)
+					}
 
-				if _, _, found := cs.Get(k); found {
-					t.Fatalf("Unexpected error: watcher %s should have been removed from the cache", k)
+					if _, _, found := cs.Get(k); found {
+						return fmt.Errorf("watcher %s should have been removed from the cache", k)
+					}
+					return nil
+				})
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
 				}
 
 			}


### PR DESCRIPTION
The cluster store tests use a `time.Sleep` to wait for events to propagate through the kubernetes API.  However, this is flaky and unreliable and can cause test failures when event propagation is slow.

Replace the 50ms sleep with a RetryFor which checks for the desired state once per second for up to 30 seconds.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
