### PR TITLE
fix(tests): adapt injection integration tests to native sidecars

### DIFF
--- a/testutil/inject.go
+++ b/testutil/inject.go
@@ -49,8 +49,8 @@ func PatchDeploy(in string, name string, annotations map[string]string) (string,
 }
 
 // GetProxyContainer get the proxy containers
-func GetProxyContainer(containers []v1.Container) *v1.Container {
-	for _, c := range containers {
+func GetProxyContainer(spec v1.PodSpec) *v1.Container {
+	for _, c := range append(spec.InitContainers, spec.Containers...) {
 		container := c
 		if container.Name == k8s.ProxyContainerName {
 			return &container


### PR DESCRIPTION
(Followup to #14566)

This refactors `./test/integration/install/inject/inject_test.go` and its dependent libraries so that it accounts for proxies injected as native sidecars.

Note that the test `TestInjectAutoAnnotationPermutations` has been removed because it was redundant with coverage provided by other tests.