### PR TITLE
fix: Synthetic proxy responses should contain an identifying header

### DIFF
--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/linkerd/linkerd2/pkg/protohttp"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -61,10 +62,12 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h *handler) servePing(w http.ResponseWriter) {
+	protohttp.SetViaHeader(w)
 	w.Write([]byte("pong\n"))
 }
 
 func (h *handler) serveReady(w http.ResponseWriter) {
+	protohttp.SetViaHeader(w)
 	if *h.ready {
 		w.Write([]byte("ok\n"))
 	} else {

--- a/pkg/protohttp/protohttp_test.go
+++ b/pkg/protohttp/protohttp_test.go
@@ -433,3 +433,46 @@ func assertResponseHasProtobufContentType(t *testing.T, responseWriter *stubResp
 		t.Fatalf("Expected content-type to be [%s], but got [%s]", expectedContentType, actualContentType)
 	}
 }
+
+func TestSetViaHeader(t *testing.T) {
+	t.Run("Sets Via header correctly", func(t *testing.T) {
+		responseWriter := newStubResponseWriter()
+		SetViaHeader(responseWriter)
+
+		actualVia := responseWriter.headers.Get(ViaHeaderName)
+		if actualVia != ViaHeaderValue {
+			t.Fatalf("Expected Via header to be [%s], but got [%s]", ViaHeaderValue, actualVia)
+		}
+	})
+}
+
+func TestWriteErrorToHTTPResponseSetsViaHeader(t *testing.T) {
+	t.Run("WriteErrorToHTTPResponse sets Via header", func(t *testing.T) {
+		responseWriter := newStubResponseWriter()
+		genericError := errors.New("test error")
+
+		WriteErrorToHTTPResponse(responseWriter, genericError)
+
+		actualVia := responseWriter.headers.Get(ViaHeaderName)
+		if actualVia != ViaHeaderValue {
+			t.Fatalf("Expected Via header to be [%s], but got [%s]", ViaHeaderValue, actualVia)
+		}
+	})
+}
+
+func TestWriteProtoToHTTPResponseSetsViaHeader(t *testing.T) {
+	t.Run("WriteProtoToHTTPResponse sets Via header", func(t *testing.T) {
+		responseWriter := newStubResponseWriter()
+		protoMessage := &metricsPb.Pod{Name: "test"}
+
+		err := WriteProtoToHTTPResponse(responseWriter, protoMessage)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		actualVia := responseWriter.headers.Get(ViaHeaderName)
+		if actualVia != ViaHeaderValue {
+			t.Fatalf("Expected Via header to be [%s], but got [%s]", ViaHeaderValue, actualVia)
+		}
+	})
+}

--- a/web/srv/server.go
+++ b/web/srv/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/linkerd/linkerd2/pkg/healthcheck"
 	"github.com/linkerd/linkerd2/pkg/k8s"
 	"github.com/linkerd/linkerd2/pkg/prometheus"
+	"github.com/linkerd/linkerd2/pkg/protohttp"
 	vizPb "github.com/linkerd/linkerd2/viz/metrics-api/gen/viz"
 	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
@@ -64,6 +65,7 @@ type (
 
 // this is called by the HTTP server to actually respond to a request
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	protohttp.SetViaHeader(w)
 	if !s.reHost.MatchString(req.Host) {
 		err := fmt.Sprintf(`It appears that you are trying to reach this service with a host of '%s'.
 This does not match /%s/ and has been denied for security reasons.


### PR DESCRIPTION
## Summary
This PR fixes #2295

## Changes
- `pkg/admin/admin.go`
- `pkg/protohttp/protohttp.go`
- `pkg/protohttp/protohttp_test.go`
- `web/srv/reverse_proxy.go`
- `web/srv/server.go`
