### PR TITLE
chore(identity): add !windows tag in run_proxy_unix.go

### DIFF
--- a/proxy-identity/run_proxy_unix.go
+++ b/proxy-identity/run_proxy_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package main
 
 import (


### PR DESCRIPTION
In a recent change #14307 we split the proxy running logic in the identity wrapper. It turns out that `_unix` suffixes are not ignored for windows builds. Therefore, we add a build tag to the file to ignore it for windows specific builds.

For context: https://github.com/golang/go/issues/51572

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>