### PR TITLE
fix(tracing): Resync informer cache in root owner retries

### DIFF
--- a/controller/k8s/metadata_api.go
+++ b/controller/k8s/metadata_api.go
@@ -279,15 +279,7 @@ func (api *MetadataAPI) GetOwnerKindAndName(ctx context.Context, pod *corev1.Pod
 // Currently, this is limited to Jobs (parented by CronJobs) and ReplicaSets (parented by
 // Deployments, StatefulSets, argo Rollouts, etc.). This list may change in the future, but
 // is sufficient for now.
-var indexedParents = map[string]indexedParent{
-	"Job":        {Job, batchv1.SchemeGroupVersion.WithResource("jobs")},
-	"ReplicaSet": {RS, appsv1.SchemeGroupVersion.WithResource("replicasets")},
-}
-
-type indexedParent struct {
-	resource APIResource
-	gvr      schema.GroupVersionResource
-}
+var indexedParents = map[string]APIResource{"Job": Job, "ReplicaSet": RS}
 
 // GetRootOwnerKindAndName returns the resource's owner's type and metadata, using owner
 // references from the Kubernetes API. Parent refs are recursively traversed to find the
@@ -310,10 +302,10 @@ func (api *MetadataAPI) GetRootOwnerKindAndName(ctx context.Context, tm *metav1.
 		log.Warnf("parent ref has no kind: %v", parentRef)
 		return tm, om
 	}
-	indexedResource, ok := indexedParents[parentRef.Kind]
+	resource, ok := indexedParents[parentRef.Kind]
 	if ok {
 		getFromInformer := func() (*metav1.TypeMeta, *metav1.ObjectMeta, error) {
-			parent, err := api.getByNamespace(indexedResource.resource, om.Namespace, parentRef.Name)
+			parent, err := api.getByNamespace(resource, om.Namespace, parentRef.Name)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -328,20 +320,19 @@ func (api *MetadataAPI) GetRootOwnerKindAndName(ctx context.Context, tm *metav1.
 		if err == nil {
 			return parentTm, parentOm
 		}
-		log.Warnf("failed to retrieve %s from informer %s/%s: %s", parentRef.Kind, om.Namespace, parentRef.Name, err)
 		if retry {
-			parentFromApi, err := api.client.
-				Resource(indexedResource.gvr).
-				Namespace(om.Namespace).
-				Get(ctx, parentRef.Name, metav1.GetOptions{})
+			log.Warnf("failed to retrieve %s from informer %s/%s, resyncing informer cache", parentRef.Kind, om.Namespace, parentRef.Name)
+			// The proxy injnector runs very soon after a resource is created,
+			// which leaves a small possibility that the informer cache hasn't
+			// picked up the new resource yet. If that is the case, we force an
+			// informer resync to pick up the new resource.
+			api.Sync(nil)
+			parentTm, parentOm, err := getFromInformer()
 			if err == nil {
-				if parentFromApi.ObjectMeta.Namespace == "" {
-					parentFromApi.ObjectMeta.Namespace = om.Namespace
-				}
-				return api.GetRootOwnerKindAndName(ctx, &parentFromApi.TypeMeta, &parentFromApi.ObjectMeta, retry)
+				return parentTm, parentOm
 			}
-			log.Warnf("failed to retrieve %s from direct API call %s/%s: %s", parentRef.Kind, om.Namespace, parentRef.Name, err)
 		}
+		log.Warnf("failed to retrieve %s from informer %s/%s: %s", parentRef.Kind, om.Namespace, parentRef.Name, err)
 		return &parentType, &metav1.ObjectMeta{Name: parentRef.Name, Namespace: om.Namespace}
 	}
 


### PR DESCRIPTION
Companion to #14682

The previous retry logic relied on direct metadata API calls in cases where the informer cache hadn't updated when injecting a pod.

This updates the retry logic to force a refresh of the informer cache instead of going to the metadata API.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
