### PR TITLE
Revert "build(deps): bump libloading from 0.8.8 to 0.8.9 (#14524)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,12 +1402,12 @@ checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.0",
+ "windows-targets",
 ]
 
 [[package]]


### PR DESCRIPTION
This reverts commit 6c4e23b741c0282e73cae000c58b9b77759a5b05.
