### PR TITLE
chore(ci): reduce integration test timeouts

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -373,8 +373,14 @@ run_test(){
   shift
 
   printf 'Test script: [%s] Params: [%s]\n' "${filename##*/}" "$*"
+  timeout="${TEST_TIMEOUT:-15m}"
   # Exit on failure here
-  GO111MODULE=on go test -v -test.timeout=60m --failfast --mod=readonly "$filename" --linkerd="$linkerd_path" --helm-path="$helm_path" --default-inbound-policy="$default_inbound_policy" --k8s-context="$context" --integration-tests "$@" || exit 1
+  GO111MODULE=on go test -v -test.timeout="$timeout" --failfast --mod=readonly "$filename" \
+    --linkerd="$linkerd_path" \
+    --helm-path="$helm_path" \
+    --default-inbound-policy="$default_inbound_policy" \
+    --k8s-context="$context" \
+    --integration-tests "$@"
 }
 
 # Returns the latest version for the release channel

--- a/test/integration/deep/install_test.go
+++ b/test/integration/deep/install_test.go
@@ -74,7 +74,7 @@ func TestInstallCNIPlugin(t *testing.T) {
 	// perform a linkerd check with --linkerd-cni-enabled
 	timeout := time.Minute
 	err = testutil.RetryFor(timeout, func() error {
-		out, err = TestHelper.LinkerdRun("check", "--pre", "--linkerd-cni-enabled", "--wait=60m")
+		out, err = TestHelper.LinkerdRun("check", "--pre", "--linkerd-cni-enabled", "--wait=5m")
 		if err != nil {
 			return err
 		}

--- a/test/integration/install/install_test.go
+++ b/test/integration/install/install_test.go
@@ -458,7 +458,7 @@ func TestUpgradeHelm(t *testing.T) {
 		"--set", "proxyInjectorProxyResources.cpu.limit=1060m",
 		"--set", "proxyInjectorProxyResources.memory.request=106Mi",
 		"--atomic",
-		"--timeout", "60m",
+		"--timeout", "5m",
 		"--wait",
 	}
 	extraArgs, vizArgs := helmUpgradeFlags(helmTLSCerts)

--- a/test/integration/install/smoke/install_smoke_test.go
+++ b/test/integration/install/smoke/install_smoke_test.go
@@ -69,7 +69,7 @@ func TestSmoke(t *testing.T) {
 		}
 
 		// Test 'linkerd check --proxy' with the current image version
-		cmd = []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", ns, "--wait=60m"}
+		cmd = []string{"check", "--proxy", "--expected-version", TestHelper.GetVersion(), "--namespace", ns, "--wait=5m"}
 		expected := getCheckOutput(t, "check.proxy.golden", TestHelper.GetLinkerdNamespace())
 
 		// Use a short time window for check tests to get rid of transient

--- a/test/integration/install/uninstall/uninstall_test.go
+++ b/test/integration/install/uninstall/uninstall_test.go
@@ -65,7 +65,7 @@ func TestInstall(t *testing.T) {
 	var (
 		vizCmd  = []string{"viz", "install"}
 		vizArgs = []string{
-			"--set", fmt.Sprintf("namespace=%s", TestHelper.GetVizNamespace()), "--wait", "60m"}
+			"--set", fmt.Sprintf("namespace=%s", TestHelper.GetVizNamespace()), "--wait", "5m"}
 	)
 
 	// Install Linkerd Viz Extension

--- a/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
+++ b/test/integration/multicluster/multicluster-traffic/mc_traffic_test.go
@@ -343,7 +343,7 @@ func TestMulticlusterStatefulSetTargetTraffic(t *testing.T) {
 
 			// Wait until "target" statefulset is up and running.
 			nginxSpec := testutil.DeploySpec{Namespace: ns, Replicas: 1}
-			o, err := TestHelper.KubectlWithContext("", contexts[testutil.TargetContextKey], "--namespace="+nginxSpec.Namespace, "rollout", "status", "--timeout=60m", "statefulset/nginx-statefulset")
+			o, err := TestHelper.KubectlWithContext("", contexts[testutil.TargetContextKey], "--namespace="+nginxSpec.Namespace, "rollout", "status", "--timeout=5m", "statefulset/nginx-statefulset")
 			if err != nil {
 				oEvt, _ := TestHelper.KubectlWithContext("", contexts[testutil.TargetContextKey], "--namespace="+nginxSpec.Namespace, "get", "event", "--field-selector", "involvedObject.name=nginx-statefulset")
 				testutil.AnnotatedFatalf(t,

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -541,7 +541,7 @@ func (h *TestHelper) HelmUpgrade(chart, releaseName string, arg ...string) (stri
 		releaseName,
 		"--kube-context", h.k8sContext,
 		"--namespace", h.namespace,
-		"--timeout", "60m",
+		"--timeout", "5m",
 		"--wait",
 		chart,
 	}, arg...)
@@ -557,7 +557,7 @@ func (h *TestHelper) HelmInstall(chart, releaseName string, arg ...string) (stri
 		"--kube-context", h.k8sContext,
 		"--namespace", h.namespace,
 		"--create-namespace",
-		"--timeout", "60m",
+		"--timeout", "5m",
 		"--wait",
 	}, arg...)
 	return combinedOutput("", h.helm.path, withParams...)


### PR DESCRIPTION
Our integration tests ship with a hardcoded 1h timeout. This is way too long, and can lead to some undesirable CI behavior.

This commit reduces the default timeout to 15 minutes and makes the value configurable via the environment.

Furthermore, some individual kubernetes operations were set with 1h timeouts. These have been reduced to 5m.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
