### PR TITLE
Upgrade gateway-api to support GatewayAPI v1.3+ CORS filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 lto = "thin"
 
 [workspace.dependencies]
-gateway-api = "0.16"
+gateway-api = "0.19"
 http = "1"
 hyper = "1"
 k8s-openapi = { version = "0.25", features = ["v1_33"] }

--- a/policy-controller/k8s/index/src/inbound/index/http.rs
+++ b/policy-controller/k8s/index/src/inbound/index/http.rs
@@ -138,6 +138,12 @@ fn try_gateway_filter(filter: gateway::HTTPRouteRulesFilters) -> Result<Filter> 
     if let Some(_extension_ref) = filter.extension_ref {
         bail!("ExtensionRef filter is not supported")
     }
+    if let Some(_cors) = filter.cors {
+        bail!("CORS filter is not supported")
+    }
+    if let Some(_external_auth) = filter.external_auth {
+        bail!("ExternalAuth filter is not supported")
+    }
     bail!("No filter specified");
 }
 

--- a/policy-controller/k8s/index/src/outbound/index/http.rs
+++ b/policy-controller/k8s/index/src/outbound/index/http.rs
@@ -338,6 +338,12 @@ pub(crate) fn convert_gateway_filter(filter: gateway::HTTPRouteRulesFilters) -> 
     if let Some(_extension_ref) = filter.extension_ref {
         bail!("ExtensionRef filter is not supported")
     }
+    if let Some(_cors) = filter.cors {
+        bail!("CORS filter is not supported")
+    }
+    if let Some(_external_auth) = filter.external_auth {
+        bail!("ExternalAuth filter is not supported")
+    }
     bail!("unknown filter")
 }
 


### PR DESCRIPTION
## Problem

The policy controller was using gateway-api crate v0.16, which only supports GatewayAPI v1.2.1. When users deployed HTTPRoutes containing CORS filters (introduced in GatewayAPI v1.3), the policy controller failed to deserialize these objects, causing:

1. Continuous retry loops leading to high CPU consumption
2. Deserialization errors in logs: `unknown variant 'CORS', expected one of 'RequestHeaderModifier', 'ResponseHeaderModifier'...`
3. Admission webhook rejecting HTTPRoutes with CORS filters

## Solution

- Upgrade the `gateway-api` dependency from v0.16 to v0.19, which supports GatewayAPI v1.4.0
- Add explicit handling for new filter types (CORS and ExternalAuth) in the inbound and outbound HTTP route indexers

## Validation

The fix allows HTTPRoute objects with CORS filters to be properly deserialized and processed, eliminating:
- ✅ The deserialization errors in logs
- ✅ The high CPU consumption from retry loops  
- ✅ The admission webhook rejections for routes with CORS filters

## Changes

- `Cargo.toml`: Upgrade gateway-api from 0.16 to 0.19
- `policy-controller/k8s/index/src/inbound/index/http.rs`: Add CORS and ExternalAuth filter handling
- `policy-controller/k8s/index/src/outbound/index/http.rs`: Add CORS and ExternalAuth filter handling

Fixes #14741