### PR TITLE
fix(helm): use parenthesized tracing guards

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -450,6 +450,6 @@ spec:
       - {{- include "partials.proxy.volumes.service-account-token" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if .Values.proxy.tracing.enable -}}
+      {{ if ((.Values.proxy.tracing).enable) -}}
       - {{- include "partials.proxy.volumes.podinfo" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -276,7 +276,7 @@ spec:
       - {{- include "partials.proxy.volumes.service-account-token" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{- if .Values.proxy.tracing.enable }}
+      {{- if ((.Values.proxy.tracing).enable) }}
       - {{- include "partials.proxy.volumes.podinfo" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{- end }}
 {{end -}}

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -187,7 +187,7 @@ spec:
       - {{- include "partials.proxy.volumes.service-account-token" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{if .Values.proxy.tracing.enable -}}
+      {{if ((.Values.proxy.tracing).enable) -}}
       - {{- include "partials.proxy.volumes.podinfo" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end }}
 ---


### PR DESCRIPTION
If upgrading linkerd to the latest edge without using the latest values.yaml, the helm chart could blow up with a nil deref. This adds guards that ensure proper defaulting.