### PR TITLE
tests: introduce `kubectlRun` to avoid conflating stdin and stdout in tests

### DIFF
--- a/test/integration/deep/endpoints/destination_api_test.go
+++ b/test/integration/deep/endpoints/destination_api_test.go
@@ -573,7 +573,8 @@ func waitForServiceEndpoints(t *testing.T, namespace, service string, timeout ti
 	// Poll Endpoints until at least one address is present. This avoids races
 	// where the service exists but endpoint publication is still in flight.
 	err := testutil.RetryFor(timeout, func() error {
-		out, err := TestHelper.Kubectl("", "-n", namespace, "get", "endpoints", service, "-o", "json")
+		// in k8s 1.35+ this call returns a warning about Endpoints being deprecated, that we ignore here
+		out, _, err := TestHelper.KubectlRun("", "-n", namespace, "get", "endpoints", service, "-o", "json")
 		if err != nil {
 			return err
 		}

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -162,12 +162,19 @@ func (h *KubernetesHelper) KubectlApplyWithArgs(stdin string, cmdArgs ...string)
 }
 
 // Kubectl executes an arbitrary Kubectl command
+// Deprecated, use KubectlRun instead
 func (h *KubernetesHelper) Kubectl(stdin string, arg ...string) (string, error) {
 	withContext := append([]string{"--context=" + h.k8sContext}, arg...)
 	cmd := exec.Command("kubectl", withContext...)
 	cmd.Stdin = strings.NewReader(stdin)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// KubectlRun executes an arbitrary kubectl command and returns stdout and stderr separately
+func (h *KubernetesHelper) KubectlRun(stdin string, arg ...string) (string, string, error) {
+	withContext := append([]string{"--context=" + h.k8sContext}, arg...)
+	return combinedOutput(stdin, "kubectl", withContext...)
 }
 
 // KubectlApplyWithContext applies a given configuration with the given flags

--- a/testutil/kubernetes_helper.go
+++ b/testutil/kubernetes_helper.go
@@ -162,7 +162,7 @@ func (h *KubernetesHelper) KubectlApplyWithArgs(stdin string, cmdArgs ...string)
 }
 
 // Kubectl executes an arbitrary Kubectl command
-// Deprecated, use KubectlRun instead
+// Deprecated: use KubectlRun instead
 func (h *KubernetesHelper) Kubectl(stdin string, arg ...string) (string, error) {
 	withContext := append([]string{"--context=" + h.k8sContext}, arg...)
 	cmd := exec.Command("kubectl", withContext...)


### PR DESCRIPTION
Introduce a new test helper `TestHelper.KubectlRun` (and mark `TestHelper.Kubectl` as deprecated), that keeps stdout and stderr separate when invoking `kubectl`. This avoids failures on Kubernetes 1.35+, where deprecation warnings for Endpoints are emitted alongside command output and can break deserialization in `TestDestinationAPIStreamTracksRolloutEndpoints`.