### PR TITLE
fix(destination): properly discover native sidecar ports

### DIFF
--- a/controller/api/destination/test_util.go
+++ b/controller/api/destination/test_util.go
@@ -631,7 +631,7 @@ spec:
   podSelector:
     matchLabels:
       app: native
-  port: 80
+  port: http
   proxyProtocol: opaque`,
 	}
 

--- a/controller/api/destination/watcher/endpoints_watcher.go
+++ b/controller/api/destination/watcher/endpoints_watcher.go
@@ -1363,7 +1363,7 @@ func (pp *portPublisher) isAddressSelected(address Address, server *v1beta3.Serv
 				return true
 			}
 		case intstr.String:
-			for _, c := range address.Pod.Spec.Containers {
+			for _, c := range append(address.Pod.Spec.InitContainers, address.Pod.Spec.Containers...) {
 				for _, p := range c.Ports {
 					if p.ContainerPort == int32(address.Port) && p.Name == server.Spec.Port.StrVal {
 						return true
@@ -1550,7 +1550,7 @@ func SetToServerProtocol(k8sAPI *k8s.API, address *Address, log *logging.Entry) 
 					portMatch = true
 				}
 			case intstr.String:
-				for _, c := range address.Pod.Spec.Containers {
+				for _, c := range append(address.Pod.Spec.InitContainers, address.Pod.Spec.Containers...) {
 					for _, p := range c.Ports {
 						if (p.ContainerPort == int32(address.Port) || p.HostPort == int32(address.Port)) &&
 							p.Name == server.Spec.Port.StrVal {


### PR DESCRIPTION
(Extracted from #14566)

The `Get` API wasn't surfacing ports marked as opaque in Servers, when:

1. ports belonged to a native sidecar (inside an init container)
2. port was referred to by name

Also changed a test fixture to use port name instead of number in order to test this issue.