### PR TITLE
fix(jaeger): Fix `_pod_ip` attribute

### DIFF
--- a/jaeger/injector/mutator/patch.go
+++ b/jaeger/injector/mutator/patch.go
@@ -51,7 +51,7 @@ const tpl = `[
     "path": "/spec/{{.ProxyPath}}/env/-",
     "value": {
       "name": "LINKERD2_PROXY_TRACE_EXTRA_ATTRIBUTES",
-      "value": "k8s.pod.ip=${_pod_ip}\nk8s.pod.uid=$(_pod_uid)\nk8s.container.name=$(_pod_containerName)"
+      "value": "k8s.pod.ip=$(_pod_ip)\nk8s.pod.uid=$(_pod_uid)\nk8s.container.name=$(_pod_containerName)"
     }
   },
   {


### PR DESCRIPTION
When using the jaeger extension, the injection patch used the wrong brackets for the `k8s.pod.ip` attribute ("{}" instead of "()"), which caused the IP to appear as "_pod_ip" in the resulting trace.

This uses the correct brackets, which makes the pod IP appear correctly in the traces.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
