### PR TITLE
fix(destination): avoid blocking in synchronizedGetStream.Stop

### DIFF
--- a/controller/api/destination/syncronized_get_stream.go
+++ b/controller/api/destination/syncronized_get_stream.go
@@ -71,5 +71,5 @@ func (s *synchronizedGetStream) Start() {
 }
 
 func (s *synchronizedGetStream) Stop() {
-	s.done <- struct{}{}
+	close(s.done)
 }


### PR DESCRIPTION
synchronizedGetStream.Stop incorrectly tried to send on an unbuffered channel. Now it closes the channel to avoid blocking.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
