### PR TITLE
chore(injector): promote native sidecars to beta

### DIFF
--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -250,7 +250,7 @@ proxy:
   # -- Configures the outbound transport mode. Valid values are "transport-header" and "transparent"
   outboundTransportMode: transport-header
   # -- Enable KEP-753 native sidecars
-  # This is an experimental feature. It requires Kubernetes >= 1.29.
+  # This is a beta feature. It requires Kubernetes >= 1.29.
   # If enabled, .proxy.waitBeforeExitSeconds should not be used.
   nativeSidecar: false
   # -- Native sidecar proxy startup probe parameters.

--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -289,8 +289,12 @@ func generateAnnotationsDocs() []annotationDoc {
 			Description: "Grace period for graceful proxy shutdowns. If this timeout elapses before all open connections have completed, the proxy will terminate forcefully, closing any remaining connections.",
 		},
 		{
-			Name:        k8s.ProxyEnableNativeSidecarAnnotation,
-			Description: "Enable KEP-753 native sidecars. This is an experimental feature. It requires Kubernetes >= 1.29. If enabled, .proxy.waitBeforeExitSeconds should not be used.",
+			Name:        k8s.ProxyEnableNativeSidecarAnnotationAlpha,
+			Description: "Enable KEP-753 native sidecars. This is a beta feature. It requires Kubernetes >= 1.29. If enabled, .proxy.waitBeforeExitSeconds should not be used. Deprecated in favor of " + k8s.ProxyEnableNativeSidecarAnnotationBeta,
+		},
+		{
+			Name:        k8s.ProxyEnableNativeSidecarAnnotationBeta,
+			Description: "Enable KEP-753 native sidecars. This is a beta feature. It requires Kubernetes >= 1.29. If enabled, .proxy.waitBeforeExitSeconds should not be used.",
 		},
 	}
 }

--- a/cli/cmd/inject.go
+++ b/cli/cmd/inject.go
@@ -505,7 +505,7 @@ func getOverrideAnnotations(values *linkerd2.Values, base *linkerd2.Values) map[
 	}
 
 	if proxy.NativeSidecar != baseProxy.NativeSidecar {
-		overrideAnnotations[k8s.ProxyEnableNativeSidecarAnnotation] = strconv.FormatBool(proxy.NativeSidecar)
+		overrideAnnotations[k8s.ProxyEnableNativeSidecarAnnotationBeta] = strconv.FormatBool(proxy.NativeSidecar)
 	}
 
 	return overrideAnnotations

--- a/cli/cmd/inject_test.go
+++ b/cli/cmd/inject_test.go
@@ -739,16 +739,16 @@ func TestProxyConfigurationAnnotations(t *testing.T) {
 		k8s.ProxyLogLevelAnnotation:            "debug",
 		k8s.ProxyLogFormatAnnotation:           "cool",
 
-		k8s.ProxyEnableExternalProfilesAnnotation: "true",
-		k8s.ProxyCPURequestAnnotation:             "10m",
-		k8s.ProxyCPULimitAnnotation:               "100m",
-		k8s.ProxyMemoryRequestAnnotation:          "10Mi",
-		k8s.ProxyMemoryLimitAnnotation:            "50Mi",
-		k8s.ProxyWaitBeforeExitSecondsAnnotation:  "10",
-		k8s.ProxyAwait:                            "disabled",
-		k8s.ProxyAccessLogAnnotation:              "apache",
-		k8s.ProxyShutdownGracePeriodAnnotation:    "60s",
-		k8s.ProxyEnableNativeSidecarAnnotation:    "true",
+		k8s.ProxyEnableExternalProfilesAnnotation:  "true",
+		k8s.ProxyCPURequestAnnotation:              "10m",
+		k8s.ProxyCPULimitAnnotation:                "100m",
+		k8s.ProxyMemoryRequestAnnotation:           "10Mi",
+		k8s.ProxyMemoryLimitAnnotation:             "50Mi",
+		k8s.ProxyWaitBeforeExitSecondsAnnotation:   "10",
+		k8s.ProxyAwait:                             "disabled",
+		k8s.ProxyAccessLogAnnotation:               "apache",
+		k8s.ProxyShutdownGracePeriodAnnotation:     "60s",
+		k8s.ProxyEnableNativeSidecarAnnotationBeta: "true",
 	}
 
 	overrides := getOverrideAnnotations(values, baseValues)

