### PR TITLE
fix: reduce default Prometheus data retention duration

### DIFF
--- a/viz/charts/linkerd-viz/values.yaml
+++ b/viz/charts/linkerd-viz/values.yaml
@@ -465,7 +465,7 @@ prometheus:
   # -- Command line options for Prometheus binary
   args:
     storage.tsdb.path: /data
-    storage.tsdb.retention.time: 6h
+    storage.tsdb.retention.time: 2h
     config.file: /etc/prometheus/prometheus.yml
   # -- The global configuration specifies parameters that are valid in all other
   # configuration contexts.

--- a/viz/cmd/testdata/install_default.golden
+++ b/viz/cmd/testdata/install_default.golden
@@ -768,7 +768,7 @@ spec:
         - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention.time=6h
+        - --storage.tsdb.retention.time=2h
         image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/viz/cmd/testdata/install_default_overrides.golden
+++ b/viz/cmd/testdata/install_default_overrides.golden
@@ -768,7 +768,7 @@ spec:
         - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention.time=6h
+        - --storage.tsdb.retention.time=2h
         image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
+++ b/viz/cmd/testdata/install_prometheus_loglevel_from_args.golden
@@ -768,7 +768,7 @@ spec:
         - --config.file=/etc/prometheus/prometheus.yml
         - --log.level=debug
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention.time=6h
+        - --storage.tsdb.retention.time=2h
         image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/viz/cmd/testdata/install_proxy_resources.golden
+++ b/viz/cmd/testdata/install_proxy_resources.golden
@@ -772,7 +772,7 @@ spec:
         - --log.format=logfmt
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/data
-        - --storage.tsdb.retention.time=6h
+        - --storage.tsdb.retention.time=2h
         image: prom/prometheus:v2.55.1
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
Reduces storage.tsdb.retention.time from 6h to 2h in the bundled Prometheus deployment (viz/charts/linkerd-viz/values.yaml). This lowers Prometheus memory footprint, addressing OOMKilled incidents reported in issue #3997.

Updates golden test fixtures to match the new default.

Fixes #3997

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
