### PR TITLE
fix(CLI): correct gateway api version in user instructions

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -421,7 +421,7 @@ func validateFinalValues(installed GatewayAPICRDs, finalValues map[string]interf
 			// if we are not installing GW API Resources and they are not present, error
 			return errors.New(`The Gateway API CRDs must be installed prior to installing Linkerd. Run:
 
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 
 or see https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api for more options.`)
 		}

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 
 lint: action-lint action-dev-check md-lint sh-lint rs-fetch rs-clippy rs-check-fmt go-lint
 
-export GWAPI_VERSION := "v1.2.1"
+export GWAPI_VERSION := "v1.2.0"
 
 ##
 ## Go
@@ -472,8 +472,7 @@ _linkerd-viz-uninit:
 ## linkerd multicluster
 ##
 
-_mc-east-k3d-flags := "--k3s-arg --disable='local-storage,metrics-server@server:*' --k3s-arg '--cluster-cidr=10.23.0.0/24@server:*'"
-_mc-north-k3d-flags := "--k3s-arg --disable='local-storage,metrics-server@server:*' --k3s-arg '--cluster-cidr=10.24.0.0/24@server:*'"
+_mc-target-k3d-flags := "--k3s-arg --disable='local-storage,metrics-server@server:*' --k3s-arg '--cluster-cidr=10.23.0.0/24@server:*'"
 
 linkerd-mc-install: _linkerd-init
     {{ _linkerd }} mc install --set='linkerdVersion={{ linkerd-tag }}' \
@@ -495,29 +494,14 @@ mc-target-k3d-delete:
 
 mc-load: _k3d-init linkerd-load
 
-mc-east-load:
+mc-target-load:
     @{{ just_executable() }} \
-        k3d-name='{{ k3d-name }}-east' \
+        k3d-name='{{ k3d-name }}-target' \
         k3d-k8s='{{ k3d-k8s }}' \
         k3d-agents='{{ k3d-agents }}' \
         k3d-servers='{{ k3d-servers }}' \
         k3d-network='{{ k3d-network }}' \
-        _k3d-flags='{{ _mc-east-k3d-flags }}' \
-        controller-image='{{ controller-image }}' \
-        proxy-image='{{ proxy-image }}' \
-        linkerd-exec='{{ linkerd-exec }}' \
-        linkerd-tag='{{ linkerd-tag }}' \
-        _pause-load \
-        mc-load
-
-mc-north-load:
-    @{{ just_executable() }} \
-        k3d-name='{{ k3d-name }}-north' \
-        k3d-k8s='{{ k3d-k8s }}' \
-        k3d-agents='{{ k3d-agents }}' \
-        k3d-servers='{{ k3d-servers }}' \
-        k3d-network='{{ k3d-network }}' \
-        _k3d-flags='{{ _mc-north-k3d-flags }}' \
+        _k3d-flags='{{ _mc-target-k3d-flags }}' \
         controller-image='{{ controller-image }}' \
         proxy-image='{{ proxy-image }}' \
         linkerd-exec='{{ linkerd-exec }}' \
@@ -536,20 +520,14 @@ k3d-source-server := "k3d-" + k3d-name + "-server-0"
 k3d-target-server := "k3d-" + k3d-name + "-target-server-0"
 
 _mc-route-output-fmt := "-o jsonpath='ip route add {.spec.podCIDR} via {.status.addresses[?(.type==\"InternalIP\")].address}'"
-_mc-print-north-route := "kubectl --context=k3d-l5d-test-north get node k3d-l5d-test-north-server-0" + " " + _mc-route-output-fmt
-_mc-print-east-route := "kubectl --context=k3d-l5d-test-east get node k3d-l5d-test-east-server-0" + " " + _mc-route-output-fmt
-_mc-print-west-route := "kubectl --context=k3d-l5d-test get node k3d-l5d-test-server-0" + " " + _mc-route-output-fmt
+_mc-print-source-route := _kubectl + " " + "get node " + k3d-source-server + " " + _mc-route-output-fmt
+_mc-print-target-route := "kubectl --context=k3d-" + k3d-name + "-target "+ "get node " + k3d-target-server + " " + _mc-route-output-fmt
 
 # Allow two k3d server nodes to participate in a flat network
 mc-flat-network-init:
-	@docker exec k3d-l5d-test-server-0 `{{_mc-print-east-route}}`
-	@docker exec k3d-l5d-test-server-0 `{{_mc-print-north-route}}`
+	@docker exec k3d-{{k3d-name}}-server-0 `{{_mc-print-target-route}}`
+	@docker exec k3d-{{k3d-name}}-target-server-0 `{{_mc-print-source-route}}`
 
-	@docker exec k3d-l5d-test-east-server-0 `{{_mc-print-west-route}}`
-	@docker exec k3d-l5d-test-east-server-0 `{{_mc-print-north-route}}`
-
-	@docker exec k3d-l5d-test-north-server-0 `{{_mc-print-east-route}}`
-	@docker exec k3d-l5d-test-north-server-0 `{{_mc-print-west-route}}`
 
 # Run the multicluster tests without any setup
 mc-test-run *flags:

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 
 lint: action-lint action-dev-check md-lint sh-lint rs-fetch rs-clippy rs-check-fmt go-lint
 
