### PR TITLE
Support separate inbound and outbound subnet skips

### DIFF
--- a/charts/linkerd-control-plane/values.yaml
+++ b/charts/linkerd-control-plane/values.yaml
@@ -341,6 +341,10 @@ proxyInit:
   kubeAPIServerPorts: "443,6443"
   # -- Comma-separated list of subnets in valid CIDR format that should be skipped by the proxy
   skipSubnets: ""
+  # -- Comma-separated list of inbound source subnets in valid CIDR format that should be skipped by the proxy
+  skipInboundSubnets: ""
+  # -- Comma-separated list of outbound destination subnets in valid CIDR format that should be skipped by the proxy
+  skipOutboundSubnets: ""
   # -- Log level for the proxy-init
   # @default -- info
   logLevel: ""

--- a/charts/partials/templates/_proxy-init.tpl
+++ b/charts/partials/templates/_proxy-init.tpl
@@ -46,6 +46,14 @@ args:
 - --subnets-to-ignore
 - {{ .Values.proxyInit.skipSubnets | quote }}
 {{- end }}
+{{- if .Values.proxyInit.skipInboundSubnets }}
+- --inbound-subnets-to-ignore
+- {{ .Values.proxyInit.skipInboundSubnets | quote }}
+{{- end }}
+{{- if .Values.proxyInit.skipOutboundSubnets }}
+- --outbound-subnets-to-ignore
+- {{ .Values.proxyInit.skipOutboundSubnets | quote }}
+{{- end }}
 image: {{.Values.proxy.image.name}}:{{.Values.proxy.image.version | default .Values.linkerdVersion}}
 command: ["/usr/lib/linkerd/linkerd2-proxy-init"]
 imagePullPolicy: {{.Values.proxy.image.pullPolicy | default .Values.imagePullPolicy}}

--- a/pkg/charts/linkerd2/values.go
+++ b/pkg/charts/linkerd2/values.go
@@ -223,6 +223,8 @@ type (
 		IgnoreOutboundPorts string           `json:"ignoreOutboundPorts"`
 		KubeAPIServerPorts  string           `json:"kubeAPIServerPorts"`
 		SkipSubnets         string           `json:"skipSubnets"`
+		SkipInboundSubnets  string           `json:"skipInboundSubnets"`
+		SkipOutboundSubnets string           `json:"skipOutboundSubnets"`
 		LogLevel            string           `json:"logLevel"`
 		LogFormat           string           `json:"logFormat"`
 		SAMountPath         *VolumeMountPath `json:"saMountPath"`

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -73,6 +73,8 @@ var (
 		k8s.ProxyAwait,
 		k8s.ProxyDefaultInboundPolicyAnnotation,
 		k8s.ProxySkipSubnetsAnnotation,
+		k8s.ProxySkipInboundSubnetsAnnotation,
+		k8s.ProxySkipOutboundSubnetsAnnotation,
 		k8s.ProxyAccessLogAnnotation,
 		k8s.ProxyShutdownGracePeriodAnnotation,
 		k8s.ProxyOutboundDiscoveryCacheUnusedTimeout,
@@ -599,6 +601,14 @@ func ApplyAnnotationOverrides(values *l5dcharts.Values, annotations map[string]s
 
 	if override, ok := annotations[k8s.ProxySkipSubnetsAnnotation]; ok {
 		values.ProxyInit.SkipSubnets = override
+	}
+
+	if override, ok := annotations[k8s.ProxySkipInboundSubnetsAnnotation]; ok {
+		values.ProxyInit.SkipInboundSubnets = override
+	}
+
+	if override, ok := annotations[k8s.ProxySkipOutboundSubnetsAnnotation]; ok {
+		values.ProxyInit.SkipOutboundSubnets = override
 	}
 
 	if override, ok := annotations[k8s.ProxyAccessLogAnnotation]; ok {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -67,6 +67,8 @@ func TestGetOverriddenValues(t *testing.T) {
 							k8s.ProxyOpaquePortsAnnotation:                   "4320-4325,3306",
 							k8s.ProxyAwait:                                   "enabled",
 							k8s.ProxySkipSubnetsAnnotation:                   "172.17.0.0/16",
+							k8s.ProxySkipInboundSubnetsAnnotation:            "10.0.0.0/8",
+							k8s.ProxySkipOutboundSubnetsAnnotation:           "192.168.0.0/16",
 							k8s.ProxyAccessLogAnnotation:                     "apache",
 							k8s.ProxyShutdownGracePeriodAnnotation:           "30s",
 							k8s.ProxyOutboundDiscoveryCacheUnusedTimeout:     "50000ms",
@@ -113,6 +115,8 @@ func TestGetOverriddenValues(t *testing.T) {
 				values.ProxyInit.IgnoreInboundPorts = "4222,6222"
 				values.ProxyInit.IgnoreOutboundPorts = "8079,8080"
 				values.ProxyInit.SkipSubnets = "172.17.0.0/16"
+				values.ProxyInit.SkipInboundSubnets = "10.0.0.0/8"
+				values.ProxyInit.SkipOutboundSubnets = "192.168.0.0/16"
 				values.Proxy.RequireIdentityOnInboundPorts = "8888,9999"
 				values.Proxy.OutboundConnectTimeout = "6000ms"
 				values.Proxy.InboundConnectTimeout = "600ms"

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -164,6 +164,14 @@ const (
 	// ProxySkipSubnetsAnnotation can be used to override the skipSubnets config
 	ProxySkipSubnetsAnnotation = ProxyConfigAnnotationsPrefix + "/skip-subnets"
 
+	// ProxySkipInboundSubnetsAnnotation can be used to override the inbound
+	// subnet exclusions configured for proxy-init.
+	ProxySkipInboundSubnetsAnnotation = ProxyConfigAnnotationsPrefix + "/skip-inbound-subnets"
+
+	// ProxySkipOutboundSubnetsAnnotation can be used to override the outbound
+	// subnet exclusions configured for proxy-init.
+	ProxySkipOutboundSubnetsAnnotation = ProxyConfigAnnotationsPrefix + "/skip-outbound-subnets"
+
 	// ProxyInboundPortAnnotation can be used to override the inboundPort config.
 	ProxyInboundPortAnnotation = ProxyConfigAnnotationsPrefix + "/inbound-port"
 


### PR DESCRIPTION
## Problem

The existing `config.linkerd.io/skip-subnets` setting cannot distinguish inbound source-subnet exclusions from outbound destination-subnet exclusions. This makes it impossible to configure the desired behavior for both traffic directions.

## Solution

Add `config.linkerd.io/skip-inbound-subnets` and `config.linkerd.io/skip-outbound-subnets` pod annotations, chart values, and proxy-init argument wiring. The existing `skip-subnets` annotation and value remain backwards compatible.

This is the Linkerd control-plane companion to linkerd/linkerd2-proxy-init#792 and addresses linkerd/linkerd2#10726.

## Validation

- `go test ./pkg/inject -run '^TestGetOverriddenValues$' -count=1`
- `go test ./pkg/charts/linkerd2 ./pkg/k8s`
- `git diff --check`

Signed-off-by: ADITYA CHAUHAN <hooiv@users.noreply.github.com>