### PR TITLE
refactor(deps): use `linkerd-kubert` git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,8 +1268,7 @@ dependencies = [
 [[package]]
 name = "kubert"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9f0a6d5aea62e120a6875be7d06f74c2ff4e8f33c40cfc331b4adee2f93a76"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.25.0#a2ff424f072a0de77d98ab97592d6f66ae1d9546"
 dependencies = [
  "ahash",
  "backon",
@@ -1306,8 +1305,7 @@ dependencies = [
 [[package]]
 name = "kubert-prometheus-process"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b89e2a641a3f74c2e7366eb050282ac4a6194b63dae5294084215c457237e47"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.25.0#a2ff424f072a0de77d98ab97592d6f66ae1d9546"
 dependencies = [
  "libc",
  "procfs",
@@ -1318,8 +1316,7 @@ dependencies = [
 [[package]]
 name = "kubert-prometheus-tokio"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639670482534c37eb44caf6f4b72cc5da2f2c06aed39d1fb0cba940569428212"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.25.0#a2ff424f072a0de77d98ab97592d6f66ae1d9546"
 dependencies = [
  "prometheus-client",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ http = "1"
 hyper = "1"
 k8s-openapi = { version = "0.25", features = ["v1_33"] }
 kube = { version = "1.1", default-features = false }
-kubert = { version = "0.25", default-features = false }
 prometheus-client = { version = "0.23", default-features = false }
 tonic = { version = "0.14", default-features = false }
 tower = { version = "0.5", default-features = false }
@@ -35,6 +34,12 @@ linkerd-policy-test = { path = "./policy-test" }
 version = "0.1"
 default-features = false
 features = ["tracing"]
+
+[workspace.dependencies.kubert]
+version = "0.25"
+default-features = false
+git = "https://github.com/linkerd/linkerd-kubert.git"
+tag = "kubert/v0.25.0"
 
 [workspace.dependencies.linkerd-policy-controller-k8s-index]
 path = "./policy-controller/k8s/index"


### PR DESCRIPTION
see <https://github.com/linkerd/linkerd-kubert>.

we now have a fork of the kubert library. at the time of writing, this
is a 1:1 fork with no additional changes included. soon, we will
introduce some additional changes so that we can (1) pull in changes
like linkerd/linkerd-kubert@b27f147 that migrate away from abandoned
dependencies, and (2) update dependencies so that we can update our
gateway api bindings.

as an initial step towards this tasks, we alter our dependency upon
`kubert` so that it points to our new git repository.

kubert depends upon kubert-prometheus-process v0.2.3, and
kubert-prometheus-tokio v0.2.0. because these are conditional path
dependencies, and because tags in the kubert repository are
per-workspace member, this technically moves the
kubert-prometheus-process and kubert-prometheus-tokio dependencies
forward a few commits.

i don't see a particularly great way around this. to help convince
reviewers that this is a safe change, see the changes in
kubert-prometheus-process from the 0.2.3 tag to the kubert/0.25.0 tag
here:

* https://github.com/linkerd/linkerd-kubert/compare/linkerd:linkerd-kubert:kubert-prometheus-process/v0.2.3...kubert/v0.25.0

we updated the rust toolchain. the only changes within the library's
source are here:

* https://github.com/linkerd/linkerd-kubert/compare/linkerd:linkerd-kubert:kubert-prometheus-process/v0.2.3...kubert/v0.25.0#diff-b6b1b645d789ddf019f5836d3fcf3ed38003860b4e40e89298a42c2c4d937199
* https://github.com/linkerd/linkerd-kubert/compare/linkerd:linkerd-kubert:kubert-prometheus-process/v0.2.3...kubert/v0.25.0#diff-a5b48fac4f9680bb3450d33ce95390cc527a92c50e626c71975d5bdedfd9d5bd

these are both like-for-like changes addressing linter warnings, related
to new functionality in fmt-strings.

see the changes in
kubert-prometheus-tokio from the 0.2.0 tag to the kubert/0.25.0 tag
here:

* https://github.com/linkerd/linkerd-kubert/compare/linkerd:linkerd-kubert:kubert-prometheus-tokio/v0.2.0...kubert/v0.25.0

there are no changes within the kubert-prometheus-tokio library.

Signed-off-by: katelyn martin <kate@buoyant.io>
