### PR TITLE
chore(deps): bump proxy-init(v2.4.4), linkerd-cni(v1.6.5) and validator(0.1.5)

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -28,7 +28,7 @@ RUN --mount=type=secret,id=github \
 RUN echo "$LINKERD2_PROXY_VERSION" > proxy-version
 ARG LINKERD_AWAIT_VERSION=v0.3.1
 RUN bin/scurl -o linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
-ARG LINKERD_VALIDATOR_VERSION=v0.1.4
+ARG LINKERD_VALIDATOR_VERSION=v0.1.5
 RUN bin/scurl -O https://github.com/linkerd/linkerd2-proxy-init/releases/download/validator%2F${LINKERD_VALIDATOR_VERSION}/linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}-linux.tgz
 RUN tar -zxvf linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}-linux.tgz && mv linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}-linux/linkerd-network-validator .
 
@@ -48,7 +48,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/proxy-identity 
 FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v48-go AS proxy-init
 WORKDIR /build
 ARG PROXY_INIT_REPO="linkerd/linkerd2-proxy-init"
-ARG PROXY_INIT_REF="proxy-init/v2.4.3"
+ARG PROXY_INIT_REF="proxy-init/v2.4.4"
 RUN --mount=type=secret,id=github \
     export GITHUB_TOKEN_FILE=/run/secrets/github; \
     git init --initial-branch=main . && \

--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -69,7 +69,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.6.4"
+  version: "v1.6.5"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/testdata/install-cni-plugin_default.golden
+++ b/cli/cmd/testdata/install-cni-plugin_default.golden
@@ -117,7 +117,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.5
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
+++ b/cli/cmd/testdata/install-cni-plugin_skip_ports.golden
@@ -118,7 +118,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.5
         imagePullPolicy: 
         env:
         - name: DEST_CNI_NET_DIR

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -110,7 +110,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.5
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR

--- a/pkg/healthcheck/healthcheck_test.go
+++ b/pkg/healthcheck/healthcheck_test.go
@@ -2358,7 +2358,7 @@ spec:
       serviceAccountName: linkerd-cni
       containers:
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.4
+        image: cr.l5d.io/linkerd/cni-plugin:v1.6.5
         env:
         - name: DEST_CNI_NET_DIR
           valueFrom:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ import (
 // DO NOT EDIT
 var Version = undefinedVersion
 
-var LinkerdCNIVersion = "v1.6.4"
+var LinkerdCNIVersion = "v1.6.5"
 
 const (
 	// undefinedVersion should take the form `channel-version` to conform to


### PR DESCRIPTION
- https://github.com/linkerd/linkerd2-proxy-init/releases/tag/proxy-init%2Fv2.4.4
- https://github.com/linkerd/linkerd2-proxy-init/releases/tag/cni-plugin%2Fv1.6.5
- https://github.com/linkerd/linkerd2-proxy-init/releases/tag/validator%2Fv0.1.5