### PR TITLE
chore(ci): disable fail-fast on test matrixes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -129,6 +129,7 @@ jobs:
     needs: [meta, build-cli, build-core]
     if: needs.meta.outputs.changed == 'true'
     strategy:
+      fail-fast: false
       matrix:
         test:
           - cni-calico-deep
@@ -163,6 +164,7 @@ jobs:
     runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         # Test the latest Kubernetes version with the latest Gateway API
         # version, as well as the vendored Gateway API CRDs.
@@ -271,6 +273,7 @@ jobs:
     needs: [meta, build-cli, build-core, build-ext]
     if: needs.meta.outputs.changed == 'true'
     strategy:
+      fail-fast: false
       matrix:
         integration_test:
           - cluster-domain
@@ -336,6 +339,7 @@ jobs:
     runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         cases:
         - {k8s: "v1.23", manage-controllers: false}


### PR DESCRIPTION
We frequently hit flakes and have to retry failed jobs. We do not disable fail-fast so, when a job fails, we cancel all other in-flight tests.

It's preferable to let all jobs have a chance to pass to reduce redundant work.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
