### PR TITLE
fix(policy-k8s): use correct resource labels in outbound indexer logs

### DIFF
--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -214,7 +214,7 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
     fn apply(&mut self, service: Service) {
         let name = service.name_unchecked();
         let ns = service.namespace().expect("Service must have a namespace");
-        tracing::debug!(name, ns, "indexing service");
+        tracing::debug!(service = name, namespace = ns, "indexing service");
         let accrual = parse_accrual_config(service.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();
@@ -376,7 +376,11 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
         let ns = egress_network
             .namespace()
             .expect("EgressNetwork must have a namespace");
-        tracing::debug!(name, ns, "indexing EgressNetwork");
+        tracing::debug!(
+            egress_network = name,
+            namespace = ns,
+            "indexing EgressNetwork"
+        );
         let accrual = parse_accrual_config(egress_network.annotations())
             .map_err(|error| tracing::warn!(%error, egress_network=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -378,7 +378,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             .expect("EgressNetwork must have a namespace");
         tracing::debug!(name, ns, "indexing EgressNetwork");
         let accrual = parse_accrual_config(egress_network.annotations())
-            .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse accrual config"))
+            .map_err(|error| tracing::warn!(%error, egress_network=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();
         let opaque_ports = ports_annotation(
             egress_network.annotations(),
@@ -391,14 +391,14 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             .collect();
 
         let timeouts = parse_timeouts(egress_network.annotations())
-            .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse timeouts"))
+            .map_err(|error| tracing::warn!(%error, egress_network=name, namespace=ns, "Failed to parse timeouts"))
             .unwrap_or_default();
 
         let http_retry = http::parse_http_retry(egress_network.annotations()).map_err(|error| {
-            tracing::warn!(%error, service=name, namespace=ns, "Failed to parse http retry")
+            tracing::warn!(%error, egress_network=name, namespace=ns, "Failed to parse http retry")
         }).unwrap_or_default();
         let grpc_retry = grpc::parse_grpc_retry(egress_network.annotations()).map_err(|error| {
-            tracing::warn!(%error, service=name, namespace=ns, "Failed to parse grpc retry")
+            tracing::warn!(%error, egress_network=name, namespace=ns, "Failed to parse grpc retry")
         }).unwrap_or_default();
 
         let egress_net_ref = ResourceRef {


### PR DESCRIPTION
The outbound policy index's `IndexNamespacedResource<EgressNetwork>`
implementation used `service=name` as the structured log field in its
four `warn!()` calls (accrual config, timeouts, HTTP retry, gRPC
retry). This was probably a copy-paste artifact from the adjacent
`IndexNamespacedResource<Service>` implementation, making log output
misleading when an EgressNetwork resource fails annotation parsing.

Additionally, both indexers used bare `name, ns` fields in their
`debug!()` calls while their sibling `warn!()` calls used explicit
labeled fields (`service=name, namespace=ns` and
`egress_network=name, namespace=ns`). This inconsistency meant the
same resource appeared under different field names depending on log
level.

This replaces `service=name` with `egress_network=name` in the four
EgressNetwork `warn!()` calls so operators see the correct resource
type when investigating parse errors, and adds explicit labels to
both indexers' `debug!()` calls so field names are consistent across
log levels within each implementation.

Signed-off-by: Alejandro Martinez Ruiz &lt;amr@buoyant.io&gt;