### PR TITLE
tests: repurpose deep-native-sidecar as deep-non-native-sidecar

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -120,7 +120,7 @@ jobs:
         test:
           - cni-calico-deep
           - deep
-          - deep-native-sidecar
+          - deep-non-native-sidecar
     runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:

--- a/bin/_test-helpers.sh
+++ b/bin/_test-helpers.sh
@@ -12,7 +12,7 @@ testdir=$bindir/../test/integration
 
 ##### Test setup helpers #####
 
-export default_test_names=(deep deep-native-sidecar viz tracing external helm-upgrade uninstall upgrade-edge default-policy-deny rsa-ca)
+export default_test_names=(deep deep-non-native-sidecar viz tracing external helm-upgrade uninstall upgrade-edge default-policy-deny rsa-ca)
 export external_resource_test_names=(external-resources)
 # TODO(alpeb): add test cni-calico-deep-dual-stack
 export dual_stack_test_names=(deep-dual-stack)
@@ -25,7 +25,7 @@ tests_usage() {
 
 Optionally specify a test with the --name flag: [${all_test_names[*]}]
 
-Note: The cluster-domain, deep-native-sidecar cni-calico-deep and multicluster tests require a custom cluster configuration (see bin/_test-helpers.sh)
+Note: The cluster-domain, deep-non-native-sidecar cni-calico-deep and multicluster tests require a custom cluster configuration (see bin/_test-helpers.sh)
 
 Usage:
     ${progname} [--images docker|archive|skip] [--name test-name] [--skip-cluster-create] /path/to/linkerd
@@ -445,8 +445,8 @@ run_deep_test() {
   run_test "$testdir/deep/..."
 }
 
-run_deep-native-sidecar_test() {
-  run_test "$testdir/deep/..." --native-sidecar
+run_deep-non-native-sidecar_test() {
+  run_test "$testdir/deep/..." --non-native-sidecar
 }
 
 run_deep-dual-stack_test() {

--- a/test/integration/deep/install_test.go
+++ b/test/integration/deep/install_test.go
@@ -152,8 +152,8 @@ func TestInstall(t *testing.T) {
 		cmd = append(cmd, "--linkerd-cni-enabled")
 	}
 
-	if TestHelper.NativeSidecar() {
-		cmd = append(cmd, "--set", "proxy.nativeSidecar=true")
+	if TestHelper.NonNativeSidecar() {
+		cmd = append(cmd, "--set", "proxy.nativeSidecar=false")
 	}
 
 	if TestHelper.DualStack() {

--- a/test/integration/viz/install_test.go
+++ b/test/integration/viz/install_test.go
@@ -89,8 +89,8 @@ func TestInstallVizHA(t *testing.T) {
 		"--ha",
 	}
 
-	if TestHelper.NativeSidecar() {
-		cmd = append(cmd, "--set", "proxy.nativeSidecar=true")
+	if TestHelper.NonNativeSidecar() {
+		cmd = append(cmd, "--set", "proxy.nativeSidecar=false")
 	}
 
 	out, err := TestHelper.LinkerdRun(cmd...)

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -42,7 +42,7 @@ type TestHelper struct {
 	cni                           bool
 	calico                        bool
 	dualStack                     bool
-	nativeSidecar                 bool
+	nonNativeSidecar              bool
 	defaultInboundPolicy          string
 	httpClient                    http.Client
 	KubernetesHelper
@@ -207,7 +207,7 @@ func NewTestHelper() *TestHelper {
 	cni := flag.Bool("cni", false, "whether to install linkerd with CNI enabled")
 	calico := flag.Bool("calico", false, "whether to install calico CNI plugin")
 	dualStack := flag.Bool("dual-stack", false, "whether to run the dual-stack tests")
-	nativeSidecar := flag.Bool("native-sidecar", false, "whether to install using native sidecar injection")
+	nonNativeSidecar := flag.Bool("non-native-sidecar", false, "whether to install using non-native sidecar injection")
 	defaultInboundPolicy := flag.String("default-inbound-policy", "", "if non-empty, passed to --set proxy.defaultInboundPolicy at linkerd's install time")
 	flag.Parse()
 
@@ -255,7 +255,7 @@ func NewTestHelper() *TestHelper {
 		cni:                  *cni,
 		calico:               *calico,
 		dualStack:            *dualStack,
-		nativeSidecar:        *nativeSidecar,
+		nonNativeSidecar:     *nonNativeSidecar,
 		uninstall:            *uninstall,
 		defaultInboundPolicy: *defaultInboundPolicy,
 	}
@@ -409,9 +409,9 @@ func (h *TestHelper) DualStack() bool {
 	return h.dualStack
 }
 
-// NativeSidecar determines whether native sidecar injection is enabled
-func (h *TestHelper) NativeSidecar() bool {
-	return h.nativeSidecar
+// NativeSidecar determines whether non-native sidecar injection is enabled
+func (h *TestHelper) NonNativeSidecar() bool {
+	return h.nonNativeSidecar
 }
 
 // AddInstalledExtension adds an extension name to installedExtensions to


### PR DESCRIPTION
Now that native sidecars are enabled by default since #15267, repurpose the `deep-native-sidecar` test into `deep-non-native-sidecar`, so that it runs the deep suite using the now non-default non-native-sidecar mode.