### PR TITLE
fix(ci): double `cli-build` workflow timeout

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435


### PR DESCRIPTION
we've observed timeouts in ci when building the cli.

this commit doubles the timeout from 10 minutes to 20 minutes.