### PR TITLE
chore(test): explicit registry for ducker hub images

### DIFF
--- a/policy-test/src/bb.rs
+++ b/policy-test/src/bb.rs
@@ -13,6 +13,7 @@ impl Terminus {
     const PORT: i32 = 80;
     const PORT_NAME: &'static str = "http";
     const APP: &'static str = "bb-terminus";
+    const IMAGE: &'static str = "docker.io/buoyantio/bb:latest";
     pub const SERVICE_NAME: &'static str = Self::APP;
 
     /// Builds a `bb-terminus` pod that can be configured to fail some (or all)
@@ -72,7 +73,7 @@ impl Terminus {
             spec: Some(k8s::PodSpec {
                 containers: vec![k8s::api::core::v1::Container {
                     name: "bb-terminus".to_string(),
-                    image: Some("buoyantio/bb:latest".to_string()),
+                    image: Some(Self::IMAGE.to_string()),
                     ports: Some(vec![k8s::api::core::v1::ContainerPort {
                         name: Some(Self::PORT_NAME.to_string()),
                         container_port: Self::PORT,

--- a/policy-test/tests/e2e_http_local_ratelimit_policy.rs
+++ b/policy-test/tests/e2e_http_local_ratelimit_policy.rs
@@ -10,6 +10,8 @@ use linkerd_policy_test::{
 };
 use maplit::{btreemap, convert_args};
 
+const FORTIO_IMAGE: &str = "docker.io/fortio/fortio:latest";
+
 #[tokio::test(flavor = "current_thread")]
 /// Tests reaching the rate limit for:
 /// - a client with a meshed identity
@@ -229,7 +231,7 @@ async fn create_fortio_pod(
         spec: Some(k8s::PodSpec {
             containers: vec![k8s::api::core::v1::Container {
                 name: "fortio".to_string(),
-                image: Some("fortio/fortio:latest".to_string()),
+                image: Some(FORTIO_IMAGE.to_string()),
                 args: Some(vec![
                     "load".to_string(),
                     "-qps".to_string(),


### PR DESCRIPTION
Do not omit registry when addressing ducker hub images, as OKE's CRI-O enforces fully-qualified image names.