### PR TITLE
fix(tracing): traces are not exposing pod metadata

### DIFF
--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -450,6 +450,6 @@ spec:
       - {{- include "partials.proxy.volumes.service-account-token" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{ if ((.Values.proxy.tracing).enable) -}}
+      {{ if ((.Values.proxy.tracing).enabled) -}}
       - {{- include "partials.proxy.volumes.podinfo" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end }}

--- a/charts/linkerd-control-plane/templates/identity.yaml
+++ b/charts/linkerd-control-plane/templates/identity.yaml
@@ -276,7 +276,7 @@ spec:
       - {{- include "partials.proxy.volumes.service-account-token" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{- if ((.Values.proxy.tracing).enable) }}
+      {{- if ((.Values.proxy.tracing).enabled) }}
       - {{- include "partials.proxy.volumes.podinfo" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{- end }}
 {{end -}}

--- a/charts/linkerd-control-plane/templates/proxy-injector.yaml
+++ b/charts/linkerd-control-plane/templates/proxy-injector.yaml
@@ -187,7 +187,7 @@ spec:
       - {{- include "partials.proxy.volumes.service-account-token" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}
       - {{- include "partials.proxy.volumes.identity" . | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{if ((.Values.proxy.tracing).enable) -}}
+      {{if ((.Values.proxy.tracing).enabled) -}}
       - {{- include "partials.proxy.volumes.podinfo" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end }}
 ---

--- a/charts/partials/templates/_proxy.tpl
+++ b/charts/partials/templates/_proxy.tpl
@@ -320,7 +320,7 @@ lifecycle:
 volumeMounts:
 - mountPath: /var/run/linkerd/identity/end-entity
   name: linkerd-identity-end-entity
-{{- if .Values.proxy.tracing | default (dict) | dig "enable" false }}
+{{- if .Values.proxy.tracing | default (dict) | dig "enabled" false }}
 - mountPath: /var/run/linkerd/podinfo
   name: linkerd-podinfo
 {{- end }}

--- a/charts/patch/templates/patch.json
+++ b/charts/patch/templates/patch.json
@@ -103,7 +103,7 @@ structs.
       }
     }
   },
-  {{- if .Values.proxy.tracing | default (dict) | dig "enable" false }}
+  {{- if .Values.proxy.tracing | default (dict) | dig "enabled" false }}
   {
     "op": "add",
     "path": "{{$prefix}}/spec/volumes/-",

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -1203,6 +1203,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/end-entity
           name: linkerd-identity-end-entity
+        - mountPath: /var/run/linkerd/podinfo
+          name: linkerd-podinfo
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       initContainers:
@@ -1284,6 +1286,15 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      - name: linkerd-podinfo
+        downwardAPI:
+          items:
+            - path: labels
+              fieldRef:
+                fieldPath: metadata.labels
+            - path: annotations
+              fieldRef:
+                fieldPath: metadata.annotations
 ---
 ###
 ### Destination Controller Service
@@ -1615,6 +1626,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/end-entity
           name: linkerd-identity-end-entity
+        - mountPath: /var/run/linkerd/podinfo
+          name: linkerd-podinfo
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       - args:
@@ -1840,6 +1853,15 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      - name: linkerd-podinfo
+        downwardAPI:
+          items:
+            - path: labels
+              fieldRef:
+                fieldPath: metadata.labels
+            - path: annotations
+              fieldRef:
+                fieldPath: metadata.annotations
       
 ---
 ###
@@ -2161,6 +2183,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/linkerd/identity/end-entity
           name: linkerd-identity-end-entity
+        - mountPath: /var/run/linkerd/podinfo
+          name: linkerd-podinfo
         - mountPath: /var/run/secrets/tokens
           name: linkerd-identity-token
       - args:
@@ -2290,6 +2314,15 @@ spec:
       - emptyDir:
           medium: Memory
         name: linkerd-identity-end-entity
+      - name: linkerd-podinfo
+        downwardAPI:
+          items:
+            - path: labels
+              fieldRef:
+                fieldPath: metadata.labels
+            - path: annotations
+              fieldRef:
+                fieldPath: metadata.annotations
       
 ---
 kind: Service


### PR DESCRIPTION
The `linkerd-podinfo` volume wasn't being added to injected pods, thus forbidding traces to expose the pod's metadata.

The cause was that the linkerd-control-plane `values.yaml` file declared the entry `proxy.tracing.enabled` whereas the templates were using `proxy.tracing.enable`.