### PR TITLE
fix(viz/tap): avoid empty path segment when tapping a resource kind

### DIFF
--- a/viz/tap/api/handlers.go
+++ b/viz/tap/api/handlers.go
@@ -93,6 +93,12 @@ func initRouter(h *handler) *httprouter.Router {
 		if !res.namespaced {
 			route = fmt.Sprintf("/apis/%s/watch/%s/:namespace", gvk.GroupVersion().String(), res.name)
 		} else {
+			// Collection route (empty name): .../namespaces/:namespace/:resource/tap
+			// Named route: .../namespaces/:namespace/:resource/:name/tap
+			collectionRoute := fmt.Sprintf("/apis/%s/watch/namespaces/:namespace/%s", gvk.GroupVersion().String(), res.name)
+			router.GET(collectionRoute, handleRoot)
+			router.POST(collectionRoute+"/tap", h.handleTap)
+
 			route = fmt.Sprintf("/apis/%s/watch/namespaces/:namespace/%s/:name", gvk.GroupVersion().String(), res.name)
 		}
 
@@ -104,6 +110,7 @@ func initRouter(h *handler) *httprouter.Router {
 }
 
 // POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/tap
+// POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/:resource/tap
 // POST /apis/tap.linkerd.io/v1alpha1/watch/namespaces/:namespace/:resource/:name/tap
 func (h *handler) handleTap(w http.ResponseWriter, req *http.Request, p httprouter.Params) {
 	namespace := p.ByName("namespace")
@@ -111,11 +118,17 @@ func (h *handler) handleTap(w http.ResponseWriter, req *http.Request, p httprout
 	resource := ""
 
 	path := strings.Split(req.URL.Path, "/")
-	if len(path) == 8 {
+	switch len(path) {
+	case 8:
+		// /apis/.../watch/namespaces/:namespace/tap
 		resource = path[5]
-	} else if len(path) == 10 {
+	case 9:
+		// /apis/.../watch/namespaces/:namespace/:resource/tap
 		resource = path[7]
-	} else {
+	case 10:
+		// /apis/.../watch/namespaces/:namespace/:resource/:name/tap
+		resource = path[7]
+	default:
 		err := fmt.Errorf("invalid path: %q", req.URL.Path)
 		h.log.Error(err)
 		renderJSONError(w, err, http.StatusBadRequest)

--- a/viz/tap/pkg/protohttp.go
+++ b/viz/tap/pkg/protohttp.go
@@ -21,13 +21,26 @@ func TapReqToURL(req *tapPb.TapByResourceRequest) string {
 		)
 	}
 
-	// namespaced
+	resourceType := url.PathEscape(res.GetType() + "s")
+	namespace := url.PathEscape(res.GetNamespace())
+
+	// When tapping an entire resource category (e.g. `linkerd tap po`), the
+	// name is empty. Avoid an empty path segment (`.../pods//tap`) which some
+	// API servers reject with unexpected EOF.
+	if res.GetName() == "" {
+		return fmt.Sprintf(
+			"/apis/tap.linkerd.io/v1alpha1/watch/namespaces/%s/%s/tap",
+			namespace,
+			resourceType,
+		)
+	}
+
 	return fmt.Sprintf(
 		"/apis/tap.linkerd.io/v1alpha1/watch/namespaces/%s/%s/%s/tap",
-		url.PathEscape(res.GetNamespace()),
+		namespace,
 		// FIXME(olix0r): This pluralization is probably not correct for all
 		// resource types.
-		url.PathEscape(res.GetType()+"s"),
+		resourceType,
 		url.PathEscape(res.GetName()),
 	)
 }

--- a/viz/tap/pkg/protohttp_test.go
+++ b/viz/tap/pkg/protohttp_test.go
@@ -15,7 +15,19 @@ func TestTapReqToURL(t *testing.T) {
 	}{
 		{
 			req: &tapPb.TapByResourceRequest{},
-			url: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces//s//tap",
+			url: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces//s/tap",
+		},
+		{
+			req: &tapPb.TapByResourceRequest{
+				Target: &metricsPb.ResourceSelection{
+					Resource: &metricsPb.Resource{
+						Namespace: "linkerd",
+						Type:      "pod",
+						Name:      "",
+					},
+				},
+			},
+			url: "/apis/tap.linkerd.io/v1alpha1/watch/namespaces/linkerd/pods/tap",
 		},
 		{
 			req: &tapPb.TapByResourceRequest{


### PR DESCRIPTION
Fixes #5219

Tapping a whole resource category (`linkerd tap po`) builds a URL with a blank name segment (`.../pods//tap`). Some API servers, including k3d/k3s, reject that with unexpected EOF. Named resources still worked.

Collection taps now use `.../pods/tap`, and the tap API registers a matching route.

## Testing

- `go test ./viz/tap/pkg/ ./viz/tap/api/ -count=1`