### PR TITLE
chore(policy): Remove OpenSSL from the policy controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,25 +1013,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-openssl"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527d4d619ca2c2aafa31ec139a3d1d60bf557bf7578a1f20f743637eccd9ca19"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "linked_hash_set",
- "once_cell",
- "openssl",
- "openssl-sys",
- "parking_lot",
- "pin-project",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,14 +1275,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-http-proxy",
- "hyper-openssl",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
- "openssl",
  "pem",
  "rustls",
  "secrecy",
@@ -1393,7 +1372,6 @@ dependencies = [
  "futures-util",
  "http-body-util",
  "hyper",
- "hyper-openssl",
  "hyper-util",
  "k8s-openapi",
  "kube-client",
@@ -1401,8 +1379,6 @@ dependencies = [
  "kube-runtime",
  "kubert-prometheus-process",
  "kubert-prometheus-tokio",
- "once_cell",
- "openssl",
  "parking_lot",
  "pin-project-lite",
  "prometheus-client",
@@ -1411,7 +1387,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tokio-openssl",
  "tokio-rustls",
  "tower 0.5.2",
  "tower-http",
@@ -1469,21 +1444,6 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linked_hash_set"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae85b5be22d9843c80e5fc80e9b64c8a3b1f98f867c709956eca3efff4e92e2"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -1833,15 +1793,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.1+3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,7 +1800,6 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2007,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2698,17 +2648,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-openssl"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
-dependencies = [
- "openssl",
- "openssl-sys",
- "tokio",
 ]
 
 [[package]]

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -5,21 +5,13 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 
-[features]
-default = ["rustls-tls"]
-openssl-tls = ["linkerd-policy-controller-runtime/openssl-tls"]
-# Vendor openssl to statically link lib
-openssl-vendored = ["linkerd-policy-controller-runtime/openssl-vendored"]
-rustls-tls = ["linkerd-policy-controller-runtime/rustls-tls", "dep:rustls", "rustls/aws-lc-rs"]
-
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
-rustls = { version = "0.23.29", default-features = false, optional = true }
+rustls = { version = "0.23.29", default-features = false, features = ["aws-lc-rs"] }
 
 [dependencies.linkerd-policy-controller-runtime]
 workspace = true
-default-features = false
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.5"

--- a/policy-controller/runtime/Cargo.toml
+++ b/policy-controller/runtime/Cargo.toml
@@ -6,13 +6,6 @@ edition = "2021"
 license = "Apache-2.0"
 publish = false
 
-[features]
-default = ["rustls-tls"]
-openssl-tls = ["kube/openssl-tls", "kubert/openssl-tls"]
-# Vendor openssl to statically link lib
-openssl-vendored = ["openssl-tls", "openssl/vendored"]
-rustls-tls = ["kube/rustls-tls", "kubert/rustls-tls"]
-
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
@@ -49,7 +42,7 @@ features = ["derive", "env", "std"]
 [dependencies.kube]
 workspace = true
 default-features = false
-features = ["admission", "derive"]
+features = ["admission", "derive", "rustls-tls"]
 
 [dependencies.kubert]
 workspace = true
@@ -61,6 +54,7 @@ features = [
     "prometheus-client",
     "runtime",
     "server",
+    "rustls-tls"
 ]
 
 [dependencies.tokio]

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -7,14 +7,11 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    #[cfg(feature = "rustls-tls")]
+    if rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .is_err()
     {
-        if rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .is_err()
-        {
-            anyhow::bail!("No other crypto provider should be installed yet");
-        }
+        anyhow::bail!("No other crypto provider should be installed yet");
     }
 
     linkerd_policy_controller_runtime::Args::parse_and_run().await


### PR DESCRIPTION
This removes OpenSSL entirely as a TLS backend from the policy controller, instead focusing entirely on rustls for TLS. This removes the propagation of cargo features down the stack that select the TLS backend, instead relying entirely on the backend being set in the policy controller `main.rs`.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
