### PR TITLE
fix(destination): properly discover hostports in native sidecars

### DIFF
--- a/controller/api/destination/watcher/k8s.go
+++ b/controller/api/destination/watcher/k8s.go
@@ -145,7 +145,7 @@ func InitializeIndexers(k8sAPI *k8s.API) error {
 		// each of its containers' ports that exposes a host port, add
 		// that hostIP:hostPort endpoint to the indexer.
 		addrs := []string{}
-		for _, c := range pod.Spec.Containers {
+		for _, c := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 			for _, p := range c.Ports {
 				if p.HostPort == 0 {
 					continue


### PR DESCRIPTION
(Extracted from #14566)

Those types of ports were getting ignored in `getProfile` responses. A new test case was added that clarifies an example, that wouldn't pass before this fix.