### PR TITLE
feat(policy): unified failure accrual and response-penalty load biasing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,7 @@ dependencies = [
  "linkerd-policy-controller-k8s-api",
  "linkerd2-proxy-api",
  "maplit",
+ "prost-types",
  "rand 0.10.1",
  "regex",
  "schemars",

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -150,7 +150,15 @@ pub struct WeightedEgressNetwork {
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum FailureAccrual {
-    Consecutive { max_failures: u32, backoff: Backoff },
+    Consecutive {
+        max_failures: u32,
+        backoff: Backoff,
+    },
+    Unified {
+        max_failures: u32,
+        backoff: Backoff,
+        success_rate: SuccessRateConfig,
+    },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -159,6 +167,45 @@ pub struct Backoff {
     pub max_penalty: time::Duration,
     pub jitter: f32,
 }
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SuccessRateConfig {
+    pub threshold: f64,
+    /// Length of the trailing window over which the success ratio is
+    /// measured. The proxy samples responses into a ring of fixed-duration
+    /// buckets that span this window. The value sets a window length and
+    /// does not act as an EWMA time constant.
+    pub window: time::Duration,
+    pub min_requests: u32,
+}
+
+pub const DEFAULT_SUCCESS_RATE_THRESHOLD: f64 = 0.8;
+pub const DEFAULT_SUCCESS_RATE_WINDOW: time::Duration = time::Duration::from_secs(10);
+pub const DEFAULT_SUCCESS_RATE_MIN_REQUESTS: u32 = 5;
+
+/// Minimum success-rate window the proxy accepts. A shorter window
+/// invalidates the whole client policy (MIN_SUCCESS_RATE_DECAY in the proxy).
+pub const MIN_SUCCESS_RATE_WINDOW: time::Duration = time::Duration::from_millis(10);
+/// Maximum success-rate min-requests the proxy accepts. A larger value
+/// invalidates the whole client policy (MAX_SUCCESS_RATE_MIN_REQUESTS in the proxy).
+pub const MAX_SUCCESS_RATE_MIN_REQUESTS: u32 = 1_000_000;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct LoadBiaserConfig {
+    pub penalty: time::Duration,
+    /// Ceiling the biaser applies to a Retry-After hint before it raises the
+    /// effective RTT. The breaker honors Retry-After on its own, bounded by its
+    /// backoff maximum.
+    pub max_retry_after: time::Duration,
+}
+
+pub const DEFAULT_LOAD_BIASER_PENALTY: time::Duration = time::Duration::from_secs(5);
+/// Decay the proxy folds into its single rtt_decay EWMA. The biaser has no
+/// separate penalty-decay knob, so the default is emitted to keep the wire
+/// stable.
+pub const DEFAULT_LOAD_BIASER_PENALTY_DECAY: time::Duration = time::Duration::from_secs(10);
+
+pub const DEFAULT_LOAD_BIASER_MAX_RETRY_AFTER: time::Duration = time::Duration::from_secs(300);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Filter {

--- a/policy-controller/core/src/outbound/policy.rs
+++ b/policy-controller/core/src/outbound/policy.rs
@@ -1,6 +1,6 @@
 use super::{
     AppProtocol, FailureAccrual, GrpcRetryCondition, GrpcRoute, HttpRetryCondition, HttpRoute,
-    RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+    LoadBiaserConfig, RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
 };
 
 use std::num::NonZeroU16;
@@ -31,6 +31,8 @@ pub struct OutboundPolicy {
     pub port: NonZeroU16,
     pub app_protocol: Option<AppProtocol>,
     pub accrual: Option<FailureAccrual>,
+    pub load_biaser: Option<LoadBiaserConfig>,
+    pub honor_retry_after: bool,
     pub http_retry: Option<RouteRetry<HttpRetryCondition>>,
     pub grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
     pub timeouts: RouteTimeouts,

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -12,9 +12,9 @@ use linkerd2_proxy_api::{
 };
 use linkerd_policy_controller_core::{
     outbound::{
-        AppProtocol, DiscoverOutboundPolicy, ExternalPolicyStream, Kind, OutboundDiscoverTarget,
-        OutboundPolicy, OutboundPolicyStream, ParentInfo, ResourceTarget, Route,
-        WeightedEgressNetwork, WeightedService,
+        AppProtocol, Backoff, DiscoverOutboundPolicy, ExternalPolicyStream, Kind, LoadBiaserConfig,
+        OutboundDiscoverTarget, OutboundPolicy, OutboundPolicyStream, ParentInfo, ResourceTarget,
+        Route, WeightedEgressNetwork, WeightedService, DEFAULT_LOAD_BIASER_PENALTY_DECAY,
     },
     routes::GroupKindNamespaceName,
 };
@@ -470,26 +470,48 @@ fn to_proto(
     allow_l5d_request_headers: bool,
     original_dst: Option<SocketAddr>,
 ) -> outbound::OutboundPolicy {
-    let backend: outbound::Backend = default_backend(&policy, original_dst);
+    // Captured before policy fields move, then folded into the balancer
+    // load once so every route backend shares one estimator.
+    let load_biaser = policy.load_biaser;
+    let honor_retry_after = policy.honor_retry_after;
+    let load = service_balancer_config(load_biaser.as_ref());
 
-    let accrual = policy.accrual.map(|accrual| outbound::FailureAccrual {
-        kind: Some(match accrual {
-            linkerd_policy_controller_core::outbound::FailureAccrual::Consecutive {
-                max_failures,
-                backoff,
-            } => outbound::failure_accrual::Kind::ConsecutiveFailures(
+    let backend: outbound::Backend = default_backend(&policy, original_dst, &load);
+
+    let accrual = policy.accrual.map(|accrual| match accrual {
+        linkerd_policy_controller_core::outbound::FailureAccrual::Consecutive {
+            max_failures,
+            backoff,
+        } => outbound::FailureAccrual {
+            kind: Some(outbound::failure_accrual::Kind::ConsecutiveFailures(
                 outbound::failure_accrual::ConsecutiveFailures {
                     max_failures,
-                    backoff: Some(outbound::ExponentialBackoff {
-                        min_backoff: convert_duration("min_backoff", backoff.min_penalty),
-                        max_backoff: convert_duration("max_backoff", backoff.max_penalty),
-                        jitter_ratio: backoff.jitter,
-                        respect_retry_after_hint: false,
-                    }),
+                    backoff: Some(convert_backoff(backoff, honor_retry_after)),
                 },
-            ),
-        }),
-        ejection: None,
+            )),
+            ejection: None,
+        },
+        linkerd_policy_controller_core::outbound::FailureAccrual::Unified {
+            max_failures,
+            backoff,
+            success_rate,
+        } => outbound::FailureAccrual {
+            kind: Some(outbound::failure_accrual::Kind::Unified(
+                outbound::failure_accrual::Unified {
+                    success_rate_threshold: success_rate.threshold,
+                    // The proxy-api field is named `decay` on the wire (0.20.0).
+                    // It holds the trailing sliding-window length.
+                    decay: convert_duration("success_rate_window", success_rate.window),
+                    min_requests: success_rate.min_requests,
+                    max_consecutive_failures: max_failures,
+                    // The proxy treats a missing backoff as an invalid accrual
+                    // config. The Retry-After opt-in is attached to the accrual
+                    // backoff for both kinds.
+                    backoff: Some(convert_backoff(backoff, honor_retry_after)),
+                },
+            )),
+            ejection: None,
+        },
     });
 
     let mut http_routes = policy.http_routes.clone().into_iter().collect::<Vec<_>>();
@@ -506,6 +528,7 @@ fn to_proto(
                 allow_l5d_request_headers,
                 &policy.parent_info,
                 original_dst,
+                &load,
             )
         }
         Some(AppProtocol::Http2) => {
@@ -522,6 +545,7 @@ fn to_proto(
                     allow_l5d_request_headers,
                     &policy.parent_info,
                     original_dst,
+                    &load,
                 )
             } else {
                 http_routes.sort_by(timestamp_then_name);
@@ -534,6 +558,7 @@ fn to_proto(
                     allow_l5d_request_headers,
                     &policy.parent_info,
                     original_dst,
+                    &load,
                 )
             }
         }
@@ -574,6 +599,7 @@ fn to_proto(
                     allow_l5d_request_headers,
                     &policy.parent_info,
                     original_dst,
+                    &load,
                 )
             } else if !http_routes.is_empty() {
                 http_routes.sort_by(timestamp_then_name);
@@ -586,6 +612,7 @@ fn to_proto(
                     allow_l5d_request_headers,
                     &policy.parent_info,
                     original_dst,
+                    &load,
                 )
             } else if !tls_routes.is_empty() {
                 tls_routes.sort_by(timestamp_then_name);
@@ -614,6 +641,7 @@ fn to_proto(
                     allow_l5d_request_headers,
                     &policy.parent_info,
                     original_dst,
+                    &load,
                 )
             }
         }
@@ -663,7 +691,11 @@ fn timestamp_then_name<R: Route>(
     by_ts.then_with(|| left_id.name.cmp(&right_id.name))
 }
 
-fn default_backend(policy: &OutboundPolicy, original_dst: Option<SocketAddr>) -> outbound::Backend {
+fn default_backend(
+    policy: &OutboundPolicy,
+    original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
+) -> outbound::Backend {
     match policy.parent_info.clone() {
         ParentInfo::Service {
             authority,
@@ -691,7 +723,19 @@ fn default_backend(policy: &OutboundPolicy, original_dst: Option<SocketAddr>) ->
                             },
                         )),
                     }),
-                    load: Some(default_balancer_config()),
+                    // The response-code penalty applies only to HTTP and gRPC traffic.
+                    // An explicitly opaque service keeps the plain estimator on its
+                    // default backend. A service with no appProtocol still gets the
+                    // penalty estimator here. That backend also serves the Detect
+                    // opaque fallback and the tls and tcp traffic, where the proxy
+                    // drops the penalty and balances on round-trip time, logging once
+                    // per policy update.
+                    load: Some(match policy.app_protocol {
+                        Some(AppProtocol::Opaque) | Some(AppProtocol::Unknown(_)) => {
+                            default_balancer_config()
+                        }
+                        _ => *load,
+                    }),
                 },
             )),
         },
@@ -772,19 +816,63 @@ fn default_outbound_opaq_route(
     }
 }
 
+const BALANCER_DEFAULT_RTT: time::Duration = time::Duration::from_millis(30);
+const BALANCER_RTT_DECAY: time::Duration = time::Duration::from_secs(10);
+
 fn default_balancer_config() -> outbound::backend::balance_p2c::Load {
     outbound::backend::balance_p2c::Load::PeakEwma(outbound::backend::balance_p2c::PeakEwma {
         default_rtt: Some(
-            time::Duration::from_millis(30)
+            BALANCER_DEFAULT_RTT
                 .try_into()
                 .expect("failed to convert ewma default_rtt to protobuf"),
         ),
         decay: Some(
-            time::Duration::from_secs(10)
+            BALANCER_RTT_DECAY
                 .try_into()
                 .expect("failed to convert ewma decay to protobuf"),
         ),
     })
+}
+
+// Selects the load estimator for a service's own balancer. Without
+// penalization the plain PeakEwma applies. Penalization emits the penalty
+// estimator (PenaltyPeakEwma), which holds the penalty and the Retry-After
+// cap the biaser applies. The honor-retry-after flag is separate. It sets
+// respect_retry_after_hint on the failure-accrual backoff, which the breaker
+// bounds by its own backoff maximum.
+fn service_balancer_config(
+    load_biaser: Option<&LoadBiaserConfig>,
+) -> outbound::backend::balance_p2c::Load {
+    let Some(load_biaser) = load_biaser else {
+        return default_balancer_config();
+    };
+
+    outbound::backend::balance_p2c::Load::PenaltyPeakEwma(
+        outbound::backend::balance_p2c::PenaltyPeakEwma {
+            default_rtt: Some(
+                BALANCER_DEFAULT_RTT
+                    .try_into()
+                    .expect("failed to convert ewma default_rtt to protobuf"),
+            ),
+            decay: Some(
+                BALANCER_RTT_DECAY
+                    .try_into()
+                    .expect("failed to convert ewma decay to protobuf"),
+            ),
+            penalty: convert_duration("load_biaser_penalty", load_biaser.penalty),
+            // The proxy folds penalty_decay into its single rtt_decay EWMA, so
+            // it is not operator-tunable. The default is emitted to keep the
+            // proto representation complete.
+            penalty_decay: convert_duration(
+                "load_biaser_penalty_decay",
+                DEFAULT_LOAD_BIASER_PENALTY_DECAY,
+            ),
+            max_retry_after: convert_duration(
+                "load_biaser_max_retry_after",
+                load_biaser.max_retry_after,
+            ),
+        },
+    )
 }
 
 fn default_queue_config() -> outbound::Queue {
@@ -795,6 +883,18 @@ fn default_queue_config() -> outbound::Queue {
                 .try_into()
                 .expect("failed to convert failfast_timeout to protobuf"),
         ),
+    }
+}
+
+fn convert_backoff(
+    backoff: Backoff,
+    respect_retry_after_hint: bool,
+) -> outbound::ExponentialBackoff {
+    outbound::ExponentialBackoff {
+        min_backoff: convert_duration("min_backoff", backoff.min_penalty),
+        max_backoff: convert_duration("max_backoff", backoff.max_penalty),
+        jitter_ratio: backoff.jitter,
+        respect_retry_after_hint,
     }
 }
 

