### PR TITLE
docs: fix "a HTTP" -> "an HTTP" grammar

### DIFF
--- a/pkg/k8s/metrics.go
+++ b/pkg/k8s/metrics.go
@@ -37,7 +37,7 @@ func GetContainerMetrics(
 	return getResponse(metricsURL)
 }
 
-// getResponse makes a http Get request to the passed url and returns the response/error
+// getResponse makes an HTTP Get request to the passed url and returns the response/error
 func getResponse(url string) ([]byte, error) {
 	// url has been constructed by k8s.newPortForward and is not passed in by
 	// the user.

--- a/pkg/profiles/template.go
+++ b/pkg/profiles/template.go
@@ -51,7 +51,7 @@ spec:
     # Each response class must define a condition.  All responses from this
     # route that match the condition will be classified as this response class.
     - condition:
-        # The simplest condition is a HTTP status code range.
+        # The simplest condition is an HTTP status code range.
         status:
           min: 500
           max: 599


### PR DESCRIPTION

**Repo:** linkerd/linkerd2 (⭐ 10000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Corrects two instances of "a HTTP" to the grammatically correct "an HTTP" (HTTP is pronounced with a vowel sound, "aitch"). One is in a godoc comment on `getResponse` in `pkg/k8s/metrics.go`; the other is in the service-profile YAML template in `pkg/profiles/template.go`, which is emitted to users via `linkerd profile --template` and therefore user-visible. The comment was also modernized to "HTTP Get" (caps).

## Why
Small documentation polish. The template change in particular shows up in output users copy-paste, so the typo is visible beyond the source tree. Non-generated files only — the many similar occurrences under `controller/gen/` are produced by code generators upstream.

## Testing
Pure comment / YAML-comment change, no behavioral impact. `go vet ./pkg/k8s/... ./pkg/profiles/...` would pass since nothing executable changed. Template remains valid YAML (only a `#` comment line is edited).

## Risk
Low — comment-only edits, no code or exported-API changes.
