### PR TITLE
Deploy the local service mirror only in flat mode

### DIFF
--- a/multicluster/charts/linkerd-multicluster/templates/local-service-mirror.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/local-service-mirror.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Values.gateway.enabled | default false) -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -165,3 +166,4 @@ spec:
     matchLabels:
       component: local-service-mirror
 {{- end}}
+{{end -}}


### PR DESCRIPTION
# Problem

We are currently deploying the **local-service-mirror** resources in Gateway mode, even though these resources are strictly related to federated services.

# Solution

Make the deployment of resources related to **local-service-mirror** conditional based on `gateway.enabled`. If `gateway.enabled` exists and is set to `true`, skip deploying these resources.

# Validation

1. **k3d-01 cluster:** Deploy the following application
```
apiVersion: v1
kind: Namespace
metadata:
  name: simple-app
  annotations:
    linkerd.io/inject: enabled
---
apiVersion: v1
kind: Service
metadata:
  name: simple-app-v1
  namespace: simple-app
spec:
  selector:
    app: simple-app-v1
    version: v1
  ports:
    - port: 80
      targetPort: 5678
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: simple-app-v1
  namespace: simple-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: simple-app-v1
      version: v1
  template:
    metadata:
      labels:
        app: simple-app-v1
        version: v1
    spec:
      containers:
        - name: http-app
          image: hashicorp/http-echo:latest
          args:
            - "-text=Simple App v1 - CLUSTER_NAME"
          ports:
            - containerPort: 5678
```
2. **k3d-02 cluster:** Deploy the following Namespace resource
```
apiVersion: v1
kind: Namespace
metadata:
  name: simple-app
  annotations:
    linkerd.io/inject: enabled
```
3. **k3d-01 cluster:** Install Linkerd multicluster with the following values
```
helm upgrade --install multicluster --version 2.18.1 --namespace linkerd-multicluster --create-namespace --set "gateway.enabled=true" --set "controllers[0].link.ref.name=k3d-02" ./Repositories/linkerd-enterprise-multicluster/
 ```
4. **k3d-02 cluster:** Install Linkerd multicluster with the following values
```
helm upgrade --install multicluster --version 2.18.1 --namespace linkerd-multicluster --create-namespace --set "gateway.enabled=true" --set "controllers[0].link.ref.name=k3d-01" ./Repositories/linkerd-enterprise-multicluster/
 ```
 5. **k3d-01 cluster:** Link to the k3d-02 cluster, and vice versa
```
linkerd multicluster link-gen --context=k3d-01 --cluster-name=k3d-01 --gateway=true --api-server-address=https://172.20.0.3:6443 | kubectl --context=k3d-02 apply -f -
linkerd multicluster link-gen --context=k3d-02 --cluster-name=k3d-02 --gateway=true --api-server-address=https://172.20.0.7:6443 | kubectl --context=k3d-01 apply -f -
```
6. **k3d-01 cluster:** Verify that the local-service-mirror deployment is absent
```
kubectl get pods --context=k3d-01 -n linkerd-multicluster 
NAME                                                         READY   STATUS    RESTARTS   AGE
controller-k3d-02-d7c58f459-z2gwx    2/2         Running    0                   30m
linkerd-gateway-55bc8c7df6-s44js       2/2         Running    0                   30m

kubectl get pods --context=k3d-02 -n linkerd-multicluster 
NAME                                                           READY   STATUS    RESTARTS   AGE
controller-k3d-01-68cf8f69b8-klpns      2/2         Running    0                   19m
linkerd-gateway-55bc8c7df6-dkb2g       2/2         Running    0                   27m
```
7. **k3d-01 cluster:** Add the mirror.linkerd.io/exported=true label to the simple-app-v1 service
```
kubectl label svc -n simple-app simple-app-v1 mirror.linkerd.io/exported=true
```
8. **k3d-02 cluster:** Validate the presence of the mirrored service
```
kubectl get svc -n simple-app
NAME                               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
simple-app-v1-k3d-01   ClusterIP   10.248.234.7   <none>              80/TCP      21m
```
9. **k3d-02 cluster:** Deploy the following traffic generator
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: traffic-v2
  namespace: simple-app
  labels:
    app: traffic-v2
spec:
  replicas: 1
  selector:
    matchLabels:
      app: traffic-v2
  template:
    metadata:
      labels:
        app: traffic-v2
    spec:
      containers:
      - name: traffic-v2
        image: curlimages/curl:latest 
        command: ["/bin/sh", "-c"]
        args:
        - |
          while true
          do 
            TIMESTAMP_SEND=$(date '+%Y-%m-%d %H:%M:%S')
            echo "$TIMESTAMP_SEND - Sending request to http://simple-app-v1-k3d-01.simple-app.svc.cluster.local:80"
            RESPONSE=$(curl -s http://simple-app-v1-k3d-01.simple-app.svc.cluster.local:80)
            TIMESTAMP_RESPONSE=$(date '+%Y-%m-%d %H:%M:%S')
            echo "$TIMESTAMP_RESPONSE - RESPONSE: $RESPONSE"
            sleep 0.001
          done
```
10. **k3d-02 cluster:** Check the logs and verify that the requests are successful
```
kubectl logs -n simple-app traffic-v2-65856dfcdb-vgr7f   -c traffic-v2
...
2025-10-14 20:27:53 - RESPONSE: Simple App v1 - CLUSTER_NAME
2025-10-14 20:27:53 - Sending request to http://simple-app-v1-k3d-01.simple-app.svc.cluster.local:80
```
