### PR TITLE
feat(destionation): add --stream-queue-capacity arg

### DIFF
--- a/controller/api/destination/endpoint_profile_translator.go
+++ b/controller/api/destination/endpoint_profile_translator.go
@@ -54,6 +54,7 @@ func newEndpointProfileTranslator(
 	stream pb.Destination_GetProfileServer,
 	endStream chan struct{},
 	log *logging.Entry,
+	queueCapacity int,
 ) *endpointProfileTranslator {
 	return &endpointProfileTranslator{
 		forceOpaqueTransport: forceOpaqueTransport,
@@ -66,7 +67,7 @@ func newEndpointProfileTranslator(
 
 		stream:    stream,
 		endStream: endStream,
-		updates:   make(chan *watcher.Address, updateQueueCapacity),
+		updates:   make(chan *watcher.Address, queueCapacity),
 		stop:      make(chan struct{}),
 
 		log: log.WithField("component", "endpoint-profile-translator"),

--- a/controller/api/destination/endpoint_translator.go
+++ b/controller/api/destination/endpoint_translator.go
@@ -27,8 +27,6 @@ const (
 	envAdminListenAddr   = "LINKERD2_PROXY_ADMIN_LISTEN_ADDR"
 	envControlListenAddr = "LINKERD2_PROXY_CONTROL_LISTEN_ADDR"
 
-	updateQueueCapacity = 100
-
 	defaultProxyInboundPort = 4143
 )
 
@@ -101,6 +99,7 @@ func newEndpointTranslator(
 	stream pb.Destination_GetServer,
 	endStream chan struct{},
 	log *logging.Entry,
+	queueCapacity int,
 ) (*endpointTranslator, error) {
 	log = log.WithFields(logging.Fields{
 		"component": "endpoint-translator",
@@ -139,7 +138,7 @@ func newEndpointTranslator(
 		endStream,
 		log,
 		counter,
-		make(chan interface{}, updateQueueCapacity),
+		make(chan interface{}, queueCapacity),
 		make(chan struct{}),
 	}, nil
 }

--- a/controller/api/destination/federated_service_watcher.go
+++ b/controller/api/destination/federated_service_watcher.go
@@ -364,6 +364,7 @@ func (fs *federatedService) remoteDiscoverySubscribe(
 		subscriber.stream,
 		subscriber.endStream,
 		fs.log,
+		fs.config.StreamQueueCapacity,
 	)
 	if err != nil {
 		fs.log.Errorf("Failed to create endpoint translator for remote discovery service %q in cluster %s: %s", id.service.Name, id.cluster, err)
@@ -418,6 +419,7 @@ func (fs *federatedService) localDiscoverySubscribe(
 		subscriber.stream,
 		subscriber.endStream,
 		fs.log,
+		fs.config.StreamQueueCapacity,
 	)
 	if err != nil {
 		fs.log.Errorf("Failed to create endpoint translator for %s: %s", localDiscovery, err)

--- a/controller/api/destination/federated_service_watcher_test.go
+++ b/controller/api/destination/federated_service_watcher_test.go
@@ -151,7 +151,7 @@ func mockFederatedServiceWatcher(t *testing.T) (*federatedServiceWatcher, error)
 	if err != nil {
 		return nil, fmt.Errorf("NewClusterStoreWithDecoder returned an error: %w", err)
 	}
-	fsw, err := newFederatedServiceWatcher(k8sAPI, metadataAPI, &Config{}, clusterStore, localEndpoints, logging.WithField("test", t.Name()))
+	fsw, err := newFederatedServiceWatcher(k8sAPI, metadataAPI, &Config{StreamQueueCapacity: DefaultStreamQueueCapacity}, clusterStore, localEndpoints, logging.WithField("test", t.Name()))
 	if err != nil {
 		return nil, fmt.Errorf("newFederatedServiceWatcher returned an error: %w", err)
 	}

--- a/controller/api/destination/profile_translator.go
+++ b/controller/api/destination/profile_translator.go
@@ -47,6 +47,10 @@ var profileUpdatesQueueOverflowCounter = promauto.NewCounterVec(
 )
 
 func newProfileTranslator(serviceID watcher.ServiceID, stream pb.Destination_GetProfileServer, log *logging.Entry, fqn string, port uint32, endStream chan struct{}) (*profileTranslator, error) {
+	return newProfileTranslatorWithCapacity(serviceID, stream, log, fqn, port, endStream, DefaultStreamQueueCapacity)
+}
+
+func newProfileTranslatorWithCapacity(serviceID watcher.ServiceID, stream pb.Destination_GetProfileServer, log *logging.Entry, fqn string, port uint32, endStream chan struct{}, queueCapacity int) (*profileTranslator, error) {
 	parentRef := &meta.Metadata{
 		Kind: &meta.Metadata_Resource{
 			Resource: &meta.Resource{
@@ -73,7 +77,7 @@ func newProfileTranslator(serviceID watcher.ServiceID, stream pb.Destination_Get
 		endStream:       endStream,
 		log:             log.WithField("component", "profile-translator"),
 		overflowCounter: overflowCounter,
-		updates:         make(chan *sp.ServiceProfile, updateQueueCapacity),
+		updates:         make(chan *sp.ServiceProfile, queueCapacity),
 		stop:            make(chan struct{}),
 	}, nil
 }

--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -1062,7 +1062,7 @@ spec:
 		t.Fatalf("can't create cluster store: %s", err)
 	}
 
-	federatedServices, err := newFederatedServiceWatcher(k8sAPI, metadataAPI, &Config{}, clusterStore, endpoints, log)
+	federatedServices, err := newFederatedServiceWatcher(k8sAPI, metadataAPI, &Config{StreamQueueCapacity: DefaultStreamQueueCapacity}, clusterStore, endpoints, log)
 	if err != nil {
 		t.Fatalf("can't create federated service watcher: %s", err)
 	}
@@ -1082,6 +1082,7 @@ spec:
 			ClusterDomain:       "mycluster.local",
 			IdentityTrustDomain: "trust.domain",
 			DefaultOpaquePorts:  defaultOpaquePorts,
+			StreamQueueCapacity: DefaultStreamQueueCapacity,
 		},
 		workloads,
 		endpoints,
@@ -1191,6 +1192,7 @@ metadata:
 		mockGetServer,
 		nil,
 		logging.WithField("test", t.Name()),
+		DefaultStreamQueueCapacity,
 	)
 	if err != nil {
 		t.Fatalf("failed to create endpoint translator: %s", err)

--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -47,6 +47,7 @@ func Main(args []string) {
 	// This will default to true. It can be overridden with experimental CLI
 	// flags. Currently not exposed as a configuration value through Helm.
 	exportControllerQueueMetrics := cmd.Bool("export-queue-metrics", true, "Exports queue metrics for the external workload controller")
+	streamQueueCapacity := cmd.Int("stream-queue-capacity", destination.DefaultStreamQueueCapacity, "Maximum number of updates buffered per stream before the stream is closed")
 
 	traceCollector := flags.AddTraceFlags(cmd)
 
@@ -65,6 +66,10 @@ func Main(args []string) {
 		"HTTP/2 client parameters for meshed connections in JSON format")
 
 	flags.ConfigureAndParse(cmd, args)
+
+	if *streamQueueCapacity <= 0 {
+		log.Fatalf("--stream-queue-capacity must be greater than 0")
+	}
 
 	if *enableIPv6 && !*enableEndpointSlices {
 		log.Fatal("If --enable-ipv6=true then --enable-endpoint-slices needs to be true")
@@ -190,6 +195,7 @@ func Main(args []string) {
 		EnableIPv6:              *enableIPv6,
 		ExtEndpointZoneWeights:  *extEndpointZoneWeights,
 		MeshedHttp2ClientParams: meshedHTTP2ClientParams,
+		StreamQueueCapacity:     *streamQueueCapacity,
 	}
 	server, err := destination.NewServer(
 		*addr,


### PR DESCRIPTION
The destination controller has a hardcoded stream queue capacity of 100. This commit introduces a new command-line argument `--stream-queue-capacity` that allows users to customize this value according to their needs.

We believe that '1' is a better default value for most use cases, as it more eagerly detects backpressure and liveness issues. However, we want to be incremental about this change. Therefore, this configuration allows for us to test this new default value in a controlled manner.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
