### PR TITLE
fix(policy): skip admission validation for Gateway routes with unsupported fields

### DIFF
--- a/policy-controller/runtime/src/admission.rs
+++ b/policy-controller/runtime/src/admission.rs
@@ -11,7 +11,10 @@ use futures::future;
 use http_body_util::BodyExt;
 use hyper::{http, Request, Response};
 use k8s_openapi::api::core::v1::{Namespace, ServiceAccount};
-use kube::{core::DynamicObject, Resource, ResourceExt};
+use kube::{
+    core::{DeserializeGuard, DynamicObject},
+    Resource, ResourceExt,
+};
 use linkerd_policy_controller_k8s_api::gateway;
 use linkerd_policy_controller_k8s_index::{self as index, outbound::index as outbound_index};
 use serde::de::DeserializeOwned;
@@ -138,19 +141,39 @@ impl Admission {
         }
 
         if is_kind::<gateway::HTTPRoute>(&req) {
-            return self.admit_spec::<gateway::HTTPRouteSpec>(req).await;
+            return self
+                .admit_guarded_resource::<gateway::HTTPRoute, gateway::HTTPRouteSpec, _>(
+                    req,
+                    |route| route.spec,
+                )
+                .await;
         }
 
         if is_kind::<gateway::GRPCRoute>(&req) {
-            return self.admit_spec::<gateway::GRPCRouteSpec>(req).await;
+            return self
+                .admit_guarded_resource::<gateway::GRPCRoute, gateway::GRPCRouteSpec, _>(
+                    req,
+                    |route| route.spec,
+                )
+                .await;
         }
 
         if is_kind::<gateway::TLSRoute>(&req) {
-            return self.admit_spec::<gateway::TLSRouteSpec>(req).await;
+            return self
+                .admit_guarded_resource::<gateway::TLSRoute, gateway::TLSRouteSpec, _>(
+                    req,
+                    |route| route.spec,
+                )
+                .await;
         }
 
         if is_kind::<gateway::TCPRoute>(&req) {
-            return self.admit_spec::<gateway::TCPRouteSpec>(req).await;
+            return self
+                .admit_guarded_resource::<gateway::TCPRoute, gateway::TCPRouteSpec, _>(
+                    req,
+                    |route| route.spec,
+                )
+                .await;
         }
 
         if is_kind::<HttpLocalRateLimitPolicy>(&req) {
@@ -184,6 +207,56 @@ impl Admission {
         let annotations = obj.annotations();
 
         if let Err(error) = self.validate(&ns, &name, annotations, spec).await {
+            info!(%error, %ns, %name, %kind, "Denied");
+            return rsp.deny(error);
+        }
+
+        rsp
+    }
+
+    async fn admit_guarded_resource<R, T, F>(
+        self,
+        req: AdmissionRequest,
+        get_spec: F,
+    ) -> AdmissionResponse
+    where
+        R: DeserializeOwned + Resource + ResourceExt,
+        F: FnOnce(R) -> T,
+        Self: Validate<T>,
+    {
+        let rsp = AdmissionResponse::from(&req);
+
+        let kind = req.kind.kind.clone();
+        let obj = match parse_resource::<R>(req) {
+            Ok(obj) => obj,
+            Err(error) => {
+                info!(%error, "Failed to parse {} resource", kind);
+                return rsp.deny(error);
+            }
+        };
+
+        let obj = match obj.0 {
+            Ok(obj) => obj,
+            Err(error) => {
+                let ns = error.metadata.namespace.clone().unwrap_or_default();
+                let name = error.metadata.name.clone().unwrap_or_default();
+                info!(
+                    error = %error,
+                    %ns,
+                    %name,
+                    %kind,
+                    "Skipping validation for resource with unsupported fields"
+                );
+                return rsp;
+            }
+        };
+
+        let ns = obj.namespace().unwrap_or_default();
+        let name = obj.name_any();
+        let annotations = obj.annotations().clone();
+        let spec = get_spec(obj);
+
+        if let Err(error) = self.validate(&ns, &name, &annotations, spec).await {
             info!(%error, %ns, %name, %kind, "Denied");
             return rsp.deny(error);
         }
@@ -226,6 +299,17 @@ fn parse_spec<T: DeserializeOwned>(req: AdmissionRequest) -> Result<(DynamicObje
     };
 
     Ok((obj, spec))
+}
+
+fn parse_resource<R>(req: AdmissionRequest) -> Result<DeserializeGuard<R>>
+where
+    R: DeserializeOwned + Resource,
+{
+    let obj = req
+        .object
+        .ok_or_else(|| anyhow!("admission request missing 'object"))?;
+
+    Ok(obj.try_parse::<DeserializeGuard<R>>()?)
 }
 
 #[async_trait::async_trait]
@@ -824,5 +908,60 @@ impl Validate<RateLimitPolicySpec> for Admission {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn accepts_gateway_http_route_with_unsupported_filter() {
+        let review: Review = serde_json::from_value(json!({
+            "apiVersion": "admission.k8s.io/v1",
+            "kind": "AdmissionReview",
+            "request": {
+                "uid": "test-uid",
+                "kind": {
+                    "group": "gateway.networking.k8s.io",
+                    "version": "v1",
+                    "kind": "HTTPRoute"
+                },
+                "resource": {
+                    "group": "gateway.networking.k8s.io",
+                    "version": "v1",
+                    "resource": "httproutes"
+                },
+                "name": "test-route",
+                "namespace": "test-ns",
+                "operation": "CREATE",
+                "userInfo": {
+                    "username": "test-user",
+                    "groups": []
+                },
+                "object": {
+                    "apiVersion": "gateway.networking.k8s.io/v1",
+                    "kind": "HTTPRoute",
+                    "metadata": {
+                        "name": "test-route",
+                        "namespace": "test-ns"
+                    },
+                    "spec": {
+                        "rules": [{
+                            "filters": [{
+                                "type": "CORS"
+                            }]
+                        }]
+                    }
+                }
+            }
+        }))
+        .expect("admission review must parse");
+
+        let req: AdmissionRequest = review.try_into().expect("request must parse");
+        let rsp = Admission::new().admit(req).await;
+
+        assert!(rsp.allowed, "unsupported filters should be admitted");
     }
 }

--- a/policy-controller/runtime/src/admission.rs
+++ b/policy-controller/runtime/src/admission.rs
@@ -38,6 +38,13 @@ type AdmissionReview = kube::core::admission::AdmissionReview<DynamicObject>;
 
 #[async_trait::async_trait]
 trait Validate<T> {
+    // If true, parse failures are admitted with a warning instead of denied.
+    // Used for Gateway API types, where interoperability with other controllers
+    // takes precedence over strict schema enforcement.
+    fn lenient() -> bool {
+        false
+    }
+
     async fn validate(
         self,
         ns: &str,
@@ -174,6 +181,10 @@ impl Admission {
         let (obj, spec) = match parse_spec::<T>(req) {
             Ok(spec) => spec,
             Err(error) => {
+                if <Self as Validate<T>>::lenient() {
+                    warn!(%error, "Failed to parse {} spec; admitting anyway", kind);
+                    return rsp;
+                }
                 info!(%error, "Failed to parse {} spec", kind);
                 return rsp.deny(error);
             }
@@ -589,6 +600,10 @@ fn validate_grpc_backend_if_service(br: &gateway::GRPCRouteRulesBackendRefs) -> 
 
 #[async_trait::async_trait]
 impl Validate<gateway::HTTPRouteSpec> for Admission {
+    fn lenient() -> bool {
+        true
+    }
+
     async fn validate(
         self,
         _ns: &str,
@@ -655,6 +670,10 @@ impl Validate<gateway::HTTPRouteSpec> for Admission {
 
 #[async_trait::async_trait]
 impl Validate<gateway::GRPCRouteSpec> for Admission {
+    fn lenient() -> bool {
+        true
+    }
+
     async fn validate(
         self,
         _ns: &str,
@@ -723,6 +742,10 @@ impl Validate<gateway::GRPCRouteSpec> for Admission {
 
 #[async_trait::async_trait]
 impl Validate<gateway::TLSRouteSpec> for Admission {
+    fn lenient() -> bool {
+        true
+    }
+
     async fn validate(
         self,
         _ns: &str,
@@ -748,6 +771,10 @@ impl Validate<gateway::TLSRouteSpec> for Admission {
 
 #[async_trait::async_trait]
 impl Validate<gateway::TCPRouteSpec> for Admission {
+    fn lenient() -> bool {
+        true
+    }
+
     async fn validate(
         self,
         _ns: &str,

--- a/policy-controller/runtime/src/admission.rs
+++ b/policy-controller/runtime/src/admission.rs
@@ -11,10 +11,7 @@ use futures::future;
 use http_body_util::BodyExt;
 use hyper::{http, Request, Response};
 use k8s_openapi::api::core::v1::{Namespace, ServiceAccount};
-use kube::{
-    core::{DeserializeGuard, DynamicObject},
-    Resource, ResourceExt,
-};
+use kube::{core::DynamicObject, Resource, ResourceExt};
 use linkerd_policy_controller_k8s_api::gateway;
 use linkerd_policy_controller_k8s_index::{self as index, outbound::index as outbound_index};
 use serde::de::DeserializeOwned;
@@ -141,39 +138,19 @@ impl Admission {
         }
 
         if is_kind::<gateway::HTTPRoute>(&req) {
-            return self
-                .admit_guarded_resource::<gateway::HTTPRoute, gateway::HTTPRouteSpec, _>(
-                    req,
-                    |route| route.spec,
-                )
-                .await;
+            return self.admit_spec::<gateway::HTTPRouteSpec>(req).await;
         }
 
         if is_kind::<gateway::GRPCRoute>(&req) {
-            return self
-                .admit_guarded_resource::<gateway::GRPCRoute, gateway::GRPCRouteSpec, _>(
-                    req,
-                    |route| route.spec,
-                )
-                .await;
+            return self.admit_spec::<gateway::GRPCRouteSpec>(req).await;
         }
 
         if is_kind::<gateway::TLSRoute>(&req) {
-            return self
-                .admit_guarded_resource::<gateway::TLSRoute, gateway::TLSRouteSpec, _>(
-                    req,
-                    |route| route.spec,
-                )
-                .await;
+            return self.admit_spec::<gateway::TLSRouteSpec>(req).await;
         }
 
         if is_kind::<gateway::TCPRoute>(&req) {
-            return self
-                .admit_guarded_resource::<gateway::TCPRoute, gateway::TCPRouteSpec, _>(
-                    req,
-                    |route| route.spec,
-                )
-                .await;
+            return self.admit_spec::<gateway::TCPRouteSpec>(req).await;
         }
 
         if is_kind::<HttpLocalRateLimitPolicy>(&req) {
@@ -207,56 +184,6 @@ impl Admission {
         let annotations = obj.annotations();
 
         if let Err(error) = self.validate(&ns, &name, annotations, spec).await {
-            info!(%error, %ns, %name, %kind, "Denied");
-            return rsp.deny(error);
-        }
-
-        rsp
-    }
-
-    async fn admit_guarded_resource<R, T, F>(
-        self,
-        req: AdmissionRequest,
-        get_spec: F,
-    ) -> AdmissionResponse
-    where
-        R: DeserializeOwned + Resource + ResourceExt,
-        F: FnOnce(R) -> T,
-        Self: Validate<T>,
-    {
-        let rsp = AdmissionResponse::from(&req);
-
-        let kind = req.kind.kind.clone();
-        let obj = match parse_resource::<R>(req) {
-            Ok(obj) => obj,
-            Err(error) => {
-                info!(%error, "Failed to parse {} resource", kind);
-                return rsp.deny(error);
-            }
-        };
-
-        let obj = match obj.0 {
-            Ok(obj) => obj,
-            Err(error) => {
-                let ns = error.metadata.namespace.clone().unwrap_or_default();
-                let name = error.metadata.name.clone().unwrap_or_default();
-                info!(
-                    error = %error,
-                    %ns,
-                    %name,
-                    %kind,
-                    "Skipping validation for resource with unsupported fields"
-                );
-                return rsp;
-            }
-        };
-
-        let ns = obj.namespace().unwrap_or_default();
-        let name = obj.name_any();
-        let annotations = obj.annotations().clone();
-        let spec = get_spec(obj);
-
-        if let Err(error) = self.validate(&ns, &name, &annotations, spec).await {
             info!(%error, %ns, %name, %kind, "Denied");
             return rsp.deny(error);
         }
@@ -299,17 +226,6 @@ fn parse_spec<T: DeserializeOwned>(req: AdmissionRequest) -> Result<(DynamicObje
     };
 
     Ok((obj, spec))
-}
-
-fn parse_resource<R>(req: AdmissionRequest) -> Result<DeserializeGuard<R>>
-where
-    R: DeserializeOwned + Resource,
-{
-    let obj = req
-        .object
-        .ok_or_else(|| anyhow!("admission request missing 'object"))?;
-
-    Ok(obj.try_parse::<DeserializeGuard<R>>()?)
 }
 
 #[async_trait::async_trait]
@@ -908,60 +824,5 @@ impl Validate<RateLimitPolicySpec> for Admission {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn accepts_gateway_http_route_with_unsupported_filter() {
-        let review: Review = serde_json::from_value(json!({
-            "apiVersion": "admission.k8s.io/v1",
-            "kind": "AdmissionReview",
-            "request": {
-                "uid": "test-uid",
-                "kind": {
-                    "group": "gateway.networking.k8s.io",
-                    "version": "v1",
-                    "kind": "HTTPRoute"
-                },
-                "resource": {
-                    "group": "gateway.networking.k8s.io",
-                    "version": "v1",
-                    "resource": "httproutes"
-                },
-                "name": "test-route",
-                "namespace": "test-ns",
-                "operation": "CREATE",
-                "userInfo": {
-                    "username": "test-user",
-                    "groups": []
-                },
-                "object": {
-                    "apiVersion": "gateway.networking.k8s.io/v1",
-                    "kind": "HTTPRoute",
-                    "metadata": {
-                        "name": "test-route",
-                        "namespace": "test-ns"
-                    },
-                    "spec": {
-                        "rules": [{
-                            "filters": [{
-                                "type": "CORS"
-                            }]
-                        }]
-                    }
-                }
-            }
-        }))
-        .expect("admission review must parse");
-
-        let req: AdmissionRequest = review.try_into().expect("request must parse");
-        let rsp = Admission::new().admit(req).await;
-
-        assert!(rsp.allowed, "unsupported filters should be admitted");
     }
 }


### PR DESCRIPTION
Fixes #14986, followup to #14844

Linkerd currently doesn't support Gateway API versions with HTTPRoute with CORS filters. ~This change introduces the usage of `DeserializedGuard` in order to not fail when unknown elements are found in Gateway API objects (as per the CRD version Linkerd supports), and bypass their validation. This aligns with the behavior adopted  in the policy controller itself, introduced in #14844.~

This change ignores deserialization errors for Gateway API objects, so that interoperability with other controllers takes precedence over strict schema enforcement.

Note that this addresses the case when the cluster has Gateway API CRDs installed that do support CORS filters (even if Linkerd itself currently only knows about Gateway API CRDs v1.2.1 which do _not_ account for CORS filters). Without the fix in this PR, applying such resources would error with:
```
Error from server: error when creating "httproute.yml": admission webhook "linkerd-policy-validator.linkerd.io" denied the request: unknown variant `CORS`, expected one of `RequestHeaderModifier`, `ResponseHeaderModifier`, `RequestMirror`, `RequestRedirect`, `URLRewrite`, `ExtensionRef`
```

If the Gateway API CRDs installed in the cluster do not support CORS filters, the error would be something like:
```
Error from server (BadRequest): error when creating "httproute.yml": HTTPRoute in version "v1" cannot be handled as a HTTPRoute: strict decoding error: unknown field "spec.rules[0].filters[0].cors"
```
Which happens at the kube-api level and there's nothing Linkerd can do about it.

