### PR TITLE
feat(cli): refactor versions channels parsing to support fips channels

### DIFF
--- a/pkg/version/channels_test.go
+++ b/pkg/version/channels_test.go
@@ -25,16 +25,27 @@ func TestGetLatestVersions(t *testing.T) {
 				"fooHotpatch": "foo-1.2.3-4",
 				"stable":      "stable-2.1.0",
 				"edge":        "edge-2.1.0",
+				"edgeFIPS":    "edge-2.1.0-fips",
 			},
 			nil,
 			Channels{
 				[]channelVersion{
-					{"foo", "1.2.3", nil, "foo-1.2.3"},
-					{"foo", "1.2.3", &four, "foo-1.2.3-4"},
-					{"stable", "2.1.0", nil, "stable-2.1.0"},
-					{"edge", "2.1.0", nil, "edge-2.1.0"},
+					{"foo", "1.2.3", nil, false, "foo-1.2.3"},
+					{"foo", "1.2.3", &four, false, "foo-1.2.3-4"},
+					{"stable", "2.1.0", nil, false, "stable-2.1.0"},
+					{"edge", "2.1.0", nil, false, "edge-2.1.0"},
+					{"edge", "2.1.0", nil, true, "edge-2.1.0-fips"},
 				},
 			},
+		},
+		{
+			"fips channel name mismatch",
+			map[string]string{
+				"foo":  "foo-1.2.3",
+				"edge": "edge-2.1.0-fips",
+			},
+			fmt.Errorf("unexpected versioncheck response: channel in edge-2.1.0-fips does not match edge"),
+			Channels{},
 		},
 		{
 			"channel version mismatch",
@@ -102,7 +113,7 @@ func channelsEqual(c1, c2 Channels) bool {
 	for _, cv1 := range c1.array {
 		found := false
 		for _, cv2 := range c2.array {
-			if cv1.channel == cv2.channel && cv1.version == cv2.version && cv1.hotpatchEqual(cv2) {
+			if cv1.channel == cv2.channel && cv1.version == cv2.version && cv1.suffixEqual(cv2) {
 				found = true
 				break
 			}
@@ -119,10 +130,12 @@ func TestChannelsMatch(t *testing.T) {
 	four := int64(4)
 	channels := Channels{
 		[]channelVersion{
-			{"stable", "2.1.0", nil, "stable-2.1.0"},
-			{"foo", "1.2.3", nil, "foo-1.2.3"},
-			{"foo", "1.2.3", &four, "foo-1.2.3-4"},
-			{"version", "3.2.1", nil, "version-3.2.1"},
+			{"stable", "2.1.0", nil, false, "stable-2.1.0"},
+			{"foo", "1.2.3", nil, false, "foo-1.2.3"},
+			{"foo", "1.2.3", &four, false, "foo-1.2.3-4"},
+			{"version", "3.2.1", nil, false, "version-3.2.1"},
+			{"edge", "2.1.0", nil, false, "edge-2.1.0"},
+			{"edge", "2.1.0", nil, true, "edge-2.1.0-fips"},
 		},
 	}
 
@@ -136,6 +149,17 @@ func TestChannelsMatch(t *testing.T) {
 		{"foo-1.2.3-4", nil},
 		{"foo-1.2.3-4-buildinfo", nil},
 		{"version-3.2.1", nil},
+		// A FIPS build routes to the separate "edgeFIPS" update channel and is
+		// up-to-date with the latest FIPS version.
+		{"edge-2.1.0", nil},
+		{"edge-2.1.0-fips", nil},
+		{"edge-2.1.0-fips-buildinfo", nil},
+		{
+			// An out-of-date FIPS build is compared against the latest FIPS
+			// version in the edgeFIPS channel.
+			"edge-2.0.0-fips",
+			fmt.Errorf("is running version 2.0.0-fips but the latest edge version is 2.1.0-fips"),
+		},
 		{
 			"foo-1.2.2",
 			fmt.Errorf("is running version 1.2.2 but the latest foo version is 1.2.3"),

--- a/pkg/version/channelversion.go
+++ b/pkg/version/channelversion.go
@@ -12,12 +12,21 @@ type channelVersion struct {
 	channel  string
 	version  string
 	hotpatch *int64
+	fips     bool
 	original string
 }
 
 // hotpatchSuffix is the suffix applied to channel names to indicate that the
 // version string includes a hotpatch number (e.g. dev-0.1.2-3)
 const hotpatchSuffix = "Hotpatch"
+
+// fipsSuffix is the suffix applied to channel names to indicate that the
+// version represents a FIPS-compliant build (e.g. devFIPS: dev-0.1.2-fips)
+const fipsSuffix = "FIPS"
+
+// fipsVersionSuffix is the suffix applied to version string to indicate that
+// the version represents a FIPS-compliant build (e.g. dev-0.1.2-fips)
+const fipsVersionSuffix = "fips"
 
 func (cv channelVersion) String() string {
 	return cv.original
@@ -31,19 +40,28 @@ func (cv channelVersion) updateChannel() string {
 	if cv.hotpatch != nil {
 		return cv.channel + hotpatchSuffix
 	}
+	if cv.fips {
+		return cv.channel + fipsSuffix
+	}
 	return cv.channel
 }
 
-// versionWithHotpatch returns the version string, suffixed with the hotpatch
-// number if it exists.
-func (cv channelVersion) versionWithHotpatch() string {
-	if cv.hotpatch == nil {
-		return cv.version
+// versionWithSuffix returns the version string, suffixed with the hotpatch
+// number or "-fips" if appropriate.
+func (cv channelVersion) versionWithSuffix() string {
+	if cv.hotpatch != nil {
+		return fmt.Sprintf("%s-%d", cv.version, *cv.hotpatch)
 	}
-	return fmt.Sprintf("%s-%d", cv.version, *cv.hotpatch)
+	if cv.fips {
+		return fmt.Sprintf("%s-%s", cv.version, fipsVersionSuffix)
+	}
+	return cv.version
 }
 
-func (cv channelVersion) hotpatchEqual(other channelVersion) bool {
+func (cv channelVersion) suffixEqual(other channelVersion) bool {
+	if cv.fips != other.fips {
+		return false
+	}
 	if cv.hotpatch == nil && other.hotpatch == nil {
 		return true
 	}
@@ -56,9 +74,9 @@ func (cv channelVersion) hotpatchEqual(other channelVersion) bool {
 // parseChannelVersion parses a build string into a channelVersion struct. it
 // expects the channel and version to be separated by a hyphen (e.g. dev-0.1.2).
 // the version may additionally include a hotpatch number, which is separated
-// from the base version by another hyphen (e.g. dev-0.1.2-3). if the version is
-// suffixed with any other non-numeric build info strings (e.g. dev-0.1.2-foo),
-// those strings are ignored.
+// from the base version by another hyphen (e.g. dev-0.1.2-3), or "-fips". if
+// the version is suffixed with any other non-numeric build info strings (e.g.
+// dev-0.1.2-foo), those strings are ignored.
 func parseChannelVersion(cv string) (channelVersion, error) {
 	parts := strings.Split(cv, "-")
 	if len(parts) < 2 {
@@ -68,15 +86,20 @@ func parseChannelVersion(cv string) (channelVersion, error) {
 	channel := parts[0]
 	version := parts[1]
 	var hotpatch *int64
+	fips := false
 
 	for _, part := range parts[2:] {
+		if part == fipsVersionSuffix {
+			fips = true
+			break
+		}
 		if i, err := strconv.ParseInt(part, 10, 64); err == nil {
 			hotpatch = &i
 			break
 		}
 	}
 
-	return channelVersion{channel, version, hotpatch, cv}, nil
+	return channelVersion{channel, version, hotpatch, fips, cv}, nil
 }
 
 // IsReleaseChannel returns true if the channel of the version is "edge" or

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -57,9 +57,9 @@ func match(expectedVersion, actualVersion string) error {
 			actual, expected)
 	}
 
-	if actual.version != expected.version || !actual.hotpatchEqual(expected) {
+	if actual.version != expected.version || !actual.suffixEqual(expected) {
 		return fmt.Errorf("is running version %s but the latest %s version is %s",
-			actual.versionWithHotpatch(), actual.channel, expected.versionWithHotpatch())
+			actual.versionWithSuffix(), actual.channel, expected.versionWithSuffix())
 	}
 
 	return nil

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -56,6 +56,22 @@ func TestMatch(t *testing.T) {
 			err:      errors.New("is running version 0.1.2-2 but the latest dev version is 0.1.2-3"),
 		},
 		{
+			name:     "up-to-date with fips",
+			expected: "dev-0.1.2-fips",
+			actual:   "dev-0.1.2-fips",
+		},
+		{
+			name:     "up-to-date with fips and different build info",
+			expected: "dev-0.1.2-fips",
+			actual:   "dev-0.1.2-fips-baz",
+		},
+		{
+			name:     "not up-to-date with fips",
+			expected: "dev-0.1.3-fips",
+			actual:   "dev-0.1.2-fips",
+			err:      errors.New("is running version 0.1.2-fips but the latest dev version is 0.1.3-fips"),
+		},
+		{
 			name:     "mismatched channels",
 			expected: "dev-0.1.2",
 			actual:   "git-cb21f1bc",


### PR DESCRIPTION
This change ultimately allows for the "linkerd-version" and "control-plane-version" sections of `linkerd check` to properly deal with fips channels that will get exposed in the `CheckURL` endpoint.