### PR TITLE
added missing destination rbac rule for statefulsets

### DIFF
--- a/charts/linkerd-control-plane/templates/destination-rbac.yaml
+++ b/charts/linkerd-control-plane/templates/destination-rbac.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- with .Values.commonLabels }}{{ toYaml . | trim | nindent 4 }}{{- end }}
 rules:
 - apiGroups: ["apps"]
-  resources: ["replicasets"]
+  resources: ["replicasets", "statefulsets"]
   verbs: ["list", "get", "watch"]
 - apiGroups: ["batch"]
   resources: ["jobs"]


### PR DESCRIPTION
What is the issue?
When using Linkerd (Edge build 2025.10.*), the linkerd-destination component logs repeated warnings such as:

failed to retrieve resource from direct API call apps/v1, Kind=StatefulSet/: statefulsets.apps "" is forbidden:
User "system:serviceaccount:linkerd:linkerd-destination" cannot get resource "statefulsets" in API group "apps" in the namespace ""

This occurs for multiple workloads using StatefulSets (e.g., Elasticsearch, Redis, RabbitMQ).
The issue seems to stem from missing RBAC permissions for statefulsets in the linkerd-destination ClusterRole.

How can it be reproduced?
Deploy Linkerd Edge build 2025.10.2 (including CRDs and control plane).

Deploy workloads that use StatefulSets (for example, Redis or Elasticsearch).

Observe linkerd-destination logs in the linkerd namespace:
kubectl logs -n linkerd deploy/linkerd-destination

You’ll see permission errors similar to:

failed to retrieve resource from direct API call apps/v1, Kind=StatefulSet/... is forbidden

Logs, error output, etc
level=warning msg="failed to retrieve resource from direct API call apps/v1, Kind=StatefulSet/elastic-system/elasticsearch-es-default: statefulsets.apps "elasticsearch-es-default" is forbidden: User "system:serviceaccount:linkerd:linkerd-destination" cannot get resource "statefulsets" in API group "apps" in the namespace "elastic-system""

Image
output of linkerd check -o short
Image
Environment
Linkerd version: edge-2025.10.2

Possible solution
Add missing RBAC permissions for StatefulSets to the linkerd-destination ClusterRole:

apiGroups: ["apps"]
resources: ["replicasets", "statefulsets"]
verbs: ["list", "get", "watch"]