### PR TITLE
Synchronize gateway liveness (#15096)

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/linkerd/linkerd2/controller/gen/apis/link/v1alpha3"
@@ -60,7 +61,7 @@ type (
 		eventsQueue              workqueue.TypedRateLimitingInterface[any]
 		requeueLimit             int
 		repairPeriod             time.Duration
-		gatewayAlive             bool
+		gatewayAlive             atomic.Bool
 		liveness                 chan bool
 		headlessServicesEnabled  bool
 		namespaceCreationEnabled bool
@@ -216,7 +217,7 @@ func NewRemoteClusterServiceWatcher(
 	})
 
 	stopper := make(chan struct{})
-	return &RemoteClusterServiceWatcher{
+	rcsw := &RemoteClusterServiceWatcher{
 		serviceMirrorNamespace: serviceMirrorNamespace,
 		link:                   link,
 		remoteAPIClient:        remoteAPI,
@@ -235,9 +236,12 @@ func NewRemoteClusterServiceWatcher(
 		liveness:                 liveness,
 		headlessServicesEnabled:  enableHeadlessSvc,
 		namespaceCreationEnabled: enableNamespaceCreation,
-		// always instantiate the gatewayAlive=true to prevent unexpected service fail fast
-		gatewayAlive: true,
-	}, nil
+	}
+
+	// always instantiate the gatewayAlive=true to prevent unexpected service fail fast
+	rcsw.setGatewayAlive(true)
+
+	return rcsw, nil
 }
 
 func (rcsw *RemoteClusterServiceWatcher) mirrorServiceName(remoteName string) string {
@@ -369,6 +373,14 @@ func (rcsw *RemoteClusterServiceWatcher) getMirrorServiceAnnotations(remoteServi
 	annotations[consts.RemoteResourceVersionAnnotation] = remoteService.ResourceVersion // needed to detect real changes
 
 	return annotations
+}
+
+func (rcsw *RemoteClusterServiceWatcher) getGatewayAlive() bool {
+	return rcsw.gatewayAlive.Load()
+}
+
+func (rcsw *RemoteClusterServiceWatcher) setGatewayAlive(alive bool) {
+	rcsw.gatewayAlive.Store(alive)
 }
 
 // Provides annotations for federated service
@@ -1468,25 +1480,29 @@ func (rcsw *RemoteClusterServiceWatcher) Start(ctx context.Context) error {
 	ev := RepairEndpoints{}
 	rcsw.eventsQueue.Add(&ev)
 
-	go func() {
-		ticker := time.NewTicker(rcsw.repairPeriod)
-		for {
-			select {
-			case <-ticker.C:
-				ev := RepairEndpoints{}
-				rcsw.eventsQueue.Add(&ev)
-			case alive := <-rcsw.liveness:
-				rcsw.log.Debugf("gateway liveness change from %t to %t", rcsw.gatewayAlive, alive)
-				rcsw.gatewayAlive = alive
-				ev := RepairEndpoints{}
-				rcsw.eventsQueue.Add(&ev)
-			case <-rcsw.stopper:
-				return
-			}
-		}
-	}()
+	go rcsw.watchGatewayLiveness()
 
 	return nil
+}
+
+func (rcsw *RemoteClusterServiceWatcher) watchGatewayLiveness() {
+	ticker := time.NewTicker(rcsw.repairPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			ev := RepairEndpoints{}
+			rcsw.eventsQueue.Add(&ev)
+		case alive := <-rcsw.liveness:
+			rcsw.log.Debugf("gateway liveness change from %t to %t", rcsw.getGatewayAlive(), alive)
+			rcsw.setGatewayAlive(alive)
+			ev := RepairEndpoints{}
+			rcsw.eventsQueue.Add(&ev)
+		case <-rcsw.stopper:
+			return
+		}
+	}
 }
 
 // Stop stops watching the cluster and cleans up all mirrored resources
@@ -1786,7 +1802,7 @@ func (rcsw *RemoteClusterServiceWatcher) updateMirrorEndpoints(ctx context.Conte
 }
 
 func (rcsw *RemoteClusterServiceWatcher) updateReadiness(endpoints *corev1.Endpoints) {
-	if !rcsw.gatewayAlive {
+	if !rcsw.getGatewayAlive() {
 		rcsw.log.Warnf("gateway for %s/%s does not have ready addresses; setting addresses to not ready", endpoints.Namespace, endpoints.Name)
 		for i := range endpoints.Subsets {
 			endpoints.Subsets[i].NotReadyAddresses = append(endpoints.Subsets[i].NotReadyAddresses, endpoints.Subsets[i].Addresses...)

--- a/multicluster/service-mirror/cluster_watcher_mirroring_test.go
+++ b/multicluster/service-mirror/cluster_watcher_mirroring_test.go
@@ -433,9 +433,9 @@ func TestLocalNamespaceCreatedAfterServiceExport(t *testing.T) {
 		log:                     logging.WithFields(logging.Fields{"cluster": clusterName}),
 		eventsQueue:             q,
 		requeueLimit:            0,
-		gatewayAlive:            true,
 		headlessServicesEnabled: true,
 	}
+	watcher.setGatewayAlive(true)
 
 	q.Add(&RemoteServiceExported{
 		service: remoteService("service-one", "ns1", "111", map[string]string{
@@ -525,8 +525,8 @@ func TestServiceCreatedGatewayAlive(t *testing.T) {
 		log:             logging.WithFields(logging.Fields{"cluster": clusterName}),
 		eventsQueue:     events,
 		requeueLimit:    0,
-		gatewayAlive:    true,
 	}
+	watcher.setGatewayAlive(true)
 
 	events.Add(&RemoteServiceExported{
 		service: remoteService("svc", "ns", "1", map[string]string{
@@ -567,7 +567,7 @@ func TestServiceCreatedGatewayAlive(t *testing.T) {
 
 	// The gateway is now down which triggers repairing Endpoints on the local
 	// cluster.
-	watcher.gatewayAlive = false
+	watcher.setGatewayAlive(false)
 	events.Add(&RepairEndpoints{})
 	for events.Len() > 0 {
 		watcher.processNextEvent(context.Background())
@@ -683,7 +683,6 @@ func TestServiceCreatedGatewayDown(t *testing.T) {
 		log:             logging.WithFields(logging.Fields{"cluster": clusterName}),
 		eventsQueue:     events,
 		requeueLimit:    0,
-		gatewayAlive:    false,
 	}
 
 	events.Add(&RemoteServiceExported{
@@ -725,7 +724,7 @@ func TestServiceCreatedGatewayDown(t *testing.T) {
 
 	// The gateway is now alive which triggers repairing Endpoints on the
 	// local cluster.
-	watcher.gatewayAlive = true
+	watcher.setGatewayAlive(true)
 	events.Add(&RepairEndpoints{})
 	for events.Len() > 0 {
 		watcher.processNextEvent(context.Background())

--- a/multicluster/service-mirror/cluster_watcher_race_test.go
+++ b/multicluster/service-mirror/cluster_watcher_race_test.go
@@ -1,0 +1,48 @@
+package servicemirror
+
+import (
+	"testing"
+	"time"
+
+	logging "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestGatewayAliveSynchronization(t *testing.T) {
+	stopper := make(chan struct{})
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+	defer queue.ShutDown()
+
+	watcher := &RemoteClusterServiceWatcher{
+		stopper:      stopper,
+		log:          logging.NewEntry(logging.New()),
+		eventsQueue:  queue,
+		repairPeriod: time.Hour,
+		liveness:     make(chan bool, 1024),
+	}
+	watcher.setGatewayAlive(true)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		watcher.watchGatewayLiveness()
+	}()
+
+	endpoints := &corev1.Endpoints{
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: "192.0.2.1",
+			}},
+		}},
+	}
+
+	for i := 0; i < 1024; i++ {
+		watcher.liveness <- i%2 == 0
+		ep := endpoints.DeepCopy()
+		watcher.updateReadiness(ep)
+	}
+
+	close(stopper)
+	<-done
+}

--- a/multicluster/service-mirror/cluster_watcher_test_util.go
+++ b/multicluster/service-mirror/cluster_watcher_test_util.go
@@ -65,9 +65,9 @@ func (te *testEnvironment) runEnvironment(watcherQueue workqueue.TypedRateLimiti
 		log:                     logging.WithFields(logging.Fields{"cluster": clusterName}),
 		eventsQueue:             watcherQueue,
 		requeueLimit:            0,
-		gatewayAlive:            true,
 		headlessServicesEnabled: true,
 	}
+	watcher.setGatewayAlive(true)
 
 	for _, ev := range te.events {
 		watcherQueue.Add(ev)


### PR DESCRIPTION
Problem

RemoteClusterServiceWatcher updates gateway liveness from a background goroutine while mirror endpoint reconciliation reads the same state without synchronization. This leaves the multicluster service mirror vulnerable to race detector failures and inconsistent readiness updates under gateway flapping.

Solution

Protect gateway liveness with a dedicated RWMutex-backed accessor, route the liveness loop through a helper that uses those accessors, and update existing tests to use the synchronized setter. Add a race-focused regression test that exercises the liveness watcher concurrently with endpoint readiness updates.

Validation

- go test ./multicluster/service-mirror/...
- go test -race ./multicluster/service-mirror/...
- go test -race ./multicluster/service-mirror -run TestGatewayAliveSynchronization -count=1

Fixes #15096

Signed-off-by: Asish Kumar <officialasishkumar@gmail.com>
