### PR TITLE
chore(policy-controller): remove unused `hyper` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,6 @@ dependencies = [
  "drain",
  "futures",
  "http",
- "hyper",
  "linkerd-policy-controller-core",
  "linkerd2-proxy-api",
  "maplit",

--- a/policy-controller/grpc/Cargo.toml
+++ b/policy-controller/grpc/Cargo.toml
@@ -11,7 +11,6 @@ async-trait = "0.1"
 drain = "0.2"
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
-hyper = { workspace = true, features = ["http2", "server"] }
 maplit = "1"
 prometheus-client = { workspace = true }
 prost-types = "0.14"


### PR DESCRIPTION
i noticed while investigating something that
`linerd-policy-controller-grpc` included a dependency upon `hyper` that
is not used. this commit removes it.

Signed-off-by: katelyn martin <kate@buoyant.io>
