### PR TITLE
chore(deps): introduce a `serde` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,6 +88,10 @@ updates:
         patterns:
           - tracing
           - tracing-*
+      serde:
+        patterns:
+          - serde
+          - serde_*
 
   - package-ecosystem: "github-actions"
     directories:


### PR DESCRIPTION
this commit introduces a dependabot group that will manage `serde`, and its constituent crates like `serde_json`, `serde_core`, and `serde_derive`, in unison.

see linkerd/linkerd2-proxy#4160, and pull requests like linkerd/linkerd2#14492 and linkerd/linkerd2#14495 for a motivating example.