### PR TITLE
Allow ReadAllLimit inputs at byte limit

### DIFF
--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -54,11 +54,11 @@ func ParseMethod(method string) *httpPb.HttpMethod {
 // reached, the full bytes are returned. If the limit is reached, an error is
 // returned.
 func ReadAllLimit(r io.Reader, limit int) ([]byte, error) {
-	bytes, err := io.ReadAll(io.LimitReader(r, int64(limit)))
+	bytes, err := io.ReadAll(io.LimitReader(r, int64(limit)+1))
 	if err != nil {
 		return nil, err
 	}
-	if len(bytes) == limit {
+	if len(bytes) > limit {
 		return nil, fmt.Errorf("limit reached while reading: %d", limit)
 	}
 	return bytes, nil

--- a/pkg/util/http_test.go
+++ b/pkg/util/http_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -47,6 +48,26 @@ func TestParseScheme(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadAllLimit(t *testing.T) {
+	t.Run("Allows input at limit", func(t *testing.T) {
+		input := "12345"
+		got, err := ReadAllLimit(strings.NewReader(input), len(input))
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if string(got) != input {
+			t.Fatalf("expected %q but received %q", input, string(got))
+		}
+	})
+
+	t.Run("Rejects input over limit", func(t *testing.T) {
+		_, err := ReadAllLimit(strings.NewReader("123456"), 5)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	})
 }
 
 func TestParseMethod(t *testing.T) {


### PR DESCRIPTION
Problem
ReadAllLimit was off by one: a body exactly at the configured cap returned `limit reached`. This can hit normal HTTP paths with 1MiB/10MiB/100MiB caps; no special infra magic needed, an exact-size request or response body does it.

Repro
Before this patch:
```sh
go test ./pkg/util -run TestReadAllLimit -count=1
```
fails on `Allows input at limit` with `limit reached while reading: 5`.

Fix
Read one byte past the cap, so exactly-cap bytes are ok and cap+1 still fails. tiny off-by-one cleanup, imo.

Validation
```sh
go test ./pkg/util -count=1
go test ./pkg/protohttp -count=1
go test ./controller/webhook -count=1
go test ./controller/heartbeat -count=1
go test ./pkg/version -count=1
```