### PR TITLE
fix(proxy-identity): use execve call on Linux to start the proxy

### DIFF
--- a/proxy-identity/main.go
+++ b/proxy-identity/main.go
@@ -8,9 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 
 	"github.com/linkerd/linkerd2/pkg/tls"
 	log "github.com/sirupsen/logrus"
@@ -142,21 +140,4 @@ func generateAndStoreCSR(p, id string, key *ecdsa.PrivateKey) ([]byte, error) {
 	}
 
 	return csrb, nil
-}
-
-func runProxy() {
-	path := "/usr/lib/linkerd/linkerd2-proxy"
-	if runtime.GOOS == "windows" {
-		path = "C:\\linkerd\\linkerd2-proxy.exe"
-	}
-
-	cmd := exec.Command(path)
-	cmd.Env = os.Environ()
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
-		log.Fatalf("Failed to run proxy: %s", err)
-	}
 }

--- a/proxy-identity/run_proxy_unix.go
+++ b/proxy-identity/run_proxy_unix.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func runProxy() {
+	// The input arguments are static.
+	//nolint:gosec
+	err := syscall.Exec("/usr/lib/linkerd/linkerd2-proxy", []string{}, os.Environ())
+	if err != nil {
+		log.Fatalf("Failed to run proxy: %s", err)
+	}
+}

--- a/proxy-identity/run_proxy_windows.go
+++ b/proxy-identity/run_proxy_windows.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func runProxy() {
+	path := "C:\\linkerd\\linkerd2-proxy.exe"
+	cmd := exec.Command(path)
+	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		log.Fatalf("Failed to run proxy: %s", err)
+	}
+}


### PR DESCRIPTION
A recent change (https://github.com/linkerd/linkerd2/pull/14126) altered the semantics of running the proxy from the identity wrapper. This has introduced [regression in behavior on Linux systems](https://github.com/linkerd/linkerd2/issues/14289). This PR reverts the logic on Unix to use `execve`. This way we use `os/exec` only on Windows systems. 

Further investigation into Windows behavior will be carried out but for now we aim to revert back to the behavior we had on Unix prior to https://github.com/linkerd/linkerd2/pull/14126