-export GWAPI_VERSION := "v1.2.0"
+export GWAPI_VERSION := "v1.2.1"
 
 ##
 ## Go
@@ -472,7 +472,8 @@ _linkerd-viz-uninit:
 ## linkerd multicluster
 ##
 
-_mc-target-k3d-flags := "--k3s-arg --disable='local-storage,metrics-server@server:*' --k3s-arg '--cluster-cidr=10.23.0.0/24@server:*'"
+_mc-east-k3d-flags := "--k3s-arg --disable='local-storage,metrics-server@server:*' --k3s-arg '--cluster-cidr=10.23.0.0/24@server:*'"
+_mc-north-k3d-flags := "--k3s-arg --disable='local-storage,metrics-server@server:*' --k3s-arg '--cluster-cidr=10.24.0.0/24@server:*'"
 
 linkerd-mc-install: _linkerd-init
     {{ _linkerd }} mc install --set='linkerdVersion={{ linkerd-tag }}' \
@@ -494,14 +495,29 @@ mc-target-k3d-delete:
 
 mc-load: _k3d-init linkerd-load
 
-mc-target-load:
+mc-east-load:
     @{{ just_executable() }} \
-        k3d-name='{{ k3d-name }}-target' \
+        k3d-name='{{ k3d-name }}-east' \
         k3d-k8s='{{ k3d-k8s }}' \
         k3d-agents='{{ k3d-agents }}' \
         k3d-servers='{{ k3d-servers }}' \
         k3d-network='{{ k3d-network }}' \
-        _k3d-flags='{{ _mc-target-k3d-flags }}' \
+        _k3d-flags='{{ _mc-east-k3d-flags }}' \
+        controller-image='{{ controller-image }}' \
+        proxy-image='{{ proxy-image }}' \
+        linkerd-exec='{{ linkerd-exec }}' \
+        linkerd-tag='{{ linkerd-tag }}' \
+        _pause-load \
+        mc-load
+
+mc-north-load:
+    @{{ just_executable() }} \
+        k3d-name='{{ k3d-name }}-north' \
+        k3d-k8s='{{ k3d-k8s }}' \
+        k3d-agents='{{ k3d-agents }}' \
+        k3d-servers='{{ k3d-servers }}' \
+        k3d-network='{{ k3d-network }}' \
+        _k3d-flags='{{ _mc-north-k3d-flags }}' \
         controller-image='{{ controller-image }}' \
         proxy-image='{{ proxy-image }}' \
         linkerd-exec='{{ linkerd-exec }}' \
@@ -520,14 +536,20 @@ k3d-source-server := "k3d-" + k3d-name + "-server-0"
 k3d-target-server := "k3d-" + k3d-name + "-target-server-0"
 
 _mc-route-output-fmt := "-o jsonpath='ip route add {.spec.podCIDR} via {.status.addresses[?(.type==\"InternalIP\")].address}'"
-_mc-print-source-route := _kubectl + " " + "get node " + k3d-source-server + " " + _mc-route-output-fmt
-_mc-print-target-route := "kubectl --context=k3d-" + k3d-name + "-target "+ "get node " + k3d-target-server + " " + _mc-route-output-fmt
+_mc-print-north-route := "kubectl --context=k3d-l5d-test-north get node k3d-l5d-test-north-server-0" + " " + _mc-route-output-fmt
+_mc-print-east-route := "kubectl --context=k3d-l5d-test-east get node k3d-l5d-test-east-server-0" + " " + _mc-route-output-fmt
+_mc-print-west-route := "kubectl --context=k3d-l5d-test get node k3d-l5d-test-server-0" + " " + _mc-route-output-fmt
 
 # Allow two k3d server nodes to participate in a flat network
 mc-flat-network-init:
-	@docker exec k3d-{{k3d-name}}-server-0 `{{_mc-print-target-route}}`
-	@docker exec k3d-{{k3d-name}}-target-server-0 `{{_mc-print-source-route}}`
+	@docker exec k3d-l5d-test-server-0 `{{_mc-print-east-route}}`
+	@docker exec k3d-l5d-test-server-0 `{{_mc-print-north-route}}`
 
+	@docker exec k3d-l5d-test-east-server-0 `{{_mc-print-west-route}}`
+	@docker exec k3d-l5d-test-east-server-0 `{{_mc-print-north-route}}`
+
+	@docker exec k3d-l5d-test-north-server-0 `{{_mc-print-east-route}}`
+	@docker exec k3d-l5d-test-north-server-0 `{{_mc-print-west-route}}`
 
 # Run the multicluster tests without any setup
 mc-test-run *flags:

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const GATEWAY_API_VERSION = "v1.2.0"
+const GATEWAY_API_VERSION = "v1.2.1"
 
 // TestHelper provides helpers for running the linkerd integration tests.
 type TestHelper struct {


### PR DESCRIPTION
When a user runs `linkerd install --crds` but does not have the Gateway API CRDs installed on the cluster, Linkerd prints this error message:

```
The Gateway API CRDs must be installed prior to installing Linkerd. Run:

kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml

or see https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api for more options.
```

However, the Gateway API version v1.4.0 is outside of the range of versions that Linkerd supports.  

Replace this version with the maximum supported Gateway API version of v1.2.1.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
