### PR TITLE
Stop watching v1 Endpoints when EndpointSlices are enabled

### DIFF
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -146,12 +146,16 @@ func Main(args []string) {
 	// (see issue #12710).
 	var k8sAPI *k8s.API
 	if *enableEndpointSlices {
+		// The v1 Endpoints informer is omitted here: when EndpointSlices are
+		// enabled, nothing in the destination controller reads from it, and
+		// keeping it running only produces unused watches and log noise from
+		// the deprecated v1 Endpoints API.
 		k8sAPI, err = k8s.InitializeAPI(
 			ctx,
 			*kubeConfigPath,
 			true,
 			"local",
-			k8s.Endpoint, k8s.ES, k8s.Pod, k8s.Svc, k8s.SP, k8s.Srv, k8s.ExtWorkload,
+			k8s.ES, k8s.Pod, k8s.Svc, k8s.SP, k8s.Srv, k8s.ExtWorkload,
 		)
 	} else {
 		k8sAPI, err = k8s.InitializeAPI(


### PR DESCRIPTION
## Stop watching v1 Endpoints when EndpointSlices are enabled

**Problem**

The destination controller always started a v1 Endpoints informer (controller/cmd/destination/main.go), even when --enable-endpoint-slices is true (the default). Every consumer of that informer in the watcher package (endpoints_watcher.go, workload_watcher.go, service_publisher.go, port_publisher.go) already branches on enableEndpointSlices and only reads from it when EndpointSlices are disabled, so with the default configuration the informer's LIST/WATCH calls to the v1 Endpoints API served no purpose. On clusters that flag v1 Endpoints as deprecated (e.g. EKS 1.34+), those unused calls flood linkerd-destination's logs with:

```
level=info msg="Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
```

This is log noise only; destination service behavior is unchanged before and after this fix, since the v1 Endpoints informer was never actually read from in this mode.

**Solution**

Only request the k8s.Endpoint informer resource when --enable-endpoint-slices is false, mirroring the conditional resource selection already used for the destination controller's remote-cluster watchers in controller/api/destination/watcher/cluster_store.go.

**Validation**

Ran, all passing:

```
go build ./controller/...
go test -race ./controller/cmd/destination/... ./controller/api/destination/... ./controller/k8s/...
```

This confirms the build and existing behavioral tests (including coverage of the enableEndpointSlices-gated code paths) are unaffected by no longer constructing the v1 Endpoints informer. This was not reproduced against a live cluster exhibiting the deprecation warning; the fix follows directly from removing the only remaining unconditional consumer of the v1 Endpoints API in this code path, which is what triggers the apiserver's deprecation warning on List/Watch.

Fixes #15561

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.