### PR TITLE
nit(policy-controller): replace extern crate directive

### DIFF
--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -1,9 +1,7 @@
-extern crate http as http_crate;
-
 use crate::metrics::{self, GrpcServerMetricsFamily, GrpcServerRPCMetrics};
 use crate::workload;
+use ::http::uri::Authority;
 use futures::{prelude::*, StreamExt};
-use http_crate::uri::Authority;
 use linkerd2_proxy_api::{
     self as api, destination,
     meta::{metadata, Metadata, Resource},


### PR DESCRIPTION
in the policy controller we have a module named `http` which conflicts
with a dependency of the same name.

instead of relying on an `extern crate` directive to alias this
dependency, which is no longer idiomatic in modern rust code, we can
rely on an absolute path in a `use` directive.

Signed-off-by: katelyn martin <kate@buoyant.io>
