### PR TITLE
fix(lint): re-enable the gosec G402 rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,14 +97,6 @@ issues:
     - gosec
     text: "G101: Potential hardcoded credentials"
 
-  # Temporarily disable this check until the next golang-ci upgrade (greater
-  # than v1.50.1) which upgrades gosec from v2.13.1 to v2.14.0. The fix is in
-  # this commit, that refers to G404 but it seems it also affects G402:
-  # https://github.com/securego/gosec/commit/dfde579243e1bfe0856ddafc5fc6aebb29c0edf6
-  - linters:
-    - gosec
-    text: "G402: TLS MinVersion too low"
-
   # Flag operations are fallible if the flag does not exist. We assume these
   # exist as they are generally flags we are deprecating or use only for
   # development.


### PR DESCRIPTION
## Problem

`G402: TLS MinVersion too low` has been excluded from gosec since #9693. The exclusion was explicitly temporary — the comment says to revert it once golangci-lint moved past v1.50.1, which brought in the gosec v2.13.1 → v2.14.0 fix for the false positive:

```yaml
  # Temporarily disable this check until the next golang-ci upgrade (greater
  # than v1.50.1) which upgrades gosec from v2.13.1 to v2.14.0. ...
  - linters:
    - gosec
    text: "G402: TLS MinVersion too low"
```

That upgrade landed long ago. CI runs golangci-lint **v1.64.8** (via `ghcr.io/linkerd/dev:v50-go`, which installs `cmd/golangci-lint@latest`), so the workaround is dead weight and a real TLS misconfiguration would currently go unreported.

## Solution

Delete the exclusion. No code changes were needed.

## Validation

Run with golangci-lint v1.64.8 to match the dev image.

**1. Baseline on `main`** — clean:
```
$ golangci-lint run --timeout=15m
(exit 0, no output)
```

**2. With the exclusion removed** — still clean, so there are no real G402 violations to fix:
```
$ golangci-lint run --timeout=15m
(exit 0, no output)
```

**3. Confirmed the rule actually fires** rather than the removal being a no-op. Temporarily added:
```go
// pkg/tls/g402_probe.go
func TempProbe() *tls.Config {
	return &tls.Config{MinVersion: tls.VersionTLS10}
}
```
```
pkg/tls/g402_probe.go:7:10: G402: TLS MinVersion too low. (gosec)
	return &tls.Config{MinVersion: tls.VersionTLS10}
	        ^
```

**4. Confirmed the exclusion was genuinely suppressing it** — restoring the old config and re-running against the same probe reports nothing.

The probe file was removed before committing; the diff is the 8-line config deletion only.

Fixes #9700

Signed-off-by: Sudhir Jaiswal <jaiswalsudhir2944@gmail.com>
