### PR TITLE
feat(inject): add proxy-additional-env annotation for per-scope env overrides

### DIFF
--- a/cli/cmd/doc.go
+++ b/cli/cmd/doc.go
@@ -288,5 +288,9 @@ func generateAnnotationsDocs() []annotationDoc {
 			Name:        k8s.ProxyEnableNativeSidecarAnnotationBeta,
 			Description: "Enable KEP-753 native sidecars. This is a beta feature. It requires Kubernetes >= 1.29. If enabled, .proxy.waitBeforeExitSeconds should not be used.",
 		},
+		{
+			Name:        k8s.ProxyAdditionalEnvAnnotation,
+			Description: "Set additional proxy environment variables via a JSON-encoded list of Kubernetes EnvVar objects. Env vars are merged by name across three layers with increasing precedence: Helm proxy.additionalEnv < namespace annotation < workload annotation. Higher-precedence layers override entries with the same env var name rather than replacing the entire list.",
+		},
 	}
 }

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -201,7 +202,65 @@ func GetOverriddenValues(rc *ResourceConfig) (*l5dcharts.Values, error) {
 	}
 
 	ApplyAnnotationOverrides(copyValues, rc.GetAnnotationOverrides(), rc.GetLabelOverrides(), namedPorts)
+	MergeAdditionalEnv(copyValues, rc.GetNsAnnotations(), rc.GetWorkloadAnnotations())
 	return copyValues, nil
