### PR TITLE
fix(ci): remove `windows_static_cli_tests`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,25 +78,6 @@ jobs:
     with:
       version: ${{ needs.tag.outputs.tag }}
 
-  windows_static_cli_tests:
-    name: Static CLI tests (windows)
-    timeout-minutes: 30
-    runs-on: windows-latest
-    needs: [cli, docker_build]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
-        with:
-          go-version: "1.24"
-      - name: Download image archives
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
-        with:
-          name: image-archives-cli
-          path: image-archives
-      - name: Run CLI Integration tests
-        run: go test --failfast --mod=readonly ".\test\cli" --linkerd="$PWD\image-archives\linkerd-windows.exe" --cli-tests -v
-
   integration_tests:
     name: Integration tests
     needs: [tag, cli, docker_build]


### PR DESCRIPTION
this piece of our ci system runs the cli integration tests on windows, but does so within the course of our release workflow rather than regular ci.

this currently does not work because it cannot find its artifact.

this commit removes it from the release workflow. if we determine that we would like to restore this, we should do so by placing this in the ci action for pull requests to catch issues with this earlier.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
