### PR TITLE
fix(tracing): Add more guards and fallback to control plane tracing config

### DIFF
--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -52,7 +52,9 @@ controller:
     # -- Enables trace collection and export in the proxy
     enabled: false
     collector:
-      # -- The collector endpoint to send traces to. Required if tracing is enabled
+      # -- The collector endpoint to send traces to. Required if tracing is
+      # enabled. If this is unset and `proxy.tracing.collector.endpoint` is set,
+      # that endpoint will be re-used here.
       endpoint: ""
 # -- enabling this omits the NET_ADMIN capability in the PSP
 # and the proxy-init container when injecting the proxy;

--- a/charts/partials/templates/_trace.tpl
+++ b/charts/partials/templates/_trace.tpl
@@ -1,8 +1,11 @@
 {{ define "partials.linkerd.trace" -}}
 {{ if ((.Values.controller.tracing).enabled) -}}
-{{- if empty .Values.controller.tracing.collector.endpoint }}
-{{- fail "controller.tracing.collector.endpoint must be set if control plane tracing is enabled" }}
-{{- end }}
+{{- if (.Values.controller.tracing.collector).endpoint }}
 - -trace-collector={{.Values.controller.tracing.collector.endpoint}}
+{{- else if ((.Values.proxy.tracing).collector).endpoint }}
+- -trace-collector={{.Values.proxy.tracing.collector.endpoint}}
+{{- else }}
+{{- fail "controller.tracing.collector.endpoint or proxy.tracing.collector.endpoint must be set if control plane tracing is enabled" }}
+{{- end }}
 {{ end -}}
 {{- end }}


### PR DESCRIPTION
This adds more guards to the control plane tracing values. Additionally, this adds a fallback to re-use the proxy tracing endpoint if control plane tracing is enabled without an endpoint set.

See https://github.com/linkerd/linkerd2/pull/14636 for a similar fix.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