+}
+
+// parseAdditionalEnvAnnotation parses a JSON-encoded list of Kubernetes EnvVar
+// objects from the given annotation value. Returns nil if the value is empty.
+func parseAdditionalEnvAnnotation(value string) ([]corev1.EnvVar, error) {
+	if value == "" {
+		return nil, nil
+	}
+	var envVars []corev1.EnvVar
+	if err := json.Unmarshal([]byte(value), &envVars); err != nil {
+		return nil, fmt.Errorf("invalid JSON in %s annotation: %w", k8s.ProxyAdditionalEnvAnnotation, err)
+	}
+	return envVars, nil
+}
+
+// mergeEnvByName merges src into dst by env var name. Entries in src with
+// the same name as an entry in dst replace it; new entries are appended.
+func mergeEnvByName(dst, src []corev1.EnvVar) []corev1.EnvVar {
+	if len(src) == 0 {
+		return dst
+	}
+	result := slices.Clone(dst)
+	for _, s := range src {
+		if i := slices.IndexFunc(result, func(e corev1.EnvVar) bool { return e.Name == s.Name }); i >= 0 {
+			result[i] = s
+		} else {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// MergeAdditionalEnv merges proxy additional env vars from three layers:
+// 1. proxy.additionalEnv from Helm values (already in values.Proxy.AdditionalEnv)
+// 2. Namespace-level proxy-additional-env annotation
+// 3. Workload-level proxy-additional-env annotation
+// Higher-precedence layers override entries with the same env var name.
+func MergeAdditionalEnv(values *l5dcharts.Values, nsAnnotations map[string]string, workloadAnnotations map[string]string) {
+	nsEnvStr := nsAnnotations[k8s.ProxyAdditionalEnvAnnotation]
+	if nsEnvStr != "" {
+		nsEnv, err := parseAdditionalEnvAnnotation(nsEnvStr)
+		if err != nil {
+			log.Warnf("%s", err)
+		} else {
+			values.Proxy.AdditionalEnv = mergeEnvByName(values.Proxy.AdditionalEnv, nsEnv)
+		}
+	}
+
+	wlEnvStr := workloadAnnotations[k8s.ProxyAdditionalEnvAnnotation]
+	if wlEnvStr != "" {
+		wlEnv, err := parseAdditionalEnvAnnotation(wlEnvStr)
+		if err != nil {
+			log.Warnf("%s", err)
+		} else {
+			values.Proxy.AdditionalEnv = mergeEnvByName(values.Proxy.AdditionalEnv, wlEnv)
+		}
+	}
 }
 
 func ApplyAnnotationOverrides(values *l5dcharts.Values, annotations map[string]string, labels map[string]string, namedPorts map[string]int32) {

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -80,6 +80,7 @@ var (
 		k8s.ProxyDisableOutboundProtocolDetectTimeout,
 		k8s.ProxyDisableInboundProtocolDetectTimeout,
 		k8s.ProxyEnableNativeSidecarAnnotationBeta,
+		k8s.ProxyAdditionalEnvAnnotation,
 	}
 	// ProxyAlphaConfigAnnotations is the list of all alpha configuration
 	// (config.alpha prefix) that can be applied to a pod or namespace.

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -404,6 +404,118 @@ func TestApplyAnnotationOverridesInitializesTracingLabels(t *testing.T) {
 	}
 }
 
+func TestMergeAdditionalEnv(t *testing.T) {
+	testCases := []struct {
+		id                  string
+		helmAdditionalEnv   []corev1.EnvVar
+		nsAnnotations       map[string]string
+		workloadAnnotations map[string]string
+		expected            []corev1.EnvVar
+	}{
+		{
+			id: "no annotations, helm only",
+			helmAdditionalEnv: []corev1.EnvVar{
+				{Name: "FOO", Value: "helm"},
+			},
+			nsAnnotations:       map[string]string{},
+			workloadAnnotations: map[string]string{},
+			expected: []corev1.EnvVar{
+				{Name: "FOO", Value: "helm"},
+			},
+		},
+		{
+			id:                "namespace annotation adds env vars",
+			helmAdditionalEnv: nil,
+			nsAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `[{"name":"BAR","value":"ns"}]`,
+			},
+			workloadAnnotations: map[string]string{},
+			expected: []corev1.EnvVar{
+				{Name: "BAR", Value: "ns"},
+			},
+		},
+		{
+			id:                "workload overrides namespace by name",
+			helmAdditionalEnv: nil,
+			nsAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `[{"name":"BACKLOG","value":"4096"},{"name":"OTHER","value":"ns"}]`,
+			},
+			workloadAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `[{"name":"BACKLOG","value":"8192"}]`,
+			},
+			expected: []corev1.EnvVar{
+				{Name: "BACKLOG", Value: "8192"},
+				{Name: "OTHER", Value: "ns"},
+			},
+		},
+		{
+			id: "three-layer merge: helm < namespace < workload",
+			helmAdditionalEnv: []corev1.EnvVar{
+				{Name: "A", Value: "helm"},
+				{Name: "B", Value: "helm"},
+			},
+			nsAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `[{"name":"B","value":"ns"},{"name":"C","value":"ns"}]`,
+			},
+			workloadAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `[{"name":"C","value":"wl"}]`,
+			},
+			expected: []corev1.EnvVar{
+				{Name: "A", Value: "helm"},
+				{Name: "B", Value: "ns"},
+				{Name: "C", Value: "wl"},
+			},
+		},
+		{
+			id:                "invalid JSON in namespace is skipped",
+			helmAdditionalEnv: nil,
+			nsAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `not-json`,
+			},
+			workloadAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `[{"name":"OK","value":"wl"}]`,
+			},
+			expected: []corev1.EnvVar{
+				{Name: "OK", Value: "wl"},
+			},
+		},
+		{
+			id:                "invalid JSON in workload is skipped",
+			helmAdditionalEnv: nil,
+			nsAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `[{"name":"NS","value":"ok"}]`,
+			},
+			workloadAnnotations: map[string]string{
+				k8s.ProxyAdditionalEnvAnnotation: `{bad`,
+			},
+			expected: []corev1.EnvVar{
+				{Name: "NS", Value: "ok"},
+			},
+		},
+		{
+			id:                  "no annotations and no helm",
+			helmAdditionalEnv:   nil,
+			nsAnnotations:       map[string]string{},
+			workloadAnnotations: map[string]string{},
+			expected:            nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			values := &l5dcharts.Values{
+				Proxy: &l5dcharts.Proxy{
+					AdditionalEnv: tc.helmAdditionalEnv,
+				},
+			}
+			MergeAdditionalEnv(values, tc.nsAnnotations, tc.workloadAnnotations)
+			if diff := deep.Equal(values.Proxy.AdditionalEnv, tc.expected); diff != nil {
+				t.Errorf("%+v", diff)
+			}
+		})
+	}
+}
+
 func TestWholeCPUCores(t *testing.T) {
 	for _, c := range []struct {
 		v string

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -325,6 +325,12 @@ const (
 
 	// ProxyAdditionalEnvAnnotation allows setting additional proxy environment
 	// variables via a JSON-encoded list of Kubernetes EnvVar objects.
+	// Unlike other override annotations, this annotation is not inherited
+	// wholesale from the namespace. Instead, env vars are merged by name
+	// across three layers with increasing precedence:
+	// Helm proxy.additionalEnv < namespace annotation < workload annotation.
+	// Entries from higher-precedence layers override entries with the same
+	// env var name rather than replacing the entire list.
 	ProxyAdditionalEnvAnnotation = ProxyConfigAnnotationsPrefix + "/proxy-additional-env"
 
 	/*

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -323,6 +323,10 @@ const (
 	// graceful shutdowns in the proxy.
 	ProxyShutdownGracePeriodAnnotation = ProxyConfigAnnotationsPrefix + "/shutdown-grace-period"
 
+	// ProxyAdditionalEnvAnnotation allows setting additional proxy environment
+	// variables via a JSON-encoded list of Kubernetes EnvVar objects.
+	ProxyAdditionalEnvAnnotation = ProxyConfigAnnotationsPrefix + "/proxy-additional-env"
+
 	/*
 	 * Component Names
 	 */

--- a/test/integration/install/inject/inject_test.go
+++ b/test/integration/install/inject/inject_test.go
@@ -222,6 +222,7 @@ func TestInjectAutoNamespaceOverrideAnnotations(t *testing.T) {
 		k8s.ProxyInjectAnnotation:        k8s.ProxyInjectEnabled,
 		k8s.ProxyCPURequestAnnotation:    nsProxyCPUReq,
 		k8s.ProxyMemoryRequestAnnotation: nsProxyMemReq,
+		k8s.ProxyAdditionalEnvAnnotation: `[{"name":"NS_VAR","value":"ns_val"},{"name":"SHARED_VAR","value":"from_ns"}]`,
 	}
 
 	ctx := context.Background()
@@ -230,7 +231,8 @@ func TestInjectAutoNamespaceOverrideAnnotations(t *testing.T) {
 		// Pod Level proxy configuration override
 		podProxyCPUReq := "600m"
 		podAnnotations := map[string]string{
-			k8s.ProxyCPURequestAnnotation: podProxyCPUReq,
+			k8s.ProxyCPURequestAnnotation:    podProxyCPUReq,
+			k8s.ProxyAdditionalEnvAnnotation: `[{"name":"POD_VAR","value":"pod_val"},{"name":"SHARED_VAR","value":"from_pod"}]`,
 		}
 
 		patchedYAML, err := testutil.PatchDeploy(injectYAML, deployName, podAnnotations)
@@ -266,6 +268,22 @@ func TestInjectAutoNamespaceOverrideAnnotations(t *testing.T) {
 		// Match with proxy level override
 		if proxyContainer.Resources.Requests["cpu"] != resource.MustParse(podProxyCPUReq) {
 			testutil.Fatalf(t, "proxy cpu resource request failed to match with pod level override")
+		}
+
+		// Match proxy-additional-env merge semantics: ns sets NS_VAR+SHARED_VAR,
+		// pod sets POD_VAR+SHARED_VAR; pod takes precedence for SHARED_VAR
+		envMap := make(map[string]string)
+		for _, e := range proxyContainer.Env {
+			envMap[e.Name] = e.Value
+		}
+		if envMap["NS_VAR"] != "ns_val" {
+			testutil.Fatalf(t, "proxy NS_VAR failed to match namespace-level proxy-additional-env annotation")
+		}
+		if envMap["POD_VAR"] != "pod_val" {
+			testutil.Fatalf(t, "proxy POD_VAR failed to match pod-level proxy-additional-env annotation")
+		}
+		if envMap["SHARED_VAR"] != "from_pod" {
+			testutil.Fatalf(t, "proxy SHARED_VAR failed to be overridden by pod-level proxy-additional-env annotation")
 		}
 	})
 }

--- a/testutil/inject.go
+++ b/testutil/inject.go
@@ -38,7 +38,7 @@ func PatchDeploy(in string, name string, annotations map[string]string) (string,
 		ops = append(ops, `{"op": "add", "path": "/spec/template/metadata/annotations", "value": {}}`)
 		for k, v := range annotations {
 			ops = append(ops,
-				fmt.Sprintf(`{"op": "add", "path": "/spec/template/metadata/annotations/%s", "value": "%s"}`, strings.ReplaceAll(k, "/", "~1"), v),
+				fmt.Sprintf(`{"op": "add", "path": "/spec/template/metadata/annotations/%s", "value": %q}`, strings.ReplaceAll(k, "/", "~1"), v),
 			)
 		}
 	}


### PR DESCRIPTION
Add support for a generic annotation that allows setting additional proxy environment variables via a JSON-encoded list of Kubernetes EnvVar objects on namespaces and workloads.

During injection, env vars are merged by name with precedence: Helm proxy.additionalEnv < namespace annotation < workload annotation

This provides a generic mechanism for per-namespace/workload proxy env var overrides without requiring dedicated annotations for each new proxy setting.

Addresses #15152
