### PR TITLE
   docs: replace invalid Zoom link with Service Mesh Academy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ welcome to attend, but audio and video participation is limited to Steering
 Committee members and maintainers. These meetings are currently scheduled on an
 ad-hoc basis and announced on the [linkerd-users][linkerd-users] mailing list.
 
-* [Zoom link](https://zoom.us/my/cncflinkerd)
+* [Service Mesh Academy](https://www.youtube.com/playlist?list=PLI9FkLPXDscB89y4q2ghguHMXyGadtQ-E)
 * [Minutes from previous meetings](https://docs.google.com/document/d/1GDNM5eosiyjVDo6YHXBMsvlpyzUldgg-XLMNzf7I404/edit)
 * [Recordings from previous meetings](https://www.youtube.com/playlist?list=PLI9FkLPXDscBHP91Ud3lyJScI4ZCjRG6F)
 


### PR DESCRIPTION
  ## Problem

   The Zoom meeting link in the Steering Committee section of `README.md` returns error 3001 (meeting not found):

   ```
   https://zoom.us/my/cncflinkerd
   ```

   ## Solution

   Replace the invalid Zoom link with the [Service Mesh Academy](https://www.youtube.com/playlist?list=PLI9FkLPXDscB89y4q2ghguHMXyGadtQ-E) YouTube playlist in the Steering Committee section.

   ## Validation

   - Confirmed the Zoom link returns error 3001 (invalid meeting)
   - Confirmed the new Service Mesh Academy link opens correctly

   Fixes #15247
