### PR TITLE
test: assert parsed port ranges

### DIFF
--- a/pkg/util/portrange_test.go
+++ b/pkg/util/portrange_test.go
@@ -47,8 +47,13 @@ func TestParsePortRange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			check, _ := ParsePortRange(tt.input)
-			reflect.DeepEqual(tt.expected, check)
+			check, err := ParsePortRange(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if !reflect.DeepEqual(tt.expected, check) {
+				t.Fatalf("expected %+v but received %+v", tt.expected, check)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Tiny test hardening PR.

`TestParsePortRange` called `reflect.DeepEqual` but dropped the bool, so the test could go green even when the parsed range was wrong. small but real, imo.

Repro on main:
- change the first expected range in `pkg/util/portrange_test.go` from `23-23` to `24-24`
- run `go test ./pkg/util`
- it still passes, which is not what we want

This makes the test fail on bad parsed ranges and on unexpected errors.

Validation:
- `go test ./pkg/util`
- `go test ./pkg/inject ./pkg/util`
- `go vet ./pkg/util`