### PR TITLE
chore: update linkerd-await from 0.3.2 to 0.3.3

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -26,7 +26,7 @@ RUN --mount=type=secret,id=github \
     proxy=$(bin/fetch-proxy "$LINKERD2_PROXY_VERSION" "$TARGETARCH"); \
     mv "$proxy" linkerd2-proxy
 RUN echo "$LINKERD2_PROXY_VERSION" > proxy-version
-ARG LINKERD_AWAIT_VERSION=v0.3.2
+ARG LINKERD_AWAIT_VERSION=v0.3.3
 RUN bin/scurl -o linkerd-await https://github.com/linkerd/linkerd-await/releases/download/release%2F${LINKERD_AWAIT_VERSION}/linkerd-await-${LINKERD_AWAIT_VERSION}-${TARGETARCH} && chmod +x linkerd-await
 ARG LINKERD_VALIDATOR_VERSION=v0.1.9
 RUN bin/scurl -O https://github.com/linkerd/linkerd2-proxy-init/releases/download/validator%2F${LINKERD_VALIDATOR_VERSION}/linkerd-network-validator-${LINKERD_VALIDATOR_VERSION}-${TARGETARCH}-linux.tgz


### PR DESCRIPTION
this commit updates the linkerd-await version.

this release contains an accumulation of dependency updates:

* build(deps): bump actions/download-artifact from 7.0.0 to 8.0.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/514
* build(deps): bump softprops/action-gh-release from 2.5.0 to 2.6.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/515
* build(deps): bump DavidAnson/markdownlint-cli2-action from 22.0.0 to 23.0.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/516
* build(deps): bump actions/upload-artifact from 6.0.0 to 7.0.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/518
* build(deps): bump http-body-util from 0.1.1 to 0.1.3 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/520
* build(deps): bump mio from 1.0.4 to 1.2.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/521
* build(deps): bump pin-project-lite from 0.2.14 to 0.2.17 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/522
* build(deps): bump log from 0.4.21 to 0.4.29 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/523
* build(deps): bump clap_lex from 0.7.0 to 0.7.7 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/524
* build(deps): bump EmbarkStudios/cargo-deny-action from 2.0.15 to 2.0.17 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/525
* build(deps): bump actions/checkout from 6.0.1 to 6.0.2 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/509
* build(deps): bump softprops/action-gh-release from 2.6.1 to 3.0.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/517
* build(deps): bump httparse from 1.8.0 to 1.10.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/526
* build(deps): bump once_cell from 1.19.0 to 1.21.4 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/527
* build(deps): bump tower-service from 0.3.2 to 0.3.3 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/528
* build(deps): bump wasi from 0.11.0+wasi-snapshot-preview1 to 0.11.1+wasi-snapshot-preview1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/529
* build(deps): bump clap from 4.5.4 to 4.5.60 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/530
* build(deps): bump DavidAnson/markdownlint-cli2-action from 23.0.0 to 23.1.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/531
* build(deps): bump syn from 2.0.64 to 2.0.65 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/532
* build(deps): bump hyper from 1.3.1 to 1.9.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/534
* build(deps): bump smallvec from 1.13.2 to 1.15.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/535
* build(deps): bump http-body from 1.0.0 to 1.0.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/536
* build(deps): bump backtrace from 0.3.71 to 0.3.76 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/537
* build(deps): bump rustc-demangle from 0.1.24 to 0.1.27 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/538
* build(deps): bump itoa from 1.0.11 to 1.0.18 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/540
* build(deps): bump hyper-util from 0.1.3 to 0.1.20 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/541
* build(deps): bump proc-macro2 from 1.0.82 to 1.0.106 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/542
* build(deps): bump autocfg from 1.3.0 to 1.5.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/543
* build(deps): bump DavidAnson/markdownlint-cli2-action from 23.1.0 to 23.2.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/545
* build(deps): bump tokio from 1.45.0 to 1.52.2 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/546
* build(deps): bump clap from 4.5.60 to 4.6.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/548
* build(deps): bump tracing from 0.1.40 to 0.1.44 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/549
* build(deps): bump futures from 0.3.30 to 0.3.31 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/550
* build(deps): bump signal-hook-registry from 1.4.2 to 1.4.8 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/551
* build(deps): bump EmbarkStudios/cargo-deny-action from 2.0.17 to 2.0.18 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/552
* build(deps): bump tokio from 1.52.2 to 1.52.3 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/554
* build(deps): bump libc from 0.2.184 to 0.2.186 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/555
* build(deps): bump cfg-if from 1.0.0 to 1.0.4 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/553
* build(deps): bump futures from 0.3.31 to 0.3.32 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/557
* build(deps): bump http from 1.1.0 to 1.4.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/558
* build(deps): bump EmbarkStudios/cargo-deny-action from 2.0.18 to 2.0.19 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/559
* build(deps): bump autocfg from 1.5.0 to 1.5.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/560
* build(deps): bump http from 1.4.0 to 1.4.1 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/562
* build(deps): update nix from 0.26.4 to 0.31.3 by @cratelyn in https://github.com/linkerd/linkerd-await/pull/561
* build(deps): bump hyper from 1.9.0 to 1.10.0 by @dependabot[bot] in https://github.com/linkerd/linkerd-await/pull/564

see https://github.com/linkerd/linkerd-await/releases/tag/release%2Fv0.3.3.

Signed-off-by: katelyn martin <kate@buoyant.io>
