### PR TITLE
chore(ci): replace bitnami/kubectl with chainguard/kubectl

### DIFF
--- a/justfile
+++ b/justfile
@@ -153,14 +153,14 @@ policy-test-cleanup:
     @while [ $({{ _kubectl }} get ns --selector='linkerd-policy-test' -o json |jq '.items | length') != "0" ]; do sleep 1 ; done
 
 policy-test-deps-pull:
-    docker pull -q docker.io/chainguard/kubectl:latest
+    docker pull -q docker.io/chainguard/kubectl:latest-dev
     docker pull -q docker.io/curlimages/curl:latest
     docker pull -q ghcr.io/olix0r/hokay:latest
 
 # Load all images into the test cluster.
 policy-test-deps-load: _k3d-init policy-test-deps-pull
     for i in {1..3} ; do {{ _k3d-load }} \
-        chainguard/kubectl:latest \
+        chainguard/kubectl:latest-dev \
         curlimages/curl:latest \
         fortio/fortio:latest \
         ghcr.io/olix0r/hokay:latest && exit || sleep 1 ; done

--- a/justfile
+++ b/justfile
@@ -153,14 +153,14 @@ policy-test-cleanup:
     @while [ $({{ _kubectl }} get ns --selector='linkerd-policy-test' -o json |jq '.items | length') != "0" ]; do sleep 1 ; done
 
 policy-test-deps-pull:
-    docker pull -q docker.io/bitnami/kubectl:latest
+    docker pull -q docker.io/alpine/kubectl:latest
     docker pull -q docker.io/curlimages/curl:latest
     docker pull -q ghcr.io/olix0r/hokay:latest
 
 # Load all images into the test cluster.
 policy-test-deps-load: _k3d-init policy-test-deps-pull
     for i in {1..3} ; do {{ _k3d-load }} \
-        bitnami/kubectl:latest \
+        alpine/kubectl:latest \
         curlimages/curl:latest \
         fortio/fortio:latest \
         ghcr.io/olix0r/hokay:latest && exit || sleep 1 ; done

--- a/justfile
+++ b/justfile
@@ -153,14 +153,14 @@ policy-test-cleanup:
     @while [ $({{ _kubectl }} get ns --selector='linkerd-policy-test' -o json |jq '.items | length') != "0" ]; do sleep 1 ; done
 
 policy-test-deps-pull:
-    docker pull -q docker.io/alpine/kubectl:latest
+    docker pull -q docker.io/chainguard/kubectl:latest
     docker pull -q docker.io/curlimages/curl:latest
     docker pull -q ghcr.io/olix0r/hokay:latest
 
 # Load all images into the test cluster.
 policy-test-deps-load: _k3d-init policy-test-deps-pull
     for i in {1..3} ; do {{ _k3d-load }} \
-        alpine/kubectl:latest \
+        chainguard/kubectl:latest \
         curlimages/curl:latest \
         fortio/fortio:latest \
         ghcr.io/olix0r/hokay:latest && exit || sleep 1 ; done

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -198,7 +198,7 @@ impl Runner {
                 service_account: Some("curl".to_string()),
                 init_containers: Some(vec![k8s::api::core::v1::Container {
                     name: "wait-for-web".to_string(),
-                    image: Some("docker.io/bitnami/kubectl:latest".to_string()),
+                    image: Some("docker.io/alpine/kubectl:latest".to_string()),
                     // In CI, we can hit failures where the watch isn't updated
                     // after the configmap is deleted, even with a long timeout.
                     // Instead, we use a relatively short timeout and retry the

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -198,7 +198,7 @@ impl Runner {
                 service_account: Some("curl".to_string()),
                 init_containers: Some(vec![k8s::api::core::v1::Container {
                     name: "wait-for-web".to_string(),
-                    image: Some("docker.io/alpine/kubectl:latest".to_string()),
+                    image: Some("docker.io/chainguard/kubectl:latest".to_string()),
                     // In CI, we can hit failures where the watch isn't updated
                     // after the configmap is deleted, even with a long timeout.
                     // Instead, we use a relatively short timeout and retry the

--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -198,7 +198,7 @@ impl Runner {
                 service_account: Some("curl".to_string()),
                 init_containers: Some(vec![k8s::api::core::v1::Container {
                     name: "wait-for-web".to_string(),
-                    image: Some("docker.io/chainguard/kubectl:latest".to_string()),
+                    image: Some("docker.io/chainguard/kubectl:latest-dev".to_string()),
                     // In CI, we can hit failures where the watch isn't updated
                     // after the configmap is deleted, even with a long timeout.
                     // Instead, we use a relatively short timeout and retry the


### PR DESCRIPTION
bitnami/containers#83267 documents how the bitnami container images are being browned out to signal a change. To unblock our CI, we can switch to [chainguard/kubectl](https://hub.docker.com/r/chainguard/kubectl).

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
