### PR TITLE
fix(multicluster): make service cleanup logic respect namespaces

### DIFF
--- a/multicluster/service-mirror/cluster_watcher.go
+++ b/multicluster/service-mirror/cluster_watcher.go
@@ -563,7 +563,7 @@ func (rcsw *RemoteClusterServiceWatcher) handleRemoteServiceUnexported(ctx conte
 		matchLabels := map[string]string{
 			consts.MirroredHeadlessSvcNameLabel: localServiceName,
 		}
-		endpointMirrorServices, err := rcsw.localAPIClient.Svc().Lister().List(labels.Set(matchLabels).AsSelector())
+		endpointMirrorServices, err := rcsw.localAPIClient.Svc().Lister().Services(ev.Namespace).List(labels.Set(matchLabels).AsSelector())
 		if err != nil {
 			if !kerrors.IsNotFound(err) {
 				errors = append(errors, fmt.Errorf("could not fetch endpoint mirrors for mirror service %s/%s: %w", ev.Namespace, localServiceName, err))

--- a/multicluster/service-mirror/cluster_watcher_headless.go
+++ b/multicluster/service-mirror/cluster_watcher_headless.go
@@ -142,7 +142,7 @@ func (rcsw *RemoteClusterServiceWatcher) createOrUpdateHeadlessEndpoints(ctx con
 	}
 
 	// Fetch all Endpoint Mirror services that belong to the same Headless Mirror
-	endpointMirrorServices, err := rcsw.localAPIClient.Svc().Lister().List(labels.Set(matchLabels).AsSelector())
+	endpointMirrorServices, err := rcsw.localAPIClient.Svc().Lister().Services(exportedService.Namespace).List(labels.Set(matchLabels).AsSelector())
 	if err != nil {
 		return err
 	}

--- a/multicluster/service-mirror/cluster_watcher_mirroring_test.go
+++ b/multicluster/service-mirror/cluster_watcher_mirroring_test.go
@@ -967,6 +967,138 @@ func TestRemoteEndpointsUpdatedMirroring(t *testing.T) {
 	}
 }
 
+func TestHeadlessEndpointMirrorCleanupRespectsNamespaces(t *testing.T) {
+	onUpdateEndpointsCalledEnv := *multiNamespaceHeadlessMirrorEndpointsWithSameServiceName
+	onUpdateEndpointsCalledEnv.events = []interface{}{
+		&OnUpdateEndpointsCalled{
+			ep: remoteHeadlessEndpoints(
+				"service-one",
+				"ns1",
+				"999",
+				"192.0.0.1",
+				[]corev1.EndpointPort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				},
+			),
+		},
+	}
+
+	remoteServiceUnexportedEnv := *multiNamespaceHeadlessMirrorEndpointsWithSameServiceName
+	remoteServiceUnexportedEnv.events = []interface{}{
+		&RemoteServiceUnexported{
+			Name:      "service-one",
+			Namespace: "ns1",
+		},
+	}
+
+	for _, tt := range []mirroringTestCase{
+		{
+			description: "OnUpdateEndpointsCalled headless endpoint mirror GC is scoped to the appropriate namespace",
+			environment: &onUpdateEndpointsCalledEnv,
+			expectedLocalServices: []*corev1.Service{
+				headlessMirrorService("service-one-remote", "ns1", "111", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+				endpointMirrorService("pod-0", "service-one-remote", "ns1", "333", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+				headlessMirrorService("service-one-remote", "ns2", "222", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+				endpointMirrorService("pod-0", "service-one-remote", "ns2", "444", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+				endpointMirrorService("pod-1", "service-one-remote", "ns2", "555", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+			},
+			expectedLocalEndpoints: []*corev1.Endpoints{
+				headlessMirrorEndpoints(
+					"service-one-remote",
+					"ns1",
+					nil,
+					"gateway-identity",
+					[]corev1.EndpointPort{
+						{Name: "port1", Protocol: "TCP", Port: 555},
+						{Name: "port2", Protocol: "TCP", Port: 666},
+					},
+				),
+				endpointMirrorEndpoints("service-one-remote", "ns1", nil, "pod-0", "192.0.2.127", "gateway-identity", []corev1.EndpointPort{
+					{Name: "port1", Protocol: "TCP", Port: 888},
+					{Name: "port2", Protocol: "TCP", Port: 888},
+				}),
+				headlessMirrorEndpointsUpdated(
+					"service-one-remote",
+					"ns2",
+					[]string{"pod-0", "pod-1"},
+					[]string{"", ""},
+					"gateway-identity",
+					[]corev1.EndpointPort{
+						{Name: "port1", Protocol: "TCP", Port: 555},
+						{Name: "port2", Protocol: "TCP", Port: 666},
+					},
+				),
+				endpointMirrorEndpoints("service-one-remote", "ns2", nil, "pod-0", "192.0.2.127", "gateway-identity", []corev1.EndpointPort{
+					{Name: "port1", Protocol: "TCP", Port: 888},
+					{Name: "port2", Protocol: "TCP", Port: 888},
+				}),
+				endpointMirrorEndpoints("service-one-remote", "ns2", nil, "pod-1", "192.0.2.127", "gateway-identity", []corev1.EndpointPort{
+					{Name: "port1", Protocol: "TCP", Port: 888},
+					{Name: "port2", Protocol: "TCP", Port: 888},
+				}),
+			},
+		},
+		{
+			description: "RemoteServiceUnexported headless endpoint mirror GC is scoped to the appropriate namespace",
+			environment: &remoteServiceUnexportedEnv,
+			expectedLocalServices: []*corev1.Service{
+				headlessMirrorService("service-one-remote", "ns2", "222", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+				endpointMirrorService("pod-0", "service-one-remote", "ns2", "444", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+				endpointMirrorService("pod-1", "service-one-remote", "ns2", "555", nil, []corev1.ServicePort{
+					{Name: "port1", Protocol: "TCP", Port: 555},
+					{Name: "port2", Protocol: "TCP", Port: 666},
+				}),
+			},
+			expectedLocalEndpoints: []*corev1.Endpoints{
+				headlessMirrorEndpointsUpdated(
+					"service-one-remote",
+					"ns2",
+					[]string{"pod-0", "pod-1"},
+					[]string{"", ""},
+					"gateway-identity",
+					[]corev1.EndpointPort{
+						{Name: "port1", Protocol: "TCP", Port: 555},
+						{Name: "port2", Protocol: "TCP", Port: 666},
+					},
+				),
+				endpointMirrorEndpoints("service-one-remote", "ns2", nil, "pod-0", "192.0.2.127", "gateway-identity", []corev1.EndpointPort{
+					{Name: "port1", Protocol: "TCP", Port: 888},
+					{Name: "port2", Protocol: "TCP", Port: 888},
+				}),
+				endpointMirrorEndpoints("service-one-remote", "ns2", nil, "pod-1", "192.0.2.127", "gateway-identity", []corev1.EndpointPort{
+					{Name: "port1", Protocol: "TCP", Port: 888},
+					{Name: "port2", Protocol: "TCP", Port: 888},
+				}),
+			},
+		},
+	} {
+		tc := tt // pin
+		tc.run(t)
+	}
+}
+
 func TestClusterUnregisteredMirroring(t *testing.T) {
 	for _, tt := range []mirroringTestCase{
 		{

--- a/multicluster/service-mirror/cluster_watcher_test_util.go
+++ b/multicluster/service-mirror/cluster_watcher_test_util.go
@@ -717,6 +717,122 @@ var updateEndpointsWithChangedHosts = &testEnvironment{
 		},
 	},
 }
+
+var multiNamespaceHeadlessMirrorEndpointsWithSameServiceName = &testEnvironment{
+	remoteResources: []string{
+		asYaml(gateway("gateway", "gateway-ns", "currentGatewayResVersion", "192.0.2.127", "mc-gateway", 888, "", defaultProbePort, defaultProbePath, defaultProbePeriod)),
+		asYaml(remoteHeadlessService("service-one", "ns1", "111", map[string]string{consts.DefaultExportedServiceSelector: "true"}, []corev1.ServicePort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(remoteHeadlessService("service-one", "ns2", "222", map[string]string{consts.DefaultExportedServiceSelector: "true"}, []corev1.ServicePort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(remoteHeadlessEndpoints("service-one", "ns1", "998", "192.0.0.1", []corev1.EndpointPort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(remoteHeadlessEndpointsUpdate("service-one", "ns2", "997", "192.0.0.2", []corev1.EndpointPort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+	},
+	localResources: []string{
+		asYaml(namespace("ns1")),
+		asYaml(namespace("ns2")),
+		asYaml(headlessMirrorService("service-one-remote", "ns1", "111", nil, []corev1.ServicePort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(endpointMirrorService("pod-0", "service-one-remote", "ns1", "333", nil, []corev1.ServicePort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(headlessMirrorEndpoints(
+			"service-one-remote",
+			"ns1",
+			nil,
+			"gateway-identity",
+			[]corev1.EndpointPort{
+				{Name: "port1", Protocol: "TCP", Port: 555},
+				{Name: "port2", Protocol: "TCP", Port: 666},
+			},
+		)),
+		asYaml(endpointMirrorEndpoints(
+			"service-one-remote",
+			"ns1",
+			nil,
+			"pod-0",
+			"192.0.2.127",
+			"gateway-identity",
+			[]corev1.EndpointPort{
+				{Name: "port1", Protocol: "TCP", Port: 888},
+				{Name: "port2", Protocol: "TCP", Port: 888},
+			},
+		)),
+		asYaml(headlessMirrorService("service-one-remote", "ns2", "222", nil, []corev1.ServicePort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(endpointMirrorService("pod-0", "service-one-remote", "ns2", "444", nil, []corev1.ServicePort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(endpointMirrorService("pod-1", "service-one-remote", "ns2", "555", nil, []corev1.ServicePort{
+			{Name: "port1", Protocol: "TCP", Port: 555},
+			{Name: "port2", Protocol: "TCP", Port: 666},
+		})),
+		asYaml(headlessMirrorEndpointsUpdated(
+			"service-one-remote",
+			"ns2",
+			[]string{"pod-0", "pod-1"},
+			[]string{"", ""},
+			"gateway-identity",
+			[]corev1.EndpointPort{
+				{Name: "port1", Protocol: "TCP", Port: 555},
+				{Name: "port2", Protocol: "TCP", Port: 666},
+			},
+		)),
+		asYaml(endpointMirrorEndpoints(
+			"service-one-remote",
+			"ns2",
+			nil,
+			"pod-0",
+			"192.0.2.127",
+			"gateway-identity",
+			[]corev1.EndpointPort{
+				{Name: "port1", Protocol: "TCP", Port: 888},
+				{Name: "port2", Protocol: "TCP", Port: 888},
+			},
+		)),
+		asYaml(endpointMirrorEndpoints(
+			"service-one-remote",
+			"ns2",
+			nil,
+			"pod-1",
+			"192.0.2.127",
+			"gateway-identity",
+			[]corev1.EndpointPort{
+				{Name: "port1", Protocol: "TCP", Port: 888},
+				{Name: "port2", Protocol: "TCP", Port: 888},
+			},
+		)),
+	},
+	link: v1alpha3.Link{
+		Spec: v1alpha3.LinkSpec{
+			TargetClusterName:       clusterName,
+			TargetClusterDomain:     clusterDomain,
+			GatewayIdentity:         "gateway-identity",
+			GatewayAddress:          "192.0.2.127",
+			GatewayPort:             "888",
+			ProbeSpec:               defaultProbeSpec,
+			Selector:                defaultSelector,
+			RemoteDiscoverySelector: defaultRemoteDiscoverySelector,
+		},
+	},
+}
+
 var clusterUnregistered = &testEnvironment{
 	events: []interface{}{
 		&ClusterUnregistered{},
@@ -1043,6 +1159,7 @@ func remoteHeadlessService(name, namespace, resourceVersion string, labels map[s
 	}
 }
 
+//nolint:unparam
 func remoteHeadlessEndpoints(name, namespace, resourceVersion, address string, ports []corev1.EndpointPort) *corev1.Endpoints {
 	return &corev1.Endpoints{
 		TypeMeta: metav1.TypeMeta{
@@ -1076,6 +1193,7 @@ func remoteHeadlessEndpoints(name, namespace, resourceVersion, address string, p
 	}
 }
 
+//nolint:unparam
 func remoteHeadlessEndpointsUpdate(name, namespace, resourceVersion, address string, ports []corev1.EndpointPort) *corev1.Endpoints {
 	return &corev1.Endpoints{
 		TypeMeta: metav1.TypeMeta{
@@ -1375,6 +1493,7 @@ func headlessMirrorEndpoints(name, namespace string, labels map[string]string, g
 	return endpoints
 }
 
+//nolint:unparam
 func headlessMirrorEndpointsUpdated(name, namespace string, hostnames, hostIPs []string, gatewayIdentity string, ports []corev1.EndpointPort) *corev1.Endpoints {
 	endpoints := &corev1.Endpoints{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #15200 

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->

createOrUpdateHeadlessEndpoints and handleRemoteServiceUnexported compare a list of namespace-level endpoint mirror services to a cluster-wide list of services that match the headless mirror name. This results in unintended service deletion when multiple headless mirror services of the same name exist in different namespaces. Fix this by restricting the list call to the namespace of the exported service.

Fixes https://github.com/linkerd/linkerd2/issues/15200
