### PR TITLE
chore(deps): bump anyhow from 1.0.102 to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-broadcast"


### PR DESCRIPTION
see https://rustsec.org/advisories/RUSTSEC-2026-0190.

this updates anyhow to a version that does not include this unsoundness.

Signed-off-by: katelyn martin <kate@buoyant.io>
