### PR TITLE
feat(cni-plugin): update version

### DIFF
--- a/charts/linkerd2-cni/values.yaml
+++ b/charts/linkerd2-cni/values.yaml
@@ -69,7 +69,7 @@ image:
   # -- Docker image for the CNI plugin
   name: "cr.l5d.io/linkerd/cni-plugin"
   # -- Tag for the CNI container Docker image
-  version: "v1.6.8"
+  version: "v1.7.0-alpha.1"
   # -- Pull policy for the linkerd-cni container
   pullPolicy: IfNotPresent
 

--- a/cli/cmd/testdata/install_cni_helm_default_output.golden
+++ b/cli/cmd/testdata/install_cni_helm_default_output.golden
@@ -110,7 +110,7 @@ spec:
       # script copies the files into place and then sleeps so
       # that Kubernetes doesn't keep trying to restart it.
       - name: install-cni
-        image: cr.l5d.io/linkerd/cni-plugin:v1.6.8
+        image: cr.l5d.io/linkerd/cni-plugin:v1.7.0-alpha.1
         imagePullPolicy: IfNotPresent
         env:
         - name: DEST_CNI_NET_DIR


### PR DESCRIPTION
Update the version of the cni plugin, use the alpha version that has the new go installer as well as changes to the plugin that search PATH for iptables binaries.

Signed-off-by: Raymond Kroeker <raymond@buoyant.io>