### PR TITLE
fix: guard nil externalWorkload in opaque protocol computation (#15551)

### DIFF
--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -770,8 +770,10 @@ func (wp *workloadPublisher) updateExternalWorkload(externalWorkload *ext.Extern
 	}
 
 	// Compute opaque protocol.
-	if err := SetToServerProtocolExternalWorkload(wp.k8sAPI, &wp.addr); err != nil {
-		wp.log.Errorf("Error computing opaque protocol for externalworkload %s: %q", wp.addr.ExternalWorkload.GetName(), err)
+	if externalWorkload != nil {
+		if err := SetToServerProtocolExternalWorkload(wp.k8sAPI, &wp.addr); err != nil {
+			wp.log.Errorf("Error computing opaque protocol for externalworkload %s: %q", externalWorkload.GetName(), err)
+		}
 	}
 
 	for _, l := range wp.listeners {


### PR DESCRIPTION
When `submitExternalWorkloadUpdate` is called with `remove=true` (workload deletion), it passes `nil` to `updateExternalWorkload`. The function then calls `SetToServerProtocolExternalWorkload` and logs an error message that dereferences `wp.addr.ExternalWorkload.GetName()` — but `ExternalWorkload` is `nil` at that point, causing a panic.

## Fix

Guard the opaque protocol computation and error log with a nil check on `externalWorkload`. When the workload is being deleted (nil), there is no opaque protocol to compute, and the listeners are still notified of the empty address.

### Stack trace from the bug

```
panic: runtime error: invalid memory address or nil pointer dereference
watcher.(*workloadPublisher).updateExternalWorkload(0xc0022db0e0, 0x0)
    controller/api/destination/watcher/workload_watcher.go:774 +0x175
```

## Testing

- The ownership fill block (lines 767-769) already had a nil guard — this fix extends the same pattern to the opaque protocol computation block.
- Existing tests in `controller/api/destination/watcher/` continue to pass since the change only adds a nil guard that is a no-op for non-nil inputs.

Closes #15551
