### PR TITLE
chore(ci): enable overriding the runner in workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 10
     steps:
       - uses: linkerd/dev/actions/setup-tools@v46
@@ -19,7 +19,7 @@ jobs:
       - run: just-dev lint-actions
 
   devcontainer-versions:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: linkerd/dev/actions/setup-tools@v46
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,7 +12,7 @@ jobs:
   go:
     name: Go
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container:
       image: golang:1.24
     steps:
@@ -27,7 +27,7 @@ jobs:
   js:
     name: JS
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container:
       image: node:20-stretch
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   rust:
     name: Rust
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     container:
       image: docker://rust:1.88.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   rust-version:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -37,7 +37,7 @@ jobs:
           fi
 
   devcontainer-image:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: linkerd/dev/actions/setup-tools@v46
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   meta:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: tj-actions/changed-files@055970845dd036d7345da7399b7e89f2e10f2b04
@@ -28,7 +28,7 @@ jobs:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -39,7 +39,7 @@ jobs:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -50,7 +50,7 @@ jobs:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-go
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -63,7 +63,7 @@ jobs:
   go-test-retry:
     needs: go-test
     if: failure() && fromJSON(github.run_attempt) < 3
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     permissions:
       actions: write
     env:
@@ -77,7 +77,7 @@ jobs:
   go-ok:
     needs: [go-lint, go-format, go-test]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - name: Results
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   meta:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: tag
@@ -54,7 +54,7 @@ jobs:
 
   info:
     needs: meta
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 2
     steps:
       - name: Info
@@ -65,7 +65,7 @@ jobs:
   build-cli:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -97,7 +97,7 @@ jobs:
   build-core:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     strategy:
       matrix:
         component:
@@ -134,7 +134,7 @@ jobs:
           - cni-calico-deep
           - deep
           - deep-native-sidecar
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -160,7 +160,7 @@ jobs:
   test-policy:
     needs: [meta, build-cli, build-core]
     if: needs.meta.outputs.changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
     strategy:
       matrix:
@@ -239,7 +239,7 @@ jobs:
   build-ext:
     needs: meta
     if: needs.meta.outputs.changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     strategy:
       matrix:
         component:
@@ -280,7 +280,7 @@ jobs:
           - helm-upgrade
           - uninstall
           - upgrade-edge
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -307,7 +307,7 @@ jobs:
   test-viz:
     needs: [meta, build-cli, build-core, build-ext]
     if: needs.meta.outputs.changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -333,7 +333,7 @@ jobs:
   test-multicluster:
     needs: [meta, build-cli, build-core, build-ext]
     if: needs.meta.outputs.changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
     strategy:
       matrix:
@@ -383,7 +383,7 @@ jobs:
   build-ok:
     needs: [build-cli, build-core, build-ext]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - name: Results
         run: |
@@ -400,7 +400,7 @@ jobs:
     needs:
       [build-ok, test-core, test-policy, test-ext, test-viz, test-multicluster]
     if: failure() && fromJSON(github.run_attempt) < 3 && needs.build-ok.result == 'success'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     permissions:
       actions: write
     env:
@@ -415,7 +415,7 @@ jobs:
     needs:
       [build-ok, test-core, test-policy, test-ext, test-viz, test-multicluster]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - name: Results
         run: |

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   js-web-test:
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container:
       image: node:20-bookworm
     env:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   action:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771
         with:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   markdownlint:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   proto-diff:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-go
     steps:
       - run: apt update && apt install -y unzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   # especially the TAG variable. And it would be great to stop relying
   # on the root-tag script altogether.
   tag:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: echo "tag=$(CI_FORCE_CLEAN=1 bin/root-tag)" >> "$GITHUB_OUTPUT"
@@ -32,7 +32,7 @@ jobs:
   docker_build:
     name: Docker build
     needs: [tag]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     permissions:
       id-token: write # needed for signing the images with GitHub OIDC Token
     strategy:
@@ -126,7 +126,7 @@ jobs:
           - uninstall
           - upgrade-edge
     timeout-minutes: 60
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -154,7 +154,7 @@ jobs:
       - tag
       - integration_tests
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     permissions:
       contents: write
     steps:
@@ -188,7 +188,7 @@ jobs:
     needs: [chart_deploy]
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     permissions:
       contents: write
     steps:
@@ -204,7 +204,7 @@ jobs:
     needs: [tag, website_publish]
     timeout-minutes: 30
     if: startsWith(github.ref, 'refs/tags/stable') || startsWith(github.ref, 'refs/tags/edge')
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set install target for stable
@@ -231,7 +231,7 @@ jobs:
     name: Helm chart deploy
     needs: [gh_release]
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   rerun:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     permissions:
       actions: write

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   audit:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
 
   fmt:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -51,7 +51,7 @@ jobs:
 
   clippy:
     timeout-minutes: 20
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -62,7 +62,7 @@ jobs:
 
   check:
     timeout-minutes: 20
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -72,7 +72,7 @@ jobs:
 
   test:
     name: test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     container: ghcr.io/linkerd/dev:v46-rust
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   rust-toolchain:
     name: rust toolchain
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -14,7 +14,7 @@ jobs:
   # https://github.com/koalaman/shellcheck/wiki/Checks
   shellcheck:
     timeout-minutes: 10
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: linkerd/dev/actions/setup-tools@v46
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/sync-proxy.yml
+++ b/.github/workflows/sync-proxy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   meta:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     env:
       GH_REPO: ${{ vars.LINKERD2_PROXY_REPO || 'linkerd/linkerd2-proxy' }}
@@ -59,7 +59,7 @@ jobs:
 
   changed:
     needs: meta
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     env:
       VERSION: ${{ needs.meta.outputs.name }}
@@ -81,7 +81,7 @@ jobs:
   sync-proxy:
     needs: [meta, changed]
     if: needs.changed.outputs.changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     permissions:
       checks: read


### PR DESCRIPTION
We use the ubuntu-24.04 runner by default, but in forks this may not be appropriate. This change updates the runners to support overriding via the LINKERD2_RUNNER variable.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
