### PR TITLE
chore(deps): introduce a `pest` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,6 +92,10 @@ updates:
         patterns:
           - serde
           - serde_*
+      pest:
+        patterns:
+          - pest
+          - pest_*
 
   - package-ecosystem: "github-actions"
     directories:


### PR DESCRIPTION
like https://github.com/linkerd/linkerd2/pull/14497, this introduces a group for managing our `pest` crates in lockstep.

see https://github.com/linkerd/linkerd2/pull/14501, https://github.com/linkerd/linkerd2/pull/14500, https://github.com/linkerd/linkerd2/pull/14499, as examples of redundant pr's bumping these individually.

this branch is based on https://github.com/linkerd/linkerd2/pull/14497, to avoid merge conflicts.