### PR TITLE
build(deps): bump linkerd-cni from 1.6.3 to 1.6.4

### DIFF
--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -69,7 +69,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.6.3"
+  version: "v1.6.4"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -117,8 +117,8 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
-        imagePullPolicy: 
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
+        imagePullPolicy:
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -118,8 +118,8 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
-        imagePullPolicy: 
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
+        imagePullPolicy:
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -110,7 +110,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2372,7 +2372,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.3
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,7 +16,7 @@ var Version = undefinedVersion
 // https://github.com/linkerd/linkerd2-proxy-init This has to be kept in sync
 // with the default version in the control plane's values.yaml.
 var ProxyInitVersion = "v2.4.3"
-var LinkerdCNIVersion = "v1.6.3"
+var LinkerdCNIVersion = "v1.6.4"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
No user-facing updates, just dependency updates, including replacing the TLS infra from openssl to aws-lc.