### PR TITLE
inject: wire debug-image annotations through to injected container

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -1218,11 +1218,23 @@ func (conf *ResourceConfig) injectPodSpec(values *podPatch) {
 
 		if debug {
 			log.Infof("inject debug container")
+			debugName := values.Values.DebugContainer.Image.Name
+			debugVersion := values.Values.DebugContainer.Image.Version
+			debugPullPolicy := values.Values.DebugContainer.Image.PullPolicy
+			if v, ok := conf.pod.meta.Annotations[k8s.DebugImageAnnotation]; ok && v != "" {
+				debugName = v
+			}
+			if v, ok := conf.pod.meta.Annotations[k8s.DebugImageVersionAnnotation]; ok && v != "" {
+				debugVersion = v
+			}
+			if v, ok := conf.pod.meta.Annotations[k8s.DebugImagePullPolicyAnnotation]; ok && v != "" {
+				debugPullPolicy = v
+			}
 			values.DebugContainer = &l5dcharts.DebugContainer{
 				Image: &l5dcharts.Image{
-					Name:       values.Values.DebugContainer.Image.Name,
-					Version:    values.Values.DebugContainer.Image.Version,
-					PullPolicy: values.Values.DebugContainer.Image.PullPolicy,
+					Name:       debugName,
+					Version:    debugVersion,
+					PullPolicy: debugPullPolicy,
 				},
 			}
 		}


### PR DESCRIPTION
Fixes #13636

When `config.linkerd.io/inject: enabled` and
`config.linkerd.io/debug-sidecar: enabled` are both set, the debug container was always built from chart-default values, silently ignoring:

  config.linkerd.io/debug-image
  config.linkerd.io/debug-image-version
  config.linkerd.io/debug-image-pull-policy

Inside `injectPodSpec` the annotation values are now read from the pod metadata and applied as overrides before constructing `l5dcharts.DebugContainer`, so users can point the debug sidecar at a custom registry or version without modifying the Helm chart values.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
