### PR TITLE
chore: update golang to 1.25.10

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -45,7 +45,7 @@ COPY proxy-identity proxy-identity
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/proxy-identity -mod=readonly -ldflags "-s -w" ./proxy-identity
 
 ## build proxy-init
-FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine AS proxy-init
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS proxy-init
 WORKDIR /build
 ARG PROXY_INIT_REPO="linkerd/linkerd2-proxy-init"
 ARG PROXY_INIT_REF="proxy-init/v2.4.8"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkerd/linkerd2
 
-go 1.25.9
+go 1.25.10
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.0


### PR DESCRIPTION
this commit updates the go toolchain from 1.25.9 to 1.25.10. this
addresses a number of cve's that affect 1.25.9.

for more information, see:

- https://www.cve.org/CVERecord?id=CVE-2026-42501
- https://www.cve.org/CVERecord?id=CVE-2026-42499
- https://www.cve.org/CVERecord?id=CVE-2026-39836
- https://www.cve.org/CVERecord?id=CVE-2026-39826
- https://www.cve.org/CVERecord?id=CVE-2026-39825
- https://www.cve.org/CVERecord?id=CVE-2026-39823
- https://www.cve.org/CVERecord?id=CVE-2026-39820
- https://www.cve.org/CVERecord?id=CVE-2026-39819
- https://www.cve.org/CVERecord?id=CVE-2026-39817
- https://www.cve.org/CVERecord?id=CVE-2026-33814
- https://www.cve.org/CVERecord?id=CVE-2026-33811

Signed-off-by: katelyn martin <kate@buoyant.io>