--- a/policy-controller/grpc/src/outbound.rs
+++ b/policy-controller/grpc/src/outbound.rs
@@ -486,7 +486,8 @@ fn to_proto(
             kind: Some(outbound::failure_accrual::Kind::ConsecutiveFailures(
                 outbound::failure_accrual::ConsecutiveFailures {
                     max_failures,
-                    backoff: Some(convert_backoff(backoff, honor_retry_after)),
+                    // Consecutive failure accrual does not act on the Retry-After hint.
+                    backoff: Some(convert_backoff(backoff, false)),
                 },
             )),
             ejection: None,
@@ -838,8 +839,8 @@ fn default_balancer_config() -> outbound::backend::balance_p2c::Load {
 // penalization the plain PeakEwma applies. Penalization emits the penalty
 // estimator (PenaltyPeakEwma), which holds the penalty and the Retry-After
 // cap the biaser applies. The honor-retry-after flag is separate. It sets
-// respect_retry_after_hint on the failure-accrual backoff, which the breaker
-// bounds by its own backoff maximum.
+// respect_retry_after_hint on the unified breaker's backoff, where the
+// breaker bounds it by its own backoff maximum.
 fn service_balancer_config(
     load_biaser: Option<&LoadBiaserConfig>,
 ) -> outbound::backend::balance_p2c::Load {

--- a/policy-controller/grpc/src/outbound/grpc.rs
+++ b/policy-controller/grpc/src/outbound/grpc.rs
@@ -1,4 +1,4 @@
-use super::{convert_duration, default_balancer_config, default_queue_config};
+use super::{convert_duration, default_queue_config};
 use crate::routes::{
     convert_host_match, convert_request_header_modifier_filter, grpc::convert_match,
 };
@@ -26,6 +26,7 @@ pub(crate) fn protocol(
     allow_l5d_request_headers: bool,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::proxy_protocol::Kind {
     let mut routes = routes
         .map(|(gknn, route)| {
@@ -38,6 +39,7 @@ pub(crate) fn protocol(
                 allow_l5d_request_headers,
                 parent_info,
                 original_dst,
+                load,
             )
         })
         .collect::<Vec<_>>();
@@ -71,6 +73,7 @@ fn convert_outbound_route(
     allow_l5d_request_headers: bool,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::GrpcRoute {
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Resource(meta::Resource {
@@ -96,7 +99,7 @@ fn convert_outbound_route(
              }| {
                 let backends = backends
                     .into_iter()
-                    .map(|b| convert_backend(b, parent_info, original_dst))
+                    .map(|b| convert_backend(b, parent_info, original_dst, load))
                     .collect::<Vec<_>>();
                 let dist = if backends.is_empty() {
                     outbound::grpc_route::distribution::Kind::FirstAvailable(
@@ -183,6 +186,7 @@ fn convert_backend(
     backend: Backend,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::grpc_route::WeightedRouteBackend {
     let original_dst_port = original_dst.map(|o| o.port());
 
@@ -230,7 +234,7 @@ fn convert_backend(
                                         },
                                     )),
                                 }),
-                                load: Some(default_balancer_config()),
+                                load: Some(*load),
                             },
                         )),
                     }),

--- a/policy-controller/grpc/src/outbound/http.rs
+++ b/policy-controller/grpc/src/outbound/http.rs
@@ -1,6 +1,4 @@
-use super::{
-    convert_duration, default_balancer_config, default_outbound_opaq_route, default_queue_config,
-};
+use super::{convert_duration, default_outbound_opaq_route, default_queue_config};
 use crate::routes::{
     convert_host_match, convert_redirect_filter, convert_request_header_modifier_filter,
     convert_response_header_modifier_filter,
@@ -26,6 +24,7 @@ pub(crate) fn protocol(
     allow_l5d_request_headers: bool,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::proxy_protocol::Kind {
     let opaque_route = default_outbound_opaq_route(default_backend.clone(), parent_info);
     let mut routes = routes
@@ -39,6 +38,7 @@ pub(crate) fn protocol(
                 allow_l5d_request_headers,
                 parent_info,
                 original_dst,
+                load,
             )
         })
         .collect::<Vec<_>>();
@@ -94,6 +94,7 @@ pub(crate) fn http1_only_protocol(
     allow_l5d_request_headers: bool,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::proxy_protocol::Kind {
     outbound::proxy_protocol::Kind::Http1(outbound::proxy_protocol::Http1 {
         routes: base_http_routes(
@@ -104,6 +105,7 @@ pub(crate) fn http1_only_protocol(
             allow_l5d_request_headers,
             parent_info,
             original_dst,
+            load,
         ),
         failure_accrual: accrual,
     })
@@ -119,6 +121,7 @@ pub(crate) fn http2_only_protocol(
     allow_l5d_request_headers: bool,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::proxy_protocol::Kind {
     outbound::proxy_protocol::Kind::Http2(outbound::proxy_protocol::Http2 {
         routes: base_http_routes(
@@ -129,11 +132,13 @@ pub(crate) fn http2_only_protocol(
             allow_l5d_request_headers,
             parent_info,
             original_dst,
+            load,
         ),
         failure_accrual: accrual,
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn base_http_routes(
     default_backend: outbound::Backend,
     routes: impl Iterator<Item = (GroupKindNamespaceName, HttpRoute)>,
@@ -142,6 +147,7 @@ fn base_http_routes(
     allow_l5d_request_headers: bool,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> Vec<outbound::HttpRoute> {
     let mut routes = routes
         .map(|(gknn, route)| {
@@ -154,6 +160,7 @@ fn base_http_routes(
                 allow_l5d_request_headers,
                 parent_info,
                 original_dst,
+                load,
             )
         })
         .collect::<Vec<_>>();
@@ -195,6 +202,7 @@ fn convert_outbound_route(
     allow_l5d_request_headers: bool,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::HttpRoute {
     let metadata = Some(meta::Metadata {
         kind: Some(meta::metadata::Kind::Resource(meta::Resource {
@@ -220,7 +228,7 @@ fn convert_outbound_route(
              }| {
                 let backends = backends
                     .into_iter()
-                    .map(|b| convert_backend(b, parent_info, original_dst))
+                    .map(|b| convert_backend(b, parent_info, original_dst, load))
                     .collect::<Vec<_>>();
                 let dist = if backends.is_empty() {
                     outbound::http_route::distribution::Kind::FirstAvailable(
@@ -271,6 +279,7 @@ fn convert_backend(
     backend: Backend,
     parent_info: &ParentInfo,
     original_dst: Option<SocketAddr>,
+    load: &outbound::backend::balance_p2c::Load,
 ) -> outbound::http_route::WeightedRouteBackend {
     let original_dst_port = original_dst.map(|o| o.port());
     match backend {
@@ -317,7 +326,7 @@ fn convert_backend(
                                         },
                                     )),
                                 }),
-                                load: Some(default_balancer_config()),
+                                load: Some(*load),
                             },
                         )),
                     }),

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -241,7 +241,7 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         // honor-retry-after only configures the failure-accrual backoff. It
         // does nothing without a mode set.
         if honor_retry_after && accrual.is_none() {
-            tracing::warn!(
+            tracing::debug!(
                 service = name,
                 namespace = ns,
                 "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after has \
@@ -432,7 +432,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
         // honor-retry-after only configures the failure-accrual backoff. It
         // does nothing without a mode set.
         if honor_retry_after && accrual.is_none() {
-            tracing::warn!(
+            tracing::debug!(
                 egress_network = name,
                 namespace = ns,
                 "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after has \
@@ -446,7 +446,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
             egress_network.annotations(),
             "balancer.alpha.linkerd.io/penalize-failures",
         ) {
-            Ok(true) => tracing::warn!(
+            Ok(true) => tracing::debug!(
                 egress_network = name,
                 namespace = ns,
                 "penalize-failures annotation has no effect on EgressNetwork; \
@@ -2031,7 +2031,7 @@ pub fn parse_accrual_config(
             .keys()
             .any(|k| k.starts_with(success_rate_key!("")))
         {
-            tracing::warn!(
+            tracing::debug!(
                 "success-rate annotations are set but no failure-accrual mode \
                  is configured; set balancer.linkerd.io/failure-accrual to \
                  'unified'"
@@ -2048,7 +2048,7 @@ pub fn parse_accrual_config(
             .keys()
             .any(|k| k.starts_with(success_rate_key!("")))
         {
-            tracing::warn!(
+            tracing::debug!(
                 "success-rate annotations have no effect under \
                  failure-accrual mode 'consecutive'; use mode 'unified' \
                  to enable success-rate circuit breaking"
@@ -2073,14 +2073,14 @@ pub fn parse_accrual_config(
         for key in annotations.keys() {
             if let Some(suffix) = key.strip_prefix(success_rate_key!("")) {
                 if !matches!(suffix, "-threshold" | "-window" | "-min-requests") {
-                    tracing::warn!("unrecognized success-rate annotation: {key}");
+                    tracing::debug!("unrecognized success-rate annotation: {key}");
                 }
             }
         }
 
         // Both dimensions disabled means no breaker runs at all.
         if max_failures == 0 && success_rate.threshold == 0.0 {
-            tracing::warn!(
+            tracing::debug!(
                 "unified failure-accrual has both dimensions disabled \
                  (max-failures=0 and success-rate-threshold=0); no breaker \
                  will run"
@@ -2163,7 +2163,7 @@ fn parse_success_rate_params(
     );
 
     if threshold == 0.0 {
-        tracing::warn!(
+        tracing::debug!(
             "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold=0 \
              disables success-rate circuit breaking; the success-rate window \
              will not trip the breaker"
@@ -2193,7 +2193,7 @@ fn parse_success_rate_params(
 
     // Skip the advisory when success-rate is off, like the floor above.
     if threshold != 0.0 && window < time::Duration::from_secs(1) {
-        tracing::warn!(
+        tracing::debug!(
             "balancer.alpha.linkerd.io/failure-accrual-success-rate-window={window:?} \
              is below 1s; the window is divided into ~10 fixed-duration buckets, \
              so a sub-second window gives very coarse buckets and may cause \
@@ -2219,7 +2219,7 @@ fn parse_success_rate_params(
 
     // Skip when success-rate is off, like the window advisory above.
     if threshold != 0.0 && min_requests == 0 {
-        tracing::warn!(
+        tracing::debug!(
             "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests=0 \
              means the breaker can trip on the very first failure; \
              consider setting a higher value"

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -231,7 +231,7 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         let load_biaser = parse_load_biaser_config(service.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse load biaser config"))
             .unwrap_or_default();
-        let honor_retry_after = parse_balancer_toggle(
+        let honor_retry_after = parse_bool_annotation(
             service.annotations(),
             "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after",
         )
@@ -422,7 +422,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
         // The Retry-After opt-in is attached to the failure-accrual backoff.
         // That backoff reaches only the Service-backed route backends.
         let load_biaser = None;
-        let honor_retry_after = parse_balancer_toggle(
+        let honor_retry_after = parse_bool_annotation(
             egress_network.annotations(),
             "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after",
         )
@@ -442,7 +442,7 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
 
         // Read the penalize-failures toggle directly to warn the operator.
         // A full load biaser parse here would only be discarded.
-        match parse_balancer_toggle(
+        match parse_bool_annotation(
             egress_network.annotations(),
             "balancer.alpha.linkerd.io/penalize-failures",
         ) {
@@ -2259,7 +2259,7 @@ pub fn parse_load_biaser_config(
     annotations: &std::collections::BTreeMap<String, String>,
 ) -> Result<Option<LoadBiaserConfig>> {
     let enabled =
-        parse_balancer_toggle(annotations, "balancer.alpha.linkerd.io/penalize-failures")?;
+        parse_bool_annotation(annotations, "balancer.alpha.linkerd.io/penalize-failures")?;
     if !enabled {
         return Ok(None);
     }
@@ -2285,13 +2285,13 @@ pub fn parse_load_biaser_config(
     }))
 }
 
-/// Reads an opt-in boolean balancer annotation. Absence is treated as `false`,
+/// Reads an opt-in boolean annotation. Absence is treated as `false`,
 /// matching the failure-accrual annotations, where an unset toggle leaves the
 /// feature off. Accepts the same token set as Go's `strconv.ParseBool`, the
 /// parser every boolean control-plane annotation already passes through.
 /// An unrecognized value is rejected. A typo surfaces rather than silently
 /// flipping the feature.
-fn parse_balancer_toggle(
+fn parse_bool_annotation(
     annotations: &std::collections::BTreeMap<String, String>,
     key: &str,
 ) -> Result<bool> {
@@ -2652,7 +2652,7 @@ mod tests {
     fn honor_retry_after_true() {
         let mut annotations = BTreeMap::new();
         annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), "true".to_string());
-        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+        let honor = parse_bool_annotation(&annotations, HONOR_RETRY_AFTER_KEY)
             .expect("honor-retry-after=true should succeed");
         assert!(honor, "honor-retry-after=true should be true");
     }
@@ -2661,7 +2661,7 @@ mod tests {
     fn honor_retry_after_false() {
         let mut annotations = BTreeMap::new();
         annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), "false".to_string());
-        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+        let honor = parse_bool_annotation(&annotations, HONOR_RETRY_AFTER_KEY)
             .expect("honor-retry-after=false should succeed");
         assert!(!honor, "honor-retry-after=false should be false");
     }
@@ -2669,7 +2669,7 @@ mod tests {
     #[test]
     fn honor_retry_after_absent_is_false() {
         let annotations = BTreeMap::new();
-        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+        let honor = parse_bool_annotation(&annotations, HONOR_RETRY_AFTER_KEY)
             .expect("absent annotation should succeed");
         assert!(!honor, "absent annotation should be false");
     }
@@ -2678,7 +2678,7 @@ mod tests {
     fn honor_retry_after_whitespace_true_accepted() {
         let mut annotations = BTreeMap::new();
         annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), " true ".to_string());
-        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+        let honor = parse_bool_annotation(&annotations, HONOR_RETRY_AFTER_KEY)
             .expect("whitespace-padded 'true' should succeed");
         assert!(honor, "whitespace-padded 'true' should be true");
     }
@@ -2687,7 +2687,7 @@ mod tests {
     fn honor_retry_after_invalid_value_rejected() {
         let mut annotations = BTreeMap::new();
         annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), "sometimes".to_string());
-        let err = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+        let err = parse_bool_annotation(&annotations, HONOR_RETRY_AFTER_KEY)
             .expect_err("sometimes should be rejected");
         assert!(
             err.to_string().contains("'sometimes'"),

--- a/policy-controller/k8s/index/src/outbound/index.rs
+++ b/policy-controller/k8s/index/src/outbound/index.rs
@@ -4,13 +4,17 @@ use crate::{
     ClusterInfo,
 };
 use ahash::AHashMap as HashMap;
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, ensure, Context, Result};
 use egress_network::EgressNetwork;
 use linkerd_policy_controller_core::{
     outbound::{
         AppProtocol, Backend, Backoff, FailureAccrual, GrpcRetryCondition, GrpcRoute,
-        HttpRetryCondition, HttpRoute, Kind, OutboundDiscoverTarget, OutboundPolicy, ParentInfo,
-        ResourceTarget, RouteRetry, RouteSet, RouteTimeouts, TcpRoute, TlsRoute, TrafficPolicy,
+        HttpRetryCondition, HttpRoute, Kind, LoadBiaserConfig, OutboundDiscoverTarget,
+        OutboundPolicy, ParentInfo, ResourceTarget, RouteRetry, RouteSet, RouteTimeouts,
+        SuccessRateConfig, TcpRoute, TlsRoute, TrafficPolicy, DEFAULT_LOAD_BIASER_MAX_RETRY_AFTER,
+        DEFAULT_LOAD_BIASER_PENALTY, DEFAULT_SUCCESS_RATE_MIN_REQUESTS,
+        DEFAULT_SUCCESS_RATE_THRESHOLD, DEFAULT_SUCCESS_RATE_WINDOW, MAX_SUCCESS_RATE_MIN_REQUESTS,
+        MIN_SUCCESS_RATE_WINDOW,
     },
     routes::GroupKindNamespaceName,
 };
@@ -101,6 +105,8 @@ struct Namespace {
 struct ResourceInfo {
     app_protocols: PortMap<AppProtocol>,
     accrual: Option<FailureAccrual>,
+    load_biaser: Option<LoadBiaserConfig>,
+    honor_retry_after: bool,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
     timeouts: RouteTimeouts,
@@ -122,6 +128,8 @@ struct ResourceRoutes {
     watches_by_ns: HashMap<String, RoutesWatch>,
     app_protocol: Option<AppProtocol>,
     accrual: Option<FailureAccrual>,
+    load_biaser: Option<LoadBiaserConfig>,
+    honor_retry_after: bool,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
     timeouts: RouteTimeouts,
@@ -132,6 +140,8 @@ struct RoutesWatch {
     parent_info: ParentInfo,
     app_protocol: Option<AppProtocol>,
     accrual: Option<FailureAccrual>,
+    load_biaser: Option<LoadBiaserConfig>,
+    honor_retry_after: bool,
     http_retry: Option<RouteRetry<HttpRetryCondition>>,
     grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
     timeouts: RouteTimeouts,
@@ -218,6 +228,26 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         let accrual = parse_accrual_config(service.annotations())
             .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();
+        let load_biaser = parse_load_biaser_config(service.annotations())
+            .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse load biaser config"))
+            .unwrap_or_default();
+        let honor_retry_after = parse_balancer_toggle(
+            service.annotations(),
+            "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after",
+        )
+        .map_err(|error| tracing::warn!(%error, service=name, namespace=ns, "Failed to parse honor-retry-after toggle"))
+        .unwrap_or_default();
+
+        // honor-retry-after only configures the failure-accrual backoff. It
+        // does nothing without a mode set.
+        if honor_retry_after && accrual.is_none() {
+            tracing::warn!(
+                service = name,
+                namespace = ns,
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after has \
+                 no effect without a failure-accrual mode"
+            );
+        }
 
         let mut app_protocols = service
             .spec
@@ -321,6 +351,8 @@ impl kubert::index::IndexNamespacedResource<Service> for Index {
         let service_info = ResourceInfo {
             app_protocols,
             accrual,
+            load_biaser,
+            honor_retry_after,
             http_retry,
             grpc_retry,
             timeouts,
@@ -384,6 +416,51 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
         let accrual = parse_accrual_config(egress_network.annotations())
             .map_err(|error| tracing::warn!(%error, egress_network=name, namespace=ns, "Failed to parse accrual config"))
             .unwrap_or_default();
+        // EgressNetwork's default backend forwards without a balancer. The
+        // penalty estimator never applies there. Route backends that resolve
+        // to Services do balance, and the code below disables their penalty.
+        // The Retry-After opt-in is attached to the failure-accrual backoff.
+        // That backoff reaches only the Service-backed route backends.
+        let load_biaser = None;
+        let honor_retry_after = parse_balancer_toggle(
+            egress_network.annotations(),
+            "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after",
+        )
+        .map_err(|error| tracing::warn!(%error, egress_network=name, namespace=ns, "Failed to parse honor-retry-after toggle"))
+        .unwrap_or_default();
+
+        // honor-retry-after only configures the failure-accrual backoff. It
+        // does nothing without a mode set.
+        if honor_retry_after && accrual.is_none() {
+            tracing::warn!(
+                egress_network = name,
+                namespace = ns,
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after has \
+                 no effect without a failure-accrual mode"
+            );
+        }
+
+        // Read the penalize-failures toggle directly to warn the operator.
+        // A full load biaser parse here would only be discarded.
+        match parse_balancer_toggle(
+            egress_network.annotations(),
+            "balancer.alpha.linkerd.io/penalize-failures",
+        ) {
+            Ok(true) => tracing::warn!(
+                egress_network = name,
+                namespace = ns,
+                "penalize-failures annotation has no effect on EgressNetwork; \
+                 the forward path has no balancer and Service-backed routes \
+                 drop the penalty"
+            ),
+            Ok(false) => {}
+            Err(error) => tracing::warn!(
+                %error,
+                egress_network = name,
+                namespace = ns,
+                "Failed to parse penalize-failures toggle"
+            ),
+        }
         let opaque_ports = ports_annotation(
             egress_network.annotations(),
             "config.linkerd.io/opaque-ports",
@@ -425,6 +502,8 @@ impl kubert::index::IndexNamespacedResource<linkerd_k8s_api::EgressNetwork> for 
         let egress_network_info = ResourceInfo {
             app_protocols,
             accrual,
+            load_biaser,
+            honor_retry_after,
             http_retry,
             grpc_retry,
             timeouts,
@@ -1256,6 +1335,8 @@ impl Namespace {
             resource_routes.update_resource(
                 app_protocol,
                 resource.accrual,
+                resource.load_biaser,
+                resource.honor_retry_after,
                 resource.http_retry.clone(),
                 resource.grpc_retry.clone(),
                 resource.timeouts.clone(),
@@ -1341,12 +1422,16 @@ impl Namespace {
                 };
                 let mut app_protocol = None;
                 let mut accrual = None;
+                let mut load_biaser = None;
+                let mut honor_retry_after = false;
                 let mut http_retry = None;
                 let mut grpc_retry = None;
                 let mut timeouts = Default::default();
                 if let Some(resource) = resource_info.get(&resource_ref) {
                     app_protocol = resource.app_protocols.get(&rp.port).cloned();
                     accrual = resource.accrual;
+                    load_biaser = resource.load_biaser;
+                    honor_retry_after = resource.honor_retry_after;
                     http_retry = resource.http_retry.clone();
                     grpc_retry = resource.grpc_retry.clone();
                     timeouts = resource.timeouts.clone();
@@ -1387,6 +1472,8 @@ impl Namespace {
                     parent_info,
                     app_protocol,
                     accrual,
+                    load_biaser,
+                    honor_retry_after,
                     http_retry,
                     grpc_retry,
                     timeouts,
@@ -1608,6 +1695,8 @@ impl ResourceRoutes {
                 port: self.port,
                 app_protocol: self.app_protocol.clone(),
                 accrual: self.accrual,
+                load_biaser: self.load_biaser,
+                honor_retry_after: self.honor_retry_after,
                 http_retry: self.http_retry.clone(),
                 grpc_retry: self.grpc_retry.clone(),
                 timeouts: self.timeouts.clone(),
@@ -1626,6 +1715,8 @@ impl ResourceRoutes {
                 watch: sender,
                 app_protocol: self.app_protocol.clone(),
                 accrual: self.accrual,
+                load_biaser: self.load_biaser,
+                honor_retry_after: self.honor_retry_after,
                 http_retry: self.http_retry.clone(),
                 grpc_retry: self.grpc_retry.clone(),
                 timeouts: self.timeouts.clone(),
@@ -1721,10 +1812,13 @@ impl ResourceRoutes {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn update_resource(
         &mut self,
         app_protocol: Option<AppProtocol>,
         accrual: Option<FailureAccrual>,
+        load_biaser: Option<LoadBiaserConfig>,
+        honor_retry_after: bool,
         http_retry: Option<RouteRetry<HttpRetryCondition>>,
         grpc_retry: Option<RouteRetry<GrpcRetryCondition>>,
         timeouts: RouteTimeouts,
@@ -1732,6 +1826,8 @@ impl ResourceRoutes {
     ) {
         self.app_protocol = app_protocol.clone();
         self.accrual = accrual;
+        self.load_biaser = load_biaser;
+        self.honor_retry_after = honor_retry_after;
         self.http_retry = http_retry.clone();
         self.grpc_retry = grpc_retry.clone();
         self.timeouts = timeouts.clone();
@@ -1739,6 +1835,8 @@ impl ResourceRoutes {
         for watch in self.watches_by_ns.values_mut() {
             watch.app_protocol = app_protocol.clone();
             watch.accrual = accrual;
+            watch.load_biaser = load_biaser;
+            watch.honor_retry_after = honor_retry_after;
             watch.http_retry = http_retry.clone();
             watch.grpc_retry = grpc_retry.clone();
             watch.timeouts = timeouts.clone();
@@ -1838,6 +1936,16 @@ impl RoutesWatch {
                 modified = true;
             }
 
+            if self.load_biaser != policy.load_biaser {
+                policy.load_biaser = self.load_biaser;
+                modified = true;
+            }
+
+            if self.honor_retry_after != policy.honor_retry_after {
+                policy.honor_retry_after = self.honor_retry_after;
+                modified = true;
+            }
+
             if self.http_retry != policy.http_retry {
                 policy.http_retry = self.http_retry.clone();
                 modified = true;
@@ -1902,59 +2010,227 @@ impl RoutesWatch {
     }
 }
 
+/// Builds a success-rate annotation key from its suffix. The shared
+/// prefix then stays in one place.
+macro_rules! success_rate_key {
+    ($suffix:literal) => {
+        concat!(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate",
+            $suffix
+        )
+    };
+}
+
 pub fn parse_accrual_config(
     annotations: &std::collections::BTreeMap<String, String>,
 ) -> Result<Option<FailureAccrual>> {
-    annotations
-        .get("balancer.linkerd.io/failure-accrual")
-        .map(|mode| {
-            if mode == "consecutive" {
-                let max_failures = annotations
-                    .get("balancer.linkerd.io/failure-accrual-consecutive-max-failures")
-                    .map(|s| s.parse::<u32>())
-                    .transpose()?
-                    .unwrap_or(7);
+    let Some(mode) = annotations.get("balancer.linkerd.io/failure-accrual") else {
+        // Success-rate annotations only take effect under a failure-accrual
+        // mode. Warn if they are set without one.
+        if annotations
+            .keys()
+            .any(|k| k.starts_with(success_rate_key!("")))
+        {
+            tracing::warn!(
+                "success-rate annotations are set but no failure-accrual mode \
+                 is configured; set balancer.linkerd.io/failure-accrual to \
+                 'unified'"
+            );
+        }
+        return Ok(None);
+    };
 
-                let max_penalty = annotations
-                    .get("balancer.linkerd.io/failure-accrual-consecutive-max-penalty")
-                    .map(|s| parse_duration(s))
-                    .transpose()?
-                    .unwrap_or_else(|| time::Duration::from_secs(60));
+    if mode == "consecutive" {
+        // Success-rate annotations apply only in unified mode. Under
+        // consecutive mode they have no effect. Warn and keep the
+        // consecutive breaker instead of dropping the whole config.
+        if annotations
+            .keys()
+            .any(|k| k.starts_with(success_rate_key!("")))
+        {
+            tracing::warn!(
+                "success-rate annotations have no effect under \
+                 failure-accrual mode 'consecutive'; use mode 'unified' \
+                 to enable success-rate circuit breaking"
+            );
+        }
 
-                let min_penalty = annotations
-                    .get("balancer.linkerd.io/failure-accrual-consecutive-min-penalty")
-                    .map(|s| parse_duration(s))
-                    .transpose()?
-                    .unwrap_or_else(|| time::Duration::from_secs(1));
-                let jitter = annotations
-                    .get("balancer.linkerd.io/failure-accrual-consecutive-jitter-ratio")
-                    .map(|s| s.parse::<f32>())
-                    .transpose()?
-                    .unwrap_or(0.5);
-                ensure!(
-                    min_penalty <= max_penalty,
-                    "min_penalty ({min_penalty:?}) cannot exceed max_penalty ({max_penalty:?})"
-                );
-                ensure!(
-                    max_penalty > time::Duration::from_millis(0),
-                    "max_penalty cannot be zero"
-                );
-                ensure!(jitter >= 0.0, "jitter cannot be negative");
-                ensure!(jitter <= 100.0, "jitter cannot be greater than 100");
+        let (max_failures, backoff) = parse_consecutive_params(annotations)?;
 
-                Ok(FailureAccrual::Consecutive {
-                    max_failures,
-                    backoff: Backoff {
-                        min_penalty,
-                        max_penalty,
-                        jitter,
-                    },
-                })
-            } else {
-                bail!("unsupported failure accrual mode: {mode}");
+        Ok(Some(FailureAccrual::Consecutive {
+            max_failures,
+            backoff,
+        }))
+    } else if mode == "unified" {
+        // The unified breaker keeps the consecutive-failures dimension.
+        // Its parameters are read from the same annotations that the
+        // consecutive mode uses, with the same defaults.
+        let (max_failures, backoff) = parse_consecutive_params(annotations)?;
+        let success_rate = parse_success_rate_params(annotations)?;
+
+        // Warn about success-rate annotations the parser does not
+        // recognize. A typo here silently falls back to the default.
+        for key in annotations.keys() {
+            if let Some(suffix) = key.strip_prefix(success_rate_key!("")) {
+                if !matches!(suffix, "-threshold" | "-window" | "-min-requests") {
+                    tracing::warn!("unrecognized success-rate annotation: {key}");
+                }
             }
-        })
-        .transpose()
+        }
+
+        // Both dimensions disabled means no breaker runs at all.
+        if max_failures == 0 && success_rate.threshold == 0.0 {
+            tracing::warn!(
+                "unified failure-accrual has both dimensions disabled \
+                 (max-failures=0 and success-rate-threshold=0); no breaker \
+                 will run"
+            );
+        }
+
+        Ok(Some(FailureAccrual::Unified {
+            max_failures,
+            backoff,
+            success_rate,
+        }))
+    } else {
+        bail!("unsupported failure accrual mode: {mode}");
+    }
+}
+
+/// Parses the failure-accrual-consecutive-* annotations shared by the
+/// consecutive and unified accrual modes.
+fn parse_consecutive_params(
+    annotations: &std::collections::BTreeMap<String, String>,
+) -> Result<(u32, Backoff)> {
+    let max_failures = annotations
+        .get("balancer.linkerd.io/failure-accrual-consecutive-max-failures")
+        .map(|s| s.trim().parse::<u32>())
+        .transpose()?
+        .unwrap_or(7);
+
+    let max_penalty = annotations
+        .get("balancer.linkerd.io/failure-accrual-consecutive-max-penalty")
+        .map(|s| parse_duration(s))
+        .transpose()?
+        .unwrap_or_else(|| time::Duration::from_secs(60));
+
+    let min_penalty = annotations
+        .get("balancer.linkerd.io/failure-accrual-consecutive-min-penalty")
+        .map(|s| parse_duration(s))
+        .transpose()?
+        .unwrap_or_else(|| time::Duration::from_secs(1));
+    let jitter = annotations
+        .get("balancer.linkerd.io/failure-accrual-consecutive-jitter-ratio")
+        .map(|s| s.trim().parse::<f32>())
+        .transpose()?
+        .unwrap_or(0.5);
+    ensure!(
+        min_penalty <= max_penalty,
+        "min_penalty ({min_penalty:?}) cannot exceed max_penalty ({max_penalty:?})"
+    );
+    ensure!(
+        max_penalty > time::Duration::from_millis(0),
+        "max_penalty cannot be zero"
+    );
+    ensure!(jitter >= 0.0, "jitter cannot be negative");
+    ensure!(jitter <= 100.0, "jitter cannot be greater than 100");
+
+    Ok((
+        max_failures,
+        Backoff {
+            min_penalty,
+            max_penalty,
+            jitter,
+        },
+    ))
+}
+
+/// Parses the balancer.alpha.linkerd.io success-rate annotations read by the
+/// unified accrual mode.
+fn parse_success_rate_params(
+    annotations: &std::collections::BTreeMap<String, String>,
+) -> Result<SuccessRateConfig> {
+    let threshold = annotations
+        .get(success_rate_key!("-threshold"))
+        // The proto defines success_rate_threshold as a double, unlike the
+        // f32 jitter_ratio.
+        .map(|s| s.trim().parse::<f64>())
+        .transpose()?
+        .unwrap_or(DEFAULT_SUCCESS_RATE_THRESHOLD);
+    ensure!(
+        (0.0..=1.0).contains(&threshold),
+        "success-rate threshold must be between 0.0 and 1.0, got {threshold}"
+    );
+
+    if threshold == 0.0 {
+        tracing::warn!(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold=0 \
+             disables success-rate circuit breaking; the success-rate window \
+             will not trip the breaker"
+        );
+    }
+
+    let window = annotations
+        .get(success_rate_key!("-window"))
+        .map(|s| parse_duration(s))
+        .transpose()?
+        .unwrap_or(DEFAULT_SUCCESS_RATE_WINDOW);
+    ensure!(
+        window > time::Duration::ZERO,
+        "success-rate-window must be greater than zero"
+    );
+    // The proxy rejects a success-rate window below 10ms, its minimum
+    // sampling window, when converting the client policy. A rejected
+    // conversion invalidates the entire policy. The proxy applies this
+    // floor only when the threshold is non-zero. Gate it the same way to
+    // keep a consecutive-only unified policy (threshold 0) intact.
+    if threshold != 0.0 {
+        ensure!(
+            window >= MIN_SUCCESS_RATE_WINDOW,
+            "success-rate-window must be at least 10ms, got {window:?}"
+        );
+    }
+
+    // Skip the advisory when success-rate is off, like the floor above.
+    if threshold != 0.0 && window < time::Duration::from_secs(1) {
+        tracing::warn!(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-window={window:?} \
+             is below 1s; the window is divided into ~10 fixed-duration buckets, \
+             so a sub-second window gives very coarse buckets and may cause \
+             spurious circuit-breaker trips"
+        );
+    }
+
+    let min_requests = annotations
+        .get(success_rate_key!("-min-requests"))
+        .map(|s| s.trim().parse::<u32>())
+        .transpose()?
+        .unwrap_or(DEFAULT_SUCCESS_RATE_MIN_REQUESTS);
+    // The proxy rejects min-requests above 1,000,000 when converting the
+    // client policy. A rejected conversion invalidates the entire policy.
+    // Like the window floor, this ceiling applies only when the threshold
+    // is non-zero. Gate it to match.
+    if threshold != 0.0 {
+        ensure!(
+            min_requests <= MAX_SUCCESS_RATE_MIN_REQUESTS,
+            "success-rate-min-requests cannot exceed 1000000, got {min_requests}"
+        );
+    }
+
+    // Skip when success-rate is off, like the window advisory above.
+    if threshold != 0.0 && min_requests == 0 {
+        tracing::warn!(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests=0 \
+             means the breaker can trip on the very first failure; \
+             consider setting a higher value"
+        );
+    }
+
+    Ok(SuccessRateConfig {
+        threshold,
+        window,
+        min_requests,
+    })
 }
 
 pub fn parse_timeouts(
@@ -1979,21 +2255,100 @@ pub fn parse_timeouts(
     })
 }
 
+pub fn parse_load_biaser_config(
+    annotations: &std::collections::BTreeMap<String, String>,
+) -> Result<Option<LoadBiaserConfig>> {
+    let enabled =
+        parse_balancer_toggle(annotations, "balancer.alpha.linkerd.io/penalize-failures")?;
+    if !enabled {
+        return Ok(None);
+    }
+    let penalty = parse_duration_annotation(
+        annotations,
+        "balancer.alpha.linkerd.io/load-biaser-penalty",
+        DEFAULT_LOAD_BIASER_PENALTY,
+    )?;
+    // The proxy clamps the penalty to a u32 of milliseconds. Reject a larger
+    // value here so it does not saturate silently on the wire.
+    ensure!(
+        penalty.as_millis() <= u32::MAX as u128,
+        "load-biaser-penalty exceeds the maximum supported value (~49.7 days)"
+    );
+    let max_retry_after = parse_duration_annotation(
+        annotations,
+        "balancer.alpha.linkerd.io/load-biaser-max-retry-after",
+        DEFAULT_LOAD_BIASER_MAX_RETRY_AFTER,
+    )?;
+    Ok(Some(LoadBiaserConfig {
+        penalty,
+        max_retry_after,
+    }))
+}
+
+/// Reads an opt-in boolean balancer annotation. Absence is treated as `false`,
+/// matching the failure-accrual annotations, where an unset toggle leaves the
+/// feature off. Accepts the same token set as Go's `strconv.ParseBool`, the
+/// parser every boolean control-plane annotation already passes through.
+/// An unrecognized value is rejected. A typo surfaces rather than silently
+/// flipping the feature.
+fn parse_balancer_toggle(
+    annotations: &std::collections::BTreeMap<String, String>,
+    key: &str,
+) -> Result<bool> {
+    match annotations.get(key).map(|s| s.trim()) {
+        None | Some("0" | "f" | "F" | "false" | "FALSE" | "False") => Ok(false),
+        Some("1" | "t" | "T" | "true" | "TRUE" | "True") => Ok(true),
+        Some(other) => {
+            bail!(
+                "unsupported {key} value: '{other}' (expected a boolean such as 'true' or 'false')"
+            )
+        }
+    }
+}
+
+/// Reads an optional Duration annotation. Returns `default` when the key is
+/// absent. A present value is parsed and surfaces any error.
+fn parse_duration_annotation(
+    annotations: &std::collections::BTreeMap<String, String>,
+    key: &str,
+    default: time::Duration,
+) -> Result<time::Duration> {
+    match annotations.get(key) {
+        Some(v) => parse_duration(v).with_context(|| format!("invalid {key} value")),
+        None => Ok(default),
+    }
+}
+
 fn parse_duration(s: &str) -> Result<time::Duration> {
     let s = s.trim();
+    if s.starts_with('-') {
+        bail!("duration value cannot be negative: '{s}'");
+    }
     let offset = s
         .rfind(|c: char| c.is_ascii_digit())
         .ok_or_else(|| anyhow::anyhow!("{s} does not contain a timeout duration value"))?;
     let (magnitude, unit) = s.split_at(offset + 1);
+
+    // Any fractional duration is rejected. A fractional value with a 's'
+    // suffix could in principle round to a whole number of milliseconds, but
+    // every other case in this branch also rejects, so a single message is
+    // clearer than enumerating the individual reasons.
+    if magnitude.contains('.') {
+        bail!("fractional values not supported");
+    }
+
     let magnitude = magnitude.parse::<u64>()?;
 
     let mul = match unit {
+        // Special case: "0" is valid as zero duration without requiring a unit suffix.
+        // Non-zero bare numbers (ie. "5") require a unit.
         "" if magnitude == 0 => 0,
         "ms" => 1,
         "s" => 1000,
         "m" => 1000 * 60,
         "h" => 1000 * 60 * 60,
         "d" => 1000 * 60 * 60 * 24,
+        "" => bail!("missing duration unit; did you mean '{magnitude}s' or '{magnitude}ms'?"),
         _ => bail!("invalid duration unit {unit} (expected one of 'ms', 's', 'm', 'h', or 'd')"),
     };
 
@@ -2001,4 +2356,860 @@ fn parse_duration(s: &str) -> Result<time::Duration> {
         .checked_mul(mul)
         .ok_or_else(|| anyhow::anyhow!("Timeout value {s} overflows when converted to 'ms'"))?;
     Ok(time::Duration::from_millis(ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// Returns an annotation map with the failure-accrual mode set to
+    /// "unified" plus any additional key-value pairs.
+    fn accrual_annotations(extra: &[(&str, &str)]) -> BTreeMap<String, String> {
+        let mut m = BTreeMap::new();
+        m.insert(
+            "balancer.linkerd.io/failure-accrual".to_string(),
+            "unified".to_string(),
+        );
+        for (k, v) in extra {
+            m.insert(k.to_string(), v.to_string());
+        }
+        m
+    }
+
+    #[test]
+    fn parse_duration_integer_seconds() {
+        let d = parse_duration("10s").expect("should parse");
+        assert_eq!(d, time::Duration::from_secs(10));
+    }
+
+    #[test]
+    fn parse_duration_milliseconds() {
+        let d = parse_duration("500ms").expect("should parse");
+        assert_eq!(d, time::Duration::from_millis(500));
+    }
+
+    #[test]
+    fn parse_duration_minutes() {
+        let d = parse_duration("5m").expect("should parse");
+        assert_eq!(d, time::Duration::from_secs(300));
+    }
+
+    #[test]
+    fn parse_duration_hours() {
+        let d = parse_duration("2h").expect("should parse");
+        assert_eq!(d, time::Duration::from_secs(7200));
+    }
+
+    #[test]
+    fn parse_duration_days() {
+        let d = parse_duration("1d").expect("should parse");
+        assert_eq!(d, time::Duration::from_secs(86400));
+    }
+
+    #[test]
+    fn parse_duration_zero() {
+        let d = parse_duration("0").expect("zero without unit should parse");
+        assert_eq!(d, time::Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_duration_zero_seconds() {
+        let d = parse_duration("0s").expect("0s should parse");
+        assert_eq!(d, time::Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_duration_zero_milliseconds() {
+        let d = parse_duration("0ms").expect("0ms should parse");
+        assert_eq!(d, time::Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_duration_fractional_seconds_rejected() {
+        let err = parse_duration("0.5s").expect_err("fractional seconds should fail");
+        assert!(
+            err.to_string().contains("fractional values not supported"),
+            "should reject fractional: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_fractional_zero_seconds_rejected() {
+        let err = parse_duration("0.0s").expect_err("fractional zero should fail");
+        assert!(
+            err.to_string().contains("fractional values not supported"),
+            "should reject fractional: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_fractional_non_seconds_rejected() {
+        let err = parse_duration("0.5m").expect_err("fractional minutes should fail");
+        assert!(
+            err.to_string().contains("fractional values not supported"),
+            "should reject fractional: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_bare_number_rejected() {
+        let err = parse_duration("5").expect_err("bare number should fail");
+        assert!(
+            err.to_string().contains("missing duration unit"),
+            "should mention missing unit: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_bare_number_error_suggests_units() {
+        let err = parse_duration("100").expect_err("bare number should fail");
+        assert!(
+            err.to_string().contains("'100s' or '100ms'"),
+            "should suggest likely units: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_overflow_rejected() {
+        let err = parse_duration("999999999999999999d").expect_err("huge value should overflow");
+        assert!(
+            err.to_string().contains("overflows"),
+            "should mention overflow: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_invalid_unit_rejected() {
+        let err = parse_duration("10x").expect_err("invalid unit should fail");
+        assert!(
+            err.to_string().contains("invalid duration unit"),
+            "should mention invalid unit: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_empty_rejected() {
+        let result = parse_duration("");
+        assert!(result.is_err(), "empty string should fail");
+    }
+
+    #[test]
+    fn parse_duration_negative_seconds_rejected() {
+        let err = parse_duration("-5s").expect_err("negative should fail");
+        assert!(
+            err.to_string().contains("cannot be negative"),
+            "should mention negative: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_duration_negative_fractional_rejected() {
+        let err = parse_duration("-0.5s").expect_err("negative fractional should fail");
+        assert!(
+            err.to_string().contains("cannot be negative"),
+            "should mention negative: {err}"
+        );
+    }
+
+    #[test]
+    fn penalize_failures_true_returns_defaults() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "true".to_string(),
+        );
+        let config = parse_load_biaser_config(&annotations)
+            .expect("penalize-failures=true should succeed")
+            .expect("should return Some");
+        assert_eq!(config.penalty, DEFAULT_LOAD_BIASER_PENALTY);
+        assert_eq!(config.max_retry_after, DEFAULT_LOAD_BIASER_MAX_RETRY_AFTER);
+    }
+
+    #[test]
+    fn penalize_failures_false_returns_none() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "false".to_string(),
+        );
+        let result =
+            parse_load_biaser_config(&annotations).expect("penalize-failures=false should succeed");
+        assert!(
+            result.is_none(),
+            "penalize-failures=false should return None"
+        );
+    }
+
+    #[test]
+    fn penalize_failures_absent_returns_none() {
+        let annotations = BTreeMap::new();
+        let result =
+            parse_load_biaser_config(&annotations).expect("absent annotation should succeed");
+        assert!(result.is_none(), "absent annotation should return None");
+    }
+
+    #[test]
+    fn penalize_failures_invalid_value_rejected() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "maybe".to_string(),
+        );
+        let err = parse_load_biaser_config(&annotations).expect_err("maybe should be rejected");
+        assert!(
+            err.to_string().contains("'maybe'"),
+            "error should quote the invalid value: {err}"
+        );
+    }
+
+    #[test]
+    fn penalize_failures_empty_value_rejected_with_visible_quotes() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "".to_string(),
+        );
+        let err =
+            parse_load_biaser_config(&annotations).expect_err("empty value should be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("''"),
+            "error should show empty value in quotes: {msg}"
+        );
+    }
+
+    #[test]
+    fn penalize_failures_whitespace_true_accepted() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            " true ".to_string(),
+        );
+        parse_load_biaser_config(&annotations)
+            .expect("whitespace-padded 'true' should succeed")
+            .expect("should return Some");
+    }
+
+    #[test]
+    fn penalize_failures_whitespace_false_returns_none() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            " false ".to_string(),
+        );
+        let result = parse_load_biaser_config(&annotations)
+            .expect("whitespace-padded 'false' should succeed");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn penalize_failures_parsebool_truthy_accepted() {
+        for value in ["True", "TRUE", "1", "t", "T"] {
+            let mut annotations = BTreeMap::new();
+            annotations.insert(
+                "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+                value.to_string(),
+            );
+            parse_load_biaser_config(&annotations)
+                .unwrap_or_else(|e| panic!("ParseBool truthy '{value}' should succeed: {e}"))
+                .unwrap_or_else(|| panic!("ParseBool truthy '{value}' should return Some"));
+        }
+    }
+
+    #[test]
+    fn penalize_failures_parsebool_falsy_returns_none() {
+        for value in ["False", "FALSE", "0", "f", "F"] {
+            let mut annotations = BTreeMap::new();
+            annotations.insert(
+                "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+                value.to_string(),
+            );
+            let result = parse_load_biaser_config(&annotations)
+                .unwrap_or_else(|e| panic!("ParseBool falsy '{value}' should succeed: {e}"));
+            assert!(result.is_none(), "value '{value}' should return None");
+        }
+    }
+
+    #[test]
+    fn penalize_failures_non_parsebool_rejected() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "yes".to_string(),
+        );
+        let err = parse_load_biaser_config(&annotations).expect_err("yes should be rejected");
+        assert!(
+            err.to_string().contains("'yes'"),
+            "error should quote the invalid value: {err}"
+        );
+    }
+
+    const HONOR_RETRY_AFTER_KEY: &str =
+        "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after";
+
+    #[test]
+    fn honor_retry_after_true() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), "true".to_string());
+        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+            .expect("honor-retry-after=true should succeed");
+        assert!(honor, "honor-retry-after=true should be true");
+    }
+
+    #[test]
+    fn honor_retry_after_false() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), "false".to_string());
+        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+            .expect("honor-retry-after=false should succeed");
+        assert!(!honor, "honor-retry-after=false should be false");
+    }
+
+    #[test]
+    fn honor_retry_after_absent_is_false() {
+        let annotations = BTreeMap::new();
+        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+            .expect("absent annotation should succeed");
+        assert!(!honor, "absent annotation should be false");
+    }
+
+    #[test]
+    fn honor_retry_after_whitespace_true_accepted() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), " true ".to_string());
+        let honor = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+            .expect("whitespace-padded 'true' should succeed");
+        assert!(honor, "whitespace-padded 'true' should be true");
+    }
+
+    #[test]
+    fn honor_retry_after_invalid_value_rejected() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(HONOR_RETRY_AFTER_KEY.to_string(), "sometimes".to_string());
+        let err = parse_balancer_toggle(&annotations, HONOR_RETRY_AFTER_KEY)
+            .expect_err("sometimes should be rejected");
+        assert!(
+            err.to_string().contains("'sometimes'"),
+            "error should quote the invalid value: {err}"
+        );
+    }
+
+    #[test]
+    fn load_biaser_penalty_explicit_value_parsed() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "true".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/load-biaser-penalty".to_string(),
+            "2s".to_string(),
+        );
+        let config = parse_load_biaser_config(&annotations)
+            .expect("explicit penalty should succeed")
+            .expect("should return Some");
+        assert_eq!(config.penalty, time::Duration::from_secs(2));
+        assert_eq!(config.max_retry_after, DEFAULT_LOAD_BIASER_MAX_RETRY_AFTER);
+    }
+
+    #[test]
+    fn load_biaser_max_retry_after_explicit_value_parsed() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "true".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/load-biaser-max-retry-after".to_string(),
+            "60s".to_string(),
+        );
+        let config = parse_load_biaser_config(&annotations)
+            .expect("explicit max-retry-after should succeed")
+            .expect("should return Some");
+        assert_eq!(config.penalty, DEFAULT_LOAD_BIASER_PENALTY);
+        assert_eq!(config.max_retry_after, time::Duration::from_secs(60));
+    }
+
+    #[test]
+    fn load_biaser_duration_whitespace_tolerated() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "true".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/load-biaser-penalty".to_string(),
+            " 2s ".to_string(),
+        );
+        let config = parse_load_biaser_config(&annotations)
+            .expect("whitespace-padded duration should succeed")
+            .expect("should return Some");
+        assert_eq!(config.penalty, time::Duration::from_secs(2));
+    }
+
+    #[test]
+    fn load_biaser_invalid_duration_rejected() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "true".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/load-biaser-penalty".to_string(),
+            "1.5s".to_string(),
+        );
+        assert!(
+            parse_load_biaser_config(&annotations).is_err(),
+            "fractional duration should be rejected"
+        );
+    }
+
+    #[test]
+    fn load_biaser_penalty_over_u32_millis_rejected() {
+        // 50 days exceeds u32::MAX milliseconds (~49.7 days), which the proxy
+        // would otherwise saturate.
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "true".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/load-biaser-penalty".to_string(),
+            "50d".to_string(),
+        );
+        assert!(
+            parse_load_biaser_config(&annotations).is_err(),
+            "penalty over u32::MAX ms should be rejected"
+        );
+    }
+
+    #[test]
+    fn load_biaser_annotations_ignored_when_penalize_off() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/penalize-failures".to_string(),
+            "false".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/load-biaser-penalty".to_string(),
+            "2s".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/load-biaser-max-retry-after".to_string(),
+            "60s".to_string(),
+        );
+        let result = parse_load_biaser_config(&annotations)
+            .expect("disabled toggle should ignore duration annotations");
+        assert!(
+            result.is_none(),
+            "penalize-failures=false should return None even with overrides present"
+        );
+    }
+
+    #[test]
+    fn mode_unified_uses_success_rate_defaults() {
+        let annotations = accrual_annotations(&[]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("mode=unified should succeed")
+            .expect("should return Some");
+        let FailureAccrual::Unified {
+            max_failures,
+            backoff,
+            success_rate,
+        } = accrual
+        else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(max_failures, 7);
+        assert_eq!(backoff.min_penalty, time::Duration::from_secs(1));
+        assert_eq!(backoff.max_penalty, time::Duration::from_secs(60));
+        assert!((backoff.jitter - 0.5).abs() < f32::EPSILON);
+        assert!((success_rate.threshold - 0.8).abs() < f64::EPSILON);
+        assert_eq!(success_rate.window, time::Duration::from_secs(10));
+        assert_eq!(success_rate.min_requests, 5);
+    }
+
+    #[test]
+    fn mode_unified_with_explicit_values() {
+        let annotations = accrual_annotations(&[
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold",
+                "0.9",
+            ),
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-window",
+                "15s",
+            ),
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests",
+                "10",
+            ),
+            (
+                "balancer.linkerd.io/failure-accrual-consecutive-max-failures",
+                "3",
+            ),
+            (
+                "balancer.linkerd.io/failure-accrual-consecutive-min-penalty",
+                "2s",
+            ),
+        ]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("mode=unified should succeed")
+            .expect("should return Some");
+        let FailureAccrual::Unified {
+            max_failures,
+            backoff,
+            success_rate,
+        } = accrual
+        else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(max_failures, 3);
+        assert_eq!(backoff.min_penalty, time::Duration::from_secs(2));
+        assert!((success_rate.threshold - 0.9).abs() < f64::EPSILON);
+        assert_eq!(success_rate.window, time::Duration::from_secs(15));
+        assert_eq!(success_rate.min_requests, 10);
+    }
+
+    #[test]
+    fn success_rate_threshold_whitespace_accepted() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold",
+            " 0.9 ",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("whitespace-padded threshold should succeed")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert!((success_rate.threshold - 0.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn success_rate_min_requests_whitespace_accepted() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests",
+            " 5 ",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("whitespace-padded min-requests should succeed")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(success_rate.min_requests, 5);
+    }
+
+    #[test]
+    fn mode_consecutive_unchanged() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.linkerd.io/failure-accrual".to_string(),
+            "consecutive".to_string(),
+        );
+        let accrual = parse_accrual_config(&annotations)
+            .expect("mode=consecutive should succeed")
+            .expect("should return Some");
+        assert_eq!(
+            accrual,
+            FailureAccrual::Consecutive {
+                max_failures: 7,
+                backoff: Backoff {
+                    min_penalty: time::Duration::from_secs(1),
+                    max_penalty: time::Duration::from_secs(60),
+                    jitter: 0.5,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn unified_threshold_out_of_range_rejected() {
+        for value in ["-0.1", "1.5"] {
+            let annotations = accrual_annotations(&[(
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold",
+                value,
+            )]);
+            let err = parse_accrual_config(&annotations)
+                .expect_err("out-of-range threshold should be rejected");
+            assert!(
+                err.to_string().contains("between 0.0 and 1.0"),
+                "error should mention the valid range: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn boolean_accrual_modes_rejected() {
+        for mode in ["true", "false"] {
+            let mut annotations = BTreeMap::new();
+            annotations.insert(
+                "balancer.linkerd.io/failure-accrual".to_string(),
+                mode.to_string(),
+            );
+            let err =
+                parse_accrual_config(&annotations).expect_err("boolean modes should be rejected");
+            assert!(
+                err.to_string().contains("unsupported failure accrual mode"),
+                "error should mention the unsupported mode: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn window_zero_rejected() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-window",
+            "0s",
+        )]);
+        let err = parse_accrual_config(&annotations).expect_err("window=0 should be rejected");
+        assert!(
+            err.to_string()
+                .contains("success-rate-window must be greater than zero"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn window_below_proxy_bound_rejected() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-window",
+            "9ms",
+        )]);
+        let err =
+            parse_accrual_config(&annotations).expect_err("window below 10ms should be rejected");
+        assert!(
+            err.to_string().contains("10ms"),
+            "error should mention the bound: {err}"
+        );
+    }
+
+    #[test]
+    fn window_at_proxy_bound_accepted() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-window",
+            "10ms",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("window at the bound should parse")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(success_rate.window, MIN_SUCCESS_RATE_WINDOW);
+    }
+
+    #[test]
+    fn min_requests_zero_warns_but_succeeds() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests",
+            "0",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("min_requests=0 should succeed with a warning")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(success_rate.min_requests, 0);
+    }
+
+    #[test]
+    fn threshold_zero_warns_but_succeeds() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold",
+            "0.0",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("threshold=0.0 should succeed with a warning")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert!((success_rate.threshold - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn sub_second_window_warns_but_succeeds() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-window",
+            "500ms",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("sub-second window should succeed with a warning")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(success_rate.window, time::Duration::from_millis(500));
+    }
+
+    #[test]
+    fn success_rate_annotations_ignored_under_consecutive() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.linkerd.io/failure-accrual".to_string(),
+            "consecutive".to_string(),
+        );
+        annotations.insert(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold".to_string(),
+            "0.9".to_string(),
+        );
+        let accrual = parse_accrual_config(&annotations)
+            .expect("consecutive mode should keep the breaker despite success-rate annotations")
+            .expect("should return Some");
+        assert!(
+            matches!(accrual, FailureAccrual::Consecutive { .. }),
+            "expected consecutive accrual, got: {accrual:?}"
+        );
+    }
+
+    #[test]
+    fn mode_consecutive_without_success_rate_succeeds() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.linkerd.io/failure-accrual".to_string(),
+            "consecutive".to_string(),
+        );
+        let accrual = parse_accrual_config(&annotations)
+            .expect("consecutive without success-rate annotations should succeed")
+            .expect("should return Some");
+        assert!(
+            matches!(accrual, FailureAccrual::Consecutive { .. }),
+            "expected consecutive accrual, got: {accrual:?}"
+        );
+    }
+
+    #[test]
+    fn min_requests_above_proxy_bound_rejected() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests",
+            "1000001",
+        )]);
+        let err = parse_accrual_config(&annotations)
+            .expect_err("min-requests above 1000000 should be rejected");
+        assert!(
+            err.to_string().contains("1000000"),
+            "error should mention the bound: {err}"
+        );
+    }
+
+    #[test]
+    fn min_requests_at_proxy_bound_accepted() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests",
+            "1000000",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("min-requests at the bound should parse")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(success_rate.min_requests, MAX_SUCCESS_RATE_MIN_REQUESTS);
+    }
+
+    #[test]
+    fn unified_threshold_zero_accepts_sub_10ms_window() {
+        let annotations = accrual_annotations(&[
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold",
+                "0",
+            ),
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-window",
+                "5ms",
+            ),
+        ]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("threshold 0 should gate off the 10ms window floor")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(success_rate.window, time::Duration::from_millis(5));
+    }
+
+    #[test]
+    fn unified_threshold_zero_accepts_large_min_requests() {
+        let annotations = accrual_annotations(&[
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold",
+                "0",
+            ),
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests",
+                "2000000",
+            ),
+        ]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("threshold 0 should gate off the min-requests ceiling")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(success_rate.min_requests, 2_000_000);
+    }
+
+    #[test]
+    fn success_rate_keys_without_mode_returns_none() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold".to_string(),
+            "0.9".to_string(),
+        );
+        let result = parse_accrual_config(&annotations)
+            .expect("success-rate annotations without a mode should succeed");
+        assert!(
+            result.is_none(),
+            "no mode means no accrual, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn unified_unknown_success_rate_key_ignored() {
+        let annotations = accrual_annotations(&[(
+            "balancer.alpha.linkerd.io/failure-accrual-success-rate-thresold",
+            "0.99",
+        )]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("a typo'd success-rate key should be ignored, not rejected")
+            .expect("should return Some");
+        let FailureAccrual::Unified { success_rate, .. } = accrual else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert!(
+            (success_rate.threshold - DEFAULT_SUCCESS_RATE_THRESHOLD).abs() < f64::EPSILON,
+            "typo'd key must not be parsed; threshold should be the default"
+        );
+    }
+
+    #[test]
+    fn unified_both_dimensions_disabled_parses() {
+        let annotations = accrual_annotations(&[
+            (
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold",
+                "0",
+            ),
+            (
+                "balancer.linkerd.io/failure-accrual-consecutive-max-failures",
+                "0",
+            ),
+        ]);
+        let accrual = parse_accrual_config(&annotations)
+            .expect("both dimensions disabled should still parse")
+            .expect("should return Some");
+        let FailureAccrual::Unified {
+            max_failures,
+            success_rate,
+            ..
+        } = accrual
+        else {
+            panic!("expected unified accrual, got: {accrual:?}");
+        };
+        assert_eq!(max_failures, 0);
+        assert!((success_rate.threshold - 0.0).abs() < f64::EPSILON);
+    }
 }

--- a/policy-controller/runtime/src/admission.rs
+++ b/policy-controller/runtime/src/admission.rs
@@ -495,11 +495,13 @@ impl Validate<HttpRouteSpec> for Admission {
             }
         }
 
+        // Validate retry and timeout annotations on the Route itself. The
+        // admission webhook does not intercept core/v1 Services, so annotations
+        // set directly on a Service are checked later, at indexer time.
         if spec.parent_refs.iter().flatten().any(|parent| {
             outbound_index::is_parent_service_or_egress_network(&parent.kind, &parent.group)
         }) {
             outbound_index::http::parse_http_retry(annotations)?;
-            outbound_index::parse_accrual_config(annotations)?;
             outbound_index::parse_timeouts(annotations)?;
         }
 
@@ -619,11 +621,12 @@ impl Validate<gateway::HTTPRouteSpec> for Admission {
             }
         }
 
+        // See the note in Validate<HttpRouteSpec>. This route type is
+        // validated the same way.
         if spec.parent_refs.iter().flatten().any(|parent| {
             outbound_index::is_parent_service_or_egress_network(&parent.kind, &parent.group)
         }) {
             outbound_index::http::parse_http_retry(annotations)?;
-            outbound_index::parse_accrual_config(annotations)?;
             outbound_index::parse_timeouts(annotations)?;
         }
 
@@ -689,11 +692,12 @@ impl Validate<gateway::GRPCRouteSpec> for Admission {
             }
         }
 
+        // See the note in Validate<HttpRouteSpec>. This route type is
+        // validated the same way.
         if spec.parent_refs.iter().flatten().any(|parent| {
             outbound_index::is_parent_service_or_egress_network(&parent.kind, &parent.group)
         }) {
             outbound_index::grpc::parse_grpc_retry(annotations)?;
-            outbound_index::parse_accrual_config(annotations)?;
             outbound_index::parse_timeouts(annotations)?;
         }
 

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -19,6 +19,7 @@ futures = { version = "0.3", default-features = false }
 ipnet = "2"
 k8s-openapi = { workspace = true }
 maplit = "1"
+prost-types = "0.14"
 rand = "0.10"
 serde = "1"
 serde_json = "1"

--- a/policy-test/src/outbound_api.rs
+++ b/policy-test/src/outbound_api.rs
@@ -194,23 +194,393 @@ where
 pub fn failure_accrual_consecutive(
     accrual: Option<&grpc::outbound::FailureAccrual>,
 ) -> &grpc::outbound::failure_accrual::ConsecutiveFailures {
-    assert!(
-        accrual.is_some(),
-        "failure accrual must be configured for service"
-    );
-    let kind = accrual
-        .unwrap()
+    match accrual
+        .expect("failure accrual must be configured for service")
         .kind
         .as_ref()
-        .expect("failure accrual must have kind");
-    match kind {
-        linkerd2_proxy_api::outbound::failure_accrual::Kind::ConsecutiveFailures(accrual) => {
-            accrual
-        }
-        linkerd2_proxy_api::outbound::failure_accrual::Kind::Unified(unified) => panic!(
-            "expected failure accrual to be ConsecutiveFailures but got Unified: {unified:#?}"
-        ),
+        .expect("failure accrual must have a kind")
+    {
+        grpc::outbound::failure_accrual::Kind::ConsecutiveFailures(cf) => cf,
+        other => panic!("failure accrual must be consecutive; actually got:\n{other:#?}"),
     }
+}
+
+#[track_caller]
+pub fn failure_accrual_unified(
+    accrual: Option<&grpc::outbound::FailureAccrual>,
+) -> &grpc::outbound::failure_accrual::Unified {
+    match accrual
+        .expect("failure accrual must be configured for service")
+        .kind
+        .as_ref()
+        .expect("failure accrual must have a kind")
+    {
+        grpc::outbound::failure_accrual::Kind::Unified(unified) => unified,
+        other => panic!("failure accrual must be unified; actually got:\n{other:#?}"),
+    }
+}
+
+/// A view of the penalty values held by a service balancer's
+/// PenaltyPeakEwma load estimator.
+pub struct LoadBias {
+    pub penalty: Option<prost_types::Duration>,
+    pub penalty_decay: Option<prost_types::Duration>,
+}
+
+/// A view of the Retry-After cap held by a service balancer's
+/// PenaltyPeakEwma load estimator.
+pub struct RetryAfter {
+    pub max_duration: Option<prost_types::Duration>,
+}
+
+/// Assert that a `LoadBias` view has the default penalty estimator, a 5s
+/// base penalty decaying over 10s.
+#[track_caller]
+pub fn assert_default_penalty_estimator(load_bias: &LoadBias) {
+    assert_eq!(
+        load_bias.penalty,
+        Some(std::time::Duration::from_secs(5).try_into().unwrap()),
+        "default penalty should be 5s"
+    );
+    assert_eq!(
+        load_bias.penalty_decay,
+        Some(std::time::Duration::from_secs(10).try_into().unwrap()),
+        "default penalty_decay should be 10s"
+    );
+}
+
+/// Assert that a `RetryAfter` view has the default 300s cap.
+#[track_caller]
+pub fn assert_default_retry_after_cap(retry_after: &RetryAfter) {
+    assert_eq!(
+        retry_after.max_duration,
+        Some(std::time::Duration::from_secs(300).try_into().unwrap()),
+        "default max_duration should be 300s"
+    );
+}
+
+/// Extract the penalty and Retry-After cap held by a service's default
+/// backend balancer load estimator.
+///
+/// Response penalization uses the PenaltyPeakEwma estimator, which holds
+/// the penalty and its decay. The Retry-After cap shares the same estimator, so
+/// it appears here only when penalization is also enabled. Honoring Retry-After
+/// on its own leaves the plain PeakEwma estimator in place and is observed
+/// through respect_retry_after_hint on the failure-accrual backoff instead.
+#[track_caller]
+pub fn detect_load_bias_and_retry_after(
+    config: &grpc::outbound::OutboundPolicy,
+) -> (Option<LoadBias>, Option<RetryAfter>) {
+    interpret_balancer_load(default_backend_balancer_load(config))
+}
+
+/// Interpret a balancer load estimator into its penalty and Retry-After views.
+///
+/// The PenaltyPeakEwma estimator holds the penalty, its decay, and the
+/// Retry-After cap. Plain PeakEwma (or no balancer at all, as with
+/// EgressNetwork forwarding) means no penalty and no cap.
+fn interpret_balancer_load(
+    load: Option<grpc::outbound::backend::balance_p2c::Load>,
+) -> (Option<LoadBias>, Option<RetryAfter>) {
+    match load {
+        Some(grpc::outbound::backend::balance_p2c::Load::PenaltyPeakEwma(penalty)) => {
+            let load_bias = penalty.penalty.is_some().then_some(LoadBias {
+                penalty: penalty.penalty,
+                penalty_decay: penalty.penalty_decay,
+            });
+            let retry_after = penalty.max_retry_after.map(|max_duration| RetryAfter {
+                max_duration: Some(max_duration),
+            });
+            (load_bias, retry_after)
+        }
+        _ => (None, None),
+    }
+}
+
+/// Extract the penalty and Retry-After cap held by the default backend
+/// balancer of a service served as an opaque proxy protocol.
+///
+/// An opaque service surfaces under the Opaque proxy-protocol kind rather than
+/// Detect, so its generated default backend is reached through the opaque
+/// route instead of the default HTTP route.
+#[track_caller]
+pub fn opaque_default_backend_load_bias_and_retry_after(
+    config: &grpc::outbound::OutboundPolicy,
+) -> (Option<LoadBias>, Option<RetryAfter>) {
+    interpret_balancer_load(opaque_default_backend_balancer_load(config))
+}
+
+/// Locate the default backend balancer of an Opaque proxy protocol and return
+/// its load estimator, if the backend is a balancer.
+#[track_caller]
+fn opaque_default_backend_balancer_load(
+    config: &grpc::outbound::OutboundPolicy,
+) -> Option<grpc::outbound::backend::balance_p2c::Load> {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+
+    let routes = if let grpc::outbound::proxy_protocol::Kind::Opaque(
+        grpc::outbound::proxy_protocol::Opaque { routes },
+    ) = kind
+    {
+        routes
+    } else {
+        panic!("proxy protocol must be Opaque; actually got:\n{kind:#?}")
+    };
+
+    let backend = routes
+        .iter()
+        .find_map(opaque_default_route_backend)
+        .expect("opaque default route must have a backend");
+
+    match backend.kind.as_ref() {
+        Some(grpc::outbound::backend::Kind::Balancer(balancer)) => balancer.load,
+        _ => None,
+    }
+}
+
+/// Return the first-available backend of a generated default opaque route.
+fn opaque_default_route_backend(
+    route: &grpc::outbound::OpaqueRoute,
+) -> Option<&grpc::outbound::Backend> {
+    let is_default = matches!(
+        route.metadata.as_ref().and_then(|m| m.kind.as_ref()),
+        Some(grpc::meta::metadata::Kind::Default(_))
+    );
+    if !is_default {
+        return None;
+    }
+
+    route.rules.iter().find_map(|rule| {
+        let dist = rule.backends.as_ref()?.kind.as_ref()?;
+        let grpc::outbound::opaque_route::distribution::Kind::FirstAvailable(first) = dist else {
+            return None;
+        };
+        first.backends.first()?.backend.as_ref()
+    })
+}
+
+/// Extract the penalty and Retry-After cap held by the load estimator of a
+/// non-default route's first Service backend balancer.
+///
+/// Routed services send traffic through route backends rather than the
+/// generated default backend, so this navigates the first real (Resource)
+/// HTTP route to its first balancer backend.
+#[track_caller]
+pub fn route_backend_load_bias_and_retry_after(
+    config: &grpc::outbound::OutboundPolicy,
+) -> (Option<LoadBias>, Option<RetryAfter>) {
+    interpret_balancer_load(route_backend_balancer_load(config))
+}
+
+/// Locate the service's default (non-route) backend balancer and return its
+/// load estimator, if the backend is a balancer.
+#[track_caller]
+fn default_backend_balancer_load(
+    config: &grpc::outbound::OutboundPolicy,
+) -> Option<grpc::outbound::backend::balance_p2c::Load> {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+
+    // For a Detect protocol the default backend is reached through the
+    // generated default HTTP route. Both http1 and http2 share the same
+    // backend, so http1 is sufficient.
+    let routes = if let grpc::outbound::proxy_protocol::Kind::Detect(
+        grpc::outbound::proxy_protocol::Detect { http1, .. },
+    ) = kind
+    {
+        &http1
+            .as_ref()
+            .expect("proxy protocol must have http1 field")
+            .routes
+    } else {
+        panic!("proxy protocol must be Detect; actually got:\n{kind:#?}")
+    };
+
+    let backend = routes
+        .iter()
+        .find_map(default_route_backend)
+        .expect("default route must have a backend");
+
+    match backend.kind.as_ref() {
+        Some(grpc::outbound::backend::Kind::Balancer(balancer)) => balancer.load,
+        _ => None,
+    }
+}
+
+/// Return the first-available backend of a generated default HTTP route.
+fn default_route_backend(route: &grpc::outbound::HttpRoute) -> Option<&grpc::outbound::Backend> {
+    let is_default = matches!(
+        route.metadata.as_ref().and_then(|m| m.kind.as_ref()),
+        Some(grpc::meta::metadata::Kind::Default(_))
+    );
+    if !is_default {
+        return None;
+    }
+
+    route.rules.iter().find_map(|rule| {
+        let dist = rule.backends.as_ref()?.kind.as_ref()?;
+        let grpc::outbound::http_route::distribution::Kind::FirstAvailable(first) = dist else {
+            return None;
+        };
+        first.backends.first()?.backend.as_ref()
+    })
+}
+
+/// Locate the first balancer backend of a non-default (Resource) HTTP route and
+/// return its load estimator.
+#[track_caller]
+fn route_backend_balancer_load(
+    config: &grpc::outbound::OutboundPolicy,
+) -> Option<grpc::outbound::backend::balance_p2c::Load> {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+
+    // A routed service is served as a Detect protocol. http1 and http2 share
+    // the same routes, so http1 is sufficient.
+    let routes = if let grpc::outbound::proxy_protocol::Kind::Detect(
+        grpc::outbound::proxy_protocol::Detect { http1, .. },
+    ) = kind
+    {
+        &http1
+            .as_ref()
+            .expect("proxy protocol must have http1 field")
+            .routes
+    } else {
+        panic!("proxy protocol must be Detect; actually got:\n{kind:#?}")
+    };
+
+    let backend = routes
+        .iter()
+        .find_map(route_backend)
+        .expect("a route must have a balancer backend");
+
+    match backend.kind.as_ref() {
+        Some(grpc::outbound::backend::Kind::Balancer(balancer)) => balancer.load,
+        _ => None,
+    }
+}
+
+/// Return the first balancer backend of a non-default (Resource) HTTP route.
+fn route_backend(route: &grpc::outbound::HttpRoute) -> Option<&grpc::outbound::Backend> {
+    let is_default = matches!(
+        route.metadata.as_ref().and_then(|m| m.kind.as_ref()),
+        Some(grpc::meta::metadata::Kind::Default(_))
+    );
+    if is_default {
+        return None;
+    }
+
+    // A route with real Service backends emits a RandomAvailable distribution
+    // of weighted backends.
+    route.rules.iter().find_map(|rule| {
+        let dist = rule.backends.as_ref()?.kind.as_ref()?;
+        let grpc::outbound::http_route::distribution::Kind::RandomAvailable(random) = dist else {
+            return None;
+        };
+        random.backends.iter().find_map(|weighted| {
+            let backend = weighted.backend.as_ref()?.backend.as_ref()?;
+            matches!(
+                backend.kind.as_ref(),
+                Some(grpc::outbound::backend::Kind::Balancer(_))
+            )
+            .then_some(backend)
+        })
+    })
+}
+
+/// Extract the penalty and Retry-After cap held by the load estimator of a
+/// non-default gRPC route's first Service backend balancer.
+///
+/// Routed services send traffic through route backends rather than the
+/// generated default backend, so this navigates the first real (Resource)
+/// gRPC route to its first balancer backend.
+#[track_caller]
+pub fn grpc_route_backend_load_bias_and_retry_after(
+    config: &grpc::outbound::OutboundPolicy,
+) -> (Option<LoadBias>, Option<RetryAfter>) {
+    interpret_balancer_load(grpc_route_backend_balancer_load(config))
+}
+
+/// Locate the first balancer backend of a non-default (Resource) gRPC route and
+/// return its load estimator.
+#[track_caller]
+fn grpc_route_backend_balancer_load(
+    config: &grpc::outbound::OutboundPolicy,
+) -> Option<grpc::outbound::backend::balance_p2c::Load> {
+    let kind = config
+        .protocol
+        .as_ref()
+        .expect("must have proxy protocol")
+        .kind
+        .as_ref()
+        .expect("must have kind");
+
+    // A routed gRPC service is served as a Grpc protocol that holds the gRPC
+    // routes directly.
+    let routes =
+        if let grpc::outbound::proxy_protocol::Kind::Grpc(grpc::outbound::proxy_protocol::Grpc {
+            routes,
+            ..
+        }) = kind
+        {
+            routes
+        } else {
+            panic!("proxy protocol must be Grpc; actually got:\n{kind:#?}")
+        };
+
+    let backend = routes
+        .iter()
+        .find_map(grpc_route_backend)
+        .expect("a gRPC route must have a balancer backend");
+
+    match backend.kind.as_ref() {
+        Some(grpc::outbound::backend::Kind::Balancer(balancer)) => balancer.load,
+        _ => None,
+    }
+}
+
+/// Return the first balancer backend of a non-default (Resource) gRPC route.
+fn grpc_route_backend(route: &grpc::outbound::GrpcRoute) -> Option<&grpc::outbound::Backend> {
+    let is_default = matches!(
+        route.metadata.as_ref().and_then(|m| m.kind.as_ref()),
+        Some(grpc::meta::metadata::Kind::Default(_))
+    );
+    if is_default {
+        return None;
+    }
+
+    // A gRPC route with real Service backends emits a RandomAvailable
+    // distribution of weighted backends.
+    route.rules.iter().find_map(|rule| {
+        let dist = rule.backends.as_ref()?.kind.as_ref()?;
+        let grpc::outbound::grpc_route::distribution::Kind::RandomAvailable(random) = dist else {
+            return None;
+        };
+        random.backends.iter().find_map(|weighted| {
+            let backend = weighted.backend.as_ref()?.backend.as_ref()?;
+            matches!(
+                backend.kind.as_ref(),
+                Some(grpc::outbound::backend::Kind::Balancer(_))
+            )
+            .then_some(backend)
+        })
+    })
 }
 
 #[track_caller]

--- a/policy-test/tests/outbound_api_failure_accrual.rs
+++ b/policy-test/tests/outbound_api_failure_accrual.rs
@@ -1,14 +1,17 @@
 use std::time::Duration;
 
 use futures::StreamExt;
+use kube::Resource;
 use linkerd_policy_controller_k8s_api::{self as k8s, policy};
 use linkerd_policy_test::{
     assert_default_accrual_backoff, assert_resource_meta, create, grpc,
     outbound_api::{
-        detect_failure_accrual, failure_accrual_consecutive, retry_watch_outbound_policy,
+        assert_default_penalty_estimator, assert_default_retry_after_cap, detect_failure_accrual,
+        detect_load_bias_and_retry_after, failure_accrual_consecutive, failure_accrual_unified,
+        opaque_default_backend_load_bias_and_retry_after, retry_watch_outbound_policy,
     },
     test_route::TestParent,
-    with_temp_ns,
+    update, with_temp_ns,
 };
 use maplit::btreemap;
 
@@ -243,4 +246,632 @@ async fn default_failure_accrual() {
 
     test::<k8s::Service>().await;
     test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unified_failure_accrual() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            // Create a parent configured to do unified failure accrual, with
+            // explicit values for every parameter
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "unified".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold".to_string() => "0.9".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-window".to_string() => "30s".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests".to_string() => "100".to_string(),
+                "balancer.linkerd.io/failure-accrual-consecutive-max-failures".to_string() => "8".to_string(),
+                "balancer.linkerd.io/failure-accrual-consecutive-min-penalty".to_string() => "10s".to_string(),
+                "balancer.linkerd.io/failure-accrual-consecutive-max-penalty".to_string() => "10m".to_string(),
+                "balancer.linkerd.io/failure-accrual-consecutive-jitter-ratio".to_string() => "1.0".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            detect_failure_accrual(&config, |accrual| {
+                let unified = failure_accrual_unified(accrual);
+                assert!((unified.success_rate_threshold - 0.9).abs() < f64::EPSILON);
+                assert_eq!(
+                    unified.decay,
+                    Some(Duration::from_secs(30).try_into().unwrap())
+                );
+                assert_eq!(100, unified.min_requests);
+                assert_eq!(8, unified.max_consecutive_failures);
+                assert_eq!(
+                    &grpc::outbound::ExponentialBackoff {
+                        min_backoff: Some(Duration::from_secs(10).try_into().unwrap()),
+                        max_backoff: Some(Duration::from_secs(600).try_into().unwrap()),
+                        jitter_ratio: 1.0_f32,
+                        respect_retry_after_hint: false,
+                    },
+                    unified
+                        .backoff
+                        .as_ref()
+                        .expect("backoff must be configured")
+                );
+            });
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unified_failure_accrual_defaults_no_config() {
+    async fn test<P: TestParent>() {
+        tracing::debug!(
+            parent = %P::kind(&P::DynamicType::default()),
+        );
+        with_temp_ns(|client, ns| async move {
+            // Create a parent configured to do unified failure accrual with
+            // no additional configuration
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "unified".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            // Expect default values for all five Unified fields. The default
+            // backoff leaves respect_retry_after_hint=false in the absence of
+            // honor-retry-after.
+            detect_failure_accrual(&config, |accrual| {
+                let unified = failure_accrual_unified(accrual);
+                assert!((unified.success_rate_threshold - 0.8).abs() < f64::EPSILON);
+                assert_eq!(
+                    unified.decay,
+                    Some(Duration::from_secs(10).try_into().unwrap())
+                );
+                assert_eq!(5, unified.min_requests);
+                assert_eq!(7, unified.max_consecutive_failures);
+                assert_default_accrual_backoff!(unified
+                    .backoff
+                    .as_ref()
+                    .expect("backoff must be configured"));
+            });
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unified_honor_retry_after_sets_hint() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            // The Retry-After opt-in is attached to the accrual backoff for
+            // both accrual kinds and must apply to the unified case too.
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "unified".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // Honoring Retry-After sets the hint on the unified backoff.
+            detect_failure_accrual(&config, |accrual| {
+                let unified = failure_accrual_unified(accrual);
+                let backoff = unified
+                    .backoff
+                    .as_ref()
+                    .expect("backoff must be configured");
+                assert!(
+                    backoff.respect_retry_after_hint,
+                    "honor-retry-after must set respect_retry_after_hint"
+                );
+            });
+
+            // It does not switch the estimator. The load estimator stays plain
+            // PeakEwma and reports no penalty or cap.
+            let dt = P::DynamicType::default();
+            if P::kind(&dt) != "EgressNetwork" {
+                let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+                assert!(
+                    load_bias.is_none(),
+                    "honor-retry-after alone must keep plain PeakEwma"
+                );
+                assert!(
+                    retry_after.is_none(),
+                    "honor-retry-after alone must not carry a cap on the estimator"
+                );
+            }
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn success_rate_annotations_ignored_under_consecutive() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            // mode=consecutive combined with a success-rate annotation keeps the
+            // consecutive breaker. Success-rate annotations have no effect under
+            // consecutive mode. The indexer warns and keeps the breaker.
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "consecutive".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold".to_string() => "0.9".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // The consecutive breaker reaches the wire. The stray success-rate
+            // annotation is inert rather than dropping the whole config.
+            detect_failure_accrual(&config, |accrual| {
+                let accrual = accrual.expect("failure accrual must be configured");
+                assert!(
+                    matches!(
+                        accrual.kind,
+                        Some(grpc::outbound::failure_accrual::Kind::ConsecutiveFailures(
+                            _
+                        ))
+                    ),
+                    "failure accrual kind must be consecutive failures, got:\n{:#?}",
+                    accrual.kind
+                );
+            });
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn penalize_failures_emits_penalty_estimator() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            let dt = P::DynamicType::default();
+            let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+            if P::kind(&dt) == "EgressNetwork" {
+                assert!(
+                    load_bias.is_none(),
+                    "EgressNetwork should not have a penalty estimator"
+                );
+            } else {
+                let lb = load_bias.expect("penalty estimator must be configured");
+                assert_default_penalty_estimator(&lb);
+                // The biaser's Retry-After cap belongs to the penalty estimator.
+                // So penalize-failures alone emits the 300s default cap,
+                // regardless of honor-retry-after.
+                let ra = retry_after.expect("penalty estimator holds the Retry-After cap");
+                assert_default_retry_after_cap(&ra);
+            }
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn opaque_service_keeps_plain_estimator_on_default_backend() {
+    with_temp_ns(|client, ns| async move {
+        let port = 4191;
+        // An explicitly opaque service handles non-HTTP traffic, where the
+        // response-code penalty does not apply, so its default backend stays on
+        // the plain PeakEwma estimator even with penalize-failures set.
+        let mut parent =
+            k8s::Service::make_parent_with_protocol(&ns, Some("linkerd.io/opaque".to_string()));
+        parent.meta_mut().annotations = Some(btreemap! {
+            "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+        });
+        let parent = create(&client, parent).await;
+
+        let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+
+        // penalize-failures is a no-op for opaque traffic, so the opaque
+        // default backend reports no penalty estimator.
+        let (load_bias, retry_after) = opaque_default_backend_load_bias_and_retry_after(&config);
+        assert!(
+            load_bias.is_none(),
+            "opaque service default backend must keep plain PeakEwma"
+        );
+        assert!(
+            retry_after.is_none(),
+            "opaque service default backend must not carry a Retry-After cap"
+        );
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn honor_retry_after_keeps_plain_estimator() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            // A failure-accrual backoff must exist for respect_retry_after_hint
+            // to have somewhere to land.
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "consecutive".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // Honoring Retry-After sets the hint on the accrual backoff.
+            detect_failure_accrual(&config, |accrual| {
+                let consecutive = failure_accrual_consecutive(accrual);
+                let backoff = consecutive
+                    .backoff
+                    .as_ref()
+                    .expect("backoff must be configured");
+                assert!(
+                    backoff.respect_retry_after_hint,
+                    "honor-retry-after must set respect_retry_after_hint"
+                );
+            });
+
+            // It does not switch the estimator. The load estimator stays plain
+            // PeakEwma, so no penalty or cap is reported.
+            let dt = P::DynamicType::default();
+            if P::kind(&dt) != "EgressNetwork" {
+                let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+                assert!(
+                    load_bias.is_none(),
+                    "honor-retry-after alone must keep plain PeakEwma"
+                );
+                assert!(
+                    retry_after.is_none(),
+                    "honor-retry-after alone must not carry a cap on the estimator"
+                );
+            }
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn penalize_and_honor_retry_after_combined() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "consecutive".to_string(),
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // The backoff honors Retry-After.
+            detect_failure_accrual(&config, |accrual| {
+                let consecutive = failure_accrual_consecutive(accrual);
+                let backoff = consecutive
+                    .backoff
+                    .as_ref()
+                    .expect("backoff must be configured");
+                assert!(
+                    backoff.respect_retry_after_hint,
+                    "honor-retry-after must set respect_retry_after_hint"
+                );
+            });
+
+            // The penalty estimator is emitted and holds the cap.
+            let dt = P::DynamicType::default();
+            let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+            if P::kind(&dt) == "EgressNetwork" {
+                assert!(
+                    load_bias.is_none(),
+                    "EgressNetwork should not have a penalty estimator"
+                );
+                assert!(
+                    retry_after.is_none(),
+                    "EgressNetwork should not carry a cap"
+                );
+            } else {
+                let lb = load_bias.expect("penalty estimator must be configured");
+                assert_default_penalty_estimator(&lb);
+
+                let ra = retry_after.expect("Retry-After cap must be configured");
+                assert_default_retry_after_cap(&ra);
+            }
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn invalid_penalize_failures_value_produces_default() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "invalid".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // An unrecognized value causes a parse error. The indexer logs a
+            // warning and falls through to the default (plain PeakEwma).
+            let (load_bias, _) = detect_load_bias_and_retry_after(&config);
+            assert!(
+                load_bias.is_none(),
+                "invalid penalize-failures value should keep plain PeakEwma"
+            );
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unannotated_service_has_no_new_config() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let parent = P::make_parent(&ns);
+            // No balancer annotations at all. Backwards compatibility test.
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // No annotations means no failure accrual, penalty estimator, or
+            // Retry-After cap. Zero behavior change for unannotated resources.
+            detect_failure_accrual(&config, |accrual| {
+                assert!(
+                    accrual.is_none(),
+                    "unannotated resource should have no failure accrual"
+                );
+            });
+            let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+            assert!(
+                load_bias.is_none(),
+                "unannotated resource should keep plain PeakEwma"
+            );
+            assert!(
+                retry_after.is_none(),
+                "unannotated resource should have no Retry-After cap"
+            );
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn egress_network_ignores_balancer_toggles() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // EgressNetworks use Forward instead of Balancer, so the indexer
+            // emits no penalty estimator even when the toggles are set.
+            let dt = P::DynamicType::default();
+            let kind = P::kind(&dt);
+            let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+            assert!(
+                load_bias.is_none(),
+                "{kind} should not have a penalty estimator"
+            );
+            assert!(
+                retry_after.is_none(),
+                "{kind} should not carry a Retry-After cap"
+            );
+        })
+        .await;
+    }
+
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn consecutive_accrual_pipeline_unchanged() {
+    async fn test<P: TestParent>() {
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let mut parent = P::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "consecutive".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+
+            // Consecutive mode should produce failure accrual whose kind is
+            // consecutive-failures rather than the unified policy.
+            detect_failure_accrual(&config, |accrual| {
+                let accrual = accrual.expect("failure accrual must be configured");
+                assert!(
+                    matches!(
+                        accrual.kind,
+                        Some(grpc::outbound::failure_accrual::Kind::ConsecutiveFailures(
+                            _
+                        ))
+                    ),
+                    "failure accrual kind must be consecutive failures, got:\n{:#?}",
+                    accrual.kind
+                );
+            });
+
+            // Consecutive mode alone should not switch the estimator.
+            let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+            assert!(
+                load_bias.is_none(),
+                "consecutive mode should keep plain PeakEwma"
+            );
+            assert!(
+                retry_after.is_none(),
+                "consecutive mode should not carry a cap"
+            );
+        })
+        .await;
+    }
+
+    test::<k8s::Service>().await;
+    test::<policy::EgressNetwork>().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn penalize_failures_watch_update() {
+    with_temp_ns(|client, ns| async move {
+        let port = 4191;
+        let parent = k8s::Service::make_parent(&ns);
+        let mut parent = create(&client, parent).await;
+
+        let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an initial config");
+        tracing::trace!(?config);
+
+        let (load_bias, retry_after) = detect_load_bias_and_retry_after(&config);
+        assert!(
+            load_bias.is_none(),
+            "unannotated service should keep plain PeakEwma"
+        );
+        assert!(
+            retry_after.is_none(),
+            "unannotated service should have no Retry-After cap"
+        );
+
+        parent.meta_mut().annotations = Some(btreemap! {
+            "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+        });
+        update(&client, parent).await;
+
+        let config = rx
+            .next()
+            .await
+            .expect("watch must not fail")
+            .expect("watch must return an updated config");
+        tracing::trace!(?config);
+
+        let (load_bias, _) = detect_load_bias_and_retry_after(&config);
+        let lb = load_bias.expect("penalty estimator must be present after update");
+        assert_default_penalty_estimator(&lb);
+    })
+    .await;
 }

--- a/policy-test/tests/outbound_api_failure_accrual.rs
+++ b/policy-test/tests/outbound_api_failure_accrual.rs
@@ -567,7 +567,8 @@ async fn honor_retry_after_keeps_plain_estimator() {
                 .expect("watch must return an initial config");
             tracing::trace!(?config);
 
-            // Honoring Retry-After sets the hint on the accrual backoff.
+            // The consecutive breaker leaves the hint unset on its backoff even
+            // when honor-retry-after is on.
             detect_failure_accrual(&config, |accrual| {
                 let consecutive = failure_accrual_consecutive(accrual);
                 let backoff = consecutive
@@ -575,8 +576,8 @@ async fn honor_retry_after_keeps_plain_estimator() {
                     .as_ref()
                     .expect("backoff must be configured");
                 assert!(
-                    backoff.respect_retry_after_hint,
-                    "honor-retry-after must set respect_retry_after_hint"
+                    !backoff.respect_retry_after_hint,
+                    "consecutive accrual must not set respect_retry_after_hint"
                 );
             });
 
@@ -623,7 +624,7 @@ async fn penalize_and_honor_retry_after_combined() {
                 .expect("watch must return an initial config");
             tracing::trace!(?config);
 
-            // The backoff honors Retry-After.
+            // The consecutive breaker leaves the hint unset on its backoff.
             detect_failure_accrual(&config, |accrual| {
                 let consecutive = failure_accrual_consecutive(accrual);
                 let backoff = consecutive
@@ -631,8 +632,8 @@ async fn penalize_and_honor_retry_after_combined() {
                     .as_ref()
                     .expect("backoff must be configured");
                 assert!(
-                    backoff.respect_retry_after_hint,
-                    "honor-retry-after must set respect_retry_after_hint"
+                    !backoff.respect_retry_after_hint,
+                    "consecutive accrual must not set respect_retry_after_hint"
                 );
             });
 

--- a/policy-test/tests/outbound_api_grpc.rs
+++ b/policy-test/tests/outbound_api_grpc.rs
@@ -4,7 +4,11 @@ use linkerd2_proxy_api::{self as api, outbound};
 use linkerd_policy_controller_k8s_api::{self as k8s, gateway, policy};
 use linkerd_policy_test::{
     assert_resource_meta, await_route_accepted, create,
-    outbound_api::{assert_route_is_default, assert_singleton, retry_watch_outbound_policy},
+    outbound_api::{
+        assert_default_penalty_estimator, assert_default_retry_after_cap, assert_route_is_default,
+        assert_singleton, grpc_route_backend_load_bias_and_retry_after,
+        retry_watch_outbound_policy,
+    },
     test_route::{TestParent, TestRoute},
     with_temp_ns,
 };
@@ -365,4 +369,162 @@ async fn parent_retries_and_timeouts() {
 
     test::<k8s::Service>().await;
     test::<policy::EgressNetwork>().await;
+}
+
+// A service that defines gRPC routes sends traffic through its route backends,
+// so the penalty estimator selected by the load-bias toggles must reach those
+// route backend balancers rather than only the default backend.
+#[tokio::test(flavor = "current_thread")]
+async fn grpc_route_backend_inherits_load_bias() {
+    async fn test<R: TestRoute<Route = outbound::GrpcRoute>>() {
+        tracing::debug!(route = %R::kind(&R::DynamicType::default()));
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let backend_port = 8888;
+
+            // The load-bias and Retry-After toggles are set on the parent Service.
+            let mut parent = k8s::Service::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "consecutive".to_string(),
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let route = create(
+                &client,
+                R::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![parent.backend_ref(backend_port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            // The route's own Service backend balancer holds the penalty
+            // estimator, not just the default backend.
+            let (load_bias, retry_after) = grpc_route_backend_load_bias_and_retry_after(&config);
+            let lb = load_bias.expect("route backend must carry the penalty estimator");
+            assert_default_penalty_estimator(&lb);
+
+            let ra = retry_after.expect("route backend must carry the Retry-After cap");
+            assert_default_retry_after_cap(&ra);
+        })
+        .await;
+    }
+
+    test::<gateway::GRPCRoute>().await;
+}
+
+// Load bias is parent-scoped. An annotated parent lends its penalty estimator
+// to a distinct, unannotated backend reached through one of its routes.
+#[tokio::test(flavor = "current_thread")]
+async fn grpc_penalize_failures_annotated_parent_unannotated_backend() {
+    async fn test<R: TestRoute<Route = outbound::GrpcRoute>>() {
+        tracing::debug!(route = %R::kind(&R::DynamicType::default()));
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let backend_port = 8888;
+
+            let mut parent = k8s::Service::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let backend = create(
+                &client,
+                k8s::Service::make_backend(&ns).expect("Service must produce a backend"),
+            )
+            .await;
+
+            let route = create(
+                &client,
+                R::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![backend.backend_ref(backend_port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let (load_bias, _) = grpc_route_backend_load_bias_and_retry_after(&config);
+            let lb = load_bias.expect("backend must inherit the penalty estimator from the parent");
+            assert_default_penalty_estimator(&lb);
+        })
+        .await;
+    }
+
+    test::<gateway::GRPCRoute>().await;
+}
+
+// The converse: a backend's own load-bias annotation has no effect under an
+// unannotated parent, leaving the plain PeakEwma estimator in place.
+#[tokio::test(flavor = "current_thread")]
+async fn grpc_penalize_failures_unannotated_parent_annotated_backend() {
+    async fn test<R: TestRoute<Route = outbound::GrpcRoute>>() {
+        tracing::debug!(route = %R::kind(&R::DynamicType::default()));
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let backend_port = 8888;
+
+            let parent = create(&client, k8s::Service::make_parent(&ns)).await;
+
+            let mut backend =
+                k8s::Service::make_backend(&ns).expect("Service must produce a backend");
+            backend.meta_mut().annotations = Some(btreemap! {
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+            });
+            let backend = create(&client, backend).await;
+
+            let route = create(
+                &client,
+                R::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![backend.backend_ref(backend_port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let (load_bias, _) = grpc_route_backend_load_bias_and_retry_after(&config);
+            assert!(
+                load_bias.is_none(),
+                "backend's own annotation must not select the penalty estimator under an unannotated parent"
+            );
+        })
+        .await;
+    }
+
+    test::<gateway::GRPCRoute>().await;
 }

--- a/policy-test/tests/outbound_api_http.rs
+++ b/policy-test/tests/outbound_api_http.rs
@@ -1,11 +1,15 @@
 use std::time::Duration;
 
 use futures::StreamExt;
+use kube::Resource;
 use linkerd2_proxy_api::{self as api, outbound};
 use linkerd_policy_controller_k8s_api::{self as k8s, gateway, policy};
 use linkerd_policy_test::{
     assert_resource_meta, await_route_accepted, create,
-    outbound_api::{assert_route_is_default, assert_singleton, retry_watch_outbound_policy},
+    outbound_api::{
+        assert_default_penalty_estimator, assert_default_retry_after_cap, assert_route_is_default,
+        assert_singleton, retry_watch_outbound_policy, route_backend_load_bias_and_retry_after,
+    },
     test_route::{TestParent, TestRoute},
     with_temp_ns,
 };
@@ -701,6 +705,167 @@ async fn http_route_retries_and_timeouts() {
     test::<k8s::Service, policy::HttpRoute>().await;
     test::<policy::EgressNetwork, gateway::HTTPRoute>().await;
     test::<policy::EgressNetwork, policy::HttpRoute>().await;
+}
+
+// A service that defines routes sends traffic through its route backends, so
+// the penalty estimator selected by the load-bias toggles must reach those
+// route backend balancers rather than only the default backend.
+#[tokio::test(flavor = "current_thread")]
+async fn http_route_backend_inherits_load_bias() {
+    async fn test<R: TestRoute<Route = outbound::HttpRoute>>() {
+        tracing::debug!(route = %R::kind(&R::DynamicType::default()));
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let backend_port = 8888;
+
+            // The load-bias and Retry-After toggles are set on the parent Service.
+            let mut parent = k8s::Service::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.linkerd.io/failure-accrual".to_string() => "consecutive".to_string(),
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+                "balancer.alpha.linkerd.io/failure-accrual-honor-retry-after".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let route = create(
+                &client,
+                R::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![parent.backend_ref(backend_port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            // The route's own Service backend balancer holds the penalty
+            // estimator, not just the default backend.
+            let (load_bias, retry_after) = route_backend_load_bias_and_retry_after(&config);
+            let lb = load_bias.expect("route backend must carry the penalty estimator");
+            assert_default_penalty_estimator(&lb);
+
+            let ra = retry_after.expect("route backend must carry the Retry-After cap");
+            assert_default_retry_after_cap(&ra);
+        })
+        .await;
+    }
+
+    test::<gateway::HTTPRoute>().await;
+    test::<policy::HttpRoute>().await;
+}
+
+// Load bias is parent-scoped. An annotated parent lends its penalty estimator
+// to a distinct, unannotated backend reached through one of its routes.
+#[tokio::test(flavor = "current_thread")]
+async fn http_penalize_failures_annotated_parent_unannotated_backend() {
+    async fn test<R: TestRoute<Route = outbound::HttpRoute>>() {
+        tracing::debug!(route = %R::kind(&R::DynamicType::default()));
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let backend_port = 8888;
+
+            let mut parent = k8s::Service::make_parent(&ns);
+            parent.meta_mut().annotations = Some(btreemap! {
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+            });
+            let parent = create(&client, parent).await;
+
+            let backend = create(
+                &client,
+                k8s::Service::make_backend(&ns).expect("Service must produce a backend"),
+            )
+            .await;
+
+            let route = create(
+                &client,
+                R::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![backend.backend_ref(backend_port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let (load_bias, _) = route_backend_load_bias_and_retry_after(&config);
+            let lb = load_bias.expect("backend must inherit the penalty estimator from the parent");
+            assert_default_penalty_estimator(&lb);
+        })
+        .await;
+    }
+
+    test::<gateway::HTTPRoute>().await;
+    test::<policy::HttpRoute>().await;
+}
+
+// The converse: a backend's own load-bias annotation has no effect under an
+// unannotated parent, leaving the plain PeakEwma estimator in place.
+#[tokio::test(flavor = "current_thread")]
+async fn http_penalize_failures_unannotated_parent_annotated_backend() {
+    async fn test<R: TestRoute<Route = outbound::HttpRoute>>() {
+        tracing::debug!(route = %R::kind(&R::DynamicType::default()));
+        with_temp_ns(|client, ns| async move {
+            let port = 4191;
+            let backend_port = 8888;
+
+            let parent = create(&client, k8s::Service::make_parent(&ns)).await;
+
+            let mut backend =
+                k8s::Service::make_backend(&ns).expect("Service must produce a backend");
+            backend.meta_mut().annotations = Some(btreemap! {
+                "balancer.alpha.linkerd.io/penalize-failures".to_string() => "true".to_string(),
+            });
+            let backend = create(&client, backend).await;
+
+            let route = create(
+                &client,
+                R::make_route(
+                    ns.clone(),
+                    vec![parent.obj_ref()],
+                    vec![vec![backend.backend_ref(backend_port)]],
+                ),
+            )
+            .await;
+            await_route_accepted(&client, &route).await;
+
+            let mut rx = retry_watch_outbound_policy(&client, &ns, parent.ip(), port).await;
+            let config = rx
+                .next()
+                .await
+                .expect("watch must not fail")
+                .expect("watch must return an initial config");
+            tracing::trace!(?config);
+            assert_resource_meta(&config.metadata, parent.obj_ref(), port);
+
+            let (load_bias, _) = route_backend_load_bias_and_retry_after(&config);
+            assert!(
+                load_bias.is_none(),
+                "backend's own annotation must not select the penalty estimator under an unannotated parent"
+            );
+        })
+        .await;
+    }
+
+    test::<gateway::HTTPRoute>().await;
+    test::<policy::HttpRoute>().await;
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
This adds control-plane support for two opt-in outbound-policy features served to proxies: **unified failure accrual** and **response-penalty load biasing**. Both are configured through annotations on a Service (and, for failure accrual, an EgressNetwork), and both require a data plane built against `linkerd2-proxy-api` v0.20.0.

A Service that sets none of the new annotations serializes to a wire policy identical to the prior release, so nothing changes for operators who do not opt in.

## Unified failure accrual

Linkerd already supports consecutive-failure accrual via `balancer.linkerd.io/failure-accrual: consecutive`. This PR adds a second mode, `unified`, that trips a breaker on either a run of consecutive failures or a low success ratio measured over a trailing window. The window is a ring of fixed-duration buckets.

Unified mode runs **both** breaker policies. The consecutive dimension stays active at its default of 7 even when only success-rate parameters are set. To run success-rate-only breaking, set `failure-accrual-consecutive-max-failures: 0`.

## Response-penalty load biasing

When enabled with `penalize-failures`, peak-EWMA load balancing steers traffic away from endpoints that return failures (HTTP 429, 503, every other 5xx, and the gRPC failure trailer codes). The proxy uses a `PenaltyPeakEwma` load estimator that two annotations tune. This applies to Service backends only. EgressNetwork uses a forwarding backend with no balancer, so the load-biaser annotations have no effect there.

## Annotations

| Annotation | Status | Scope | Description | Default |
|---|---|---|---|---|
| `balancer.linkerd.io/failure-accrual` | Changed | Service, EgressNetwork | Breaker mode. Existing value `consecutive`; this PR adds `unified`. | unset (no breaker) |
| `balancer.linkerd.io/failure-accrual-consecutive-max-failures` | Existing | Service, EgressNetwork | Consecutive failures that trip the breaker. `0` disables the consecutive dimension. | `7` |
| `balancer.linkerd.io/failure-accrual-consecutive-max-penalty` | Existing | Service, EgressNetwork | Maximum probation backoff before a tripped endpoint is retried. | `60s` |
| `balancer.linkerd.io/failure-accrual-consecutive-min-penalty` | Existing | Service, EgressNetwork | Minimum probation backoff. | `1s` |
| `balancer.linkerd.io/failure-accrual-consecutive-jitter-ratio` | Existing | Service, EgressNetwork | Jitter ratio applied to the probation backoff. | `0.5` |
| `balancer.alpha.linkerd.io/failure-accrual-success-rate-threshold` | Added | Service, EgressNetwork | Success ratio (0.0 to 1.0) below which the breaker trips in `unified` mode. `0` disables the success-rate dimension. | `0.8` |
| `balancer.alpha.linkerd.io/failure-accrual-success-rate-window` | Added | Service, EgressNetwork | Trailing window over which the success ratio is measured. | `10s` |
| `balancer.alpha.linkerd.io/failure-accrual-success-rate-min-requests` | Added | Service, EgressNetwork | Minimum requests in the window before the success-rate dimension can trip. | `5` |
| `balancer.alpha.linkerd.io/failure-accrual-honor-retry-after` | Added | Service, EgressNetwork | Let a tripped endpoint's probe schedule honor a server `Retry-After` or gRPC pushback hint. Stays bounded by the breaker backoff maximum. | `false` |
| `balancer.alpha.linkerd.io/penalize-failures` | Added | Service | Enable response-penalty load biasing (`PenaltyPeakEwma`). | `false` |
| `balancer.alpha.linkerd.io/load-biaser-penalty` | Added | Service | Penalty weight applied to a failing endpoint's load estimate. | `5s` |
| `balancer.alpha.linkerd.io/load-biaser-max-retry-after` | Added | Service | Upper bound on how long the penalty estimator honors a `Retry-After` hint. | `300s`

## Annotation stability

The new experimental surface (success-rate parameters, penalty load biasing, and the retry-after honoring toggle) uses the `balancer.alpha.linkerd.io/` prefix. The inherited consecutive-failure knobs keep the stable `balancer.linkerd.io/` prefix, and the `unified` value extends the existing stable `failure-accrual` key.

## Backwards compatibility

The control plane validates every annotation and rejects any value the proxy would reject, so one bad input never invalidates the whole client policy. With no new annotations set, the emitted outbound-policy proto is identical to the prior release. The new defaults (penalty 5s, max-retry-after 300s, success-rate window 10s, and so on) match what the proxy used before, so enabling a feature without tuning it keeps the previous behavior.

## Validation and failure handling

The new annotations are scoped to Services (and EgressNetwork). Malformed values are logged and the fields fall back to their defaults. A malformed accrual sub-value drops the whole accrual configuration for that Service rather than the single field.