### PR TITLE
fix(destination): discovery staleness when targetting the linkerd-admin port in native-sidecar mode

### DIFF
--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -184,6 +184,62 @@ spec:
     isRetryable: false
     condition:
       pathRegex: "/a/b/c"`,
+		`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    linkerd.io/control-plane-ns: linkerd
+  name: name1-20
+  namespace: ns
+status:
+  phase: Pending
+  conditions:
+  - type: Ready
+    status: "False"
+  podIP: 172.17.0.20
+  podIPs:
+  - ip: 172.17.0.20
+spec:
+  containers:
+    - env:
+      - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+        value: 0.0.0.0:4143
+      - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+        value: 0.0.0.0:4191
+      - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+        value: 0.0.0.0:4190
+      name: linkerd-proxy
+      ports:
+      - containerPort: 4191`,
+		`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    linkerd.io/control-plane-ns: linkerd
+  name: name1-21
+  namespace: ns
+status:
+  phase: Pending
+  conditions:
+  - type: Ready
+    status: "False"
+  podIP: 172.17.0.21
+  podIPs:
+  - ip: 172.17.0.21
+spec:
+  initContainers:
+    - env:
+      - name: LINKERD2_PROXY_INBOUND_LISTEN_ADDR
+        value: 0.0.0.0:4143
+      - name: LINKERD2_PROXY_ADMIN_LISTEN_ADDR
+        value: 0.0.0.0:4191
+      - name: LINKERD2_PROXY_CONTROL_LISTEN_ADDR
+        value: 0.0.0.0:4190
+      name: linkerd-proxy
+      ports:
+      - containerPort: 4191`,
 	}
 
 	clientSP := []string{

--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -249,7 +249,7 @@ func (ww *WorkloadWatcher) submitPodUpdate(pod *corev1.Pod, remove bool) {
 		submitPod = nil
 	}
 
-	for _, container := range pod.Spec.Containers {
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 		for _, containerPort := range container.Ports {
 			if containerPort.ContainerPort != 0 {
 				for _, pip := range pod.Status.PodIPs {


### PR DESCRIPTION
Fixes #13865 (see for repro).

Proxy clients targetting a linkerd-admin port on a target meshed in native-sidecar mode weren't getting notifications about changes in the target pod.

Summary of case detailed in #13865:

* Target pod using default-deny policy.
* The Prometheus client opened a persistent connection to the target when it wasn't ready yet, and thus not yet admitted into the mesh, so the connection wasn't mTLS'd, resulting in scrape requests failing with 403.
* After the pod became ready, the client wasn't notified and thus the bad state persisted.

The fix consists on having the workload watcher also account for subscriptions associated to ports in init-containers (where the linkerd-admin port would be located when using native sidecars).

Two new unit tests were added, making sure pod phase state changes are notified to subscribers both when using non-native-sidecar and native-sidecar. The native-sidecar case failed without this fix.