### PR TITLE
fix(ci): use correct GHCR creds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
       - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_GHCR_USERNAME }}
+          password: ${{ secrets.DOCKER_GHCR_PAT }}
       - uses: ./.github/actions/docker-build
         id: build
         with:


### PR DESCRIPTION
While the refactor in https://github.com/linkerd/linkerd2/pull/14359/files was happening, we switched to using incorrect credentials for GHCR. This PR fixes that

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>