### PR TITLE
fix(policy): set observedGeneration in status conditions

### DIFF
--- a/charts/linkerd-crds/templates/policy/egress-network.yaml
+++ b/charts/linkerd-crds/templates/policy/egress-network.yaml
@@ -112,6 +112,15 @@ spec:
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance,
+                        if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the
+                        current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     message:
                       description: message is a human readable message
                         indicating details about the transition. This may be an

--- a/charts/linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
+++ b/charts/linkerd-crds/templates/policy/http-local-ratelimit-policy.yaml
@@ -163,6 +163,15 @@ spec:
                         minLength: 1
                         pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                         type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance,
+                          if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the
+                          current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
                       message:
                         description: message is a human readable message
                           indicating details about the transition. This may be an

--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -110,6 +110,7 @@ pub(crate) struct RouteRef<S> {
     pub(crate) parents: Vec<routes::ParentReference>,
     pub(crate) backends: Vec<routes::BackendReference>,
     pub(crate) statuses: Vec<S>,
+    pub(crate) generation: Option<i64>,
 }
 
 pub(crate) type HTTPRouteRef = RouteRef<gateway::HTTPRouteStatus>;
@@ -122,12 +123,14 @@ struct HttpLocalRateLimitPolicyRef {
     creation_timestamp: Option<DateTime<Utc>>,
     target_ref: ratelimit::TargetReference,
     status_conditions: Vec<k8s::Condition>,
+    generation: Option<i64>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
 struct EgressNetworkRef {
     networks: Vec<Network>,
     status_conditions: Vec<k8s::Condition>,
+    generation: Option<i64>,
 }
 
 impl EgressNetworkRef {
@@ -591,15 +594,16 @@ impl Index {
         server: &ResourceId,
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
+        generation: Option<i64>,
     ) -> k8s::Condition {
         if self.servers.contains(server) {
             if self.parent_has_conflicting_routes(parent_ref, &id.gkn.kind) {
-                route_conflicted()
+                route_conflicted(generation)
             } else {
-                accepted()
+                accepted(generation)
             }
         } else {
-            no_matching_parent()
+            no_matching_parent(generation)
         }
     }
 
@@ -608,18 +612,19 @@ impl Index {
         service: &ResourceId,
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
+        generation: Option<i64>,
     ) -> k8s::Condition {
         // service is a valid parent if it exists and it has a cluster_ip.
         match self.services.get(service) {
             Some(svc) if svc.valid_parent_service() => {
                 if self.parent_has_conflicting_routes(parent_ref, &id.gkn.kind) {
-                    route_conflicted()
+                    route_conflicted(generation)
                 } else {
-                    accepted()
+                    accepted(generation)
                 }
             }
-            Some(_svc) => headless_parent(),
-            None => no_matching_parent(),
+            Some(_svc) => headless_parent(generation),
+            None => no_matching_parent(generation),
         }
     }
 
@@ -628,18 +633,19 @@ impl Index {
         egress_net: &ResourceId,
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
+        generation: Option<i64>,
     ) -> k8s::Condition {
         // egress network is a valid parent if it exists and is accepted.
         match self.egress_networks.get(egress_net) {
             Some(egress_net) if egress_net.is_accepted() => {
                 if self.parent_has_conflicting_routes(parent_ref, &id.gkn.kind) {
-                    route_conflicted()
+                    route_conflicted(generation)
                 } else {
-                    accepted()
+                    accepted(generation)
                 }
             }
-            Some(_) => egress_net_not_accepted(),
-            None => no_matching_parent(),
+            Some(_) => egress_net_not_accepted(generation),
+            None => no_matching_parent(generation),
         }
     }
 
@@ -648,10 +654,11 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
+        generation: Option<i64>,
     ) -> Option<gateway::GRPCRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
-                let condition = self.parent_condition_server(server, id, parent_ref);
+                let condition = self.parent_condition_server(server, id, parent_ref, generation);
                 Some(gateway::GRPCRouteStatusParents {
                     parent_ref: gateway::GRPCRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
@@ -667,7 +674,7 @@ impl Index {
             }
 
             routes::ParentReference::Service(service, port) => {
-                let condition = self.parent_condition_service(service, id, parent_ref);
+                let condition = self.parent_condition_service(service, id, parent_ref, generation);
                 Some(gateway::GRPCRouteStatusParents {
                     parent_ref: gateway::GRPCRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
@@ -683,7 +690,8 @@ impl Index {
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
-                let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
+                let condition =
+                    self.parent_condition_egress_network(egress_net, id, parent_ref, generation);
                 Some(gateway::GRPCRouteStatusParents {
                     parent_ref: gateway::GRPCRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
@@ -706,10 +714,11 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
+        generation: Option<i64>,
     ) -> Option<gateway::HTTPRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
-                let condition = self.parent_condition_server(server, id, parent_ref);
+                let condition = self.parent_condition_server(server, id, parent_ref, generation);
                 Some(gateway::HTTPRouteStatusParents {
                     parent_ref: gateway::HTTPRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
@@ -725,7 +734,7 @@ impl Index {
             }
 
             routes::ParentReference::Service(service, port) => {
-                let condition = self.parent_condition_service(service, id, parent_ref);
+                let condition = self.parent_condition_service(service, id, parent_ref, generation);
                 Some(gateway::HTTPRouteStatusParents {
                     parent_ref: gateway::HTTPRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
@@ -741,7 +750,8 @@ impl Index {
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
-                let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
+                let condition =
+                    self.parent_condition_egress_network(egress_net, id, parent_ref, generation);
                 Some(gateway::HTTPRouteStatusParents {
                     parent_ref: gateway::HTTPRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
@@ -764,10 +774,11 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
+        generation: Option<i64>,
     ) -> Option<gateway::TLSRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
-                let condition = self.parent_condition_server(server, id, parent_ref);
+                let condition = self.parent_condition_server(server, id, parent_ref, generation);
                 Some(gateway::TLSRouteStatusParents {
                     parent_ref: gateway::TLSRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
@@ -783,7 +794,7 @@ impl Index {
             }
 
             routes::ParentReference::Service(service, port) => {
-                let condition = self.parent_condition_service(service, id, parent_ref);
+                let condition = self.parent_condition_service(service, id, parent_ref, generation);
                 Some(gateway::TLSRouteStatusParents {
                     parent_ref: gateway::TLSRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
@@ -799,7 +810,8 @@ impl Index {
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
-                let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
+                let condition =
+                    self.parent_condition_egress_network(egress_net, id, parent_ref, generation);
                 Some(gateway::TLSRouteStatusParents {
                     parent_ref: gateway::TLSRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
@@ -822,10 +834,11 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
+        generation: Option<i64>,
     ) -> Option<gateway::TCPRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
-                let condition = self.parent_condition_server(server, id, parent_ref);
+                let condition = self.parent_condition_server(server, id, parent_ref, generation);
                 Some(gateway::TCPRouteStatusParents {
                     parent_ref: gateway::TCPRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
@@ -841,7 +854,7 @@ impl Index {
             }
 
             routes::ParentReference::Service(service, port) => {
-                let condition = self.parent_condition_service(service, id, parent_ref);
+                let condition = self.parent_condition_service(service, id, parent_ref, generation);
                 Some(gateway::TCPRouteStatusParents {
                     parent_ref: gateway::TCPRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
@@ -857,7 +870,8 @@ impl Index {
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
-                let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
+                let condition =
+                    self.parent_condition_egress_network(egress_net, id, parent_ref, generation);
                 Some(gateway::TCPRouteStatusParents {
                     parent_ref: gateway::TCPRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
@@ -879,23 +893,24 @@ impl Index {
         &self,
         parent_ref: &routes::ParentReference,
         backend_refs: &[routes::BackendReference],
+        generation: Option<i64>,
     ) -> k8s::Condition {
         for backend_ref in backend_refs.iter() {
             match backend_ref {
                 routes::BackendReference::Unknown => {
                     // If even one backend has a reference to an unknown / unsupported
                     // reference, return invalid backend condition
-                    return invalid_backend_kind("");
+                    return invalid_backend_kind("", generation);
                 }
 
                 routes::BackendReference::Service(service) => {
                     if !self.services.contains_key(service) {
-                        return backend_not_found();
+                        return backend_not_found(generation);
                     }
                 }
                 routes::BackendReference::EgressNetwork(egress_net) => {
                     if !self.egress_networks.contains_key(egress_net) {
-                        return backend_not_found();
+                        return backend_not_found(generation);
                     }
 
                     match parent_ref {
@@ -907,14 +922,14 @@ impl Index {
                         _ => {
                             let message =
                             "EgressNetwork backend needs to be on a route that has an EgressNetwork parent";
-                            return invalid_backend_kind(message);
+                            return invalid_backend_kind(message, generation);
                         }
                     }
                 }
             }
         }
 
-        resolved_refs()
+        resolved_refs(generation)
     }
 
     fn make_http_route_patch(
@@ -932,8 +947,9 @@ impl Index {
 
         // Compute a status for each parent_ref which has a kind we support.
         let parent_statuses = route.parents.iter().filter_map(|parent_ref| {
-            let backend_condition = self.backend_condition(parent_ref, &route.backends);
-            self.http_parent_status(id, parent_ref, backend_condition.clone())
+            let backend_condition =
+                self.backend_condition(parent_ref, &route.backends, route.generation);
+            self.http_parent_status(id, parent_ref, backend_condition.clone(), route.generation)
         });
 
         let all_statuses = unowned_statuses.chain(parent_statuses).collect::<Vec<_>>();
@@ -968,8 +984,9 @@ impl Index {
 
         // Compute a status for each parent_ref which has a kind we support.
         let parent_statuses = route.parents.iter().filter_map(|parent_ref| {
-            let backend_condition = self.backend_condition(parent_ref, &route.backends);
-            self.grpc_parent_status(id, parent_ref, backend_condition.clone())
+            let backend_condition =
+                self.backend_condition(parent_ref, &route.backends, route.generation);
+            self.grpc_parent_status(id, parent_ref, backend_condition.clone(), route.generation)
         });
 
         let all_statuses = unowned_statuses.chain(parent_statuses).collect::<Vec<_>>();
@@ -1005,8 +1022,9 @@ impl Index {
 
         // Compute a status for each parent_ref which has a kind we support.
         let parent_statuses = route.parents.iter().filter_map(|parent_ref| {
-            let backend_condition = self.backend_condition(parent_ref, &route.backends);
-            self.tls_parent_status(id, parent_ref, backend_condition.clone())
+            let backend_condition =
+                self.backend_condition(parent_ref, &route.backends, route.generation);
+            self.tls_parent_status(id, parent_ref, backend_condition.clone(), route.generation)
         });
 
         let all_statuses = unowned_statuses.chain(parent_statuses).collect::<Vec<_>>();
@@ -1042,8 +1060,9 @@ impl Index {
 
         // Compute a status for each parent_ref which has a kind we support.
         let parent_statuses = route.parents.iter().filter_map(|parent_ref| {
-            let backend_condition = self.backend_condition(parent_ref, &route.backends);
-            self.tcp_parent_status(id, parent_ref, backend_condition.clone())
+            let backend_condition =
+                self.backend_condition(parent_ref, &route.backends, route.generation);
+            self.tcp_parent_status(id, parent_ref, backend_condition.clone(), route.generation)
         });
 
         let all_statuses = unowned_statuses.chain(parent_statuses).collect::<Vec<_>>();
@@ -1068,6 +1087,7 @@ impl Index {
         &self,
         id: &NamespaceGroupKindName,
         target_ref: &ratelimit::TargetReference,
+        generation: Option<i64>,
     ) -> Option<policy::HttpLocalRateLimitPolicyStatus> {
         match target_ref {
             ratelimit::TargetReference::Server(server) => {
@@ -1096,12 +1116,12 @@ impl Index {
                     };
 
                     if first_id.name == id.gkn.name {
-                        accepted()
+                        accepted(generation)
                     } else {
-                        ratelimit_already_exists()
+                        ratelimit_already_exists(generation)
                     }
                 } else {
-                    no_matching_target()
+                    no_matching_target(generation)
                 };
 
                 Some(policy::HttpLocalRateLimitPolicyStatus {
@@ -1122,7 +1142,7 @@ impl Index {
         id: &NamespaceGroupKindName,
         ratelimit: &HttpLocalRateLimitPolicyRef,
     ) -> Option<k8s::Patch<serde_json::Value>> {
-        let status = self.target_ref_status(id, &ratelimit.target_ref)?;
+        let status = self.target_ref_status(id, &ratelimit.target_ref, ratelimit.generation)?;
         if eq_time_insensitive_conditions(&status.conditions, &ratelimit.status_conditions) {
             return None;
         }
@@ -1134,12 +1154,12 @@ impl Index {
         for egress_network_block in &egress_net.networks {
             for cluster_network_block in &self.cluster_networks {
                 if egress_network_block.intersect(cluster_network_block) {
-                    return in_cluster_net_overlap();
+                    return in_cluster_net_overlap(egress_net.generation);
                 }
             }
         }
 
-        accepted()
+        accepted(egress_net.generation)
     }
 
     fn make_egress_net_patch(
@@ -1367,6 +1387,7 @@ impl kubert::index::IndexNamespacedResource<policy::HttpRoute> for Index {
             parents,
             backends,
             statuses: vec![gateway::HTTPRouteStatus { parents: statuses }],
+            generation: resource.metadata.generation,
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1437,6 +1458,7 @@ impl kubert::index::IndexNamespacedResource<gateway::HTTPRoute> for Index {
             parents,
             backends,
             statuses: vec![gateway::HTTPRouteStatus { parents: statuses }],
+            generation: resource.metadata.generation,
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1507,6 +1529,7 @@ impl kubert::index::IndexNamespacedResource<gateway::GRPCRoute> for Index {
             parents,
             backends,
             statuses: vec![gateway::GRPCRouteStatus { parents: statuses }],
+            generation: resource.metadata.generation,
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1576,6 +1599,7 @@ impl kubert::index::IndexNamespacedResource<gateway::TLSRoute> for Index {
             parents,
             backends,
             statuses: vec![gateway::TLSRouteStatus { parents: statuses }],
+            generation: resource.metadata.generation,
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1645,6 +1669,7 @@ impl kubert::index::IndexNamespacedResource<gateway::TCPRoute> for Index {
             parents,
             backends,
             statuses: vec![gateway::TCPRouteStatus { parents: statuses }],
+            generation: resource.metadata.generation,
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1728,6 +1753,7 @@ impl kubert::index::IndexNamespacedResource<policy::HttpLocalRateLimitPolicy> fo
             creation_timestamp,
             target_ref,
             status_conditions,
+            generation: resource.metadata.generation,
         };
 
         self.index_ratelimit(id, rl);
@@ -1777,6 +1803,7 @@ impl kubert::index::IndexNamespacedResource<policy::EgressNetwork> for Index {
         let net = EgressNetworkRef {
             status_conditions,
             networks,
+            generation: resource.metadata.generation,
         };
 
         self.index_egress_network(id, net);
@@ -1822,121 +1849,124 @@ fn now() -> DateTime<Utc> {
     now
 }
 
-pub(crate) fn no_matching_parent() -> k8s::Condition {
+pub(crate) fn no_matching_parent(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::NO_MATCHING_PARENT.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-pub(crate) fn no_matching_target() -> k8s::Condition {
+pub(crate) fn no_matching_target(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::NO_MATCHING_TARGET.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-fn headless_parent() -> k8s::Condition {
+fn headless_parent(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "parent service must have a ClusterIP".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::NO_MATCHING_PARENT.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-fn egress_net_not_accepted() -> k8s::Condition {
+fn egress_net_not_accepted(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "EgressNetwork parent has not been accepted".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::NO_MATCHING_PARENT.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-pub(crate) fn route_conflicted() -> k8s::Condition {
+pub(crate) fn route_conflicted(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::ROUTE_REASON_CONFLICTED.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-pub(crate) fn ratelimit_already_exists() -> k8s::Condition {
+pub(crate) fn ratelimit_already_exists(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::RATELIMIT_REASON_ALREADY_EXISTS.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-pub(crate) fn accepted() -> k8s::Condition {
+pub(crate) fn accepted(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: conditions::ACCEPTED.to_string(),
         status: cond_statuses::STATUS_TRUE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-pub(crate) fn in_cluster_net_overlap() -> k8s::Condition {
+pub(crate) fn in_cluster_net_overlap(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "networks overlap with clusterNetworks".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::EGRESS_NET_REASON_OVERLAP.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::ACCEPTED.to_string(),
     }
 }
 
-pub(crate) fn resolved_refs() -> k8s::Condition {
+pub(crate) fn resolved_refs(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::RESOLVED_REFS.to_string(),
         status: cond_statuses::STATUS_TRUE.to_string(),
         type_: conditions::RESOLVED_REFS.to_string(),
     }
 }
 
-pub(crate) fn backend_not_found() -> k8s::Condition {
+pub(crate) fn backend_not_found(observed_generation: Option<i64>) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: "".to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::BACKEND_NOT_FOUND.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::RESOLVED_REFS.to_string(),
     }
 }
 
-pub(crate) fn invalid_backend_kind(message: &str) -> k8s::Condition {
+pub(crate) fn invalid_backend_kind(
+    message: &str,
+    observed_generation: Option<i64>,
+) -> k8s::Condition {
     k8s::Condition {
         last_transition_time: k8s::Time(now()),
         message: message.to_string(),
-        observed_generation: None,
+        observed_generation,
         reason: reasons::INVALID_KIND.to_string(),
         status: cond_statuses::STATUS_FALSE.to_string(),
         type_: conditions::RESOLVED_REFS.to_string(),

--- a/policy-controller/k8s/status/src/tests/conflict.rs
+++ b/policy-controller/k8s/status/src/tests/conflict.rs
@@ -61,6 +61,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
         &GRPCRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -76,6 +77,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
         &HTTPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -91,6 +93,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
         &TLSRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -106,6 +109,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
         &TCPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -142,6 +146,7 @@ fn http_route_conflict_grpc(p: ParentRefType) {
         &GRPCRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -178,6 +183,7 @@ fn http_route_no_conflict(p: ParentRefType) {
         &HTTPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -193,6 +199,7 @@ fn http_route_no_conflict(p: ParentRefType) {
         &TLSRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -208,6 +215,7 @@ fn http_route_no_conflict(p: ParentRefType) {
         &TCPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -244,6 +252,7 @@ fn tls_route_conflict_http(p: ParentRefType) {
         &HTTPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -280,6 +289,7 @@ fn tls_route_conflict_grpc(p: ParentRefType) {
         &GRPCRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -316,6 +326,7 @@ fn tls_route_no_conflict(p: ParentRefType) {
         &TLSRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -331,6 +342,7 @@ fn tls_route_no_conflict(p: ParentRefType) {
         &TCPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -367,6 +379,7 @@ fn tcp_route_conflict_grpc(p: ParentRefType) {
         &GRPCRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -403,6 +416,7 @@ fn tcp_route_conflict_http(p: ParentRefType) {
         &HTTPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -439,6 +453,7 @@ fn tcp_route_conflict_tls(p: ParentRefType) {
         &TLSRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );
@@ -475,6 +490,7 @@ fn tcp_route_no_conflict(p: ParentRefType) {
         &TCPRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
+            generation: None,
             backends: vec![],
         },
     );

--- a/policy-controller/k8s/status/src/tests/egress_network.rs
+++ b/policy-controller/k8s/status/src/tests/egress_network.rs
@@ -58,7 +58,7 @@ fn egress_network_with_no_networks_specified() {
 
     // Create the expected update.
     let status = EgressNetworkStatus {
-        conditions: vec![accepted()],
+        conditions: vec![accepted(None)],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
 
@@ -120,7 +120,7 @@ fn egress_network_with_nonoverlapping_networks_specified() {
 
     // Create the expected update.
     let status = EgressNetworkStatus {
-        conditions: vec![accepted()],
+        conditions: vec![accepted(None)],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
 
@@ -180,9 +180,61 @@ fn egress_network_with_overlapping_networks_specified() {
 
     // Create the expected update.
     let status = EgressNetworkStatus {
-        conditions: vec![in_cluster_net_overlap()],
+        conditions: vec![in_cluster_net_overlap(None)],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
+    let update = updates_rx.try_recv().unwrap();
+    assert_eq!(id, update.id);
+    assert_eq!(patch, update.patch);
+    assert!(updates_rx.try_recv().is_err())
+}
+
+#[test]
+fn egress_network_status_carries_observed_generation() {
+    let hostname = "test";
+    let claim = kubert::lease::Claim {
+        holder: "test".to_string(),
+        expiry: DateTime::<Utc>::MAX_UTC,
+    };
+    let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
+    let (updates_tx, mut updates_rx) = mpsc::channel(10000);
+    let index = Index::shared(
+        hostname,
+        claims_rx,
+        updates_tx,
+        IndexMetrics::register(&mut Default::default()),
+        default_cluster_networks(),
+    );
+
+    let id = NamespaceGroupKindName {
+        namespace: "ns".to_string(),
+        gkn: GroupKindName {
+            group: linkerd_k8s_api::EgressNetwork::group(&()),
+            kind: linkerd_k8s_api::EgressNetwork::kind(&()),
+            name: "egress".into(),
+        },
+    };
+
+    let egress_network = linkerd_k8s_api::EgressNetwork {
+        metadata: k8s_core_api::ObjectMeta {
+            name: Some(id.gkn.name.to_string()),
+            namespace: Some(id.namespace.clone()),
+            generation: Some(2),
+            ..Default::default()
+        },
+        spec: linkerd_k8s_api::EgressNetworkSpec {
+            networks: None,
+            traffic_policy: linkerd_k8s_api::TrafficPolicy::Allow,
+        },
+        status: None,
+    };
+    index.write().apply(egress_network.clone());
+
+    let status = EgressNetworkStatus {
+        conditions: vec![accepted(Some(2))],
+    };
+    let patch = crate::index::make_patch(&id, status).unwrap();
+
     let update = updates_rx.try_recv().unwrap();
     assert_eq!(id, update.id);
     assert_eq!(patch, update.patch);

--- a/policy-controller/k8s/status/src/tests/ratelimit.rs
+++ b/policy-controller/k8s/status/src/tests/ratelimit.rs
@@ -38,7 +38,7 @@ fn ratelimit_accepted() {
     index.write().apply(ratelimit);
 
     let expected_status = linkerd_k8s_api::HttpLocalRateLimitPolicyStatus {
-        conditions: vec![accepted()],
+        conditions: vec![accepted(None)],
         target_ref: linkerd_k8s_api::LocalTargetRef {
             group: Some("policy.linkerd.io".to_string()),
             kind: "Server".to_string(),
@@ -74,7 +74,7 @@ fn ratelimit_not_accepted_no_matching_target() {
     index.write().apply(ratelimit);
 
     let expected_status = linkerd_k8s_api::HttpLocalRateLimitPolicyStatus {
-        conditions: vec![no_matching_target()],
+        conditions: vec![no_matching_target(None)],
         target_ref: linkerd_k8s_api::LocalTargetRef {
             group: Some("policy.linkerd.io".to_string()),
             kind: "Server".to_string(),
@@ -110,7 +110,7 @@ fn ratelimit_not_accepted_already_exists() {
     index.write().apply(rl_1);
 
     let expected_status = linkerd_k8s_api::HttpLocalRateLimitPolicyStatus {
-        conditions: vec![accepted()],
+        conditions: vec![accepted(None)],
         target_ref: linkerd_k8s_api::LocalTargetRef {
             group: Some("policy.linkerd.io".to_string()),
             kind: "Server".to_string(),
@@ -130,7 +130,7 @@ fn ratelimit_not_accepted_already_exists() {
     index.write().apply(rl_2);
 
     let expected_status = linkerd_k8s_api::HttpLocalRateLimitPolicyStatus {
-        conditions: vec![ratelimit_already_exists()],
+        conditions: vec![ratelimit_already_exists(None)],
         target_ref: linkerd_k8s_api::LocalTargetRef {
             group: Some("policy.linkerd.io".to_string()),
             kind: "Server".to_string(),
@@ -215,4 +215,38 @@ fn make_ratelimit(
     };
 
     (ratelimit_id, ratelimit)
+}
+
+#[test]
+fn ratelimit_status_carries_observed_generation() {
+    let (index, mut updates_rx) = make_index_updates_rx();
+
+    let server = make_server(
+        "ns",
+        "server-1",
+        8080,
+        vec![("app", "server")],
+        vec![],
+        None,
+    );
+    index.write().apply(server);
+
+    let (ratelimit_id, mut ratelimit) = make_ratelimit("rl-1".to_string(), "server-1".to_string());
+    ratelimit.metadata.generation = Some(7);
+    index.write().apply(ratelimit);
+
+    let expected_status = linkerd_k8s_api::HttpLocalRateLimitPolicyStatus {
+        conditions: vec![accepted(Some(7))],
+        target_ref: linkerd_k8s_api::LocalTargetRef {
+            group: Some("policy.linkerd.io".to_string()),
+            kind: "Server".to_string(),
+            name: "server-1".to_string(),
+        },
+    };
+    let expected_patch = crate::index::make_patch(&ratelimit_id, expected_status).unwrap();
+
+    let update = updates_rx.try_recv().unwrap();
+    assert_eq!(ratelimit_id, update.id);
+    assert_eq!(expected_patch, update.patch);
+    assert!(updates_rx.try_recv().is_err())
 }

--- a/policy-controller/k8s/status/src/tests/routes/grpc.rs
+++ b/policy-controller/k8s/status/src/tests/routes/grpc.rs
@@ -116,9 +116,9 @@ fn route_with_valid_service_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: Some("core".to_string()),
@@ -160,7 +160,7 @@ fn route_with_valid_egress_network_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply the route.
@@ -196,9 +196,9 @@ fn route_with_valid_egress_network_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group,
@@ -291,9 +291,9 @@ fn route_with_invalid_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // One of the backends does not exist so the status should be BackendNotFound.
-    let backend_condition = backend_not_found();
+    let backend_condition = backend_not_found(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group,
@@ -335,11 +335,11 @@ fn route_with_egress_network_backend_different_from_parent() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "svc", accepted());
+    let parent = super::make_egress_network("ns-0", "svc", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -375,9 +375,10 @@ fn route_with_egress_network_backend_different_from_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
@@ -424,7 +425,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -460,9 +461,10 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
@@ -505,7 +507,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend service
@@ -545,8 +547,8 @@ fn route_with_egress_network_parent_and_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group,
@@ -695,8 +697,8 @@ fn route_accepted_after_egress_network_create() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = no_matching_parent();
-    let backend_condition = resolved_refs();
+    let accepted_condition = no_matching_parent(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -722,11 +724,11 @@ fn route_accepted_after_egress_network_create() {
     assert_eq!(patch, update.patch);
 
     // Apply the egress network
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -861,7 +863,7 @@ fn route_rejected_after_egress_network_delete() {
         default_cluster_networks(),
     );
 
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // There should be no update since there are no TLSRoutes yet.
@@ -890,8 +892,8 @@ fn route_rejected_after_egress_network_delete() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -926,7 +928,7 @@ fn route_rejected_after_egress_network_delete() {
     }
 
     // Create the expected update.
-    let rejected_condition = no_matching_parent();
+    let rejected_condition = no_matching_parent(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group,
@@ -1016,9 +1018,9 @@ fn service_route_type_conflict() {
     index.write().apply(http_route);
 
     // Create the expected update -- HTTPRoute should be accepted
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // No backends were specified, so we have vacuously resolved them all.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1055,7 +1057,7 @@ fn service_route_type_conflict() {
     for _ in 0..2 {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::HTTPRoute::kind(&()) {
-            let conflict_condition = route_conflicted();
+            let conflict_condition = route_conflicted(None);
             let parent_status = gateway::GRPCRouteStatusParents {
                 parent_ref: gateway::GRPCRouteStatusParentsParentRef {
                     group: parent.group.clone(),
@@ -1116,7 +1118,7 @@ fn egress_network_route_type_conflict() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     let parent = gateway::GRPCRouteParentRefs {
@@ -1161,9 +1163,9 @@ fn egress_network_route_type_conflict() {
     index.write().apply(http_route);
 
     // Create the expected update -- HTTPRoute should be accepted
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // No backends were specified, so we have vacuously resolved them all.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::GRPCRouteStatusParents {
         parent_ref: gateway::GRPCRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1200,7 +1202,7 @@ fn egress_network_route_type_conflict() {
     for _ in 0..2 {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::HTTPRoute::kind(&()) {
-            let conflict_condition = route_conflicted();
+            let conflict_condition = route_conflicted(None);
             let parent_status = gateway::GRPCRouteStatusParents {
                 parent_ref: gateway::GRPCRouteStatusParentsParentRef {
                     group: parent.group.clone(),

--- a/policy-controller/k8s/status/src/tests/routes/http.rs
+++ b/policy-controller/k8s/status/src/tests/routes/http.rs
@@ -86,9 +86,9 @@ fn linkerd_route_with_no_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // No backends were specified, so we have vacuously resolved them all.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -154,9 +154,9 @@ fn gateway_route_with_no_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // No backends were specified, so we have vacuously resolved them all.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -253,9 +253,9 @@ fn linkerd_route_with_valid_service_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -297,7 +297,8 @@ fn linkerd_route_with_valid_egress_networks_backends() {
     );
 
     // Apply the parent egress network
-    let parent: policy::EgressNetwork = super::make_egress_network("ns-0", "egress", accepted());
+    let parent: policy::EgressNetwork =
+        super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     let id = NamespaceGroupKindName {
@@ -332,9 +333,9 @@ fn linkerd_route_with_valid_egress_networks_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -433,9 +434,9 @@ fn gateway_route_with_valid_service_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -477,7 +478,7 @@ fn gateway_route_with_valid_egress_networks_backends() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply the route.
@@ -513,9 +514,9 @@ fn gateway_route_with_valid_egress_networks_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -608,9 +609,9 @@ fn linkerd_route_with_invalid_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // One of the backends does not exist so the status should be BackendNotFound.
-    let backend_condition = backend_not_found();
+    let backend_condition = backend_not_found(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -652,11 +653,11 @@ fn linkerd_route_with_egress_network_backend_different_from_parent() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "svc", accepted());
+    let parent = super::make_egress_network("ns-0", "svc", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -692,9 +693,10 @@ fn linkerd_route_with_egress_network_backend_different_from_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
@@ -741,7 +743,7 @@ fn linkerd_route_with_egress_network_backend_and_service_parent() {
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -778,9 +780,10 @@ fn linkerd_route_with_egress_network_backend_and_service_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
@@ -823,7 +826,7 @@ fn linkerd_route_with_egress_network_parent_and_service_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend service
@@ -864,8 +867,8 @@ fn linkerd_route_with_egress_network_parent_and_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -958,9 +961,9 @@ fn gateway_route_with_invalid_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // One of the backends does not exist so the status should be BackendNotFound.
-    let backend_condition = backend_not_found();
+    let backend_condition = backend_not_found(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -1002,11 +1005,11 @@ fn gateway_route_with_egress_network_backend_different_from_parent() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "svc", accepted());
+    let parent = super::make_egress_network("ns-0", "svc", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -1042,9 +1045,10 @@ fn gateway_route_with_egress_network_backend_different_from_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
@@ -1091,7 +1095,7 @@ fn gateway_route_with_egress_network_backend_and_service_parent() {
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -1128,9 +1132,10 @@ fn gateway_route_with_egress_network_backend_and_service_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
@@ -1173,7 +1178,7 @@ fn gateway_route_with_egress_network_parent_and_service_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend service
@@ -1214,8 +1219,8 @@ fn gateway_route_with_egress_network_parent_and_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -1364,8 +1369,8 @@ fn linkerd_route_accepted_after_egress_network_create() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = no_matching_parent();
-    let backend_condition = resolved_refs();
+    let accepted_condition = no_matching_parent(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1391,11 +1396,11 @@ fn linkerd_route_accepted_after_egress_network_create() {
     assert_eq!(patch, update.patch);
 
     // Apply the egress network
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -1547,8 +1552,8 @@ fn gateway_route_accepted_after_egress_network_create() {
     index.write().apply(route);
 
     // Create the expected update.
-    let rejected_condition = no_matching_parent();
-    let backend_condition = resolved_refs();
+    let rejected_condition = no_matching_parent(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1574,11 +1579,11 @@ fn gateway_route_accepted_after_egress_network_create() {
     assert_eq!(patch, update.patch);
 
     // Apply the egress network
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group,
@@ -1713,7 +1718,7 @@ fn linkerd_route_rejected_after_egress_network_delete() {
         default_cluster_networks(),
     );
 
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // There should be no update since there are no HTTPRoutes yet.
@@ -1742,8 +1747,8 @@ fn linkerd_route_rejected_after_egress_network_delete() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1778,7 +1783,7 @@ fn linkerd_route_rejected_after_egress_network_delete() {
     }
 
     // Create the expected update.
-    let rejected_condition = no_matching_parent();
+    let rejected_condition = no_matching_parent(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1913,7 +1918,7 @@ fn gateway_route_rejected_after_egress_network_delete() {
         default_cluster_networks(),
     );
 
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // There should be no update since there are no HTTPRoutes yet.
@@ -1942,8 +1947,8 @@ fn gateway_route_rejected_after_egress_network_delete() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1978,7 +1983,7 @@ fn gateway_route_rejected_after_egress_network_delete() {
     }
 
     // Create the expected update.
-    let rejected_condition = no_matching_parent();
+    let rejected_condition = no_matching_parent(None);
     let parent_status = gateway::HTTPRouteStatusParents {
         parent_ref: gateway::HTTPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -2072,4 +2077,167 @@ fn make_gateway_route(
             }]),
         },
     }
+}
+
+#[test]
+fn gateway_route_status_carries_observed_generation() {
+    let hostname = "test";
+    let claim = kubert::lease::Claim {
+        holder: "test".to_string(),
+        expiry: DateTime::<Utc>::MAX_UTC,
+    };
+    let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
+    let (updates_tx, mut updates_rx) = mpsc::channel(10000);
+    let index = Index::shared(
+        hostname,
+        claims_rx,
+        updates_tx,
+        IndexMetrics::register(&mut Default::default()),
+        default_cluster_networks(),
+    );
+
+    // Apply the parent service
+    let parent = super::make_service("ns-0", "svc");
+    index.write().apply(parent.clone());
+
+    let id = NamespaceGroupKindName {
+        namespace: parent.namespace().as_deref().unwrap().to_string(),
+        gkn: GroupKindName {
+            group: gateway::HTTPRoute::group(&()),
+            kind: gateway::HTTPRoute::kind(&()),
+            name: "route-foo".into(),
+        },
+    };
+    let parent = gateway::HTTPRouteParentRefs {
+        group: Some("core".to_string()),
+        kind: Some("Service".to_string()),
+        namespace: parent.namespace(),
+        name: parent.name_unchecked(),
+        section_name: None,
+        port: Some(8080),
+    };
+
+    // Apply the route with a generation set.
+    let mut route = make_gateway_route(&id, parent.clone(), None);
+    route.metadata.generation = Some(3);
+    index.write().apply(route);
+
+    // All conditions in the produced patch must carry the route's generation.
+    let accepted_condition = accepted(Some(3));
+    let backend_condition = resolved_refs(Some(3));
+    let parent_status = gateway::HTTPRouteStatusParents {
+        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+            group: parent.group.clone(),
+            kind: parent.kind.clone(),
+            namespace: parent.namespace.clone(),
+            name: parent.name.clone(),
+            section_name: None,
+            port: parent.port,
+        },
+        controller_name: POLICY_CONTROLLER_NAME.to_string(),
+        conditions: Some(vec![accepted_condition, backend_condition]),
+    };
+    let status = gateway::HTTPRouteStatus {
+        parents: vec![parent_status],
+    };
+    let patch = crate::index::make_patch(&id, status).unwrap();
+
+    let update = updates_rx.try_recv().unwrap();
+    assert_eq!(id, update.id);
+    assert_eq!(patch, update.patch);
+    assert!(updates_rx.try_recv().is_err())
+}
+
+#[test]
+fn gateway_route_generation_bump_produces_new_patch() {
+    let hostname = "test";
+    let claim = kubert::lease::Claim {
+        holder: "test".to_string(),
+        expiry: DateTime::<Utc>::MAX_UTC,
+    };
+    let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
+    let (updates_tx, mut updates_rx) = mpsc::channel(10000);
+    let index = Index::shared(
+        hostname,
+        claims_rx,
+        updates_tx,
+        IndexMetrics::register(&mut Default::default()),
+        default_cluster_networks(),
+    );
+
+    let parent = super::make_service("ns-0", "svc");
+    index.write().apply(parent.clone());
+
+    let id = NamespaceGroupKindName {
+        namespace: parent.namespace().as_deref().unwrap().to_string(),
+        gkn: GroupKindName {
+            group: gateway::HTTPRoute::group(&()),
+            kind: gateway::HTTPRoute::kind(&()),
+            name: "route-foo".into(),
+        },
+    };
+    let parent_ref = gateway::HTTPRouteParentRefs {
+        group: Some("core".to_string()),
+        kind: Some("Service".to_string()),
+        namespace: parent.namespace(),
+        name: parent.name_unchecked(),
+        section_name: None,
+        port: Some(8080),
+    };
+
+    // Apply the route at generation 3; the first patch carries Some(3).
+    let mut route = make_gateway_route(&id, parent_ref.clone(), None);
+    route.metadata.generation = Some(3);
+    index.write().apply(route.clone());
+    let update = updates_rx.try_recv().unwrap();
+    assert_eq!(id, update.id);
+    assert!(updates_rx.try_recv().is_err());
+
+    // Simulate the status watch echo: the route now has our generation-3
+    // status on it. Re-applying with a bumped generation but an unchanged
+    // spec must still produce a fresh patch carrying Some(4) — this is the
+    // staleness signal consumers like Flagger rely on.
+    let written_status = gateway::HTTPRouteStatus {
+        parents: vec![gateway::HTTPRouteStatusParents {
+            parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+                group: parent_ref.group.clone(),
+                kind: parent_ref.kind.clone(),
+                namespace: parent_ref.namespace.clone(),
+                name: parent_ref.name.clone(),
+                section_name: None,
+                port: parent_ref.port,
+            },
+            controller_name: POLICY_CONTROLLER_NAME.to_string(),
+            conditions: Some(vec![accepted(Some(3)), resolved_refs(Some(3))]),
+        }],
+    };
+    route.status = Some(written_status.clone());
+    route.metadata.generation = Some(4);
+    index.write().apply(route.clone());
+
+    let expected_status = gateway::HTTPRouteStatus {
+        parents: vec![gateway::HTTPRouteStatusParents {
+            parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+                group: parent_ref.group.clone(),
+                kind: parent_ref.kind.clone(),
+                namespace: parent_ref.namespace.clone(),
+                name: parent_ref.name.clone(),
+                section_name: None,
+                port: parent_ref.port,
+            },
+            controller_name: POLICY_CONTROLLER_NAME.to_string(),
+            conditions: Some(vec![accepted(Some(4)), resolved_refs(Some(4))]),
+        }],
+    };
+    let expected_patch = crate::index::make_patch(&id, expected_status.clone()).unwrap();
+    let update = updates_rx.try_recv().unwrap();
+    assert_eq!(id, update.id);
+    assert_eq!(expected_patch, update.patch);
+    assert!(updates_rx.try_recv().is_err());
+
+    // Control: once the status on the resource matches the current
+    // generation, re-applying must NOT produce another patch (dedup holds).
+    route.status = Some(expected_status);
+    index.write().apply(route);
+    assert!(updates_rx.try_recv().is_err());
 }

--- a/policy-controller/k8s/status/src/tests/routes/tcp.rs
+++ b/policy-controller/k8s/status/src/tests/routes/tcp.rs
@@ -114,9 +114,9 @@ fn route_with_valid_service_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group,
@@ -158,7 +158,7 @@ fn route_with_valid_egress_network_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply the route.
@@ -193,9 +193,9 @@ fn route_with_valid_egress_network_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group,
@@ -286,9 +286,9 @@ fn route_with_invalid_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // One of the backends does not exist so the status should be BackendNotFound.
-    let backend_condition = backend_not_found();
+    let backend_condition = backend_not_found(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group,
@@ -330,11 +330,11 @@ fn route_with_egress_network_backend_different_from_parent() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "svc", accepted());
+    let parent = super::make_egress_network("ns-0", "svc", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -369,9 +369,10 @@ fn route_with_egress_network_backend_different_from_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
@@ -418,7 +419,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -453,9 +454,10 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
@@ -498,7 +500,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend service
@@ -537,8 +539,8 @@ fn route_with_egress_network_parent_and_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group,
@@ -687,8 +689,8 @@ fn route_accepted_after_egress_network_create() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = no_matching_parent();
-    let backend_condition = resolved_refs();
+    let accepted_condition = no_matching_parent(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -714,11 +716,11 @@ fn route_accepted_after_egress_network_create() {
     assert_eq!(patch, update.patch);
 
     // Apply the egress network
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group,
@@ -853,7 +855,7 @@ fn route_rejected_after_egress_network_delete() {
         default_cluster_networks(),
     );
 
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // There should be no update since there are no TCPRoutes yet.
@@ -882,8 +884,8 @@ fn route_rejected_after_egress_network_delete() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -918,7 +920,7 @@ fn route_rejected_after_egress_network_delete() {
     }
 
     // Create the expected update.
-    let rejected_condition = no_matching_parent();
+    let rejected_condition = no_matching_parent(None);
     let parent_status = gateway::TCPRouteStatusParents {
         parent_ref: gateway::TCPRouteStatusParentsParentRef {
             group: parent.group.clone(),

--- a/policy-controller/k8s/status/src/tests/routes/tls.rs
+++ b/policy-controller/k8s/status/src/tests/routes/tls.rs
@@ -114,9 +114,9 @@ fn route_with_valid_service_backends() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group,
@@ -158,7 +158,7 @@ fn route_with_valid_egress_network_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply the route.
@@ -193,9 +193,9 @@ fn route_with_valid_egress_network_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // All backends exist and can be resolved.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group,
@@ -286,9 +286,9 @@ fn route_with_invalid_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // One of the backends does not exist so the status should be BackendNotFound.
-    let backend_condition = backend_not_found();
+    let backend_condition = backend_not_found(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group,
@@ -330,11 +330,11 @@ fn route_with_egress_network_backend_different_from_parent() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "svc", accepted());
+    let parent = super::make_egress_network("ns-0", "svc", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -369,9 +369,10 @@ fn route_with_egress_network_backend_different_from_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
@@ -418,7 +419,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(parent.clone());
 
     // Apply one backend egress network
-    let backend = super::make_egress_network("ns-0", "backend-1", accepted());
+    let backend = super::make_egress_network("ns-0", "backend-1", accepted(None));
     index.write().apply(backend.clone());
 
     // Apply the route.
@@ -453,9 +454,10 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
+        None,
     );
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
@@ -498,7 +500,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     // Apply one backend service
@@ -537,8 +539,8 @@ fn route_with_egress_network_parent_and_service_backend() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group,
@@ -687,8 +689,8 @@ fn route_accepted_after_egress_network_create() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = no_matching_parent();
-    let backend_condition = resolved_refs();
+    let accepted_condition = no_matching_parent(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -714,11 +716,11 @@ fn route_accepted_after_egress_network_create() {
     assert_eq!(patch, update.patch);
 
     // Apply the egress network
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // Create the expected update.
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group,
@@ -853,7 +855,7 @@ fn route_rejected_after_egress_network_delete() {
         default_cluster_networks(),
     );
 
-    let egress = super::make_egress_network("ns-0", "egress", accepted());
+    let egress = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(egress);
 
     // There should be no update since there are no TLSRoutes yet.
@@ -882,8 +884,8 @@ fn route_rejected_after_egress_network_delete() {
     index.write().apply(route);
 
     // Create the expected update.
-    let accepted_condition = accepted();
-    let backend_condition = resolved_refs();
+    let accepted_condition = accepted(None);
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -918,7 +920,7 @@ fn route_rejected_after_egress_network_delete() {
     }
 
     // Create the expected update.
-    let rejected_condition = no_matching_parent();
+    let rejected_condition = no_matching_parent(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1007,9 +1009,9 @@ fn service_route_type_conflict() {
     index.write().apply(tcp_route);
 
     // Create the expected update -- TCPRoute should be accepted
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // No backends were specified, so we have vacuously resolved them all.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1046,7 +1048,7 @@ fn service_route_type_conflict() {
     for _ in 0..2 {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::TCPRoute::kind(&()) {
-            let conflict_condition = route_conflicted();
+            let conflict_condition = route_conflicted(None);
             let parent_status = gateway::TLSRouteStatusParents {
                 parent_ref: gateway::TLSRouteStatusParentsParentRef {
                     group: parent.group.clone(),
@@ -1107,7 +1109,7 @@ fn egress_network_route_type_conflict() {
     );
 
     // Apply the parent egress network
-    let parent = super::make_egress_network("ns-0", "egress", accepted());
+    let parent = super::make_egress_network("ns-0", "egress", accepted(None));
     index.write().apply(parent.clone());
 
     let parent = gateway::TLSRouteParentRefs {
@@ -1151,9 +1153,9 @@ fn egress_network_route_type_conflict() {
     index.write().apply(tcp_route);
 
     // Create the expected update -- TCPRoute should be accepted
-    let accepted_condition = accepted();
+    let accepted_condition = accepted(None);
     // No backends were specified, so we have vacuously resolved them all.
-    let backend_condition = resolved_refs();
+    let backend_condition = resolved_refs(None);
     let parent_status = gateway::TLSRouteStatusParents {
         parent_ref: gateway::TLSRouteStatusParentsParentRef {
             group: parent.group.clone(),
@@ -1190,7 +1192,7 @@ fn egress_network_route_type_conflict() {
     for _ in 0..2 {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::TCPRoute::kind(&()) {
-            let conflict_condition = route_conflicted();
+            let conflict_condition = route_conflicted(None);
             let parent_status = gateway::TLSRouteStatusParents {
                 parent_ref: gateway::TLSRouteStatusParentsParentRef {
                     group: parent.group.clone(),


### PR DESCRIPTION
# Set `observedGeneration` in status conditions

Fixes #14964
Supersedes #14973

## Problem

The policy status controller writes status conditions with `observedGeneration` unset. The Gateway API specification requires implementations to set this field to the resource's `metadata.generation` when generating status:

Consumers use the field to detect stale status. In particular, Flagger v1.42+ checks `condition.observedGeneration < metadata.generation` after each route edit to confirm Linkerd has reconciled it. Since Linkerd never sets the field,
the check never passes and canary rollouts stall indefinitely:

```
HTTPRoute echo-blue.tools parent echo-blue is not ready
(status: True, observed generation: 0, current generation: 1)
```

## Solution

- Track `metadata.generation` on `RouteRef`, `HttpLocalRateLimitPolicyRef`, and `EgressNetworkRef`; populate it in every `apply()`. Storing it on the refs (rather than passing it down from `apply` only) keeps the periodic reconcile path consistent with the watch path.
- Thread the generation through all condition-producing functions (`accepted`, `no_matching_parent`, `resolved_refs`, etc.) so every condition the controller writes carries `observedGeneration`. 
- Add the missing `observedGeneration` property (standard `metav1.Condition` shape, mirroring the existing `httproute.policy.linkerd.io` schema) to the `EgressNetwork` and `HTTPLocalRateLimitPolicy` CRD condition schemas.

## Validation

- **New unit tests** (`policy-controller/k8s/status/src/tests/`):
  - conditions carry the resource's generation for routes, rate-limit policies, and egress networks;
  - a generation bump with an unchanged spec produces a fresh patch carrying the new generation (the signal Flagger consumes), while a re-apply whose status already matches produces no patch (no self-trigger loop).

