### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,9 @@
 
 name: CodeQL
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, stable-*]

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -2,6 +2,9 @@
 # From https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
 name: Re-run failed workflow
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sync-proxy.yml
+++ b/.github/workflows/sync-proxy.yml
@@ -1,5 +1,8 @@
 name: Sync proxy
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Problem

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows.

## Solution

With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

## Validation

Existing CI workflows continue to run unchanged; the permission scopes now follow the principle of least privilege, with `write` retained only at the job level where strictly required.

Fixes #15182

Signed-off-by: Gagan H R <hrgagan4@gmail.com>
