### PR TITLE
fix(destination): properly deal with native sidecar port opacity in getProfile

### DIFF
--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -794,7 +794,7 @@ func GetAnnotatedOpaquePorts(pod *corev1.Pod, defaultPorts map[uint32]struct{}) 
 		return defaultPorts
 	}
 	opaquePorts := make(map[uint32]struct{})
-	namedPorts := util.GetNamedPorts(pod.Spec.Containers)
+	namedPorts := util.GetNamedPorts(append(pod.Spec.InitContainers, pod.Spec.Containers...))
 	if annotation != "" {
 		for _, pr := range util.ParseContainerOpaquePorts(annotation, namedPorts) {
 			for _, port := range pr.Ports() {


### PR DESCRIPTION
(Extracted from #14566)

When hitting pods directly at their their IPs, ports in native sidecars that were marked as opaque via the `config.linkerd.io/opaque-ports` annotation, weren't really being marked as opaque.

More concretely, the issue layed in the getProfile API, that was forgoing init containers when iterating over containers in this particular case.

Endpoint profile translator tests got expanded, testing for opaque ports in both init and regular containers.