### PR TITLE
chore(deps): bump extension-init from 0.1.6 to 0.1.7

### DIFF
--- a/jaeger/charts/linkerd-jaeger/values.yaml
+++ b/jaeger/charts/linkerd-jaeger/values.yaml
@@ -239,7 +239,7 @@ namespaceMetadata:
     # -- Docker image name for the namespace-metadata instance
     name: extension-init
     # -- Docker image tag for the namespace-metadata instance
-    tag: v0.1.6
+    tag: v0.1.7
     # -- Pull policy for the namespace-metadata instance
     # @default -- imagePullPolicy
     pullPolicy: ""

--- a/multicluster/charts/linkerd-multicluster/values.yaml
+++ b/multicluster/charts/linkerd-multicluster/values.yaml
@@ -82,7 +82,7 @@ namespaceMetadata:
     # -- Docker image name for the namespace-metadata instance
     name: extension-init
     # -- Docker image tag for the namespace-metadata instance
-    tag: v0.1.6
+    tag: v0.1.7
     # -- Pull policy for the namespace-metadata instance
     # @default -- imagePullPolicy
     pullPolicy: ""

--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -416,7 +416,7 @@ namespaceMetadata:
     # -- Docker image name for the namespace-metadata instance
     name: extension-init
     # -- Docker image tag for the namespace-metadata instance
-    tag: v0.1.6
+    tag: v0.1.7
     # -- Pull policy for the namespace-metadata instance
     # @default -- defaultImagePullPolicy
     pullPolicy: ""


### PR DESCRIPTION
this commit updates the extension-init component to a new release that depends on slab 0.4.11.

see: https://github.com/BuoyantIO/enterprise-linkerd/security/dependabot/92

changes:
* https://github.com/linkerd/linkerd-extension-init/pull/174
* https://github.com/linkerd/linkerd-extension-init/pull/176
* https://github.com/linkerd/linkerd-extension-init/pull/177
* https://github.com/linkerd/linkerd-extension-init/pull/178
* https://github.com/linkerd/linkerd-extension-init/pull/179
* https://github.com/linkerd/linkerd-extension-init/pull/181
* https://github.com/linkerd/linkerd-extension-init/pull/182
* https://github.com/linkerd/linkerd-extension-init/pull/183

https://github.com/linkerd/linkerd-extension-init/releases/tag/release%2Fv0.1.7

see: https://github.com/linkerd/linkerd-extension-init/blob/8e87d9cbf2448ef97285d929c27a8607c6a4a937/Cargo.lock#L1395-L1399