### PR TITLE
fix(policy-tests): adapt curl library for native sidecar proxies

### DIFF
--- a/policy-test/src/curl.rs
+++ b/policy-test/src/curl.rs
@@ -338,12 +338,17 @@ impl Running {
             |pod: Option<&k8s::Pod>| -> bool {
                 if let Some(pod) = pod {
                     if let Some(status) = pod.status.as_ref() {
-                        return status.init_container_statuses.iter().flatten().all(|init| {
-                            init.state
-                                .as_ref()
-                                .map(|s| s.terminated.is_some())
-                                .unwrap_or(false)
-                        });
+                        return status
+                            .init_container_statuses
+                            .iter()
+                            .flatten()
+                            .filter(|init| init.name != "linkerd-proxy")
+                            .all(|init| {
+                                init.state
+                                    .as_ref()
+                                    .map(|s| s.terminated.is_some())
+                                    .unwrap_or(false)
+                            });
                     }
                 }
                 false


### PR DESCRIPTION
(Extracted from #14566)

Fixed the curl library logic so that when blocking on the init container for termination, it blocks on init containers different than the proxy.