### PR TITLE
fix(destination)!: replace ip_port_subscribers with workload_subscribers

### DIFF
--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -60,7 +60,7 @@ type (
 	}
 )
 
-var ipPortVecs = newMetricsVecs("ip_port", []string{})
+var workloadVecs = newMetricsVecs("workload", []string{})
 
 func NewWorkloadWatcher(k8sAPI *k8s.API, metadataAPI *k8s.MetadataAPI, log *logging.Entry, enableEndpointSlices bool, defaultOpaquePorts map[uint32]struct{}) (*WorkloadWatcher, error) {
 	ww := &WorkloadWatcher{
@@ -455,7 +455,7 @@ func (ww *WorkloadWatcher) getOrNewWorkloadPublisher(service *ServiceID, hostnam
 	wp, ok := ww.publishers[ipPort]
 	if !ok {
 		// Omit high-cardinality IP:port labels.
-		metrics, err := ipPortVecs.newMetrics(prometheus.Labels{})
+		metrics, err := workloadVecs.newMetrics(prometheus.Labels{})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The destination control's ip_port_subscriber and ip_port_updates metrics are potentailly exposed for every IP that is discovered. This is high cardinality and puts undo pressure on the metrics infrastructure.

This change drops these labels, so that there is a single ip_port_subscriber and ip_port_updates timeseries.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
