### PR TITLE
charts: make honorTimestamps configurable for linkerd-proxy PodMonitor

### DIFF
--- a/charts/linkerd-control-plane/templates/podmonitor.yaml
+++ b/charts/linkerd-control-plane/templates/podmonitor.yaml
@@ -22,6 +22,9 @@ spec:
   podMetricsEndpoints:
     - interval: {{ $podMonitor.scrapeInterval }}
       scrapeTimeout: {{ $podMonitor.scrapeTimeout }}
+      {{- if not (kindIs "invalid" $podMonitor.controller.honorTimestamps) }}
+      honorTimestamps: {{ $podMonitor.controller.honorTimestamps }}
+      {{- end }}
       relabelings:
         - sourceLabels:
             - __meta_kubernetes_pod_container_port_name
@@ -60,6 +63,9 @@ spec:
   podMetricsEndpoints:
     - interval: {{ $podMonitor.scrapeInterval }}
       scrapeTimeout: {{ $podMonitor.scrapeTimeout }}
+      {{- if not (kindIs "invalid" $podMonitor.serviceMirror.honorTimestamps) }}
+      honorTimestamps: {{ $podMonitor.serviceMirror.honorTimestamps }}
+      {{- end }}
       relabelings:
         - sourceLabels:
             - __meta_kubernetes_pod_label_linkerd_io_control_plane_component
@@ -99,6 +105,9 @@ spec:
   podMetricsEndpoints:
     - interval: {{ $podMonitor.scrapeInterval }}
       scrapeTimeout: {{ $podMonitor.scrapeTimeout }}
+      {{- if not (kindIs "invalid" $podMonitor.proxy.honorTimestamps) }}
+      honorTimestamps: {{ $podMonitor.proxy.honorTimestamps }}
+      {{- end }}
       relabelings:
         - sourceLabels:
             - __meta_kubernetes_pod_container_name

--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -722,12 +722,22 @@ podMonitor:
       matchNames:
         - {{ .Release.Namespace }}
         - linkerd-viz
+    # -- Sets honorTimestamps for the control-plane PodMonitor endpoint. When set to false
+    # Prometheus uses scrape time instead of exporter-provided timestamps.
+    honorTimestamps: false
   serviceMirror:
     # -- Enables the creation of PodMonitor for the Service Mirror component
     enabled: true
+    # -- Sets honorTimestamps for the Service Mirror PodMonitor endpoint. When set to false,
+    # Prometheus uses scrape time instead of exporter-provided timestamps.
+    honorTimestamps: false
   proxy:
     # -- Enables the creation of PodMonitor for the data-plane
     enabled: true
+    # -- Sets honorTimestamps for the proxy PodMonitor endpoint. When set to false,
+    # Prometheus uses scrape time instead of exporter-provided timestamps,
+    # preventing duplicate timestamp drops in clusters with frequent pod restarts.
+    honorTimestamps: false
 
 
 # Egress related configuration

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_gid_output.golden
+++ b/cli/cmd/testdata/install_gid_output.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -657,6 +657,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -664,10 +665,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -657,6 +657,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -664,10 +665,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -561,6 +561,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -568,10 +569,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -607,6 +607,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -614,10 +615,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -634,6 +634,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -641,10 +642,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha_with_gid.golden
@@ -634,6 +634,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -641,10 +642,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -638,6 +638,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -645,10 +646,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -629,6 +629,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -636,10 +637,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_tracing.golden
+++ b/cli/cmd/testdata/install_tracing.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -630,6 +630,7 @@ data:
     podMonitor:
       controller:
         enabled: true
+        honorTimestamps: false
         namespaceSelector: |
           matchNames:
             - {{ .Release.Namespace }}
@@ -637,10 +638,12 @@ data:
       enabled: false
       proxy:
         enabled: true
+        honorTimestamps: false
       scrapeInterval: 10s
       scrapeTimeout: 10s
       serviceMirror:
         enabled: true
+        honorTimestamps: false
     policyController:
       logLevel: info
       probeNetworks:

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -265,11 +265,13 @@ type (
 	PodMonitorController struct {
 		Enabled           bool   `json:"enabled"`
 		NamespaceSelector string `json:"namespaceSelector"`
+		HonorTimestamps   *bool  `json:"honorTimestamps,omitempty"`
 	}
 
 	// PodMonitorComponent contains the fields to configure the Prometheus Operator `PodMonitor` for other components
 	PodMonitorComponent struct {
-		Enabled bool `json:"enabled"`
+		Enabled         bool  `json:"enabled"`
+		HonorTimestamps *bool `json:"honorTimestamps,omitempty"`
 	}
 
 	// PolicyController contains the fields to configure the policy controller container

--- a/pkg/charts/linkerd2/values_test.go
+++ b/pkg/charts/linkerd2/values_test.go
@@ -87,9 +87,10 @@ func TestNewValues(t *testing.T) {
   - {{ .Release.Namespace }}
   - linkerd-viz
 `,
+				HonorTimestamps: func() *bool { b := false; return &b }(),
 			},
-			ServiceMirror: &PodMonitorComponent{Enabled: true},
-			Proxy:         &PodMonitorComponent{Enabled: true},
+			ServiceMirror: &PodMonitorComponent{Enabled: true, HonorTimestamps: func() *bool { b := false; return &b }()},
+			Proxy:         &PodMonitorComponent{Enabled: true, HonorTimestamps: func() *bool { b := false; return &b }()},
 		},
 		DestinationController: &DestinationController{
 			MeshedHttp2ClientProtobuf: map[string]interface{}{


### PR DESCRIPTION
When scraping linkerd-proxy metrics with Prometheus, samples are sometimes dropped due to duplicate timestamps with different values,  producing warnings like:

Error on ingesting samples with different value but same timestamp  scrape_pool=podMonitor/linkerd/linkerd-proxy

This is especially common in large clusters with frequent pod restarts and short scrape intervals, causing operational noise and alert fatigue. Add an optional `honorTimestamps` field to the `proxy` and `serviceMirror` PodMonitor endpoints in the linkerd-control-plane Helm chart. When set to `false`, Prometheus uses the scrape time instead of exporter-provided timestamps, preventing duplicate timestamp drops while keeping backward compatibility for users who do not set the field.

Usage:
``` 
  podMonitor:
    proxy:
      honorTimestamps: false
    serviceMirror:
      honorTimestamps: false
``` 
Existing behavior is preserved when the field is not configured.

Fixes #14905

Signed-off-by:  bezarsnba@gmail.com