### PR TITLE
test(cni): update k8s and calico

### DIFF
--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -313,11 +313,7 @@ start_test() {
       config=("$name" "${config[@]}" --no-lb --k3s-arg --cluster-domain=custom.domain --k3s-arg '--disable=servicelb,traefik@server:0' --image "$k8s_version_max")
       ;;
     cni-calico-deep)
-      # This requires k8s v1.27.6-k3s1 because after that Calico won't work.
-      # We have to use a config file because that version can't be set via the
-      # --image flag.
-      # See https://github.com/k3d-io/k3d/issues/1375
-      config=("$name" "${config[@]}" --no-lb --k3s-arg --write-kubeconfig-mode=644 --k3s-arg --flannel-backend=none --k3s-arg --cluster-cidr=192.168.0.0/16 --k3s-arg '--disable=servicelb,traefik@server:0' --config "$testdir"/deep/calico-k3d.yml)
+      config=("$name" "${config[@]}" --no-lb --k3s-arg --write-kubeconfig-mode=644 --k3s-arg --flannel-backend=none --k3s-arg --cluster-cidr=192.168.0.0/16 --k3s-arg '--disable=servicelb,traefik@server:0')
       ;;
     multicluster)
       config=("${config[@]}" --network multicluster-test --image "$k8s_version_max")

--- a/test/integration/deep/calico-k3d.yml
+++ b/test/integration/deep/calico-k3d.yml
@@ -1,5 +1,0 @@
-# Used by the cni-calico-deep integration test, which requires k8s v1.27.6-k3s1
-# See https://github.com/k3d-io/k3d/issues/1375
-apiVersion: k3d.io/v1alpha4
-kind: Simple
-image: rancher/k3s:v1.27.6-k3s1


### PR DESCRIPTION
We were stuck on k8s v1.27 because of k3d-io/k3d#1375, which is no longer an issue.

This change removes that constraint and installs the latest version of Calico using the tigera-operator.