--- a/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
+++ b/cli/cmd/testdata/inject_emojivoto_deployment_native_sidecar.golden.yml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.alpha.linkerd.io/proxy-enable-native-sidecar: "true"
+        config.beta.linkerd.io/proxy-enable-native-sidecar: "true"
         linkerd.io/created-by: linkerd/cli dev-undefined
         linkerd.io/proxy-version: test-inject-proxy-version
         linkerd.io/trust-root-sha256: 8dc603abd4e755c25c94da05abbf29b9b283a784733651020d72f97ca8ab98e4

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -39,7 +39,6 @@ var (
 	rTrail = regexp.MustCompile(`\},\s*\]`)
 
 	// ProxyAnnotations is the list of possible annotations that can be applied on a pod or namespace.
-	// All these annotations should be prefixed with "config.linkerd.io"
 	ProxyAnnotations = []string{
 		k8s.ProxyAdminPortAnnotation,
 		k8s.ProxyControlPortAnnotation,
@@ -81,12 +80,13 @@ var (
 		k8s.ProxyInboundDiscoveryCacheUnusedTimeout,
 		k8s.ProxyDisableOutboundProtocolDetectTimeout,
 		k8s.ProxyDisableInboundProtocolDetectTimeout,
+		k8s.ProxyEnableNativeSidecarAnnotationBeta,
 	}
 	// ProxyAlphaConfigAnnotations is the list of all alpha configuration
 	// (config.alpha prefix) that can be applied to a pod or namespace.
 	ProxyAlphaConfigAnnotations = []string{
 		k8s.ProxyWaitBeforeExitSecondsAnnotation,
-		k8s.ProxyEnableNativeSidecarAnnotation,
+		k8s.ProxyEnableNativeSidecarAnnotationAlpha,
 	}
 )
 
@@ -372,7 +372,13 @@ func ApplyAnnotationOverrides(values *l5dcharts.Values, annotations map[string]s
 		}
 	}
 
-	if override, ok := annotations[k8s.ProxyEnableNativeSidecarAnnotation]; ok {
+	// ProxyEnableNativeSidecarAnnotationBeta should take precedence over ProxyEnableNativeSidecarAnnotationAlpha
+	if override, ok := annotations[k8s.ProxyEnableNativeSidecarAnnotationBeta]; ok {
+		value, err := strconv.ParseBool(override)
+		if err == nil {
+			values.Proxy.NativeSidecar = value
+		}
+	} else if override, ok = annotations[k8s.ProxyEnableNativeSidecarAnnotationAlpha]; ok {
 		value, err := strconv.ParseBool(override)
 		if err == nil {
 			values.Proxy.NativeSidecar = value

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -75,7 +75,7 @@ func TestGetOverriddenValues(t *testing.T) {
 							k8s.ProxyInboundDiscoveryCacheUnusedTimeout:      "900s",
 							k8s.ProxyDisableOutboundProtocolDetectTimeout:    "true",
 							k8s.ProxyDisableInboundProtocolDetectTimeout:     "true",
-							k8s.ProxyEnableNativeSidecarAnnotation:           "true",
+							k8s.ProxyEnableNativeSidecarAnnotationBeta:       "true",
 						},
 					},
 					Spec: corev1.PodSpec{},
@@ -179,7 +179,7 @@ func TestGetOverriddenValues(t *testing.T) {
 				k8s.ProxyInboundDiscoveryCacheUnusedTimeout:   "6000ms",
 				k8s.ProxyDisableOutboundProtocolDetectTimeout: "true",
 				k8s.ProxyDisableInboundProtocolDetectTimeout:  "false",
-				k8s.ProxyEnableNativeSidecarAnnotation:        "true",
+				k8s.ProxyEnableNativeSidecarAnnotationBeta:    "true",
 			},
 			spec: appsv1.DeploymentSpec{
 				Template: corev1.PodTemplateSpec{

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -127,6 +127,9 @@ const (
 	// ProxyConfigAnnotationsPrefixAlpha is the prefix of newly released config-related annotations
 	ProxyConfigAnnotationsPrefixAlpha = "config.alpha.linkerd.io"
 
+	// ProxyConfigAnnotationsPrefixBeta is the prefix for config-related annotations more mature than alpha but not yet stable
+	ProxyConfigAnnotationsPrefixBeta = "config.beta.linkerd.io"
+
 	// ProxyImageAnnotation can be used to override the proxyImage config.
 	ProxyImageAnnotation = ProxyConfigAnnotationsPrefix + "/proxy-image"
 
@@ -283,8 +286,12 @@ const (
 	// configured for the Pod
 	ProxyWaitBeforeExitSecondsAnnotation = ProxyConfigAnnotationsPrefixAlpha + "/proxy-wait-before-exit-seconds"
 
-	// ProxyEnableNativeSidecarAnnotation enables the new native initContainer sidecar
-	ProxyEnableNativeSidecarAnnotation = ProxyConfigAnnotationsPrefixAlpha + "/proxy-enable-native-sidecar"
+	// ProxyEnableNativeSidecarAnnotationAlpha enables the new native initContainer sidecar.
+	// Deprecated, use ProxyEnableNativeSidecarAnnotationBeta instead.
+	ProxyEnableNativeSidecarAnnotationAlpha = ProxyConfigAnnotationsPrefixAlpha + "/proxy-enable-native-sidecar"
+
+	// ProxyEnableNativeSidecarAnnotationBeta enables the new native initContainer sidecar
+	ProxyEnableNativeSidecarAnnotationBeta = ProxyConfigAnnotationsPrefixBeta + "/proxy-enable-native-sidecar"
 
 	// ProxyAwait can be used to force the application to wait for the proxy
 	// to be ready.


### PR DESCRIPTION
- Advances native-sidecar feature from alpha to beta.
- Deprecates `config.alpha.linkerd.io/proxy-enable-native-sidecar` annotation.
- Introduces `config.beta.linkerd.io/proxy-enable-native-sidecar` as the new annotation.
- GA planned after expanded automated test coverage.