### PR TITLE
build(deps): gateway api 1.5.1 support via linkerd-kubert 0.27.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -162,7 +162,7 @@ jobs:
         gateway-api:
           - version: linkerd
             channel: experimental
-          - version: v1.4.0
+          - version: v1.5.1
             channel: experimental
         # Also test the Minimum Supported Kubernetes Version with the Minimum
         # Supported Gateway API version.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -169,7 +169,7 @@ jobs:
         include:
           - k8s: v1.31
             gateway-api:
-              version: v1.1.1
+              version: v1.2.1
               channel: standard
     env:
       GATEWAY_API_VERSION: ${{ matrix.gateway-api.version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,8 +1221,8 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.26.0"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?branch=kate%2Fupdate-kube-rs-deps#b2498f6581a35a17d9bbe8282514083534338a79"
+version = "0.27.0"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.27.0#04f6ac3543e84e814e50724dec11a5309fd9b8df"
 dependencies = [
  "ahash",
  "backon",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "kubert-prometheus-process"
 version = "0.2.4"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?branch=kate%2Fupdate-kube-rs-deps#b2498f6581a35a17d9bbe8282514083534338a79"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.27.0#04f6ac3543e84e814e50724dec11a5309fd9b8df"
 dependencies = [
  "libc",
  "procfs",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "kubert-prometheus-tokio"
 version = "0.2.1"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?branch=kate%2Fupdate-kube-rs-deps#b2498f6581a35a17d9bbe8282514083534338a79"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.27.0#04f6ac3543e84e814e50724dec11a5309fd9b8df"
 dependencies = [
  "prometheus-client",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,15 +31,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,7 +73,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -93,7 +84,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -193,6 +184,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -248,18 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "serde",
- "windows-link",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +273,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -352,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -362,27 +347,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -392,6 +376,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "delegate"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +414,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -420,7 +435,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -469,7 +484,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -495,7 +510,7 @@ checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -511,7 +526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -554,9 +569,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -632,7 +647,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -666,14 +681,13 @@ dependencies = [
 
 [[package]]
 name = "gateway-api"
-version = "0.16.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4369c3e046bbeb9c1eadb2a3e954ba7f0fbdbea165c96b7a0e698ac381b736d4"
+checksum = "4f0f7448dc566856c4e2e29511a029f1addfd1fe41fd1e397e9487b36452f547"
 dependencies = [
  "delegate",
  "k8s-openapi",
  "kube",
- "once_cell",
  "regex-lite",
  "schemars",
  "serde",
@@ -759,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -775,30 +789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,15 +799,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.0",
-]
 
 [[package]]
 name = "hostname"
@@ -899,25 +880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-http-proxy"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8021e0ae20c08eadc94d0bdafdeda66d4f0858541c146ae6e46b219bfe58497e"
-dependencies = [
- "bytes",
- "futures-util",
- "headers",
- "http",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,30 +927,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1053,6 +991,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.7.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+checksum = "2e07021eefc09f897611b067ba7897b5e9266edfc902768418968772e5bb06a7"
 dependencies = [
  "pest",
  "pest_derive",
@@ -1108,12 +1099,12 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.25.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa60a41b57ae1a0a071af77dbcf89fc9819cfe66edaf2beeb204c34459dcf0b2"
+checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
 dependencies = [
  "base64",
- "chrono",
+ "jiff",
  "schemars",
  "serde",
  "serde_json",
@@ -1121,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "1.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778f98664beaf4c3c11372721e14310d1ae00f5e2d9aabcf8906c881aa4e9f51"
+checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1134,24 +1125,22 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "1.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb276b85b6e94ded00ac8ea2c68fcf4697ea0553cb25fddc35d4a0ab718db8d"
+checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
 dependencies = [
  "base64",
  "bytes",
- "chrono",
  "either",
  "futures",
- "home",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-http-proxy",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-util",
+ "jiff",
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
@@ -1172,14 +1161,14 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "1.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c56ff45deb0031f2a476017eed60c06872251f271b8387ad8020b8fef60960"
+checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
 dependencies = [
- "chrono",
  "derive_more",
  "form_urlencoded",
  "http",
+ "jiff",
  "json-patch",
  "k8s-openapi",
  "schemars",
@@ -1191,23 +1180,23 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "1.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079fc8c1c397538628309cfdee20696ebdcc26745f9fb17f89b78782205bd995"
+checksum = "d6b9b97e121fce957f9cafc6da534abc4276983ab03190b76c09361e2df849fa"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "kube-runtime"
-version = "1.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1326e946fadf6248febdf8a1c001809c3899ccf48cb9768cbc536b741040dc"
+checksum = "c072737075826ee74d3e615e80334e41e617ca3d14fb46ef7cdfda822d6f15f2"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -1215,7 +1204,7 @@ dependencies = [
  "backon",
  "educe",
  "futures",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -1233,12 +1222,11 @@ dependencies = [
 [[package]]
 name = "kubert"
 version = "0.26.0"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.26.0#cb414cccb5099a0246f4b9b3f298f66e1bf21318"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?branch=kate%2Fupdate-kube-rs-deps#b2498f6581a35a17d9bbe8282514083534338a79"
 dependencies = [
  "ahash",
  "backon",
  "bytes",
- "chrono",
  "clap",
  "drain",
  "futures-core",
@@ -1246,6 +1234,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "jiff",
  "k8s-openapi",
  "kube-client",
  "kube-core",
@@ -1270,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "kubert-prometheus-process"
 version = "0.2.4"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.26.0#cb414cccb5099a0246f4b9b3f298f66e1bf21318"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?branch=kate%2Fupdate-kube-rs-deps#b2498f6581a35a17d9bbe8282514083534338a79"
 dependencies = [
  "libc",
  "procfs",
@@ -1281,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "kubert-prometheus-tokio"
 version = "0.2.1"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert%2Fv0.26.0#cb414cccb5099a0246f4b9b3f298f66e1bf21318"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?branch=kate%2Fupdate-kube-rs-deps#b2498f6581a35a17d9bbe8282514083534338a79"
 dependencies = [
  "prometheus-client",
  "tokio",
@@ -1319,10 +1308,10 @@ dependencies = [
  "ahash",
  "anyhow",
  "async-trait",
- "chrono",
  "futures",
  "http",
  "ipnet",
+ "jiff",
  "regex",
 ]
 
@@ -1370,9 +1359,9 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
- "chrono",
  "futures",
  "http",
+ "jiff",
  "k8s-openapi",
  "kube",
  "kubert",
@@ -1395,7 +1384,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
- "chrono",
+ "jiff",
  "kubert",
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",
@@ -1586,7 +1575,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1602,7 +1591,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1707,7 +1696,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1736,7 +1725,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1750,6 +1739,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1775,7 +1779,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "procfs-core",
  "rustix",
 ]
@@ -1786,7 +1790,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "hex",
 ]
 
@@ -1810,7 +1814,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1833,7 +1837,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1918,7 +1922,27 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1985,11 +2009,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2058,11 +2082,12 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -2070,14 +2095,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2101,7 +2126,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2161,18 +2186,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2283,6 +2308,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2341,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2342,7 +2378,7 @@ checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2392,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -2483,12 +2519,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "http",
  "http-body",
  "mime",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2526,7 +2563,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2589,9 +2626,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -2703,7 +2740,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2725,7 +2762,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2737,63 +2774,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2900,7 +2884,7 @@ checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ default-features = false
 features = ["tracing"]
 
 [workspace.dependencies.kubert]
-version = "0.26"
+version = "0.27"
 default-features = false
 git = "https://github.com/linkerd/linkerd-kubert.git"
-branch = "kate/update-kube-rs-deps"
+tag = "kubert/v0.27.0"
 
 [workspace.dependencies.linkerd-policy-controller-k8s-index]
 path = "./policy-controller/k8s/index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,12 @@ members = [
 lto = "thin"
 
 [workspace.dependencies]
-gateway-api = "0.16"
+gateway-api = "0.21"
 http = "1"
 hyper = "1"
-k8s-openapi = { version = "0.25", features = ["v1_33"] }
-kube = { version = "1.1", default-features = false }
+jiff = { version = "0.2", default-features = false, features = ["std"] }
+k8s-openapi = { version = "0.27", features = ["v1_33"] }
+kube = { version = "3.1", default-features = false }
 prometheus-client = { version = "0.24", default-features = false }
 tonic = { version = "0.14", default-features = false }
 tower = { version = "0.5", default-features = false }
@@ -39,7 +40,7 @@ features = ["tracing"]
 version = "0.26"
 default-features = false
 git = "https://github.com/linkerd/linkerd-kubert.git"
-tag = "kubert/v0.26.0"
+branch = "kate/update-kube-rs-deps"
 
 [workspace.dependencies.linkerd-policy-controller-k8s-index]
 path = "./policy-controller/k8s/index"

--- a/deny.toml
+++ b/deny.toml
@@ -50,7 +50,12 @@ multiple-versions = "deny"
 # Wildcard dependencies are used for all workspace-local crates.
 wildcards = "allow"
 highlight = "all"
-skip = []
+skip = [
+    # syn v3 is still making its way through the ecosystem. schemars v1 (via
+    # gateway-api, k8s-openapi and kube) is on v3, while most other derive
+    # macros are still on v2. Both are build-time only.
+    { name = "syn", version = "2" },
+]
 skip-tree = [
     # `serde_json` and `h2` depend on diverged versions of `indexmap` (2.0.x and
     # 1.9.x, respectively)

--- a/justfile
+++ b/justfile
@@ -293,7 +293,7 @@ proxy-image := DOCKER_REGISTRY + "/proxy"
 # When GATEWAY_API_VERSION is 'linkerd' we use the CLI's vendored gateway API
 # CRDs. Otherwise, we install the CRDs from the upstream release.
 # This should be kept up-to-date with the latest stable release of the gateway API.
-export GATEWAY_API_VERSION := env_var_or_default("GATEWAY_API_VERSION", "v1.2.1")
+export GATEWAY_API_VERSION := env_var_or_default("GATEWAY_API_VERSION", "v1.5.1")
 
 # When GATEWAY_API_CHANNEL is 'experimental', we enable testing of experimental
 # resource types (TCPRoute, TLSRoute). Alternatively, the 'standard' channel may

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -2271,7 +2271,7 @@ func CheckGatewayAPICRDsInstalled(ctx context.Context, k8sAPI *k8s.KubernetesAPI
 func GatewayAPICRDsMissingError() error {
 	return errors.New(`The Gateway API CRDs must be installed prior to installing Linkerd. Run:
 
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
 or see https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api for more options.`)
 }

--- a/policy-controller/core/Cargo.toml
+++ b/policy-controller/core/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 ahash = "0.8"
 anyhow = "1"
 async-trait = "0.1"
-chrono = { version = "0.4.45", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 http = { workspace = true }
 ipnet = "2"
+jiff = { workspace = true }
 regex = "1"

--- a/policy-controller/core/src/inbound.rs
+++ b/policy-controller/core/src/inbound.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use ahash::AHashMap as HashMap;
 use anyhow::Result;
-use chrono::{offset::Utc, DateTime};
 use futures::prelude::*;
+use jiff::Timestamp;
 use std::{pin::Pin, time::Duration};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -124,7 +124,7 @@ pub struct InboundRoute<M> {
 
     /// This is required for ordering returned `HttpRoute`s by their creation
     /// timestamp.
-    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub creation_timestamp: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/policy-controller/core/src/outbound.rs
+++ b/policy-controller/core/src/outbound.rs
@@ -4,8 +4,8 @@ use crate::routes::{
 };
 use ahash::AHashMap as HashMap;
 use anyhow::Result;
-use chrono::{offset::Utc, DateTime};
 use futures::prelude::*;
+use jiff::Timestamp;
 use std::{net::IpAddr, num::NonZeroU16, pin::Pin, str::FromStr, sync::Arc, time};
 
 mod policy;
@@ -19,7 +19,7 @@ pub use self::{
 };
 
 pub trait Route {
-    fn creation_timestamp(&self) -> Option<DateTime<Utc>>;
+    fn creation_timestamp(&self) -> Option<Timestamp>;
 }
 
 /// Models outbound policy discovery.
@@ -77,7 +77,7 @@ pub struct OutboundRoute<M, R> {
 
     /// This is required for ordering returned routes
     /// by their creation timestamp.
-    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub creation_timestamp: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -86,7 +86,7 @@ pub struct TlsRoute {
     pub rule: TcpRouteRule,
     /// This is required for ordering returned routes
     /// by their creation timestamp.
-    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub creation_timestamp: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -95,7 +95,7 @@ pub struct TcpRoute {
 
     /// This is required for ordering returned routes
     /// by their creation timestamp.
-    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub creation_timestamp: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -245,19 +245,19 @@ pub enum GrpcRetryCondition {
 }
 
 impl<M, R> Route for OutboundRoute<M, R> {
-    fn creation_timestamp(&self) -> Option<DateTime<Utc>> {
+    fn creation_timestamp(&self) -> Option<Timestamp> {
         self.creation_timestamp
     }
 }
 
 impl Route for TcpRoute {
-    fn creation_timestamp(&self) -> Option<DateTime<Utc>> {
+    fn creation_timestamp(&self) -> Option<Timestamp> {
         self.creation_timestamp
     }
 }
 
 impl Route for TlsRoute {
-    fn creation_timestamp(&self) -> Option<DateTime<Utc>> {
+    fn creation_timestamp(&self) -> Option<Timestamp> {
         self.creation_timestamp
     }
 }

--- a/policy-controller/k8s/api/Cargo.toml
+++ b/policy-controller/k8s/api/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 gateway-api = { workspace = true }
-ipnet = { version = "2.12", features = ["json"] }
+ipnet = { version = "2.12", features = ["serde", "schemars1"] }
 k8s-openapi = { workspace = true }
-schemars = "0.8"
+schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/policy-controller/k8s/api/src/duration.rs
+++ b/policy-controller/k8s/api/src/duration.rs
@@ -162,24 +162,21 @@ impl<'de> Deserialize<'de> for K8sDuration {
 impl schemars::JsonSchema for K8sDuration {
     // see
     // https://github.com/kubernetes/apimachinery/blob/756e2227bf3a486098f504af1a0ffb736ad16f4c/pkg/apis/meta/v1/duration.go#L61
-    fn schema_name() -> String {
-        "K8sDuration".to_owned()
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "K8sDuration".into()
     }
 
-    fn is_referenceable() -> bool {
-        false
+    fn inline_schema() -> bool {
+        true
     }
 
-    fn json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            // the format should *not* be "duration", because "duration" means
-            // the duration is formatted in ISO 8601, as described here:
-            // https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02#section-7.3.1
-            format: None,
-            ..Default::default()
-        }
-        .into()
+    fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // the format should *not* be "duration", because "duration" means
+        // the duration is formatted in ISO 8601, as described here:
+        // https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-02#section-7.3.1
+        schemars::json_schema!({
+            "type": "string",
+        })
     }
 }
 #[cfg(test)]

--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -38,6 +38,101 @@ pub mod gateway {
     pub use gateway_api::apis::experimental::tcproutes::*;
     pub use gateway_api::apis::experimental::tlsroutes::*;
 
+    /// A `TLSRoute` pinned to `v1alpha2`.
+    ///
+    /// This deliberately shadows the `TLSRoute` from the glob import above.
+    /// The `gateway-api` crate binds `TLSRoute` to `v1`, which is only served
+    /// by Gateway API v1.5 and later. `v1alpha2` is served by every release
+    /// from v1.1 through v1.5 (deprecated but still served, and the CRD
+    /// declares no conversion strategy, so the versions are the same object
+    /// under a different `apiVersion`). Using it keeps us compatible with
+    /// clusters that predate v1.5.
+    ///
+    /// The spec and status types are reused from the `gateway-api` crate, so
+    /// this only overrides the group/version/kind the client addresses.
+    #[derive(Clone, Debug, Default, PartialEq, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct TLSRoute {
+        pub metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
+        pub spec: TlsRouteSpec,
+        pub status: Option<TlsRouteStatus>,
+    }
+
+    impl kube::Resource for TLSRoute {
+        type DynamicType = ();
+        type Scope = kube::core::NamespaceResourceScope;
+
+        fn kind(_: &()) -> std::borrow::Cow<'_, str> {
+            "TLSRoute".into()
+        }
+
+        fn group(_: &()) -> std::borrow::Cow<'_, str> {
+            "gateway.networking.k8s.io".into()
+        }
+
+        fn version(_: &()) -> std::borrow::Cow<'_, str> {
+            "v1alpha2".into()
+        }
+
+        fn plural(_: &()) -> std::borrow::Cow<'_, str> {
+            "tlsroutes".into()
+        }
+
+        fn meta(&self) -> &k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+            &self.metadata
+        }
+
+        fn meta_mut(&mut self) -> &mut k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+            &mut self.metadata
+        }
+    }
+
+    // Mirrors what `kube::CustomResource` derives: `apiVersion` and `kind` are
+    // not stored on the struct, so they must be written out explicitly.
+    impl serde::Serialize for TLSRoute {
+        fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+            use kube::Resource;
+            use serde::ser::SerializeStruct;
+            let mut obj =
+                ser.serialize_struct("TLSRoute", 4 + usize::from(self.status.is_some()))?;
+            obj.serialize_field("apiVersion", &Self::api_version(&()))?;
+            obj.serialize_field("kind", &Self::kind(&()))?;
+            obj.serialize_field("metadata", &self.metadata)?;
+            obj.serialize_field("spec", &self.spec)?;
+            if let Some(status) = &self.status {
+                obj.serialize_field("status", status)?;
+            }
+            obj.end()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use kube::Resource;
+
+        /// `TLSRoute` must stay on `v1alpha2`; `v1` is not served before
+        /// Gateway API v1.5. A regression here fails silently at runtime: the
+        /// watch is skipped and TLSRoute policy stops being applied.
+        #[test]
+        fn tls_route_is_v1alpha2() {
+            assert_eq!(
+                TLSRoute::api_version(&()),
+                "gateway.networking.k8s.io/v1alpha2"
+            );
+            assert_eq!(
+                TLSRoute::url_path(&(), Some("ns")),
+                "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/ns/tlsroutes"
+            );
+
+            // `apiVersion` and `kind` are not struct fields, so they are only
+            // emitted by the hand-written `Serialize` impl.
+            let json = serde_json::to_value(TLSRoute::default()).unwrap();
+            assert_eq!(json["apiVersion"], "gateway.networking.k8s.io/v1alpha2");
+            assert_eq!(json["kind"], "TLSRoute");
+        }
+    }
+
     pub mod http_method {
         use gateway_api::apis::experimental::httproutes::HttpRouteRulesMatchesMethod;
 

--- a/policy-controller/k8s/api/src/lib.rs
+++ b/policy-controller/k8s/api/src/lib.rs
@@ -27,7 +27,7 @@ pub use k8s_openapi::{
 };
 pub use kube::{
     api::{Api, ListParams, ObjectMeta, Patch, PatchParams, Resource, ResourceExt},
-    error::ErrorResponse,
+    core::Status,
     runtime::watcher::Event as WatchEvent,
     Client, Error,
 };
@@ -39,25 +39,25 @@ pub mod gateway {
     pub use gateway_api::apis::experimental::tlsroutes::*;
 
     pub mod http_method {
-        use gateway_api::apis::experimental::httproutes::HTTPRouteRulesMatchesMethod;
+        use gateway_api::apis::experimental::httproutes::HttpRouteRulesMatchesMethod;
 
-        pub const GET: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Get;
-        pub const POST: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Post;
-        pub const PUT: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Put;
-        pub const DELETE: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Delete;
-        pub const PATCH: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Patch;
-        pub const HEAD: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Head;
-        pub const OPTIONS: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Options;
-        pub const CONNECT: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Connect;
-        pub const TRACE: HTTPRouteRulesMatchesMethod = HTTPRouteRulesMatchesMethod::Trace;
+        pub const GET: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Get;
+        pub const POST: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Post;
+        pub const PUT: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Put;
+        pub const DELETE: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Delete;
+        pub const PATCH: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Patch;
+        pub const HEAD: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Head;
+        pub const OPTIONS: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Options;
+        pub const CONNECT: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Connect;
+        pub const TRACE: HttpRouteRulesMatchesMethod = HttpRouteRulesMatchesMethod::Trace;
     }
 
     pub mod http_scheme {
-        use gateway_api::apis::experimental::httproutes::HTTPRouteRulesFiltersRequestRedirectScheme;
+        use gateway_api::apis::experimental::httproutes::HttpRouteRulesFiltersRequestRedirectScheme;
 
-        pub const HTTP: HTTPRouteRulesFiltersRequestRedirectScheme =
-            HTTPRouteRulesFiltersRequestRedirectScheme::Http;
-        pub const HTTPS: HTTPRouteRulesFiltersRequestRedirectScheme =
-            HTTPRouteRulesFiltersRequestRedirectScheme::Https;
+        pub const HTTP: HttpRouteRulesFiltersRequestRedirectScheme =
+            HttpRouteRulesFiltersRequestRedirectScheme::Http;
+        pub const HTTPS: HttpRouteRulesFiltersRequestRedirectScheme =
+            HttpRouteRulesFiltersRequestRedirectScheme::Https;
     }
 }

--- a/policy-controller/k8s/api/src/policy/grpcroute.rs
+++ b/policy-controller/k8s/api/src/policy/grpcroute.rs
@@ -1,6 +1,6 @@
 use crate::gateway;
 
-pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::GRPCRouteParentRefs) -> bool
+pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::GrpcRouteParentRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,
@@ -13,7 +13,7 @@ where
     super::targets_kind::<T>(parent_ref.group.as_deref(), kind)
 }
 
-pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::GRPCRouteRulesBackendRefs) -> bool
+pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::GrpcRouteRulesBackendRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,

--- a/policy-controller/k8s/api/src/policy/httproute.rs
+++ b/policy-controller/k8s/api/src/policy/httproute.rs
@@ -1,4 +1,4 @@
-use crate::gateway::{self, HTTPRouteStatus};
+use crate::gateway::{self, HttpRouteStatus};
 
 /// HTTPRoute provides a way to route HTTP requests. This includes the
 /// capability to match requests by hostname, path, header, or query param.
@@ -18,7 +18,7 @@ use crate::gateway::{self, HTTPRouteStatus};
     version = "v1beta3",
     kind = "HTTPRoute",
     root = "HttpRoute",
-    status = "HTTPRouteStatus",
+    status = "HttpRouteStatus",
     namespaced
 )]
 pub struct HttpRouteSpec {
@@ -28,7 +28,7 @@ pub struct HttpRouteSpec {
         skip_serializing_if = "Option::is_none",
         rename = "parentRefs"
     )]
-    pub parent_refs: Option<Vec<gateway::HTTPRouteParentRefs>>,
+    pub parent_refs: Option<Vec<gateway::HttpRouteParentRefs>>,
 
     /// Hostnames defines a set of hostname that should match against the HTTP
     /// Host header to select a HTTPRoute to process the request. This matches
@@ -102,7 +102,7 @@ pub struct HttpRouteRule {
     ///
     /// When no rules matching a request have been successfully attached to the
     /// parent a request is coming from, a HTTP 404 status code MUST be returned.
-    pub matches: Option<Vec<gateway::HTTPRouteRulesMatches>>,
+    pub matches: Option<Vec<gateway::HttpRouteRulesMatches>>,
 
     /// Filters define the filters that are applied to requests that match this
     /// rule.
@@ -150,7 +150,7 @@ pub struct HttpRouteRule {
     /// Support: Custom for any other resource
     ///
     /// Support for weight: Core
-    pub backend_refs: Option<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+    pub backend_refs: Option<Vec<gateway::HttpRouteRulesBackendRefs>>,
 
     /// Timeouts defines the timeouts that can be configured for an HTTP request.
     ///
@@ -173,7 +173,7 @@ pub enum HttpRouteFilter {
     /// Support: Core
     #[serde(rename_all = "camelCase")]
     RequestHeaderModifier {
-        request_header_modifier: gateway::HTTPRouteRulesFiltersRequestHeaderModifier,
+        request_header_modifier: gateway::HttpRouteRulesFiltersRequestHeaderModifier,
     },
 
     /// ResponseHeaderModifier defines a schema for a filter that modifies response
@@ -182,7 +182,7 @@ pub enum HttpRouteFilter {
     /// Support: Extended
     #[serde(rename_all = "camelCase")]
     ResponseHeaderModifier {
-        response_header_modifier: gateway::HTTPRouteRulesFiltersResponseHeaderModifier,
+        response_header_modifier: gateway::HttpRouteRulesFiltersResponseHeaderModifier,
     },
 
     /// RequestRedirect defines a schema for a filter that responds to the
@@ -191,7 +191,7 @@ pub enum HttpRouteFilter {
     /// Support: Core
     #[serde(rename_all = "camelCase")]
     RequestRedirect {
-        request_redirect: gateway::HTTPRouteRulesFiltersRequestRedirect,
+        request_redirect: gateway::HttpRouteRulesFiltersRequestRedirect,
     },
 }
 
@@ -225,7 +225,7 @@ pub struct HttpRouteTimeouts {
     pub backend_request: Option<crate::duration::K8sDuration>,
 }
 
-pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::HTTPRouteParentRefs) -> bool
+pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::HttpRouteParentRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,
@@ -238,7 +238,7 @@ where
     super::targets_kind::<T>(parent_ref.group.as_deref(), kind)
 }
 
-pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::HTTPRouteRulesBackendRefs) -> bool
+pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::HttpRouteRulesBackendRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,

--- a/policy-controller/k8s/api/src/policy/tcproute.rs
+++ b/policy-controller/k8s/api/src/policy/tcproute.rs
@@ -1,6 +1,6 @@
 use crate::gateway;
 
-pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::TCPRouteParentRefs) -> bool
+pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::TcpRouteParentRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,
@@ -13,7 +13,7 @@ where
     super::targets_kind::<T>(parent_ref.group.as_deref(), kind)
 }
 
-pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::TCPRouteRulesBackendRefs) -> bool
+pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::TcpRouteRulesBackendRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,

--- a/policy-controller/k8s/api/src/policy/tlsroute.rs
+++ b/policy-controller/k8s/api/src/policy/tlsroute.rs
@@ -1,6 +1,6 @@
 use crate::gateway;
 
-pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::TLSRouteParentRefs) -> bool
+pub fn parent_ref_targets_kind<T>(parent_ref: &gateway::TlsRouteParentRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,
@@ -13,7 +13,7 @@ where
     super::targets_kind::<T>(parent_ref.group.as_deref(), kind)
 }
 
-pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::TLSRouteRulesBackendRefs) -> bool
+pub fn backend_ref_targets_kind<T>(backend_ref: &gateway::TlsRouteRulesBackendRefs) -> bool
 where
     T: kube::Resource,
     T::DynamicType: Default,

--- a/policy-controller/k8s/index/Cargo.toml
+++ b/policy-controller/k8s/index/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 ahash = "0.8"
 anyhow = "1"
-chrono = { version = "0.4.45", default-features = false }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
+jiff = { workspace = true }
 kubert = { workspace = true, default-features = false, features = ["index"] }
 parking_lot = "0.12"
 prometheus-client = { workspace = true, default-features = false }
@@ -31,7 +31,6 @@ features = [
 ]
 
 [dev-dependencies]
-chrono = { version = "0.4", default-features = false }
 k8s-openapi = { workspace = true, features = ["schemars"] }
 maplit = "1"
 tokio-stream = "0.1"

--- a/policy-controller/k8s/index/src/inbound/index/grpc.rs
+++ b/policy-controller/k8s/index/src/inbound/index/grpc.rs
@@ -29,7 +29,7 @@ impl TryFrom<gateway::GRPCRoute> for RouteBinding<GrpcRoute> {
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRules {
+                |gateway::GrpcRouteRules {
                      matches, filters, ..
                  }| { try_grpc_rule(matches, filters, try_grpc_filter) },
             )
@@ -53,7 +53,7 @@ impl TryFrom<gateway::GRPCRoute> for RouteBinding<GrpcRoute> {
 }
 
 fn try_grpc_rule<F>(
-    matches: Option<Vec<gateway::GRPCRouteRulesMatches>>,
+    matches: Option<Vec<gateway::GrpcRouteRulesMatches>>,
     filters: Option<Vec<F>>,
     try_filter: impl Fn(F) -> Result<Filter>,
 ) -> Result<InboundRouteRule<GrpcRouteMatch>> {
@@ -72,7 +72,7 @@ fn try_grpc_rule<F>(
     Ok(InboundRouteRule { matches, filters })
 }
 
-fn try_grpc_filter(filter: gateway::GRPCRouteRulesFilters) -> Result<Filter> {
+fn try_grpc_filter(filter: gateway::GrpcRouteRulesFilters) -> Result<Filter> {
     if let Some(request_header_modifier) = filter.request_header_modifier {
         let filter = crate::routes::grpc::request_header_modifier(request_header_modifier)?;
         return Ok(Filter::RequestHeaderModifier(filter));

--- a/policy-controller/k8s/index/src/inbound/index/http.rs
+++ b/policy-controller/k8s/index/src/inbound/index/http.rs
@@ -29,7 +29,7 @@ impl TryFrom<gateway::HTTPRoute> for RouteBinding<HttpRoute> {
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRules {
+                |gateway::HttpRouteRules {
                      matches, filters, ..
                  }| try_http_rule(matches, filters, try_gateway_filter),
             )
@@ -97,7 +97,7 @@ impl TryFrom<policy::HttpRoute> for RouteBinding<HttpRoute> {
 }
 
 fn try_http_rule<F>(
-    matches: Option<Vec<gateway::HTTPRouteRulesMatches>>,
+    matches: Option<Vec<gateway::HttpRouteRulesMatches>>,
     filters: Option<Vec<F>>,
     try_filter: impl Fn(F) -> Result<Filter>,
 ) -> Result<InboundRouteRule<HttpRouteMatch>> {
@@ -116,7 +116,7 @@ fn try_http_rule<F>(
     Ok(InboundRouteRule { matches, filters })
 }
 
-fn try_gateway_filter(filter: gateway::HTTPRouteRulesFilters) -> Result<Filter> {
+fn try_gateway_filter(filter: gateway::HttpRouteRulesFilters) -> Result<Filter> {
     if let Some(request_header_modifier) = filter.request_header_modifier {
         let filter = crate::routes::http::request_header_modifier(request_header_modifier)?;
         return Ok(Filter::RequestHeaderModifier(filter));

--- a/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/ratelimit_policy.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{offset::Utc, DateTime};
+use jiff::Timestamp;
 use linkerd_policy_controller_k8s_api::{
     self as k8s,
     policy::{LocalTargetRef, NamespacedTargetRef},
@@ -9,7 +9,7 @@ use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Spec {
-    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub creation_timestamp: Option<Timestamp>,
     pub target: Target,
     pub total: Option<Limit>,
     pub identity: Option<Limit>,

--- a/policy-controller/k8s/index/src/inbound/routes.rs
+++ b/policy-controller/k8s/index/src/inbound/routes.rs
@@ -67,7 +67,7 @@ impl<R> RouteBinding<R> {
 impl ParentRef {
     pub(crate) fn collect_from_http(
         route_ns: Option<&str>,
-        parent_refs: Option<Vec<gateway::HTTPRouteParentRefs>>,
+        parent_refs: Option<Vec<gateway::HttpRouteParentRefs>>,
     ) -> Result<Vec<Self>, InvalidParentRef> {
         let parents = parent_refs
             .into_iter()
@@ -80,7 +80,7 @@ impl ParentRef {
 
     fn from_http_parent_ref(
         route_ns: Option<&str>,
-        parent_ref: gateway::HTTPRouteParentRefs,
+        parent_ref: gateway::HttpRouteParentRefs,
     ) -> Option<Result<Self, InvalidParentRef>> {
         // Skip parent refs that don't target a `Server` resource.
         if !policy::httproute::parent_ref_targets_kind::<policy::Server>(&parent_ref)
@@ -89,7 +89,7 @@ impl ParentRef {
             return None;
         }
 
-        let gateway::HTTPRouteParentRefs {
+        let gateway::HttpRouteParentRefs {
             group: _,
             kind: _,
             namespace,
@@ -113,7 +113,7 @@ impl ParentRef {
 
     pub(crate) fn collect_from_grpc(
         route_ns: Option<&str>,
-        parent_refs: Option<Vec<gateway::GRPCRouteParentRefs>>,
+        parent_refs: Option<Vec<gateway::GrpcRouteParentRefs>>,
     ) -> Result<Vec<Self>, InvalidParentRef> {
         let parents = parent_refs
             .into_iter()
@@ -126,7 +126,7 @@ impl ParentRef {
 
     fn from_grpc_parent_ref(
         route_ns: Option<&str>,
-        parent_ref: gateway::GRPCRouteParentRefs,
+        parent_ref: gateway::GrpcRouteParentRefs,
     ) -> Option<Result<Self, InvalidParentRef>> {
         // Skip parent refs that don't target a `Server` resource.
         if !policy::grpcroute::parent_ref_targets_kind::<policy::Server>(&parent_ref)
@@ -135,7 +135,7 @@ impl ParentRef {
             return None;
         }
 
-        let gateway::GRPCRouteParentRefs {
+        let gateway::GrpcRouteParentRefs {
             group: _,
             kind: _,
             namespace,
@@ -159,7 +159,7 @@ impl ParentRef {
 }
 
 impl Status {
-    pub fn collect_from_http(status: gateway::HTTPRouteStatus) -> Vec<Self> {
+    pub fn collect_from_http(status: gateway::HttpRouteStatus) -> Vec<Self> {
         status
             .parents
             .iter()
@@ -168,7 +168,7 @@ impl Status {
             .collect::<Vec<_>>()
     }
 
-    fn from_http_parent_status(status: &gateway::HTTPRouteStatusParents) -> Option<Self> {
+    fn from_http_parent_status(status: &gateway::HttpRouteStatusParents) -> Option<Self> {
         // Only match parent statuses that belong to resources of
         // `kind: Server`.
         match status.parent_ref.kind.as_deref() {
@@ -179,7 +179,6 @@ impl Status {
         let conditions = status
             .conditions
             .iter()
-            .flatten()
             .filter_map(|condition| {
                 let type_ = match condition.type_.as_ref() {
                     "Accepted" => ConditionType::Accepted,
@@ -206,7 +205,7 @@ impl Status {
         })
     }
 
-    pub fn collect_from_grpc(status: gateway::GRPCRouteStatus) -> Vec<Self> {
+    pub fn collect_from_grpc(status: gateway::GrpcRouteStatus) -> Vec<Self> {
         status
             .parents
             .iter()
@@ -215,7 +214,7 @@ impl Status {
             .collect::<Vec<_>>()
     }
 
-    fn from_grpc_parent_status(status: &gateway::GRPCRouteStatusParents) -> Option<Self> {
+    fn from_grpc_parent_status(status: &gateway::GrpcRouteStatusParents) -> Option<Self> {
         // Only match parent statuses that belong to resources of
         // `kind: Server`.
         match status.parent_ref.kind.as_deref() {
@@ -226,7 +225,6 @@ impl Status {
         let conditions = status
             .conditions
             .iter()
-            .flatten()
             .filter_map(|condition| {
                 let type_ = match condition.type_.as_ref() {
                     "Accepted" => ConditionType::Accepted,

--- a/policy-controller/k8s/index/src/inbound/tests/authorization_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/authorization_policy.rs
@@ -416,7 +416,7 @@ fn mk_http_route(
             ..Default::default()
         },
         spec: k8s::policy::HttpRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("Server".to_string()),
                 namespace: Some(ns.to_string()),
@@ -425,10 +425,10 @@ fn mk_http_route(
                 port: None,
             }]),
             rules: Some(vec![policy::httproute::HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix),
                     }),
                     ..Default::default()
                 }]),
@@ -438,17 +438,17 @@ fn mk_http_route(
             }]),
             ..Default::default()
         },
-        status: Some(gateway::HTTPRouteStatus {
-            parents: vec![gateway::HTTPRouteStatusParents {
-                conditions: Some(vec![metav1::Condition {
+        status: Some(gateway::HttpRouteStatus {
+            parents: vec![gateway::HttpRouteStatusParents {
+                conditions: vec![metav1::Condition {
                     type_: "Accepted".to_string(),
                     status: "True".to_string(),
                     message: String::new(),
                     reason: String::new(),
-                    last_transition_time: metav1::Time(chrono::Utc::now()),
+                    last_transition_time: metav1::Time(jiff::Timestamp::now()),
                     observed_generation: None,
-                }]),
-                parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+                }],
+                parent_ref: gateway::HttpRouteStatusParentsParentRef {
                     group: Some("policy.linkerd.io".to_string()),
                     kind: Some("Server".to_string()),
                     namespace: Some(ns.to_string()),

--- a/policy-controller/k8s/index/src/inbound/tests/http_routes.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/http_routes.rs
@@ -210,18 +210,18 @@ fn mk_route(
     name: impl ToString,
     server: impl ToString,
 ) -> k8s::policy::HttpRoute {
-    use chrono::Utc;
+    use jiff::Timestamp;
     use k8s::{policy::httproute::*, Time};
 
     HttpRoute {
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
-            creation_timestamp: Some(Time(Utc::now())),
+            creation_timestamp: Some(Time(Timestamp::now())),
             ..Default::default()
         },
         spec: HttpRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: Some(POLICY_API_GROUP.to_string()),
                 kind: Some("Server".to_string()),
                 namespace: None,
@@ -231,23 +231,23 @@ fn mk_route(
             }]),
             hostnames: None,
             rules: Some(vec![HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo/bar".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix),
                     }),
                     headers: None,
                     query_params: None,
-                    method: Some(gateway::HTTPRouteRulesMatchesMethod::Get),
+                    method: Some(gateway::HttpRouteRulesMatchesMethod::Get),
                 }]),
                 filters: None,
                 backend_refs: None,
                 timeouts: None,
             }]),
         },
-        status: Some(gateway::HTTPRouteStatus {
-            parents: vec![gateway::HTTPRouteStatusParents {
-                parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+        status: Some(gateway::HttpRouteStatus {
+            parents: vec![gateway::HttpRouteStatusParents {
+                parent_ref: gateway::HttpRouteStatusParentsParentRef {
                     group: Some(POLICY_API_GROUP.to_string()),
                     kind: Some("Server".to_string()),
                     namespace: None,
@@ -256,14 +256,14 @@ fn mk_route(
                     port: None,
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![k8s::Condition {
-                    last_transition_time: k8s::Time(chrono::DateTime::<chrono::Utc>::MIN_UTC),
+                conditions: vec![k8s::Condition {
+                    last_transition_time: k8s::Time(jiff::Timestamp::MIN),
                     message: "".to_string(),
                     observed_generation: None,
                     reason: "Accepted".to_string(),
                     status: "True".to_string(),
                     type_: "Accepted".to_string(),
-                }]),
+                }],
             }],
         }),
     }

--- a/policy-controller/k8s/index/src/inbound/tests/ratelimit_policy.rs
+++ b/policy-controller/k8s/index/src/inbound/tests/ratelimit_policy.rs
@@ -107,7 +107,7 @@ fn mk_ratelimit(
         },
         status: Some(k8s::policy::HttpLocalRateLimitPolicyStatus {
             conditions: vec![k8s::Condition {
-                last_transition_time: k8s::Time(chrono::DateTime::<chrono::Utc>::MIN_UTC),
+                last_transition_time: k8s::Time(jiff::Timestamp::MIN),
                 message: "".to_string(),
                 observed_generation: None,
                 reason: "".to_string(),

--- a/policy-controller/k8s/index/src/outbound/index/egress_network.rs
+++ b/policy-controller/k8s/index/src/outbound/index/egress_network.rs
@@ -1,4 +1,4 @@
-use chrono::{offset::Utc, DateTime};
+use jiff::Timestamp;
 use linkerd_policy_controller_k8s_api::policy::{Cidr, Network, TrafficPolicy};
 use linkerd_policy_controller_k8s_api::{policy as linkerd_k8s_api, ResourceExt};
 use std::net::IpAddr;
@@ -8,7 +8,7 @@ pub(crate) struct EgressNetwork {
     pub networks: Vec<Network>,
     pub name: String,
     pub namespace: String,
-    pub creation_timestamp: Option<DateTime<Utc>>,
+    pub creation_timestamp: Option<Timestamp>,
     pub traffic_policy: TrafficPolicy,
 }
 
@@ -17,7 +17,7 @@ struct MatchedEgressNetwork {
     matched_network_size: usize,
     name: String,
     namespace: String,
-    creation_timestamp: Option<DateTime<Utc>>,
+    creation_timestamp: Option<Timestamp>,
     pub traffic_policy: TrafficPolicy,
 }
 
@@ -223,7 +223,7 @@ mod test {
                 }],
                 name: "net-1".to_string(),
                 namespace: EGRESS_NETS_NS.to_string(),
-                creation_timestamp: Some(DateTime::<Utc>::MAX_UTC),
+                creation_timestamp: Some(Timestamp::MAX),
                 traffic_policy: TrafficPolicy::Allow,
             },
             EgressNetwork {
@@ -233,7 +233,7 @@ mod test {
                 }],
                 name: "net-2".to_string(),
                 namespace: EGRESS_NETS_NS.to_string(),
-                creation_timestamp: Some(DateTime::<Utc>::MIN_UTC),
+                creation_timestamp: Some(Timestamp::MIN),
                 traffic_policy: TrafficPolicy::Allow,
             },
         ];

--- a/policy-controller/k8s/index/src/outbound/index/grpc.rs
+++ b/policy-controller/k8s/index/src/outbound/index/grpc.rs
@@ -60,7 +60,7 @@ pub(super) fn convert_route(
 
 fn convert_rule(
     ns: &str,
-    rule: gateway::GRPCRouteRules,
+    rule: gateway::GrpcRouteRules,
     cluster: &ClusterInfo,
     resource_info: &HashMap<ResourceRef, ResourceInfo>,
     timeouts: RouteTimeouts,
@@ -98,7 +98,7 @@ fn convert_rule(
 
 pub(super) fn convert_backend(
     ns: &str,
-    backend: gateway::GRPCRouteRulesBackendRefs,
+    backend: gateway::GrpcRouteRulesBackendRefs,
     cluster: &ClusterInfo,
     resources: &HashMap<ResourceRef, ResourceInfo>,
 ) -> Option<Backend> {
@@ -183,7 +183,7 @@ pub(super) fn convert_backend(
     }
 }
 
-pub(crate) fn convert_filter(filter: gateway::GRPCRouteRulesFilters) -> Result<Filter> {
+pub(crate) fn convert_filter(filter: gateway::GrpcRouteRulesFilters) -> Result<Filter> {
     if let Some(request_header_modifier) = filter.request_header_modifier {
         let filter = routes::grpc::request_header_modifier(request_header_modifier)?;
         return Ok(Filter::RequestHeaderModifier(filter));
@@ -202,7 +202,7 @@ pub(crate) fn convert_filter(filter: gateway::GRPCRouteRulesFilters) -> Result<F
 }
 
 pub(crate) fn convert_backend_filter(
-    filter: gateway::GRPCRouteRulesBackendRefsFilters,
+    filter: gateway::GrpcRouteRulesBackendRefsFilters,
 ) -> Result<Filter> {
     if let Some(request_header_modifier) = filter.request_header_modifier {
         let filter = routes::grpc::backend_request_header_modifier(request_header_modifier)?;
@@ -274,7 +274,7 @@ pub fn parse_grpc_retry(
 }
 
 pub(super) fn route_accepted_by_resource_port(
-    route_status: Option<&gateway::GRPCRouteStatus>,
+    route_status: Option<&gateway::GrpcRouteStatus>,
     resource_port: &ResourcePort,
 ) -> bool {
     let (kind, group) = match resource_port.kind {
@@ -308,13 +308,12 @@ pub(super) fn route_accepted_by_resource_port(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
 pub fn route_accepted_by_service(
-    route_status: Option<&gateway::GRPCRouteStatus>,
+    route_status: Option<&gateway::GrpcRouteStatus>,
     service: &str,
 ) -> bool {
     let mut service_group = &*Service::group(&());
@@ -336,12 +335,11 @@ pub fn route_accepted_by_service(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
-pub(crate) fn backend_kind(backend: &gateway::GRPCRouteRulesBackendRefs) -> Option<ResourceKind> {
+pub(crate) fn backend_kind(backend: &gateway::GrpcRouteRulesBackendRefs) -> Option<ResourceKind> {
     let group = backend.group.as_deref();
     // Backends default to `Service` if no kind is specified.
     let kind = backend.kind.as_deref().unwrap_or("Service");

--- a/policy-controller/k8s/index/src/outbound/index/http.rs
+++ b/policy-controller/k8s/index/src/outbound/index/http.rs
@@ -156,7 +156,7 @@ fn convert_linkerd_rule(
 
 fn convert_gateway_rule(
     ns: &str,
-    rule: gateway::HTTPRouteRules,
+    rule: gateway::HttpRouteRules,
     cluster: &ClusterInfo,
     resource_info: &HashMap<ResourceRef, ResourceInfo>,
     mut timeouts: RouteTimeouts,
@@ -207,7 +207,7 @@ fn convert_gateway_rule(
 
 pub(super) fn convert_backend(
     ns: &str,
-    backend: gateway::HTTPRouteRulesBackendRefs,
+    backend: gateway::HttpRouteRulesBackendRefs,
     cluster: &ClusterInfo,
     resources: &HashMap<ResourceRef, ResourceInfo>,
 ) -> Option<Backend> {
@@ -316,7 +316,7 @@ fn convert_linkerd_filter(filter: policy::httproute::HttpRouteFilter) -> Result<
     Ok(filter)
 }
 
-pub(crate) fn convert_gateway_filter(filter: gateway::HTTPRouteRulesFilters) -> Result<Filter> {
+pub(crate) fn convert_gateway_filter(filter: gateway::HttpRouteRulesFilters) -> Result<Filter> {
     if let Some(request_header_modifier) = filter.request_header_modifier {
         let filter = routes::http::request_header_modifier(request_header_modifier)?;
         return Ok(Filter::RequestHeaderModifier(filter));
@@ -342,7 +342,7 @@ pub(crate) fn convert_gateway_filter(filter: gateway::HTTPRouteRulesFilters) -> 
 }
 
 pub(crate) fn convert_gateway_backend_filter(
-    filter: gateway::HTTPRouteRulesBackendRefsFilters,
+    filter: gateway::HttpRouteRulesBackendRefsFilters,
 ) -> Result<Filter> {
     if let Some(request_header_modifier) = filter.request_header_modifier {
         let filter = routes::http::backend_request_header_modifier(request_header_modifier)?;
@@ -445,7 +445,7 @@ pub fn parse_http_retry(
 }
 
 pub(super) fn route_accepted_by_resource_port(
-    route_status: Option<&gateway::HTTPRouteStatus>,
+    route_status: Option<&gateway::HttpRouteStatus>,
     resource_port: &ResourcePort,
 ) -> bool {
     let (kind, group) = match resource_port.kind {
@@ -479,13 +479,12 @@ pub(super) fn route_accepted_by_resource_port(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
 pub fn route_accepted_by_service(
-    route_status: Option<&gateway::HTTPRouteStatus>,
+    route_status: Option<&gateway::HttpRouteStatus>,
     service: &str,
 ) -> bool {
     let mut service_group = &*Service::group(&());
@@ -507,12 +506,11 @@ pub fn route_accepted_by_service(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
-pub(crate) fn backend_kind(backend: &gateway::HTTPRouteRulesBackendRefs) -> Option<ResourceKind> {
+pub(crate) fn backend_kind(backend: &gateway::HttpRouteRulesBackendRefs) -> Option<ResourceKind> {
     let group = backend.group.as_deref();
     // Backends default to `Service` if no kind is specified.
     let kind = backend.kind.as_deref().unwrap_or("Service");

--- a/policy-controller/k8s/index/src/outbound/index/tcp.rs
+++ b/policy-controller/k8s/index/src/outbound/index/tcp.rs
@@ -25,7 +25,6 @@ pub(super) fn convert_route(
         .backend_refs
         .clone()
         .into_iter()
-        .flatten()
         .filter_map(|b| convert_backend(ns, b, cluster, resource_info))
         .collect();
 
@@ -39,7 +38,7 @@ pub(super) fn convert_route(
 
 pub(super) fn convert_backend(
     ns: &str,
-    backend: gateway::TCPRouteRulesBackendRefs,
+    backend: gateway::TcpRouteRulesBackendRefs,
     cluster: &ClusterInfo,
     resources: &HashMap<ResourceRef, ResourceInfo>,
 ) -> Option<Backend> {
@@ -108,7 +107,7 @@ pub(super) fn convert_backend(
 }
 
 pub(super) fn route_accepted_by_resource_port(
-    route_status: Option<&gateway::TCPRouteStatus>,
+    route_status: Option<&gateway::TcpRouteStatus>,
     resource_port: &ResourcePort,
 ) -> bool {
     let (kind, group) = match resource_port.kind {
@@ -142,13 +141,12 @@ pub(super) fn route_accepted_by_resource_port(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
 pub fn route_accepted_by_service(
-    route_status: Option<&gateway::TCPRouteStatus>,
+    route_status: Option<&gateway::TcpRouteStatus>,
     service: &str,
 ) -> bool {
     let mut service_group = &*Service::group(&());
@@ -170,12 +168,11 @@ pub fn route_accepted_by_service(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
-pub(crate) fn backend_kind(backend: &gateway::TCPRouteRulesBackendRefs) -> Option<ResourceKind> {
+pub(crate) fn backend_kind(backend: &gateway::TcpRouteRulesBackendRefs) -> Option<ResourceKind> {
     let group = backend.group.as_deref();
     // Backends default to `Service` if no kind is specified.
     let kind = backend.kind.as_deref().unwrap_or("Service");

--- a/policy-controller/k8s/index/src/outbound/index/tls.rs
+++ b/policy-controller/k8s/index/src/outbound/index/tls.rs
@@ -25,7 +25,6 @@ pub(super) fn convert_route(
         .spec
         .hostnames
         .into_iter()
-        .flatten()
         .map(routes::host_match)
         .collect();
 
@@ -33,7 +32,6 @@ pub(super) fn convert_route(
         .backend_refs
         .clone()
         .into_iter()
-        .flatten()
         .filter_map(|b| convert_backend(ns, b, cluster, resource_info))
         .collect();
 
@@ -48,7 +46,7 @@ pub(super) fn convert_route(
 
 pub(super) fn convert_backend(
     ns: &str,
-    backend: gateway::TLSRouteRulesBackendRefs,
+    backend: gateway::TlsRouteRulesBackendRefs,
     cluster: &ClusterInfo,
     resources: &HashMap<ResourceRef, ResourceInfo>,
 ) -> Option<Backend> {
@@ -117,7 +115,7 @@ pub(super) fn convert_backend(
 }
 
 pub(super) fn route_accepted_by_resource_port(
-    route_status: Option<&gateway::TLSRouteStatus>,
+    route_status: Option<&gateway::TlsRouteStatus>,
     resource_port: &ResourcePort,
 ) -> bool {
     let (kind, group) = match resource_port.kind {
@@ -151,13 +149,12 @@ pub(super) fn route_accepted_by_resource_port(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
 pub fn route_accepted_by_service(
-    route_status: Option<&gateway::TLSRouteStatus>,
+    route_status: Option<&gateway::TlsRouteStatus>,
     service: &str,
 ) -> bool {
     let mut service_group = &*Service::group(&());
@@ -179,12 +176,11 @@ pub fn route_accepted_by_service(
                 && parent_status
                     .conditions
                     .iter()
-                    .flatten()
                     .any(|condition| condition.type_ == "Accepted" && condition.status == "True")
         })
 }
 
-pub(crate) fn backend_kind(backend: &gateway::TLSRouteRulesBackendRefs) -> Option<ResourceKind> {
+pub(crate) fn backend_kind(backend: &gateway::TlsRouteRulesBackendRefs) -> Option<ResourceKind> {
     let group = backend.group.as_deref();
     // Backends default to `Service` if no kind is specified.
     let kind = backend.kind.as_deref().unwrap_or("Service");

--- a/policy-controller/k8s/index/src/outbound/tests.rs
+++ b/policy-controller/k8s/index/src/outbound/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     outbound::index::{Index, SharedIndex},
     ClusterInfo,
 };
-use k8s_openapi::chrono::Utc;
+use k8s_openapi::jiff::Timestamp;
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_core::{outbound, IpNet};
 use linkerd_policy_controller_core::{
@@ -56,7 +56,7 @@ pub fn mk_egress_network(ns: impl ToString, name: impl ToString) -> policy::Egre
         },
         status: Some(policy::EgressNetworkStatus {
             conditions: vec![k8s::Condition {
-                last_transition_time: k8s::Time(Utc::now()),
+                last_transition_time: k8s::Time(Timestamp::now()),
                 message: "".to_string(),
                 observed_generation: None,
                 reason: "Accepted".to_string(),
@@ -246,7 +246,7 @@ fn update_backend_on_route_with_no_port() {
 
     test.index.write().apply(parent);
 
-    let parent_ref = gateway::HTTPRouteParentRefs {
+    let parent_ref = gateway::HttpRouteParentRefs {
         name: "parent-svc".to_string(),
         namespace: Some(ns.to_string()),
         kind: Some("Service".to_string()),
@@ -261,15 +261,15 @@ fn update_backend_on_route_with_no_port() {
             name: Some("foo-route".to_string()),
             ..Default::default()
         },
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![parent_ref.clone()]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
                 matches: None,
                 filters: None,
                 // Reference to a backend that doesn't exist yet.
-                backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                     weight: Some(1),
                     group: Some("core".to_string()),
                     kind: Some("Service".to_string()),
@@ -281,10 +281,11 @@ fn update_backend_on_route_with_no_port() {
                 }]),
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
-        status: Some(gateway::HTTPRouteStatus {
-            parents: vec![gateway::HTTPRouteStatusParents {
-                parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+        status: Some(gateway::HttpRouteStatus {
+            parents: vec![gateway::HttpRouteStatusParents {
+                parent_ref: gateway::HttpRouteStatusParentsParentRef {
                     name: "parent-svc".to_string(),
                     namespace: Some(ns.to_string()),
                     kind: Some("Service".to_string()),
@@ -293,14 +294,14 @@ fn update_backend_on_route_with_no_port() {
                     port: None, // Route is attached to parent without specifying port.
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![k8s::Condition {
-                    last_transition_time: k8s::Time(Utc::now()),
+                conditions: vec![k8s::Condition {
+                    last_transition_time: k8s::Time(Timestamp::now()),
                     message: "".to_string(),
                     observed_generation: None,
                     reason: "Accepted".to_string(),
                     status: "True".to_string(),
                     type_: "Accepted".to_string(),
-                }]),
+                }],
             }],
         }),
     };

--- a/policy-controller/k8s/index/src/outbound/tests/routes/grpc.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/grpc.rs
@@ -187,11 +187,11 @@ fn mk_route(
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
-            creation_timestamp: Some(Time(Utc::now())),
+            creation_timestamp: Some(Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::GRPCRouteSpec {
-            parent_refs: Some(vec![gateway::GRPCRouteParentRefs {
+        spec: gateway::GrpcRouteSpec {
+            parent_refs: Some(vec![gateway::GrpcRouteParentRefs {
                 group: Some(group.clone()),
                 kind: Some(kind.clone()),
                 namespace: Some(ns.to_string()),
@@ -200,18 +200,18 @@ fn mk_route(
                 port: Some(port.into()),
             }]),
             hostnames: None,
-            rules: Some(vec![gateway::GRPCRouteRules {
+            rules: Some(vec![gateway::GrpcRouteRules {
                 name: None,
-                matches: Some(vec![gateway::GRPCRouteRulesMatches {
+                matches: Some(vec![gateway::GrpcRouteRulesMatches {
                     headers: None,
-                    method: Some(gateway::GRPCRouteRulesMatchesMethod {
+                    method: Some(gateway::GrpcRouteRulesMatchesMethod {
                         method: Some("Test".to_string()),
                         service: Some("io.linkerd.Testing".to_string()),
-                        r#type: Some(gateway::GRPCRouteRulesMatchesMethodType::Exact),
+                        r#type: Some(gateway::GrpcRouteRulesMatchesMethodType::Exact),
                     }),
                 }]),
                 filters: None,
-                backend_refs: Some(vec![gateway::GRPCRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::GrpcRouteRulesBackendRefs {
                     filters: None,
                     weight: None,
                     group: Some(group.clone()),
@@ -222,10 +222,11 @@ fn mk_route(
                 }]),
                 session_persistence: None,
             }]),
+            use_default_gateways: None,
         },
-        status: Some(gateway::GRPCRouteStatus {
-            parents: vec![gateway::GRPCRouteStatusParents {
-                parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+        status: Some(gateway::GrpcRouteStatus {
+            parents: vec![gateway::GrpcRouteStatusParents {
+                parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                     group: Some(group.clone()),
                     kind: Some(kind.clone()),
                     namespace: Some(ns.to_string()),
@@ -234,14 +235,14 @@ fn mk_route(
                     port: Some(port.into()),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![k8s::Condition {
-                    last_transition_time: Time(chrono::DateTime::<Utc>::MIN_UTC),
+                conditions: vec![k8s::Condition {
+                    last_transition_time: Time(Timestamp::MIN),
                     message: "".to_string(),
                     observed_generation: None,
                     reason: "Accepted".to_string(),
                     status: "True".to_string(),
                     type_: "Accepted".to_string(),
-                }]),
+                }],
             }],
         }),
     }

--- a/policy-controller/k8s/index/src/outbound/tests/routes/http.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/http.rs
@@ -191,11 +191,11 @@ fn mk_route(
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
-            creation_timestamp: Some(Time(Utc::now())),
+            creation_timestamp: Some(Time(Timestamp::now())),
             ..Default::default()
         },
         spec: HttpRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: Some(group.clone()),
                 kind: Some(kind.clone()),
                 namespace: Some(ns.to_string()),
@@ -205,17 +205,17 @@ fn mk_route(
             }]),
             hostnames: None,
             rules: Some(vec![HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo/bar".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
                     headers: None,
                     query_params: None,
-                    method: Some(gateway::HTTPRouteRulesMatchesMethod::Get),
+                    method: Some(gateway::HttpRouteRulesMatchesMethod::Get),
                 }]),
                 filters: None,
-                backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                     weight: None,
                     group: Some(group.clone()),
                     kind: Some(kind.clone()),
@@ -227,9 +227,9 @@ fn mk_route(
                 timeouts: None,
             }]),
         },
-        status: Some(gateway::HTTPRouteStatus {
-            parents: vec![gateway::HTTPRouteStatusParents {
-                parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+        status: Some(gateway::HttpRouteStatus {
+            parents: vec![gateway::HttpRouteStatusParents {
+                parent_ref: gateway::HttpRouteStatusParentsParentRef {
                     group: Some(group),
                     kind: Some(kind),
                     namespace: Some(ns.to_string()),
@@ -238,14 +238,14 @@ fn mk_route(
                     port: Some(port.into()),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![k8s::Condition {
-                    last_transition_time: Time(chrono::DateTime::<Utc>::MIN_UTC),
+                conditions: vec![k8s::Condition {
+                    last_transition_time: Time(Timestamp::MIN),
                     message: "".to_string(),
                     observed_generation: None,
                     reason: "Accepted".to_string(),
                     status: "True".to_string(),
                     type_: "Accepted".to_string(),
-                }]),
+                }],
             }],
         }),
     }

--- a/policy-controller/k8s/index/src/outbound/tests/routes/tcp.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/tcp.rs
@@ -181,11 +181,11 @@ fn mk_route(
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
-            creation_timestamp: Some(Time(Utc::now())),
+            creation_timestamp: Some(Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::TCPRouteSpec {
-            parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+        spec: gateway::TcpRouteSpec {
+            parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                 group: Some(group.clone()),
                 kind: Some(kind.clone()),
                 namespace: Some(ns.to_string()),
@@ -193,21 +193,22 @@ fn mk_route(
                 section_name: None,
                 port: Some(port.into()),
             }]),
-            rules: vec![gateway::TCPRouteRules {
+            rules: vec![gateway::TcpRouteRules {
                 name: None,
-                backend_refs: Some(vec![gateway::TCPRouteRulesBackendRefs {
+                backend_refs: vec![gateway::TcpRouteRulesBackendRefs {
                     weight: None,
                     group: Some(group.clone()),
                     kind: Some(kind.clone()),
                     namespace: Some(ns.to_string()),
                     name: backend_name.to_string(),
                     port: Some(port.into()),
-                }]),
+                }],
             }],
+            use_default_gateways: None,
         },
-        status: Some(gateway::TCPRouteStatus {
-            parents: vec![gateway::TCPRouteStatusParents {
-                parent_ref: gateway::TCPRouteStatusParentsParentRef {
+        status: Some(gateway::TcpRouteStatus {
+            parents: vec![gateway::TcpRouteStatusParents {
+                parent_ref: gateway::TcpRouteStatusParentsParentRef {
                     group: Some(group.clone()),
                     kind: Some(kind.clone()),
                     namespace: Some(ns.to_string()),
@@ -216,14 +217,14 @@ fn mk_route(
                     port: Some(port.into()),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![k8s::Condition {
-                    last_transition_time: Time(chrono::DateTime::<Utc>::MIN_UTC),
+                conditions: vec![k8s::Condition {
+                    last_transition_time: Time(Timestamp::MIN),
                     message: "".to_string(),
                     observed_generation: None,
                     reason: "Accepted".to_string(),
                     status: "True".to_string(),
                     type_: "Accepted".to_string(),
-                }]),
+                }],
             }],
         }),
     }

--- a/policy-controller/k8s/index/src/outbound/tests/routes/tls.rs
+++ b/policy-controller/k8s/index/src/outbound/tests/routes/tls.rs
@@ -181,11 +181,11 @@ fn mk_route(
         metadata: k8s::ObjectMeta {
             namespace: Some(ns.to_string()),
             name: Some(name.to_string()),
-            creation_timestamp: Some(Time(Utc::now())),
+            creation_timestamp: Some(Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::TLSRouteSpec {
-            parent_refs: Some(vec![gateway::TLSRouteParentRefs {
+        spec: gateway::TlsRouteSpec {
+            parent_refs: Some(vec![gateway::TlsRouteParentRefs {
                 group: Some(group.clone()),
                 kind: Some(kind.clone()),
                 namespace: Some(ns.to_string()),
@@ -193,22 +193,23 @@ fn mk_route(
                 section_name: None,
                 port: Some(port.into()),
             }]),
-            hostnames: None,
-            rules: vec![gateway::TLSRouteRules {
+            hostnames: Vec::default(),
+            rules: vec![gateway::TlsRouteRules {
                 name: None,
-                backend_refs: Some(vec![gateway::TLSRouteRulesBackendRefs {
+                backend_refs: vec![gateway::TlsRouteRulesBackendRefs {
                     weight: None,
                     group: Some(group.clone()),
                     kind: Some(kind.clone()),
                     namespace: Some(ns.to_string()),
                     name: backend_name.to_string(),
                     port: Some(port.into()),
-                }]),
+                }],
             }],
+            use_default_gateways: None,
         },
-        status: Some(gateway::TLSRouteStatus {
-            parents: vec![gateway::TLSRouteStatusParents {
-                parent_ref: gateway::TLSRouteStatusParentsParentRef {
+        status: Some(gateway::TlsRouteStatus {
+            parents: vec![gateway::TlsRouteStatusParents {
+                parent_ref: gateway::TlsRouteStatusParentsParentRef {
                     group: Some(group.clone()),
                     kind: Some(kind.clone()),
                     namespace: Some(ns.to_string()),
@@ -217,14 +218,14 @@ fn mk_route(
                     port: Some(port.into()),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![k8s::Condition {
-                    last_transition_time: Time(chrono::DateTime::<Utc>::MIN_UTC),
+                conditions: vec![k8s::Condition {
+                    last_transition_time: Time(Timestamp::MIN),
                     message: "".to_string(),
                     observed_generation: None,
                     reason: "Accepted".to_string(),
                     status: "True".to_string(),
                     type_: "Accepted".to_string(),
-                }]),
+                }],
             }],
         }),
     }

--- a/policy-controller/k8s/index/src/routes.rs
+++ b/policy-controller/k8s/index/src/routes.rs
@@ -25,14 +25,14 @@ impl HttpRouteResource {
         }
     }
 
-    pub(crate) fn parent_refs(&self) -> &Option<Vec<gateway::HTTPRouteParentRefs>> {
+    pub(crate) fn parent_refs(&self) -> &Option<Vec<gateway::HttpRouteParentRefs>> {
         match self {
             Self::LinkerdHttp(route) => &route.spec.parent_refs,
             Self::GatewayHttp(route) => &route.spec.parent_refs,
         }
     }
 
-    pub(crate) fn status(&self) -> Option<&gateway::HTTPRouteStatus> {
+    pub(crate) fn status(&self) -> Option<&gateway::HttpRouteStatus> {
         match self {
             Self::LinkerdHttp(route) => route.status.as_ref(),
             Self::GatewayHttp(route) => route.status.as_ref(),

--- a/policy-controller/k8s/index/src/routes/grpc.rs
+++ b/policy-controller/k8s/index/src/routes/grpc.rs
@@ -3,7 +3,7 @@ use linkerd_policy_controller_core::routes;
 use linkerd_policy_controller_k8s_api::gateway;
 
 pub fn try_match(
-    gateway::GRPCRouteRulesMatches { headers, method }: gateway::GRPCRouteRulesMatches,
+    gateway::GrpcRouteRulesMatches { headers, method }: gateway::GrpcRouteRulesMatches,
 ) -> Result<routes::GrpcRouteMatch> {
     let headers = headers
         .into_iter()
@@ -13,7 +13,7 @@ pub fn try_match(
 
     let method = method
         .map(|value| {
-            if value.r#type == Some(gateway::GRPCRouteRulesMatchesMethodType::RegularExpression) {
+            if value.r#type == Some(gateway::GrpcRouteRulesMatchesMethodType::RegularExpression) {
                 bail!(
                     "unsupported GRPCRoute method match type: {:?}",
                     value.r#type
@@ -30,27 +30,27 @@ pub fn try_match(
 }
 
 pub fn header_match(
-    header_match: gateway::GRPCRouteRulesMatchesHeaders,
+    header_match: gateway::GrpcRouteRulesMatchesHeaders,
 ) -> Result<routes::HeaderMatch> {
     match header_match.r#type {
-        Some(gateway::GRPCRouteRulesMatchesHeadersType::Exact) | None => Ok(
+        Some(gateway::GrpcRouteRulesMatchesHeadersType::Exact) | None => Ok(
             routes::HeaderMatch::Exact(header_match.name.parse()?, header_match.value.parse()?),
         ),
-        Some(gateway::GRPCRouteRulesMatchesHeadersType::RegularExpression) => Ok(
+        Some(gateway::GrpcRouteRulesMatchesHeadersType::RegularExpression) => Ok(
             routes::HeaderMatch::Regex(header_match.name.parse()?, header_match.value.parse()?),
         ),
     }
 }
 
 pub fn request_header_modifier(
-    gateway::GRPCRouteRulesFiltersRequestHeaderModifier { set, add, remove }: gateway::GRPCRouteRulesFiltersRequestHeaderModifier,
+    gateway::GrpcRouteRulesFiltersRequestHeaderModifier { set, add, remove }: gateway::GrpcRouteRulesFiltersRequestHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesFiltersRequestHeaderModifierAdd { name, value }| {
+                |gateway::GrpcRouteRulesFiltersRequestHeaderModifierAdd { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -59,7 +59,7 @@ pub fn request_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesFiltersRequestHeaderModifierSet { name, value }| {
+                |gateway::GrpcRouteRulesFiltersRequestHeaderModifierSet { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -73,14 +73,14 @@ pub fn request_header_modifier(
 }
 
 pub fn backend_request_header_modifier(
-    gateway::GRPCRouteRulesBackendRefsFiltersRequestHeaderModifier { set, add, remove }: gateway::GRPCRouteRulesBackendRefsFiltersRequestHeaderModifier,
+    gateway::GrpcRouteRulesBackendRefsFiltersRequestHeaderModifier { set, add, remove }: gateway::GrpcRouteRulesBackendRefsFiltersRequestHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
+                |gateway::GrpcRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },
@@ -90,7 +90,7 @@ pub fn backend_request_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
+                |gateway::GrpcRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },
@@ -105,14 +105,14 @@ pub fn backend_request_header_modifier(
 }
 
 pub fn response_header_modifier(
-    gateway::GRPCRouteRulesFiltersResponseHeaderModifier { set, add, remove }: gateway::GRPCRouteRulesFiltersResponseHeaderModifier,
+    gateway::GrpcRouteRulesFiltersResponseHeaderModifier { set, add, remove }: gateway::GrpcRouteRulesFiltersResponseHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesFiltersResponseHeaderModifierAdd { name, value }| {
+                |gateway::GrpcRouteRulesFiltersResponseHeaderModifierAdd { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -121,7 +121,7 @@ pub fn response_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesFiltersResponseHeaderModifierSet { name, value }| {
+                |gateway::GrpcRouteRulesFiltersResponseHeaderModifierSet { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -135,14 +135,14 @@ pub fn response_header_modifier(
 }
 
 pub fn backend_response_header_modifier(
-    gateway::GRPCRouteRulesBackendRefsFiltersResponseHeaderModifier { set, add, remove }: gateway::GRPCRouteRulesBackendRefsFiltersResponseHeaderModifier,
+    gateway::GrpcRouteRulesBackendRefsFiltersResponseHeaderModifier { set, add, remove }: gateway::GrpcRouteRulesBackendRefsFiltersResponseHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesBackendRefsFiltersResponseHeaderModifierAdd {
+                |gateway::GrpcRouteRulesBackendRefsFiltersResponseHeaderModifierAdd {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },
@@ -152,7 +152,7 @@ pub fn backend_response_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::GRPCRouteRulesBackendRefsFiltersResponseHeaderModifierSet {
+                |gateway::GrpcRouteRulesBackendRefsFiltersResponseHeaderModifierSet {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },

--- a/policy-controller/k8s/index/src/routes/http.rs
+++ b/policy-controller/k8s/index/src/routes/http.rs
@@ -4,12 +4,12 @@ use linkerd_policy_controller_k8s_api::gateway;
 use std::num::NonZeroU16;
 
 pub fn try_match(
-    gateway::HTTPRouteRulesMatches {
+    gateway::HttpRouteRulesMatches {
         path,
         headers,
         query_params,
         method,
-    }: gateway::HTTPRouteRulesMatches,
+    }: gateway::HttpRouteRulesMatches,
 ) -> Result<routes::HttpRouteMatch> {
     let path = path.map(path_match).transpose()?;
 
@@ -26,15 +26,15 @@ pub fn try_match(
         .collect::<Result<_>>()?;
 
     let method = method.map(|m| match m {
-        gateway::HTTPRouteRulesMatchesMethod::Get => routes::Method::GET,
-        gateway::HTTPRouteRulesMatchesMethod::Head => routes::Method::HEAD,
-        gateway::HTTPRouteRulesMatchesMethod::Post => routes::Method::POST,
-        gateway::HTTPRouteRulesMatchesMethod::Put => routes::Method::PUT,
-        gateway::HTTPRouteRulesMatchesMethod::Delete => routes::Method::DELETE,
-        gateway::HTTPRouteRulesMatchesMethod::Connect => routes::Method::CONNECT,
-        gateway::HTTPRouteRulesMatchesMethod::Options => routes::Method::OPTIONS,
-        gateway::HTTPRouteRulesMatchesMethod::Trace => routes::Method::TRACE,
-        gateway::HTTPRouteRulesMatchesMethod::Patch => routes::Method::PATCH,
+        gateway::HttpRouteRulesMatchesMethod::Get => routes::Method::GET,
+        gateway::HttpRouteRulesMatchesMethod::Head => routes::Method::HEAD,
+        gateway::HttpRouteRulesMatchesMethod::Post => routes::Method::POST,
+        gateway::HttpRouteRulesMatchesMethod::Put => routes::Method::PUT,
+        gateway::HttpRouteRulesMatchesMethod::Delete => routes::Method::DELETE,
+        gateway::HttpRouteRulesMatchesMethod::Connect => routes::Method::CONNECT,
+        gateway::HttpRouteRulesMatchesMethod::Options => routes::Method::OPTIONS,
+        gateway::HttpRouteRulesMatchesMethod::Trace => routes::Method::TRACE,
+        gateway::HttpRouteRulesMatchesMethod::Patch => routes::Method::PATCH,
     });
 
     Ok(routes::HttpRouteMatch {
@@ -45,22 +45,22 @@ pub fn try_match(
     })
 }
 
-pub fn path_match(path_match: gateway::HTTPRouteRulesMatchesPath) -> Result<routes::PathMatch> {
+pub fn path_match(path_match: gateway::HttpRouteRulesMatchesPath) -> Result<routes::PathMatch> {
     let value = path_match.value.unwrap_or_else(|| "/".to_string());
     match path_match.r#type {
-        Some(gateway::HTTPRouteRulesMatchesPathType::Exact) => {
+        Some(gateway::HttpRouteRulesMatchesPathType::Exact) => {
             if !value.starts_with('/') {
                 bail!("HttpPathMatch paths must be absolute (begin with `/`); {value:?} is not an absolute path")
             }
             Ok(routes::PathMatch::Exact(value))
         }
-        Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix) | None => {
+        Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix) | None => {
             if !value.starts_with('/') {
                 bail!("HttpPathMatch paths must be absolute (begin with `/`); {value:?} is not an absolute path")
             }
             Ok(routes::PathMatch::Prefix(value))
         }
-        Some(gateway::HTTPRouteRulesMatchesPathType::RegularExpression) => value
+        Some(gateway::HttpRouteRulesMatchesPathType::RegularExpression) => value
             .parse()
             .map(routes::PathMatch::Regex)
             .map_err(Into::into),
@@ -68,40 +68,40 @@ pub fn path_match(path_match: gateway::HTTPRouteRulesMatchesPath) -> Result<rout
 }
 
 pub fn header_match(
-    header_match: gateway::HTTPRouteRulesMatchesHeaders,
+    header_match: gateway::HttpRouteRulesMatchesHeaders,
 ) -> Result<routes::HeaderMatch> {
     match header_match.r#type {
-        Some(gateway::HTTPRouteRulesMatchesHeadersType::Exact) | None => Ok(
+        Some(gateway::HttpRouteRulesMatchesHeadersType::Exact) | None => Ok(
             routes::HeaderMatch::Exact(header_match.name.parse()?, header_match.value.parse()?),
         ),
-        Some(gateway::HTTPRouteRulesMatchesHeadersType::RegularExpression) => Ok(
+        Some(gateway::HttpRouteRulesMatchesHeadersType::RegularExpression) => Ok(
             routes::HeaderMatch::Regex(header_match.name.parse()?, header_match.value.parse()?),
         ),
     }
 }
 
 pub fn query_param_match(
-    query_match: gateway::HTTPRouteRulesMatchesQueryParams,
+    query_match: gateway::HttpRouteRulesMatchesQueryParams,
 ) -> Result<routes::QueryParamMatch> {
     match query_match.r#type {
-        Some(gateway::HTTPRouteRulesMatchesQueryParamsType::Exact) | None => Ok(
+        Some(gateway::HttpRouteRulesMatchesQueryParamsType::Exact) | None => Ok(
             routes::QueryParamMatch::Exact(query_match.name, query_match.value),
         ),
-        Some(gateway::HTTPRouteRulesMatchesQueryParamsType::RegularExpression) => Ok(
+        Some(gateway::HttpRouteRulesMatchesQueryParamsType::RegularExpression) => Ok(
             routes::QueryParamMatch::Regex(query_match.name, query_match.value.parse()?),
         ),
     }
 }
 
 pub fn request_header_modifier(
-    gateway::HTTPRouteRulesFiltersRequestHeaderModifier { set, add, remove }: gateway::HTTPRouteRulesFiltersRequestHeaderModifier,
+    gateway::HttpRouteRulesFiltersRequestHeaderModifier { set, add, remove }: gateway::HttpRouteRulesFiltersRequestHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesFiltersRequestHeaderModifierAdd { name, value }| {
+                |gateway::HttpRouteRulesFiltersRequestHeaderModifierAdd { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -110,7 +110,7 @@ pub fn request_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesFiltersRequestHeaderModifierSet { name, value }| {
+                |gateway::HttpRouteRulesFiltersRequestHeaderModifierSet { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -124,14 +124,14 @@ pub fn request_header_modifier(
 }
 
 pub fn backend_request_header_modifier(
-    gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifier { set, add, remove }: gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifier,
+    gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifier { set, add, remove }: gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
+                |gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },
@@ -141,7 +141,7 @@ pub fn backend_request_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
+                |gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },
@@ -156,14 +156,14 @@ pub fn backend_request_header_modifier(
 }
 
 pub fn response_header_modifier(
-    gateway::HTTPRouteRulesFiltersResponseHeaderModifier { set, add, remove }: gateway::HTTPRouteRulesFiltersResponseHeaderModifier,
+    gateway::HttpRouteRulesFiltersResponseHeaderModifier { set, add, remove }: gateway::HttpRouteRulesFiltersResponseHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesFiltersResponseHeaderModifierAdd { name, value }| {
+                |gateway::HttpRouteRulesFiltersResponseHeaderModifierAdd { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -172,7 +172,7 @@ pub fn response_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesFiltersResponseHeaderModifierSet { name, value }| {
+                |gateway::HttpRouteRulesFiltersResponseHeaderModifierSet { name, value }| {
                     Ok((name.parse()?, value.parse()?))
                 },
             )
@@ -186,14 +186,14 @@ pub fn response_header_modifier(
 }
 
 pub fn backend_response_header_modifier(
-    gateway::HTTPRouteRulesBackendRefsFiltersResponseHeaderModifier { set, add, remove }: gateway::HTTPRouteRulesBackendRefsFiltersResponseHeaderModifier,
+    gateway::HttpRouteRulesBackendRefsFiltersResponseHeaderModifier { set, add, remove }: gateway::HttpRouteRulesBackendRefsFiltersResponseHeaderModifier,
 ) -> Result<routes::HeaderModifierFilter> {
     Ok(routes::HeaderModifierFilter {
         add: add
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesBackendRefsFiltersResponseHeaderModifierAdd {
+                |gateway::HttpRouteRulesBackendRefsFiltersResponseHeaderModifierAdd {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },
@@ -203,7 +203,7 @@ pub fn backend_response_header_modifier(
             .into_iter()
             .flatten()
             .map(
-                |gateway::HTTPRouteRulesBackendRefsFiltersResponseHeaderModifierSet {
+                |gateway::HttpRouteRulesBackendRefsFiltersResponseHeaderModifierSet {
                      name,
                      value,
                  }| { Ok((name.parse()?, value.parse()?)) },
@@ -218,17 +218,17 @@ pub fn backend_response_header_modifier(
 }
 
 pub fn req_redirect(
-    gateway::HTTPRouteRulesFiltersRequestRedirect {
+    gateway::HttpRouteRulesFiltersRequestRedirect {
         scheme,
         hostname,
         path,
         port,
         status_code,
-    }: gateway::HTTPRouteRulesFiltersRequestRedirect,
+    }: gateway::HttpRouteRulesFiltersRequestRedirect,
 ) -> Result<routes::RequestRedirectFilter> {
     let scheme = scheme.map(|s| match s {
-        gateway::HTTPRouteRulesFiltersRequestRedirectScheme::Http => routes::Scheme::HTTP,
-        gateway::HTTPRouteRulesFiltersRequestRedirectScheme::Https => routes::Scheme::HTTPS,
+        gateway::HttpRouteRulesFiltersRequestRedirectScheme::Http => routes::Scheme::HTTP,
+        gateway::HttpRouteRulesFiltersRequestRedirectScheme::Https => routes::Scheme::HTTPS,
     });
     Ok(routes::RequestRedirectFilter {
         scheme,
@@ -246,19 +246,19 @@ pub fn req_redirect(
 }
 
 pub fn backend_req_redirect(
-    gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirect {
+    gateway::HttpRouteRulesBackendRefsFiltersRequestRedirect {
         scheme,
         hostname,
         path,
         port,
         status_code,
-    }: gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirect,
+    }: gateway::HttpRouteRulesBackendRefsFiltersRequestRedirect,
 ) -> Result<routes::RequestRedirectFilter> {
     let scheme = scheme.map(|s| match s {
-        gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectScheme::Http => {
+        gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectScheme::Http => {
             routes::Scheme::HTTP
         }
-        gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectScheme::Https => {
+        gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectScheme::Https => {
             routes::Scheme::HTTPS
         }
     });
@@ -278,7 +278,7 @@ pub fn backend_req_redirect(
 }
 
 fn path_modifier(
-    path_modifier: gateway::HTTPRouteRulesFiltersRequestRedirectPath,
+    path_modifier: gateway::HttpRouteRulesFiltersRequestRedirectPath,
 ) -> Result<routes::PathModifier> {
     if let Some(path) = path_modifier.replace_full_path {
         if !path.starts_with('/') {
@@ -302,7 +302,7 @@ fn path_modifier(
 }
 
 fn backend_path_modifier(
-    path_modifier: gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectPath,
+    path_modifier: gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectPath,
 ) -> Result<routes::PathModifier> {
     if let Some(path) = path_modifier.replace_full_path {
         if !path.starts_with('/') {

--- a/policy-controller/k8s/status/Cargo.toml
+++ b/policy-controller/k8s/status/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 [dependencies]
 ahash = "0.8"
 anyhow = "1"
-# Fix for https://github.com/chronotope/chrono/issues/602
-chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
+jiff = { workspace = true }
 parking_lot = "0.12"
 prometheus-client = { workspace = true }
 serde = "1"

--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
-use chrono::{offset::Utc, DateTime};
+use jiff::Timestamp;
 use kubert::lease::Claim;
 use linkerd_policy_controller_core::{routes::GroupKindName, IpNet, POLICY_CONTROLLER_NAME};
 use linkerd_policy_controller_k8s_api::{
@@ -82,10 +82,10 @@ pub struct Index {
 
     /// Maps route ids to a list of their parent and backend refs,
     /// regardless of if those parents have accepted the route.
-    http_route_refs: HashMap<NamespaceGroupKindName, HTTPRouteRef>,
-    grpc_route_refs: HashMap<NamespaceGroupKindName, GRPCRouteRef>,
-    tcp_route_refs: HashMap<NamespaceGroupKindName, TCPRouteRef>,
-    tls_route_refs: HashMap<NamespaceGroupKindName, TLSRouteRef>,
+    http_route_refs: HashMap<NamespaceGroupKindName, HttpRouteRef>,
+    grpc_route_refs: HashMap<NamespaceGroupKindName, GrpcRouteRef>,
+    tcp_route_refs: HashMap<NamespaceGroupKindName, TcpRouteRef>,
+    tls_route_refs: HashMap<NamespaceGroupKindName, TlsRouteRef>,
 
     /// Maps rate limit ids to a list of details about these rate limits.
     ratelimits: HashMap<ResourceId, HttpLocalRateLimitPolicyRef>,
@@ -112,14 +112,14 @@ pub(crate) struct RouteRef<S> {
     pub(crate) statuses: Vec<S>,
 }
 
-pub(crate) type HTTPRouteRef = RouteRef<gateway::HTTPRouteStatus>;
-pub(crate) type GRPCRouteRef = RouteRef<gateway::GRPCRouteStatus>;
-pub(crate) type TLSRouteRef = RouteRef<gateway::TLSRouteStatus>;
-pub(crate) type TCPRouteRef = RouteRef<gateway::TCPRouteStatus>;
+pub(crate) type HttpRouteRef = RouteRef<gateway::HttpRouteStatus>;
+pub(crate) type GrpcRouteRef = RouteRef<gateway::GrpcRouteStatus>;
+pub(crate) type TlsRouteRef = RouteRef<gateway::TlsRouteStatus>;
+pub(crate) type TcpRouteRef = RouteRef<gateway::TcpRouteStatus>;
 
 #[derive(Clone, PartialEq, Debug)]
 struct HttpLocalRateLimitPolicyRef {
-    creation_timestamp: Option<DateTime<Utc>>,
+    creation_timestamp: Option<Timestamp>,
     target_ref: ratelimit::TargetReference,
     status_conditions: Vec<k8s::Condition>,
 }
@@ -441,7 +441,7 @@ impl Index {
     pub(crate) fn update_http_route(
         &mut self,
         id: NamespaceGroupKindName,
-        route: &HTTPRouteRef,
+        route: &HttpRouteRef,
     ) -> bool {
         match self.http_route_refs.entry(id) {
             Entry::Vacant(entry) => {
@@ -462,7 +462,7 @@ impl Index {
     pub(crate) fn update_grpc_route(
         &mut self,
         id: NamespaceGroupKindName,
-        route: &GRPCRouteRef,
+        route: &GrpcRouteRef,
     ) -> bool {
         match self.grpc_route_refs.entry(id) {
             Entry::Vacant(entry) => {
@@ -483,7 +483,7 @@ impl Index {
     pub(crate) fn update_tls_route(
         &mut self,
         id: NamespaceGroupKindName,
-        route: &TLSRouteRef,
+        route: &TlsRouteRef,
     ) -> bool {
         match self.tls_route_refs.entry(id) {
             Entry::Vacant(entry) => {
@@ -504,7 +504,7 @@ impl Index {
     pub(crate) fn update_tcp_route(
         &mut self,
         id: NamespaceGroupKindName,
-        route: &TCPRouteRef,
+        route: &TcpRouteRef,
     ) -> bool {
         match self.tcp_route_refs.entry(id) {
             Entry::Vacant(entry) => {
@@ -648,12 +648,12 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
-    ) -> Option<gateway::GRPCRouteStatusParents> {
+    ) -> Option<gateway::GrpcRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
                 let condition = self.parent_condition_server(server, id, parent_ref);
-                Some(gateway::GRPCRouteStatusParents {
-                    parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+                Some(gateway::GrpcRouteStatusParents {
+                    parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
                         kind: Some("Server".to_string()),
                         namespace: Some(server.namespace.clone()),
@@ -662,14 +662,14 @@ impl Index {
                         port: None,
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition]),
+                    conditions: vec![condition],
                 })
             }
 
             routes::ParentReference::Service(service, port) => {
                 let condition = self.parent_condition_service(service, id, parent_ref);
-                Some(gateway::GRPCRouteStatusParents {
-                    parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+                Some(gateway::GrpcRouteStatusParents {
+                    parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
                         kind: Some("Service".to_string()),
                         namespace: Some(service.namespace.clone()),
@@ -678,14 +678,14 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
                 let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
-                Some(gateway::GRPCRouteStatusParents {
-                    parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+                Some(gateway::GrpcRouteStatusParents {
+                    parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
                         kind: Some("EgressNetwork".to_string()),
                         namespace: Some(egress_net.namespace.clone()),
@@ -694,7 +694,7 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
             routes::ParentReference::UnknownKind => None,
@@ -706,12 +706,12 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
-    ) -> Option<gateway::HTTPRouteStatusParents> {
+    ) -> Option<gateway::HttpRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
                 let condition = self.parent_condition_server(server, id, parent_ref);
-                Some(gateway::HTTPRouteStatusParents {
-                    parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+                Some(gateway::HttpRouteStatusParents {
+                    parent_ref: gateway::HttpRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
                         kind: Some("Server".to_string()),
                         namespace: Some(server.namespace.clone()),
@@ -720,14 +720,14 @@ impl Index {
                         port: None,
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition]),
+                    conditions: vec![condition],
                 })
             }
 
             routes::ParentReference::Service(service, port) => {
                 let condition = self.parent_condition_service(service, id, parent_ref);
-                Some(gateway::HTTPRouteStatusParents {
-                    parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+                Some(gateway::HttpRouteStatusParents {
+                    parent_ref: gateway::HttpRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
                         kind: Some("Service".to_string()),
                         namespace: Some(service.namespace.clone()),
@@ -736,14 +736,14 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
                 let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
-                Some(gateway::HTTPRouteStatusParents {
-                    parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+                Some(gateway::HttpRouteStatusParents {
+                    parent_ref: gateway::HttpRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
                         kind: Some("EgressNetwork".to_string()),
                         namespace: Some(egress_net.namespace.clone()),
@@ -752,7 +752,7 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
             routes::ParentReference::UnknownKind => None,
@@ -764,12 +764,12 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
-    ) -> Option<gateway::TLSRouteStatusParents> {
+    ) -> Option<gateway::TlsRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
                 let condition = self.parent_condition_server(server, id, parent_ref);
-                Some(gateway::TLSRouteStatusParents {
-                    parent_ref: gateway::TLSRouteStatusParentsParentRef {
+                Some(gateway::TlsRouteStatusParents {
+                    parent_ref: gateway::TlsRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
                         kind: Some("Server".to_string()),
                         namespace: Some(server.namespace.clone()),
@@ -778,14 +778,14 @@ impl Index {
                         port: None,
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition]),
+                    conditions: vec![condition],
                 })
             }
 
             routes::ParentReference::Service(service, port) => {
                 let condition = self.parent_condition_service(service, id, parent_ref);
-                Some(gateway::TLSRouteStatusParents {
-                    parent_ref: gateway::TLSRouteStatusParentsParentRef {
+                Some(gateway::TlsRouteStatusParents {
+                    parent_ref: gateway::TlsRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
                         kind: Some("Service".to_string()),
                         namespace: Some(service.namespace.clone()),
@@ -794,14 +794,14 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
                 let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
-                Some(gateway::TLSRouteStatusParents {
-                    parent_ref: gateway::TLSRouteStatusParentsParentRef {
+                Some(gateway::TlsRouteStatusParents {
+                    parent_ref: gateway::TlsRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
                         kind: Some("EgressNetwork".to_string()),
                         namespace: Some(egress_net.namespace.clone()),
@@ -810,7 +810,7 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
             routes::ParentReference::UnknownKind => None,
@@ -822,12 +822,12 @@ impl Index {
         id: &NamespaceGroupKindName,
         parent_ref: &routes::ParentReference,
         backend_condition: k8s::Condition,
-    ) -> Option<gateway::TCPRouteStatusParents> {
+    ) -> Option<gateway::TcpRouteStatusParents> {
         match parent_ref {
             routes::ParentReference::Server(server) => {
                 let condition = self.parent_condition_server(server, id, parent_ref);
-                Some(gateway::TCPRouteStatusParents {
-                    parent_ref: gateway::TCPRouteStatusParentsParentRef {
+                Some(gateway::TcpRouteStatusParents {
+                    parent_ref: gateway::TcpRouteStatusParentsParentRef {
                         group: Some(POLICY_API_GROUP.to_string()),
                         kind: Some("Server".to_string()),
                         namespace: Some(server.namespace.clone()),
@@ -836,14 +836,14 @@ impl Index {
                         port: None,
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition]),
+                    conditions: vec![condition],
                 })
             }
 
             routes::ParentReference::Service(service, port) => {
                 let condition = self.parent_condition_service(service, id, parent_ref);
-                Some(gateway::TCPRouteStatusParents {
-                    parent_ref: gateway::TCPRouteStatusParentsParentRef {
+                Some(gateway::TcpRouteStatusParents {
+                    parent_ref: gateway::TcpRouteStatusParentsParentRef {
                         group: Some("core".to_string()),
                         kind: Some("Service".to_string()),
                         namespace: Some(service.namespace.clone()),
@@ -852,14 +852,14 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
 
             routes::ParentReference::EgressNetwork(egress_net, port) => {
                 let condition = self.parent_condition_egress_network(egress_net, id, parent_ref);
-                Some(gateway::TCPRouteStatusParents {
-                    parent_ref: gateway::TCPRouteStatusParentsParentRef {
+                Some(gateway::TcpRouteStatusParents {
+                    parent_ref: gateway::TcpRouteStatusParentsParentRef {
                         group: Some("policy.linkerd.io".to_string()),
                         kind: Some("EgressNetwork".to_string()),
                         namespace: Some(egress_net.namespace.clone()),
@@ -868,7 +868,7 @@ impl Index {
                         port: port.map(Into::into),
                     },
                     controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                    conditions: Some(vec![condition, backend_condition]),
+                    conditions: vec![condition, backend_condition],
                 })
             }
             routes::ParentReference::UnknownKind => None,
@@ -920,7 +920,7 @@ impl Index {
     fn make_http_route_patch(
         &self,
         id: &NamespaceGroupKindName,
-        route: &HTTPRouteRef,
+        route: &HttpRouteRef,
     ) -> Option<k8s::Patch<serde_json::Value>> {
         // To preserve any statuses from other controllers, we copy those
         // statuses.
@@ -946,7 +946,7 @@ impl Index {
             return None;
         }
 
-        let status = gateway::HTTPRouteStatus {
+        let status = gateway::HttpRouteStatus {
             parents: all_statuses,
         };
 
@@ -956,7 +956,7 @@ impl Index {
     fn make_grpc_route_patch(
         &self,
         id: &NamespaceGroupKindName,
-        route: &GRPCRouteRef,
+        route: &GrpcRouteRef,
     ) -> Option<k8s::Patch<serde_json::Value>> {
         // To preserve any statuses from other controllers, we copy those
         // statuses.
@@ -983,7 +983,7 @@ impl Index {
             return None;
         }
 
-        let status = gateway::GRPCRouteStatus {
+        let status = gateway::GrpcRouteStatus {
             parents: all_statuses,
         };
 
@@ -993,7 +993,7 @@ impl Index {
     fn make_tls_route_patch(
         &self,
         id: &NamespaceGroupKindName,
-        route: &TLSRouteRef,
+        route: &TlsRouteRef,
     ) -> Option<k8s::Patch<serde_json::Value>> {
         // To preserve any statuses from other controllers, we copy those
         // statuses.
@@ -1020,7 +1020,7 @@ impl Index {
             return None;
         }
 
-        let status = gateway::TLSRouteStatus {
+        let status = gateway::TlsRouteStatus {
             parents: all_statuses,
         };
 
@@ -1030,7 +1030,7 @@ impl Index {
     fn make_tcp_route_patch(
         &self,
         id: &NamespaceGroupKindName,
-        route: &TCPRouteRef,
+        route: &TcpRouteRef,
     ) -> Option<k8s::Patch<serde_json::Value>> {
         // To preserve any statuses from other controllers, we copy those
         // statuses.
@@ -1057,7 +1057,7 @@ impl Index {
             return None;
         }
 
-        let status = gateway::TCPRouteStatus {
+        let status = gateway::TcpRouteStatus {
             parents: all_statuses,
         };
 
@@ -1363,10 +1363,10 @@ impl kubert::index::IndexNamespacedResource<policy::HttpRoute> for Index {
 
         // Construct route and insert into the index; if the HTTPRoute is
         // already in the index, and it hasn't changed, skip creating a patch.
-        let route = HTTPRouteRef {
+        let route = HttpRouteRef {
             parents,
             backends,
-            statuses: vec![gateway::HTTPRouteStatus { parents: statuses }],
+            statuses: vec![gateway::HttpRouteStatus { parents: statuses }],
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1436,7 +1436,7 @@ impl kubert::index::IndexNamespacedResource<gateway::HTTPRoute> for Index {
         let route = RouteRef {
             parents,
             backends,
-            statuses: vec![gateway::HTTPRouteStatus { parents: statuses }],
+            statuses: vec![gateway::HttpRouteStatus { parents: statuses }],
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1506,7 +1506,7 @@ impl kubert::index::IndexNamespacedResource<gateway::GRPCRoute> for Index {
         let route = RouteRef {
             parents,
             backends,
-            statuses: vec![gateway::GRPCRouteStatus { parents: statuses }],
+            statuses: vec![gateway::GrpcRouteStatus { parents: statuses }],
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1560,8 +1560,7 @@ impl kubert::index::IndexNamespacedResource<gateway::TLSRoute> for Index {
                 .spec
                 .rules
                 .into_iter()
-                .flat_map(|rule| rule.backend_refs)
-                .flatten(),
+                .flat_map(|rule| rule.backend_refs),
         );
 
         let statuses = resource
@@ -1575,7 +1574,7 @@ impl kubert::index::IndexNamespacedResource<gateway::TLSRoute> for Index {
         let route = RouteRef {
             parents,
             backends,
-            statuses: vec![gateway::TLSRouteStatus { parents: statuses }],
+            statuses: vec![gateway::TlsRouteStatus { parents: statuses }],
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1629,8 +1628,7 @@ impl kubert::index::IndexNamespacedResource<gateway::TCPRoute> for Index {
                 .spec
                 .rules
                 .into_iter()
-                .flat_map(|rule| rule.backend_refs)
-                .flatten(),
+                .flat_map(|rule| rule.backend_refs),
         );
 
         let statuses = resource
@@ -1644,7 +1642,7 @@ impl kubert::index::IndexNamespacedResource<gateway::TCPRoute> for Index {
         let route = RouteRef {
             parents,
             backends,
-            statuses: vec![gateway::TCPRouteStatus { parents: statuses }],
+            statuses: vec![gateway::TcpRouteStatus { parents: statuses }],
         };
         tracing::trace!(?route);
         // Insert into the index; if the route is already in the index, and it hasn't
@@ -1814,11 +1812,11 @@ where
     }
 }
 
-fn now() -> DateTime<Utc> {
+fn now() -> Timestamp {
     #[cfg(not(test))]
-    let now = Utc::now();
+    let now = Timestamp::now();
     #[cfg(test)]
-    let now = DateTime::<Utc>::MIN_UTC;
+    let now = Timestamp::MIN;
     now
 }
 
@@ -1944,8 +1942,8 @@ pub(crate) fn invalid_backend_kind(message: &str) -> k8s::Condition {
 }
 
 pub(crate) fn eq_time_insensitive_http_route_parent_statuses(
-    left: &[gateway::HTTPRouteStatusParents],
-    right: &[gateway::HTTPRouteStatusParents],
+    left: &[gateway::HttpRouteStatusParents],
+    right: &[gateway::HttpRouteStatusParents],
 ) -> bool {
     if left.len() != right.len() {
         return false;
@@ -1970,18 +1968,14 @@ pub(crate) fn eq_time_insensitive_http_route_parent_statuses(
 
     // Compare each element in sorted order
     left_sorted.iter().zip(right_sorted.iter()).all(|(l, r)| {
-        let cond_eq = match (&l.conditions, &r.conditions) {
-            (Some(l), Some(r)) => eq_time_insensitive_conditions(l.as_ref(), r.as_ref()),
-            (None, None) => true,
-            _ => false,
-        };
+        let cond_eq = eq_time_insensitive_conditions(&l.conditions, &r.conditions);
         l.parent_ref == r.parent_ref && l.controller_name == r.controller_name && cond_eq
     })
 }
 
 pub(crate) fn eq_time_insensitive_grpc_route_parent_statuses(
-    left: &[gateway::GRPCRouteStatusParents],
-    right: &[gateway::GRPCRouteStatusParents],
+    left: &[gateway::GrpcRouteStatusParents],
+    right: &[gateway::GrpcRouteStatusParents],
 ) -> bool {
     if left.len() != right.len() {
         return false;
@@ -2006,18 +2000,14 @@ pub(crate) fn eq_time_insensitive_grpc_route_parent_statuses(
 
     // Compare each element in sorted order
     left_sorted.iter().zip(right_sorted.iter()).all(|(l, r)| {
-        let cond_eq = match (&l.conditions, &r.conditions) {
-            (Some(l), Some(r)) => eq_time_insensitive_conditions(l.as_ref(), r.as_ref()),
-            (None, None) => true,
-            _ => false,
-        };
+        let cond_eq = eq_time_insensitive_conditions(&l.conditions, &r.conditions);
         l.parent_ref == r.parent_ref && l.controller_name == r.controller_name && cond_eq
     })
 }
 
 pub(crate) fn eq_time_insensitive_tls_route_parent_statuses(
-    left: &[gateway::TLSRouteStatusParents],
-    right: &[gateway::TLSRouteStatusParents],
+    left: &[gateway::TlsRouteStatusParents],
+    right: &[gateway::TlsRouteStatusParents],
 ) -> bool {
     if left.len() != right.len() {
         return false;
@@ -2042,18 +2032,14 @@ pub(crate) fn eq_time_insensitive_tls_route_parent_statuses(
 
     // Compare each element in sorted order
     left_sorted.iter().zip(right_sorted.iter()).all(|(l, r)| {
-        let cond_eq = match (&l.conditions, &r.conditions) {
-            (Some(l), Some(r)) => eq_time_insensitive_conditions(l.as_ref(), r.as_ref()),
-            (None, None) => true,
-            _ => false,
-        };
+        let cond_eq = eq_time_insensitive_conditions(&l.conditions, &r.conditions);
         l.parent_ref == r.parent_ref && l.controller_name == r.controller_name && cond_eq
     })
 }
 
 pub(crate) fn eq_time_insensitive_tcp_route_parent_statuses(
-    left: &[gateway::TCPRouteStatusParents],
-    right: &[gateway::TCPRouteStatusParents],
+    left: &[gateway::TcpRouteStatusParents],
+    right: &[gateway::TcpRouteStatusParents],
 ) -> bool {
     if left.len() != right.len() {
         return false;
@@ -2078,11 +2064,7 @@ pub(crate) fn eq_time_insensitive_tcp_route_parent_statuses(
 
     // Compare each element in sorted order
     left_sorted.iter().zip(right_sorted.iter()).all(|(l, r)| {
-        let cond_eq = match (&l.conditions, &r.conditions) {
-            (Some(l), Some(r)) => eq_time_insensitive_conditions(l.as_ref(), r.as_ref()),
-            (None, None) => true,
-            _ => false,
-        };
+        let cond_eq = eq_time_insensitive_conditions(&l.conditions, &r.conditions);
         l.parent_ref == r.parent_ref && l.controller_name == r.controller_name && cond_eq
     })
 }

--- a/policy-controller/k8s/status/src/routes/grpc.rs
+++ b/policy-controller/k8s/status/src/routes/grpc.rs
@@ -10,7 +10,7 @@ use linkerd_policy_controller_k8s_api::{
 
 pub(crate) fn make_backends(
     namespace: &str,
-    backends: impl Iterator<Item = gateway::GRPCRouteRulesBackendRefs>,
+    backends: impl Iterator<Item = gateway::GrpcRouteRulesBackendRefs>,
 ) -> Vec<BackendReference> {
     backends
         .map(|backend_ref| to_backend_ref(&backend_ref, namespace))
@@ -19,7 +19,7 @@ pub(crate) fn make_backends(
 
 pub(crate) fn make_parents(
     namespace: &str,
-    parents: &[gateway::GRPCRouteParentRefs],
+    parents: &[gateway::GrpcRouteParentRefs],
 ) -> Vec<ParentReference> {
     parents
         .iter()
@@ -32,7 +32,7 @@ pub(crate) fn make_parents(
 }
 
 fn to_parent_ref(
-    parent_ref: &gateway::GRPCRouteParentRefs,
+    parent_ref: &gateway::GrpcRouteParentRefs,
     default_namespace: &str,
 ) -> Result<ParentReference> {
     if parent_ref_targets_kind::<policy::Server>(parent_ref) {
@@ -65,7 +65,7 @@ fn to_parent_ref(
 }
 
 fn to_backend_ref(
-    backend_ref: &gateway::GRPCRouteRulesBackendRefs,
+    backend_ref: &gateway::GrpcRouteRulesBackendRefs,
     default_namespace: &str,
 ) -> BackendReference {
     if backend_ref_targets_kind::<k8s::Service>(backend_ref) {
@@ -105,16 +105,16 @@ mod test {
                 name: Some("foo".to_string()),
                 ..Default::default()
             },
-            spec: gateway::GRPCRouteSpec {
+            spec: gateway::GrpcRouteSpec {
                 parent_refs: None,
                 hostnames: None,
                 rules: Some(vec![
-                    gateway::GRPCRouteRules {
+                    gateway::GrpcRouteRules {
                         name: None,
                         matches: None,
                         filters: None,
                         backend_refs: Some(vec![
-                            gateway::GRPCRouteRulesBackendRefs {
+                            gateway::GrpcRouteRulesBackendRefs {
                                 group: None,
                                 kind: None,
                                 name: "ref-1".to_string(),
@@ -123,7 +123,7 @@ mod test {
                                 filters: None,
                                 weight: None,
                             },
-                            gateway::GRPCRouteRulesBackendRefs {
+                            gateway::GrpcRouteRulesBackendRefs {
                                 group: None,
                                 kind: None,
                                 name: "ref-2".to_string(),
@@ -135,11 +135,11 @@ mod test {
                         ]),
                         session_persistence: None,
                     },
-                    gateway::GRPCRouteRules {
+                    gateway::GrpcRouteRules {
                         name: None,
                         matches: None,
                         filters: None,
-                        backend_refs: Some(vec![gateway::GRPCRouteRulesBackendRefs {
+                        backend_refs: Some(vec![gateway::GrpcRouteRulesBackendRefs {
                             group: Some("Core".to_string()),
                             kind: Some("Service".to_string()),
                             name: "ref-3".to_string(),
@@ -150,7 +150,7 @@ mod test {
                         }]),
                         session_persistence: None,
                     },
-                    gateway::GRPCRouteRules {
+                    gateway::GrpcRouteRules {
                         name: None,
                         matches: None,
                         filters: None,
@@ -158,6 +158,7 @@ mod test {
                         session_persistence: None,
                     },
                 ]),
+                use_default_gateways: None,
             },
             status: None,
         };
@@ -194,15 +195,15 @@ mod test {
                 name: Some("foo".to_string()),
                 ..Default::default()
             },
-            spec: gateway::GRPCRouteSpec {
+            spec: gateway::GrpcRouteSpec {
                 parent_refs: None,
                 hostnames: None,
-                rules: Some(vec![gateway::GRPCRouteRules {
+                rules: Some(vec![gateway::GrpcRouteRules {
                     name: None,
                     matches: None,
                     filters: None,
                     backend_refs: Some(vec![
-                        gateway::GRPCRouteRulesBackendRefs {
+                        gateway::GrpcRouteRulesBackendRefs {
                             group: None,
                             kind: None,
                             name: "ref-1".to_string(),
@@ -211,7 +212,7 @@ mod test {
                             filters: None,
                             weight: None,
                         },
-                        gateway::GRPCRouteRulesBackendRefs {
+                        gateway::GrpcRouteRulesBackendRefs {
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("EgressNetwork".to_string()),
                             name: "ref-3".to_string(),
@@ -220,7 +221,7 @@ mod test {
                             filters: None,
                             weight: None,
                         },
-                        gateway::GRPCRouteRulesBackendRefs {
+                        gateway::GrpcRouteRulesBackendRefs {
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("Server".to_string()),
                             name: "ref-2".to_string(),
@@ -232,6 +233,7 @@ mod test {
                     ]),
                     session_persistence: None,
                 }]),
+                use_default_gateways: None,
             },
             status: None,
         };

--- a/policy-controller/k8s/status/src/routes/http.rs
+++ b/policy-controller/k8s/status/src/routes/http.rs
@@ -10,14 +10,14 @@ use linkerd_policy_controller_k8s_api::{
 
 pub(crate) fn make_backends(
     namespace: &str,
-    backends: impl Iterator<Item = gateway::HTTPRouteRulesBackendRefs>,
+    backends: impl Iterator<Item = gateway::HttpRouteRulesBackendRefs>,
 ) -> Vec<BackendReference> {
     backends.map(|br| to_backend_ref(&br, namespace)).collect()
 }
 
 pub(crate) fn make_parents(
     namespace: &str,
-    parents: &[gateway::HTTPRouteParentRefs],
+    parents: &[gateway::HttpRouteParentRefs],
 ) -> Vec<ParentReference> {
     parents
         .iter()
@@ -30,7 +30,7 @@ pub(crate) fn make_parents(
 }
 
 fn to_parent_ref(
-    parent_ref: &gateway::HTTPRouteParentRefs,
+    parent_ref: &gateway::HttpRouteParentRefs,
     default_namespace: &str,
 ) -> Result<ParentReference> {
     if parent_ref_targets_kind::<policy::Server>(parent_ref) {
@@ -63,7 +63,7 @@ fn to_parent_ref(
 }
 
 fn to_backend_ref(
-    backend_ref: &gateway::HTTPRouteRulesBackendRefs,
+    backend_ref: &gateway::HttpRouteRulesBackendRefs,
     default_namespace: &str,
 ) -> BackendReference {
     if backend_ref_targets_kind::<k8s::Service>(backend_ref) {
@@ -107,7 +107,7 @@ mod test {
                         matches: None,
                         filters: None,
                         backend_refs: Some(vec![
-                            gateway::HTTPRouteRulesBackendRefs {
+                            gateway::HttpRouteRulesBackendRefs {
                                 weight: None,
                                 group: None,
                                 kind: None,
@@ -116,7 +116,7 @@ mod test {
                                 port: None,
                                 filters: None,
                             },
-                            gateway::HTTPRouteRulesBackendRefs {
+                            gateway::HttpRouteRulesBackendRefs {
                                 weight: None,
                                 group: None,
                                 kind: None,
@@ -131,7 +131,7 @@ mod test {
                     policy::httproute::HttpRouteRule {
                         matches: None,
                         filters: None,
-                        backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                        backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                             weight: None,
                             group: Some("Core".to_string()),
                             kind: Some("Service".to_string()),
@@ -192,7 +192,7 @@ mod test {
                     matches: None,
                     filters: None,
                     backend_refs: Some(vec![
-                        gateway::HTTPRouteRulesBackendRefs {
+                        gateway::HttpRouteRulesBackendRefs {
                             weight: None,
                             group: None,
                             kind: None,
@@ -201,7 +201,7 @@ mod test {
                             port: None,
                             filters: None,
                         },
-                        gateway::HTTPRouteRulesBackendRefs {
+                        gateway::HttpRouteRulesBackendRefs {
                             weight: None,
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("EgressNetwork".to_string()),
@@ -210,7 +210,7 @@ mod test {
                             port: Some(555),
                             filters: None,
                         },
-                        gateway::HTTPRouteRulesBackendRefs {
+                        gateway::HttpRouteRulesBackendRefs {
                             weight: None,
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("Server".to_string()),

--- a/policy-controller/k8s/status/src/routes/tcp.rs
+++ b/policy-controller/k8s/status/src/routes/tcp.rs
@@ -10,14 +10,14 @@ use linkerd_policy_controller_k8s_api::{
 
 pub(crate) fn make_backends(
     namespace: &str,
-    backends: impl Iterator<Item = gateway::TCPRouteRulesBackendRefs>,
+    backends: impl Iterator<Item = gateway::TcpRouteRulesBackendRefs>,
 ) -> Vec<BackendReference> {
     backends.map(|br| to_backend_ref(&br, namespace)).collect()
 }
 
 pub(crate) fn make_parents(
     namespace: &str,
-    parents: &[gateway::TCPRouteParentRefs],
+    parents: &[gateway::TcpRouteParentRefs],
 ) -> Vec<ParentReference> {
     parents
         .iter()
@@ -30,7 +30,7 @@ pub(crate) fn make_parents(
 }
 
 fn to_parent_ref(
-    parent_ref: &gateway::TCPRouteParentRefs,
+    parent_ref: &gateway::TcpRouteParentRefs,
     default_namespace: &str,
 ) -> Result<ParentReference> {
     if parent_ref_targets_kind::<policy::Server>(parent_ref) {
@@ -63,7 +63,7 @@ fn to_parent_ref(
 }
 
 fn to_backend_ref(
-    backend_ref: &gateway::TCPRouteRulesBackendRefs,
+    backend_ref: &gateway::TcpRouteRulesBackendRefs,
     default_namespace: &str,
 ) -> BackendReference {
     if backend_ref_targets_kind::<k8s::Service>(backend_ref) {
@@ -102,13 +102,13 @@ mod test {
                 name: Some("foo".to_string()),
                 ..Default::default()
             },
-            spec: gateway::TCPRouteSpec {
+            spec: gateway::TcpRouteSpec {
                 parent_refs: None,
                 rules: vec![
-                    gateway::TCPRouteRules {
+                    gateway::TcpRouteRules {
                         name: None,
-                        backend_refs: Some(vec![
-                            gateway::TCPRouteRulesBackendRefs {
+                        backend_refs: vec![
+                            gateway::TcpRouteRulesBackendRefs {
                                 weight: None,
                                 group: None,
                                 kind: None,
@@ -116,7 +116,7 @@ mod test {
                                 namespace: Some("default".to_string()),
                                 port: None,
                             },
-                            gateway::TCPRouteRulesBackendRefs {
+                            gateway::TcpRouteRulesBackendRefs {
                                 weight: None,
                                 group: None,
                                 kind: None,
@@ -124,20 +124,21 @@ mod test {
                                 namespace: None,
                                 port: None,
                             },
-                        ]),
+                        ],
                     },
-                    gateway::TCPRouteRules {
+                    gateway::TcpRouteRules {
                         name: None,
-                        backend_refs: Some(vec![gateway::TCPRouteRulesBackendRefs {
+                        backend_refs: vec![gateway::TcpRouteRulesBackendRefs {
                             weight: None,
                             group: Some("Core".to_string()),
                             kind: Some("Service".to_string()),
                             name: "ref-3".to_string(),
                             namespace: Some("default".to_string()),
                             port: None,
-                        }]),
+                        }],
                     },
                 ],
+                use_default_gateways: None,
             },
             status: None,
         };
@@ -147,7 +148,6 @@ mod test {
             .rules
             .into_iter()
             .flat_map(|rule| rule.backend_refs)
-            .flatten()
             .map(|br| to_backend_ref(&br, "default"))
             .collect();
 
@@ -169,12 +169,12 @@ mod test {
                 name: Some("foo".to_string()),
                 ..Default::default()
             },
-            spec: gateway::TCPRouteSpec {
+            spec: gateway::TcpRouteSpec {
                 parent_refs: None,
-                rules: vec![gateway::TCPRouteRules {
+                rules: vec![gateway::TcpRouteRules {
                     name: None,
-                    backend_refs: Some(vec![
-                        gateway::TCPRouteRulesBackendRefs {
+                    backend_refs: vec![
+                        gateway::TcpRouteRulesBackendRefs {
                             weight: None,
                             group: None,
                             kind: None,
@@ -182,7 +182,7 @@ mod test {
                             namespace: None,
                             port: None,
                         },
-                        gateway::TCPRouteRulesBackendRefs {
+                        gateway::TcpRouteRulesBackendRefs {
                             weight: None,
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("EgressNetwork".to_string()),
@@ -190,7 +190,7 @@ mod test {
                             namespace: None,
                             port: Some(555),
                         },
-                        gateway::TCPRouteRulesBackendRefs {
+                        gateway::TcpRouteRulesBackendRefs {
                             weight: None,
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("Server".to_string()),
@@ -198,8 +198,9 @@ mod test {
                             namespace: None,
                             port: None,
                         },
-                    ]),
+                    ],
                 }],
+                use_default_gateways: None,
             },
             status: None,
         };
@@ -209,7 +210,6 @@ mod test {
             .rules
             .into_iter()
             .flat_map(|rule| rule.backend_refs)
-            .flatten()
             .map(|br| to_backend_ref(&br, "default"))
             .collect();
 

--- a/policy-controller/k8s/status/src/routes/tls.rs
+++ b/policy-controller/k8s/status/src/routes/tls.rs
@@ -10,14 +10,14 @@ use linkerd_policy_controller_k8s_api::{
 
 pub(crate) fn make_backends(
     namespace: &str,
-    backends: impl Iterator<Item = gateway::TLSRouteRulesBackendRefs>,
+    backends: impl Iterator<Item = gateway::TlsRouteRulesBackendRefs>,
 ) -> Vec<BackendReference> {
     backends.map(|br| to_backend_ref(&br, namespace)).collect()
 }
 
 pub(crate) fn make_parents(
     namespace: &str,
-    parents: &[gateway::TLSRouteParentRefs],
+    parents: &[gateway::TlsRouteParentRefs],
 ) -> Vec<ParentReference> {
     parents
         .iter()
@@ -30,7 +30,7 @@ pub(crate) fn make_parents(
 }
 
 fn to_parent_ref(
-    parent_ref: &gateway::TLSRouteParentRefs,
+    parent_ref: &gateway::TlsRouteParentRefs,
     default_namespace: &str,
 ) -> Result<ParentReference> {
     if parent_ref_targets_kind::<policy::Server>(parent_ref) {
@@ -63,7 +63,7 @@ fn to_parent_ref(
 }
 
 fn to_backend_ref(
-    backend_ref: &gateway::TLSRouteRulesBackendRefs,
+    backend_ref: &gateway::TlsRouteRulesBackendRefs,
     default_namespace: &str,
 ) -> BackendReference {
     if backend_ref_targets_kind::<k8s::Service>(backend_ref) {
@@ -102,14 +102,14 @@ mod test {
                 name: Some("foo".to_string()),
                 ..Default::default()
             },
-            spec: gateway::TLSRouteSpec {
+            spec: gateway::TlsRouteSpec {
                 parent_refs: None,
-                hostnames: None,
+                hostnames: Vec::default(),
                 rules: vec![
-                    gateway::TLSRouteRules {
+                    gateway::TlsRouteRules {
                         name: None,
-                        backend_refs: Some(vec![
-                            gateway::TLSRouteRulesBackendRefs {
+                        backend_refs: vec![
+                            gateway::TlsRouteRulesBackendRefs {
                                 weight: None,
                                 group: None,
                                 kind: None,
@@ -117,7 +117,7 @@ mod test {
                                 namespace: Some("default".to_string()),
                                 port: None,
                             },
-                            gateway::TLSRouteRulesBackendRefs {
+                            gateway::TlsRouteRulesBackendRefs {
                                 weight: None,
                                 group: None,
                                 kind: None,
@@ -125,20 +125,21 @@ mod test {
                                 namespace: None,
                                 port: None,
                             },
-                        ]),
+                        ],
                     },
-                    gateway::TLSRouteRules {
+                    gateway::TlsRouteRules {
                         name: None,
-                        backend_refs: Some(vec![gateway::TLSRouteRulesBackendRefs {
+                        backend_refs: vec![gateway::TlsRouteRulesBackendRefs {
                             weight: None,
                             group: Some("Core".to_string()),
                             kind: Some("Service".to_string()),
                             name: "ref-3".to_string(),
                             namespace: Some("default".to_string()),
                             port: None,
-                        }]),
+                        }],
                     },
                 ],
+                use_default_gateways: None,
             },
             status: None,
         };
@@ -148,7 +149,6 @@ mod test {
             .rules
             .into_iter()
             .flat_map(|rule| rule.backend_refs)
-            .flatten()
             .map(|br| to_backend_ref(&br, "default"))
             .collect();
 
@@ -170,13 +170,13 @@ mod test {
                 name: Some("foo".to_string()),
                 ..Default::default()
             },
-            spec: gateway::TLSRouteSpec {
+            spec: gateway::TlsRouteSpec {
                 parent_refs: None,
-                hostnames: None,
-                rules: vec![gateway::TLSRouteRules {
+                hostnames: Vec::default(),
+                rules: vec![gateway::TlsRouteRules {
                     name: None,
-                    backend_refs: Some(vec![
-                        gateway::TLSRouteRulesBackendRefs {
+                    backend_refs: vec![
+                        gateway::TlsRouteRulesBackendRefs {
                             weight: None,
                             group: None,
                             kind: None,
@@ -184,7 +184,7 @@ mod test {
                             namespace: None,
                             port: None,
                         },
-                        gateway::TLSRouteRulesBackendRefs {
+                        gateway::TlsRouteRulesBackendRefs {
                             weight: None,
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("EgressNetwork".to_string()),
@@ -192,7 +192,7 @@ mod test {
                             namespace: None,
                             port: Some(555),
                         },
-                        gateway::TLSRouteRulesBackendRefs {
+                        gateway::TlsRouteRulesBackendRefs {
                             weight: None,
                             group: Some(POLICY_API_GROUP.to_string()),
                             kind: Some("Server".to_string()),
@@ -200,8 +200,9 @@ mod test {
                             namespace: None,
                             port: None,
                         },
-                    ]),
+                    ],
                 }],
+                use_default_gateways: None,
             },
             status: None,
         };
@@ -211,7 +212,6 @@ mod test {
             .rules
             .into_iter()
             .flat_map(|rule| rule.backend_refs)
-            .flatten()
             .map(|br| to_backend_ref(&br, "default"))
             .collect();
 

--- a/policy-controller/k8s/status/src/tests/conflict.rs
+++ b/policy-controller/k8s/status/src/tests/conflict.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 use crate::{
-    index::{GRPCRouteRef, HTTPRouteRef, SharedIndex, TCPRouteRef, TLSRouteRef},
+    index::{GrpcRouteRef, HttpRouteRef, SharedIndex, TcpRouteRef, TlsRouteRef},
     resource_id::{NamespaceGroupKindName, ResourceId},
     routes,
     tests::default_cluster_networks,
     Index, IndexMetrics,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use linkerd_policy_controller_core::routes::GroupKindName;
 use linkerd_policy_controller_k8s_api::{gateway, Resource};
 use std::{sync::Arc, vec};
@@ -21,7 +21,7 @@ fn make_index() -> SharedIndex {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, _) = mpsc::channel(10000);
@@ -58,7 +58,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
                 name: "grpc-1".into(),
             },
         },
-        &GRPCRouteRef {
+        &GrpcRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -73,7 +73,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
                 name: "http-1".into(),
             },
         },
-        &HTTPRouteRef {
+        &HttpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -88,7 +88,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
                 name: "tls-1".into(),
             },
         },
-        &TLSRouteRef {
+        &TlsRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -103,7 +103,7 @@ fn grpc_route_no_conflict(p: ParentRefType) {
                 name: "tcp-1".into(),
             },
         },
-        &TCPRouteRef {
+        &TcpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -139,7 +139,7 @@ fn http_route_conflict_grpc(p: ParentRefType) {
                 name: "grpc-1".into(),
             },
         },
-        &GRPCRouteRef {
+        &GrpcRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -175,7 +175,7 @@ fn http_route_no_conflict(p: ParentRefType) {
                 name: "http-1".into(),
             },
         },
-        &HTTPRouteRef {
+        &HttpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -190,7 +190,7 @@ fn http_route_no_conflict(p: ParentRefType) {
                 name: "tls-1".into(),
             },
         },
-        &TLSRouteRef {
+        &TlsRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -205,7 +205,7 @@ fn http_route_no_conflict(p: ParentRefType) {
                 name: "tcp-1".into(),
             },
         },
-        &TCPRouteRef {
+        &TcpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -241,7 +241,7 @@ fn tls_route_conflict_http(p: ParentRefType) {
                 name: "http-1".into(),
             },
         },
-        &HTTPRouteRef {
+        &HttpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -277,7 +277,7 @@ fn tls_route_conflict_grpc(p: ParentRefType) {
                 name: "grpc-1".into(),
             },
         },
-        &GRPCRouteRef {
+        &GrpcRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -313,7 +313,7 @@ fn tls_route_no_conflict(p: ParentRefType) {
                 name: "tls-1".into(),
             },
         },
-        &TLSRouteRef {
+        &TlsRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -328,7 +328,7 @@ fn tls_route_no_conflict(p: ParentRefType) {
                 name: "tcp-1".into(),
             },
         },
-        &TCPRouteRef {
+        &TcpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -364,7 +364,7 @@ fn tcp_route_conflict_grpc(p: ParentRefType) {
                 name: "grpc-1".into(),
             },
         },
-        &GRPCRouteRef {
+        &GrpcRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -400,7 +400,7 @@ fn tcp_route_conflict_http(p: ParentRefType) {
                 name: "http-1".into(),
             },
         },
-        &HTTPRouteRef {
+        &HttpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -436,7 +436,7 @@ fn tcp_route_conflict_tls(p: ParentRefType) {
                 name: "tls-1".into(),
             },
         },
-        &TLSRouteRef {
+        &TlsRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],
@@ -472,7 +472,7 @@ fn tcp_route_no_conflict(p: ParentRefType) {
                 name: "tcp-1".into(),
             },
         },
-        &TCPRouteRef {
+        &TcpRouteRef {
             parents: vec![parent.clone()],
             statuses: vec![],
             backends: vec![],

--- a/policy-controller/k8s/status/src/tests/egress_network.rs
+++ b/policy-controller/k8s/status/src/tests/egress_network.rs
@@ -4,7 +4,7 @@ use crate::{
     tests::default_cluster_networks,
     Index, IndexMetrics,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_core::routes::GroupKindName;
 use linkerd_policy_controller_k8s_api::{
@@ -20,7 +20,7 @@ fn egress_network_with_no_networks_specified() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -73,7 +73,7 @@ fn egress_network_with_nonoverlapping_networks_specified() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -135,7 +135,7 @@ fn egress_network_with_overlapping_networks_specified() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);

--- a/policy-controller/k8s/status/src/tests/ratelimit.rs
+++ b/policy-controller/k8s/status/src/tests/ratelimit.rs
@@ -4,7 +4,7 @@ use crate::{
     tests::{default_cluster_networks, make_server},
     Index, IndexMetrics,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_core::routes::GroupKindName;
 use linkerd_policy_controller_k8s_api::{
@@ -162,7 +162,7 @@ fn make_index_updates_rx() -> (SharedIndex, Receiver<Update>) {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, updates_rx) = mpsc::channel(10000);

--- a/policy-controller/k8s/status/src/tests/routes/grpc.rs
+++ b/policy-controller/k8s/status/src/tests/routes/grpc.rs
@@ -7,7 +7,7 @@ use crate::{
     tests::{default_cluster_networks, make_server},
     Index, IndexMetrics,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_core::{routes::GroupKindName, POLICY_CONTROLLER_NAME};
 use linkerd_policy_controller_k8s_api::{self as k8s, gateway, policy, Resource, ResourceExt};
@@ -20,18 +20,18 @@ pub(crate) fn make_parent_status(
     type_: impl ToString,
     status: impl ToString,
     reason: impl ToString,
-) -> gateway::GRPCRouteStatusParents {
+) -> gateway::GrpcRouteStatusParents {
     let condition = k8s::Condition {
         message: "".to_string(),
         type_: type_.to_string(),
         observed_generation: None,
         reason: reason.to_string(),
         status: status.to_string(),
-        last_transition_time: k8s::Time(DateTime::<Utc>::MIN_UTC),
+        last_transition_time: k8s::Time(Timestamp::MIN),
     };
-    gateway::GRPCRouteStatusParents {
-        conditions: Some(vec![condition]),
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    gateway::GrpcRouteStatusParents {
+        conditions: vec![condition],
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             port: None,
             section_name: None,
             name: name.to_string(),
@@ -48,7 +48,7 @@ fn route_with_valid_service_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -73,7 +73,7 @@ fn route_with_valid_service_backends() {
     index.write().apply(backend2.clone());
 
     // Apply the route.
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -93,7 +93,7 @@ fn route_with_valid_service_backends() {
         &id,
         parent.clone(),
         Some(vec![
-            gateway::GRPCRouteRulesBackendRefs {
+            gateway::GrpcRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend1.name_unchecked(),
@@ -102,7 +102,7 @@ fn route_with_valid_service_backends() {
                 weight: None,
                 filters: None,
             },
-            gateway::GRPCRouteRulesBackendRefs {
+            gateway::GrpcRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend2.name_unchecked(),
@@ -119,8 +119,8 @@ fn route_with_valid_service_backends() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: Some("core".to_string()),
             kind: Some("Service".to_string()),
             namespace: parent.namespace,
@@ -129,9 +129,9 @@ fn route_with_valid_service_backends() {
             port: Some(8080),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -147,7 +147,7 @@ fn route_with_valid_egress_network_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -164,7 +164,7 @@ fn route_with_valid_egress_network_backend() {
     index.write().apply(parent.clone());
 
     // Apply the route.
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -183,7 +183,7 @@ fn route_with_valid_egress_network_backend() {
     let route = make_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::GRPCRouteRulesBackendRefs {
+        Some(vec![gateway::GrpcRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: parent.name.clone(),
@@ -199,8 +199,8 @@ fn route_with_valid_egress_network_backend() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -209,9 +209,9 @@ fn route_with_valid_egress_network_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -227,7 +227,7 @@ fn route_with_invalid_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -248,7 +248,7 @@ fn route_with_invalid_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -268,7 +268,7 @@ fn route_with_invalid_service_backend() {
         &id,
         parent.clone(),
         Some(vec![
-            gateway::GRPCRouteRulesBackendRefs {
+            gateway::GrpcRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend.name_unchecked(),
@@ -277,7 +277,7 @@ fn route_with_invalid_service_backend() {
                 filters: None,
                 weight: None,
             },
-            gateway::GRPCRouteRulesBackendRefs {
+            gateway::GrpcRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: "nonexistant-backend".to_string(),
@@ -294,8 +294,8 @@ fn route_with_invalid_service_backend() {
     let accepted_condition = accepted();
     // One of the backends does not exist so the status should be BackendNotFound.
     let backend_condition = backend_not_found();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -304,9 +304,9 @@ fn route_with_invalid_service_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -322,7 +322,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -343,7 +343,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -362,7 +362,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     let route = make_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::GRPCRouteRulesBackendRefs {
+        Some(vec![gateway::GrpcRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -379,8 +379,8 @@ fn route_with_egress_network_backend_different_from_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -389,9 +389,9 @@ fn route_with_egress_network_backend_different_from_parent() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -407,7 +407,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -428,7 +428,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -447,7 +447,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     let route = make_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::GRPCRouteRulesBackendRefs {
+        Some(vec![gateway::GrpcRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -464,8 +464,8 @@ fn route_with_egress_network_backend_and_service_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -474,9 +474,9 @@ fn route_with_egress_network_backend_and_service_parent() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -492,7 +492,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -513,7 +513,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -532,7 +532,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     let route = make_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::GRPCRouteRulesBackendRefs {
+        Some(vec![gateway::GrpcRouteRulesBackendRefs {
             group: Some("core".to_string()),
             kind: Some("Service".to_string()),
             name: backend.name_unchecked(),
@@ -547,8 +547,8 @@ fn route_with_egress_network_parent_and_service_backend() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -557,9 +557,9 @@ fn route_with_egress_network_parent_and_service_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -575,7 +575,7 @@ fn route_accepted_after_server_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -596,7 +596,7 @@ fn route_accepted_after_server_create() {
             group: gateway::GRPCRoute::group(&()),
         },
     };
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -617,7 +617,7 @@ fn route_accepted_after_server_create() {
         "False",
         "NoMatchingParent",
     );
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -642,7 +642,7 @@ fn route_accepted_after_server_create() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -660,7 +660,7 @@ fn route_accepted_after_egress_network_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -681,7 +681,7 @@ fn route_accepted_after_egress_network_create() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -697,8 +697,8 @@ fn route_accepted_after_egress_network_create() {
     // Create the expected update.
     let accepted_condition = no_matching_parent();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -707,10 +707,10 @@ fn route_accepted_after_egress_network_create() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -727,8 +727,8 @@ fn route_accepted_after_egress_network_create() {
 
     // Create the expected update.
     let accepted_condition = accepted();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -737,10 +737,10 @@ fn route_accepted_after_egress_network_create() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
 
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -758,7 +758,7 @@ fn route_rejected_after_server_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -792,7 +792,7 @@ fn route_rejected_after_server_delete() {
             group: gateway::GRPCRoute::group(&()),
         },
     };
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -808,7 +808,7 @@ fn route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -831,7 +831,7 @@ fn route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status("ns-0", "srv-8080", "Accepted", "False", "NoMatchingParent");
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -849,7 +849,7 @@ fn route_rejected_after_egress_network_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -876,7 +876,7 @@ fn route_rejected_after_egress_network_delete() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -892,8 +892,8 @@ fn route_rejected_after_egress_network_delete() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -902,10 +902,10 @@ fn route_rejected_after_egress_network_delete() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -927,8 +927,8 @@ fn route_rejected_after_egress_network_delete() {
 
     // Create the expected update.
     let rejected_condition = no_matching_parent();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -937,10 +937,10 @@ fn route_rejected_after_egress_network_delete() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![rejected_condition, backend_condition.clone()]),
+        conditions: vec![rejected_condition, backend_condition.clone()],
     };
 
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -958,7 +958,7 @@ fn service_route_type_conflict() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -974,7 +974,7 @@ fn service_route_type_conflict() {
     let parent = super::make_service("ns-0", "svc");
     index.write().apply(parent.clone());
 
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -997,11 +997,11 @@ fn service_route_type_conflict() {
         metadata: k8s::ObjectMeta {
             name: Some(http_id.gkn.name.to_string()),
             namespace: Some(http_id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::HTTPRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+        spec: gateway::HttpRouteSpec {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: parent.group.clone(),
                 kind: parent.kind.clone(),
                 name: parent.name.clone(),
@@ -1011,6 +1011,7 @@ fn service_route_type_conflict() {
             }]),
             hostnames: None,
             rules: Some(vec![]),
+            use_default_gateways: None,
         },
     };
     index.write().apply(http_route);
@@ -1019,8 +1020,8 @@ fn service_route_type_conflict() {
     let accepted_condition = accepted();
     // No backends were specified, so we have vacuously resolved them all.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -1029,9 +1030,9 @@ fn service_route_type_conflict() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+        conditions: vec![accepted_condition.clone(), backend_condition.clone()],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&http_id, status).unwrap();
@@ -1056,8 +1057,8 @@ fn service_route_type_conflict() {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::HTTPRoute::kind(&()) {
             let conflict_condition = route_conflicted();
-            let parent_status = gateway::GRPCRouteStatusParents {
-                parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+            let parent_status = gateway::GrpcRouteStatusParents {
+                parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1066,16 +1067,16 @@ fn service_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![conflict_condition, backend_condition.clone()]),
+                conditions: vec![conflict_condition, backend_condition.clone()],
             };
-            let status = gateway::GRPCRouteStatus {
+            let status = gateway::GrpcRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&http_id, status).unwrap();
             assert_eq!(patch, update.patch);
         } else {
-            let parent_status = gateway::GRPCRouteStatusParents {
-                parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+            let parent_status = gateway::GrpcRouteStatusParents {
+                parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1084,9 +1085,9 @@ fn service_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+                conditions: vec![accepted_condition.clone(), backend_condition.clone()],
             };
-            let status = gateway::GRPCRouteStatus {
+            let status = gateway::GrpcRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&grpc_id, status).unwrap();
@@ -1103,7 +1104,7 @@ fn egress_network_route_type_conflict() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1119,7 +1120,7 @@ fn egress_network_route_type_conflict() {
     let parent = super::make_egress_network("ns-0", "egress", accepted());
     index.write().apply(parent.clone());
 
-    let parent = gateway::GRPCRouteParentRefs {
+    let parent = gateway::GrpcRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -1142,11 +1143,11 @@ fn egress_network_route_type_conflict() {
         metadata: k8s::ObjectMeta {
             name: Some(http_id.gkn.name.to_string()),
             namespace: Some(http_id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::HTTPRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+        spec: gateway::HttpRouteSpec {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: parent.group.clone(),
                 kind: parent.kind.clone(),
                 name: parent.name.clone(),
@@ -1156,6 +1157,7 @@ fn egress_network_route_type_conflict() {
             }]),
             hostnames: None,
             rules: Some(vec![]),
+            use_default_gateways: None,
         },
     };
     index.write().apply(http_route);
@@ -1164,8 +1166,8 @@ fn egress_network_route_type_conflict() {
     let accepted_condition = accepted();
     // No backends were specified, so we have vacuously resolved them all.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::GRPCRouteStatusParents {
-        parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+    let parent_status = gateway::GrpcRouteStatusParents {
+        parent_ref: gateway::GrpcRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -1174,9 +1176,9 @@ fn egress_network_route_type_conflict() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+        conditions: vec![accepted_condition.clone(), backend_condition.clone()],
     };
-    let status = gateway::GRPCRouteStatus {
+    let status = gateway::GrpcRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&http_id, status).unwrap();
@@ -1201,8 +1203,8 @@ fn egress_network_route_type_conflict() {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::HTTPRoute::kind(&()) {
             let conflict_condition = route_conflicted();
-            let parent_status = gateway::GRPCRouteStatusParents {
-                parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+            let parent_status = gateway::GrpcRouteStatusParents {
+                parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1211,16 +1213,16 @@ fn egress_network_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![conflict_condition, backend_condition.clone()]),
+                conditions: vec![conflict_condition, backend_condition.clone()],
             };
-            let status = gateway::GRPCRouteStatus {
+            let status = gateway::GrpcRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&http_id, status).unwrap();
             assert_eq!(patch, update.patch);
         } else {
-            let parent_status = gateway::GRPCRouteStatusParents {
-                parent_ref: gateway::GRPCRouteStatusParentsParentRef {
+            let parent_status = gateway::GrpcRouteStatusParents {
+                parent_ref: gateway::GrpcRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1229,9 +1231,9 @@ fn egress_network_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+                conditions: vec![accepted_condition.clone(), backend_condition.clone()],
             };
-            let status = gateway::GRPCRouteStatus {
+            let status = gateway::GrpcRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&grpc_id, status).unwrap();
@@ -1245,34 +1247,35 @@ fn egress_network_route_type_conflict() {
 
 fn make_route(
     id: &NamespaceGroupKindName,
-    parent: gateway::GRPCRouteParentRefs,
-    backends: Option<Vec<gateway::GRPCRouteRulesBackendRefs>>,
+    parent: gateway::GrpcRouteParentRefs,
+    backends: Option<Vec<gateway::GrpcRouteRulesBackendRefs>>,
 ) -> gateway::GRPCRoute {
     gateway::GRPCRoute {
         status: None,
         metadata: k8s::ObjectMeta {
             name: Some(id.gkn.name.to_string()),
             namespace: Some(id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::GRPCRouteSpec {
+        spec: gateway::GrpcRouteSpec {
             parent_refs: Some(vec![parent]),
             hostnames: None,
-            rules: Some(vec![gateway::GRPCRouteRules {
+            rules: Some(vec![gateway::GrpcRouteRules {
                 name: None,
                 filters: None,
                 backend_refs: backends,
-                matches: Some(vec![gateway::GRPCRouteRulesMatches {
+                matches: Some(vec![gateway::GrpcRouteRulesMatches {
                     headers: None,
-                    method: Some(gateway::GRPCRouteRulesMatchesMethod {
+                    method: Some(gateway::GrpcRouteRulesMatchesMethod {
                         method: Some("MakeRoute".to_string()),
                         service: Some("io.linkerd.Test".to_string()),
-                        r#type: Some(gateway::GRPCRouteRulesMatchesMethodType::Exact),
+                        r#type: Some(gateway::GrpcRouteRulesMatchesMethodType::Exact),
                     }),
                 }]),
                 session_persistence: None,
             }]),
+            use_default_gateways: None,
         },
     }
 }

--- a/policy-controller/k8s/status/src/tests/routes/http.rs
+++ b/policy-controller/k8s/status/src/tests/routes/http.rs
@@ -7,7 +7,7 @@ use crate::{
     tests::{default_cluster_networks, make_server},
     Index, IndexMetrics,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_core::{routes::GroupKindName, POLICY_CONTROLLER_NAME};
 use linkerd_policy_controller_k8s_api::{self as k8s, gateway, policy, Resource, ResourceExt};
@@ -20,18 +20,18 @@ pub(crate) fn make_parent_status(
     type_: impl ToString,
     status: impl ToString,
     reason: impl ToString,
-) -> gateway::HTTPRouteStatusParents {
+) -> gateway::HttpRouteStatusParents {
     let condition = k8s::Condition {
         message: "".to_string(),
         type_: type_.to_string(),
         observed_generation: None,
         reason: reason.to_string(),
         status: status.to_string(),
-        last_transition_time: k8s::Time(DateTime::<Utc>::MIN_UTC),
+        last_transition_time: k8s::Time(Timestamp::MIN),
     };
-    gateway::HTTPRouteStatusParents {
-        conditions: Some(vec![condition]),
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    gateway::HttpRouteStatusParents {
+        conditions: vec![condition],
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             port: None,
             section_name: None,
             name: name.to_string(),
@@ -48,7 +48,7 @@ fn linkerd_route_with_no_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -73,7 +73,7 @@ fn linkerd_route_with_no_backends() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -89,8 +89,8 @@ fn linkerd_route_with_no_backends() {
     let accepted_condition = accepted();
     // No backends were specified, so we have vacuously resolved them all.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -99,9 +99,9 @@ fn linkerd_route_with_no_backends() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -117,7 +117,7 @@ fn gateway_route_with_no_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -134,7 +134,7 @@ fn gateway_route_with_no_backends() {
     index.write().apply(parent.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -157,8 +157,8 @@ fn gateway_route_with_no_backends() {
     let accepted_condition = accepted();
     // No backends were specified, so we have vacuously resolved them all.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -167,9 +167,9 @@ fn gateway_route_with_no_backends() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -185,7 +185,7 @@ fn linkerd_route_with_valid_service_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -218,7 +218,7 @@ fn linkerd_route_with_valid_service_backends() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -230,7 +230,7 @@ fn linkerd_route_with_valid_service_backends() {
         &id,
         parent.clone(),
         Some(vec![
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -239,7 +239,7 @@ fn linkerd_route_with_valid_service_backends() {
                 port: Some(8080),
                 filters: None,
             },
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -256,8 +256,8 @@ fn linkerd_route_with_valid_service_backends() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -266,9 +266,9 @@ fn linkerd_route_with_valid_service_backends() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -284,7 +284,7 @@ fn linkerd_route_with_valid_egress_networks_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -308,7 +308,7 @@ fn linkerd_route_with_valid_egress_networks_backends() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -319,7 +319,7 @@ fn linkerd_route_with_valid_egress_networks_backends() {
     let route = make_linkerd_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             weight: None,
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
@@ -335,8 +335,8 @@ fn linkerd_route_with_valid_egress_networks_backends() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -345,9 +345,9 @@ fn linkerd_route_with_valid_egress_networks_backends() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch: linkerd_policy_controller_k8s_api::Patch<serde_json::Value> =
@@ -364,7 +364,7 @@ fn gateway_route_with_valid_service_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -389,7 +389,7 @@ fn gateway_route_with_valid_service_backends() {
     index.write().apply(backend2.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -409,7 +409,7 @@ fn gateway_route_with_valid_service_backends() {
         &id,
         parent.clone(),
         Some(vec![
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -419,7 +419,7 @@ fn gateway_route_with_valid_service_backends() {
 
                 filters: None,
             },
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -436,8 +436,8 @@ fn gateway_route_with_valid_service_backends() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -446,9 +446,9 @@ fn gateway_route_with_valid_service_backends() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -464,7 +464,7 @@ fn gateway_route_with_valid_egress_networks_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -481,7 +481,7 @@ fn gateway_route_with_valid_egress_networks_backends() {
     index.write().apply(parent.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -500,7 +500,7 @@ fn gateway_route_with_valid_egress_networks_backends() {
     let route = make_gateway_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             weight: None,
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
@@ -516,8 +516,8 @@ fn gateway_route_with_valid_egress_networks_backends() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -526,9 +526,9 @@ fn gateway_route_with_valid_egress_networks_backends() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -544,7 +544,7 @@ fn linkerd_route_with_invalid_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -565,7 +565,7 @@ fn linkerd_route_with_invalid_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -585,7 +585,7 @@ fn linkerd_route_with_invalid_service_backend() {
         &id,
         parent.clone(),
         Some(vec![
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -594,7 +594,7 @@ fn linkerd_route_with_invalid_service_backend() {
                 port: Some(8080),
                 filters: None,
             },
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -611,8 +611,8 @@ fn linkerd_route_with_invalid_service_backend() {
     let accepted_condition = accepted();
     // One of the backends does not exist so the status should be BackendNotFound.
     let backend_condition = backend_not_found();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -621,9 +621,9 @@ fn linkerd_route_with_invalid_service_backend() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -639,7 +639,7 @@ fn linkerd_route_with_egress_network_backend_different_from_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -660,7 +660,7 @@ fn linkerd_route_with_egress_network_backend_different_from_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -679,7 +679,7 @@ fn linkerd_route_with_egress_network_backend_different_from_parent() {
     let route = make_linkerd_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -696,8 +696,8 @@ fn linkerd_route_with_egress_network_backend_different_from_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -706,9 +706,9 @@ fn linkerd_route_with_egress_network_backend_different_from_parent() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -724,7 +724,7 @@ fn linkerd_route_with_egress_network_backend_and_service_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -745,7 +745,7 @@ fn linkerd_route_with_egress_network_backend_and_service_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -765,7 +765,7 @@ fn linkerd_route_with_egress_network_backend_and_service_parent() {
     let route = make_linkerd_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -782,8 +782,8 @@ fn linkerd_route_with_egress_network_backend_and_service_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -792,9 +792,9 @@ fn linkerd_route_with_egress_network_backend_and_service_parent() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -810,7 +810,7 @@ fn linkerd_route_with_egress_network_parent_and_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -831,7 +831,7 @@ fn linkerd_route_with_egress_network_parent_and_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -851,7 +851,7 @@ fn linkerd_route_with_egress_network_parent_and_service_backend() {
     let route = make_linkerd_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             group: Some("core".to_string()),
             kind: Some("Service".to_string()),
             name: backend.name_unchecked(),
@@ -866,8 +866,8 @@ fn linkerd_route_with_egress_network_parent_and_service_backend() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -876,9 +876,9 @@ fn linkerd_route_with_egress_network_parent_and_service_backend() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -894,7 +894,7 @@ fn gateway_route_with_invalid_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -915,7 +915,7 @@ fn gateway_route_with_invalid_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -935,7 +935,7 @@ fn gateway_route_with_invalid_service_backend() {
         &id,
         parent.clone(),
         Some(vec![
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -944,7 +944,7 @@ fn gateway_route_with_invalid_service_backend() {
                 port: Some(8080),
                 filters: None,
             },
-            gateway::HTTPRouteRulesBackendRefs {
+            gateway::HttpRouteRulesBackendRefs {
                 weight: None,
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
@@ -961,8 +961,8 @@ fn gateway_route_with_invalid_service_backend() {
     let accepted_condition = accepted();
     // One of the backends does not exist so the status should be BackendNotFound.
     let backend_condition = backend_not_found();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -971,9 +971,9 @@ fn gateway_route_with_invalid_service_backend() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -989,7 +989,7 @@ fn gateway_route_with_egress_network_backend_different_from_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1010,7 +1010,7 @@ fn gateway_route_with_egress_network_backend_different_from_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -1029,7 +1029,7 @@ fn gateway_route_with_egress_network_backend_different_from_parent() {
     let route = make_gateway_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -1046,8 +1046,8 @@ fn gateway_route_with_egress_network_backend_different_from_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -1056,9 +1056,9 @@ fn gateway_route_with_egress_network_backend_different_from_parent() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1074,7 +1074,7 @@ fn gateway_route_with_egress_network_backend_and_service_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1095,7 +1095,7 @@ fn gateway_route_with_egress_network_backend_and_service_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -1115,7 +1115,7 @@ fn gateway_route_with_egress_network_backend_and_service_parent() {
     let route = make_gateway_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -1132,8 +1132,8 @@ fn gateway_route_with_egress_network_backend_and_service_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -1142,9 +1142,9 @@ fn gateway_route_with_egress_network_backend_and_service_parent() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1160,7 +1160,7 @@ fn gateway_route_with_egress_network_parent_and_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1181,7 +1181,7 @@ fn gateway_route_with_egress_network_parent_and_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -1201,7 +1201,7 @@ fn gateway_route_with_egress_network_parent_and_service_backend() {
     let route = make_gateway_route(
         &id,
         parent.clone(),
-        Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        Some(vec![gateway::HttpRouteRulesBackendRefs {
             group: Some("core".to_string()),
             kind: Some("Service".to_string()),
             name: backend.name_unchecked(),
@@ -1216,8 +1216,8 @@ fn gateway_route_with_egress_network_parent_and_service_backend() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -1226,9 +1226,9 @@ fn gateway_route_with_egress_network_parent_and_service_backend() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1244,7 +1244,7 @@ fn linkerd_route_accepted_after_server_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1265,7 +1265,7 @@ fn linkerd_route_accepted_after_server_create() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -1286,7 +1286,7 @@ fn linkerd_route_accepted_after_server_create() {
         "False",
         "NoMatchingParent",
     );
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1311,7 +1311,7 @@ fn linkerd_route_accepted_after_server_create() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1329,7 +1329,7 @@ fn linkerd_route_accepted_after_egress_network_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1350,7 +1350,7 @@ fn linkerd_route_accepted_after_egress_network_create() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -1366,8 +1366,8 @@ fn linkerd_route_accepted_after_egress_network_create() {
     // Create the expected update.
     let accepted_condition = no_matching_parent();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             namespace: parent.namespace.clone(),
@@ -1376,10 +1376,10 @@ fn linkerd_route_accepted_after_egress_network_create() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1396,8 +1396,8 @@ fn linkerd_route_accepted_after_egress_network_create() {
 
     // Create the expected update.
     let accepted_condition = accepted();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -1406,10 +1406,10 @@ fn linkerd_route_accepted_after_egress_network_create() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1427,7 +1427,7 @@ fn gateway_route_accepted_after_server_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1448,7 +1448,7 @@ fn gateway_route_accepted_after_server_create() {
             group: gateway::HTTPRoute::group(&()),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -1469,7 +1469,7 @@ fn gateway_route_accepted_after_server_create() {
         "False",
         "NoMatchingParent",
     );
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1494,7 +1494,7 @@ fn gateway_route_accepted_after_server_create() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1512,7 +1512,7 @@ fn gateway_route_accepted_after_egress_network_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1533,7 +1533,7 @@ fn gateway_route_accepted_after_egress_network_create() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -1549,8 +1549,8 @@ fn gateway_route_accepted_after_egress_network_create() {
     // Create the expected update.
     let rejected_condition = no_matching_parent();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             namespace: parent.namespace.clone(),
@@ -1559,10 +1559,10 @@ fn gateway_route_accepted_after_egress_network_create() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![rejected_condition, backend_condition.clone()]),
+        conditions: vec![rejected_condition, backend_condition.clone()],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1579,8 +1579,8 @@ fn gateway_route_accepted_after_egress_network_create() {
 
     // Create the expected update.
     let accepted_condition = accepted();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             namespace: parent.namespace,
@@ -1589,10 +1589,10 @@ fn gateway_route_accepted_after_egress_network_create() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1610,7 +1610,7 @@ fn linkerd_route_rejected_after_server_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1644,7 +1644,7 @@ fn linkerd_route_rejected_after_server_delete() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -1660,7 +1660,7 @@ fn linkerd_route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1683,7 +1683,7 @@ fn linkerd_route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status("ns-0", "srv-8080", "Accepted", "False", "NoMatchingParent");
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1701,7 +1701,7 @@ fn linkerd_route_rejected_after_egress_network_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1728,7 +1728,7 @@ fn linkerd_route_rejected_after_egress_network_delete() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -1744,8 +1744,8 @@ fn linkerd_route_rejected_after_egress_network_delete() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             namespace: parent.namespace.clone(),
@@ -1754,10 +1754,10 @@ fn linkerd_route_rejected_after_egress_network_delete() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1779,8 +1779,8 @@ fn linkerd_route_rejected_after_egress_network_delete() {
 
     // Create the expected update.
     let rejected_condition = no_matching_parent();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             namespace: parent.namespace.clone(),
@@ -1789,10 +1789,10 @@ fn linkerd_route_rejected_after_egress_network_delete() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![rejected_condition, backend_condition.clone()]),
+        conditions: vec![rejected_condition, backend_condition.clone()],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1810,7 +1810,7 @@ fn gateway_route_rejected_after_server_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1844,7 +1844,7 @@ fn gateway_route_rejected_after_server_delete() {
             group: gateway::HTTPRoute::group(&()),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -1860,7 +1860,7 @@ fn gateway_route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1883,7 +1883,7 @@ fn gateway_route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status("ns-0", "srv-8080", "Accepted", "False", "NoMatchingParent");
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1901,7 +1901,7 @@ fn gateway_route_rejected_after_egress_network_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1928,7 +1928,7 @@ fn gateway_route_rejected_after_egress_network_delete() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::HTTPRouteParentRefs {
+    let parent = gateway::HttpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -1944,8 +1944,8 @@ fn gateway_route_rejected_after_egress_network_delete() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             namespace: parent.namespace.clone(),
@@ -1954,10 +1954,10 @@ fn gateway_route_rejected_after_egress_network_delete() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -1979,8 +1979,8 @@ fn gateway_route_rejected_after_egress_network_delete() {
 
     // Create the expected update.
     let rejected_condition = no_matching_parent();
-    let parent_status = gateway::HTTPRouteStatusParents {
-        parent_ref: gateway::HTTPRouteStatusParentsParentRef {
+    let parent_status = gateway::HttpRouteStatusParents {
+        parent_ref: gateway::HttpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             namespace: parent.namespace.clone(),
@@ -1989,10 +1989,10 @@ fn gateway_route_rejected_after_egress_network_delete() {
             port: parent.port,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![rejected_condition, backend_condition.clone()]),
+        conditions: vec![rejected_condition, backend_condition.clone()],
     };
 
-    let status = gateway::HTTPRouteStatus {
+    let status = gateway::HttpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -2007,28 +2007,28 @@ fn gateway_route_rejected_after_egress_network_delete() {
 
 fn make_linkerd_route(
     id: &NamespaceGroupKindName,
-    parent: gateway::HTTPRouteParentRefs,
-    backends: Option<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+    parent: gateway::HttpRouteParentRefs,
+    backends: Option<Vec<gateway::HttpRouteRulesBackendRefs>>,
 ) -> policy::HttpRoute {
     policy::HttpRoute {
         metadata: k8s::ObjectMeta {
             namespace: Some(id.namespace.clone()),
             name: Some(id.gkn.name.to_string()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
         spec: policy::HttpRouteSpec {
             parent_refs: Some(vec![parent]),
             hostnames: None,
             rules: Some(vec![policy::httproute::HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo/bar".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
                     headers: None,
                     query_params: None,
-                    method: Some(gateway::HTTPRouteRulesMatchesMethod::Get),
+                    method: Some(gateway::HttpRouteRulesMatchesMethod::Get),
                 }]),
                 filters: None,
                 backend_refs: backends,
@@ -2041,35 +2041,36 @@ fn make_linkerd_route(
 
 fn make_gateway_route(
     id: &NamespaceGroupKindName,
-    parent: gateway::HTTPRouteParentRefs,
-    backends: Option<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+    parent: gateway::HttpRouteParentRefs,
+    backends: Option<Vec<gateway::HttpRouteRulesBackendRefs>>,
 ) -> gateway::HTTPRoute {
     gateway::HTTPRoute {
         status: None,
         metadata: k8s::ObjectMeta {
             name: Some(id.gkn.name.to_string()),
             namespace: Some(id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![parent]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
                 filters: None,
                 backend_refs: backends,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
                     headers: None,
                     query_params: None,
-                    method: Some(gateway::HTTPRouteRulesMatchesMethod::Get),
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                    method: Some(gateway::HttpRouteRulesMatchesMethod::Get),
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo/bar".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix),
                     }),
                 }]),
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
     }
 }

--- a/policy-controller/k8s/status/src/tests/routes/tcp.rs
+++ b/policy-controller/k8s/status/src/tests/routes/tcp.rs
@@ -7,7 +7,7 @@ use crate::{
     tests::{default_cluster_networks, make_server},
     Index, IndexMetrics,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_core::{routes::GroupKindName, POLICY_CONTROLLER_NAME};
 use linkerd_policy_controller_k8s_api::{self as k8s, gateway, policy, Resource, ResourceExt};
@@ -20,18 +20,18 @@ pub(crate) fn make_parent_status(
     type_: impl ToString,
     status: impl ToString,
     reason: impl ToString,
-) -> gateway::TCPRouteStatusParents {
+) -> gateway::TcpRouteStatusParents {
     let condition = k8s::Condition {
         message: "".to_string(),
         type_: type_.to_string(),
         observed_generation: None,
         reason: reason.to_string(),
         status: status.to_string(),
-        last_transition_time: k8s::Time(DateTime::<Utc>::MIN_UTC),
+        last_transition_time: k8s::Time(Timestamp::MIN),
     };
-    gateway::TCPRouteStatusParents {
-        conditions: Some(vec![condition]),
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    gateway::TcpRouteStatusParents {
+        conditions: vec![condition],
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             port: None,
             section_name: None,
             name: name.to_string(),
@@ -48,7 +48,7 @@ fn route_with_valid_service_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -73,7 +73,7 @@ fn route_with_valid_service_backends() {
     index.write().apply(backend2.clone());
 
     // Apply the route.
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -93,7 +93,7 @@ fn route_with_valid_service_backends() {
         &id,
         parent.clone(),
         vec![
-            gateway::TCPRouteRulesBackendRefs {
+            gateway::TcpRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend1.name_unchecked(),
@@ -101,7 +101,7 @@ fn route_with_valid_service_backends() {
                 port: Some(8080),
                 weight: None,
             },
-            gateway::TCPRouteRulesBackendRefs {
+            gateway::TcpRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend2.name_unchecked(),
@@ -117,8 +117,8 @@ fn route_with_valid_service_backends() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -127,9 +127,9 @@ fn route_with_valid_service_backends() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -145,7 +145,7 @@ fn route_with_valid_egress_network_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -162,7 +162,7 @@ fn route_with_valid_egress_network_backend() {
     index.write().apply(parent.clone());
 
     // Apply the route.
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -181,7 +181,7 @@ fn route_with_valid_egress_network_backend() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TCPRouteRulesBackendRefs {
+        vec![gateway::TcpRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: parent.name.clone(),
@@ -196,8 +196,8 @@ fn route_with_valid_egress_network_backend() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -206,9 +206,9 @@ fn route_with_valid_egress_network_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -224,7 +224,7 @@ fn route_with_invalid_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -245,7 +245,7 @@ fn route_with_invalid_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -265,7 +265,7 @@ fn route_with_invalid_service_backend() {
         &id,
         parent.clone(),
         vec![
-            gateway::TCPRouteRulesBackendRefs {
+            gateway::TcpRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend.name_unchecked(),
@@ -273,7 +273,7 @@ fn route_with_invalid_service_backend() {
                 port: Some(8080),
                 weight: None,
             },
-            gateway::TCPRouteRulesBackendRefs {
+            gateway::TcpRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: "nonexistant-backend".to_string(),
@@ -289,8 +289,8 @@ fn route_with_invalid_service_backend() {
     let accepted_condition = accepted();
     // One of the backends does not exist so the status should be BackendNotFound.
     let backend_condition = backend_not_found();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -299,9 +299,9 @@ fn route_with_invalid_service_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -317,7 +317,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -338,7 +338,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -357,7 +357,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TCPRouteRulesBackendRefs {
+        vec![gateway::TcpRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -373,8 +373,8 @@ fn route_with_egress_network_backend_different_from_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -383,9 +383,9 @@ fn route_with_egress_network_backend_different_from_parent() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -401,7 +401,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -422,7 +422,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -441,7 +441,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TCPRouteRulesBackendRefs {
+        vec![gateway::TcpRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -457,8 +457,8 @@ fn route_with_egress_network_backend_and_service_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -467,9 +467,9 @@ fn route_with_egress_network_backend_and_service_parent() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -485,7 +485,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -506,7 +506,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -525,7 +525,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TCPRouteRulesBackendRefs {
+        vec![gateway::TcpRouteRulesBackendRefs {
             group: Some("core".to_string()),
             kind: Some("Service".to_string()),
             name: backend.name_unchecked(),
@@ -539,8 +539,8 @@ fn route_with_egress_network_parent_and_service_backend() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -549,9 +549,9 @@ fn route_with_egress_network_parent_and_service_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -567,7 +567,7 @@ fn route_accepted_after_server_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -588,7 +588,7 @@ fn route_accepted_after_server_create() {
             group: gateway::TCPRoute::group(&()),
         },
     };
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -609,7 +609,7 @@ fn route_accepted_after_server_create() {
         "False",
         "NoMatchingParent",
     );
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -634,7 +634,7 @@ fn route_accepted_after_server_create() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -652,7 +652,7 @@ fn route_accepted_after_egress_network_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -673,7 +673,7 @@ fn route_accepted_after_egress_network_create() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -689,8 +689,8 @@ fn route_accepted_after_egress_network_create() {
     // Create the expected update.
     let accepted_condition = no_matching_parent();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -699,10 +699,10 @@ fn route_accepted_after_egress_network_create() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -719,8 +719,8 @@ fn route_accepted_after_egress_network_create() {
 
     // Create the expected update.
     let accepted_condition = accepted();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -729,10 +729,10 @@ fn route_accepted_after_egress_network_create() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
 
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -750,7 +750,7 @@ fn route_rejected_after_server_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -784,7 +784,7 @@ fn route_rejected_after_server_delete() {
             group: gateway::TCPRoute::group(&()),
         },
     };
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -800,7 +800,7 @@ fn route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -823,7 +823,7 @@ fn route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status("ns-0", "srv-8080", "Accepted", "False", "NoMatchingParent");
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -841,7 +841,7 @@ fn route_rejected_after_egress_network_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -868,7 +868,7 @@ fn route_rejected_after_egress_network_delete() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::TCPRouteParentRefs {
+    let parent = gateway::TcpRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -884,8 +884,8 @@ fn route_rejected_after_egress_network_delete() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -894,10 +894,10 @@ fn route_rejected_after_egress_network_delete() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -919,8 +919,8 @@ fn route_rejected_after_egress_network_delete() {
 
     // Create the expected update.
     let rejected_condition = no_matching_parent();
-    let parent_status = gateway::TCPRouteStatusParents {
-        parent_ref: gateway::TCPRouteStatusParentsParentRef {
+    let parent_status = gateway::TcpRouteStatusParents {
+        parent_ref: gateway::TcpRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -929,10 +929,10 @@ fn route_rejected_after_egress_network_delete() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![rejected_condition, backend_condition.clone()]),
+        conditions: vec![rejected_condition, backend_condition.clone()],
     };
 
-    let status = gateway::TCPRouteStatus {
+    let status = gateway::TcpRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -947,23 +947,24 @@ fn route_rejected_after_egress_network_delete() {
 
 fn make_route(
     id: &NamespaceGroupKindName,
-    parent: gateway::TCPRouteParentRefs,
-    backends: Vec<gateway::TCPRouteRulesBackendRefs>,
+    parent: gateway::TcpRouteParentRefs,
+    backends: Vec<gateway::TcpRouteRulesBackendRefs>,
 ) -> gateway::TCPRoute {
     gateway::TCPRoute {
         status: None,
         metadata: k8s::ObjectMeta {
             name: Some(id.gkn.name.to_string()),
             namespace: Some(id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::TCPRouteSpec {
+        spec: gateway::TcpRouteSpec {
             parent_refs: Some(vec![parent]),
-            rules: vec![gateway::TCPRouteRules {
+            rules: vec![gateway::TcpRouteRules {
                 name: None,
-                backend_refs: Some(backends),
+                backend_refs: backends,
             }],
+            use_default_gateways: None,
         },
     }
 }

--- a/policy-controller/k8s/status/src/tests/routes/tls.rs
+++ b/policy-controller/k8s/status/src/tests/routes/tls.rs
@@ -7,7 +7,7 @@ use crate::{
     tests::{default_cluster_networks, make_server},
     Index, IndexMetrics,
 };
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use kubert::index::IndexNamespacedResource;
 use linkerd_policy_controller_core::{routes::GroupKindName, POLICY_CONTROLLER_NAME};
 use linkerd_policy_controller_k8s_api::{self as k8s, gateway, policy, Resource, ResourceExt};
@@ -20,18 +20,18 @@ pub(crate) fn make_parent_status(
     type_: impl ToString,
     status: impl ToString,
     reason: impl ToString,
-) -> gateway::TLSRouteStatusParents {
+) -> gateway::TlsRouteStatusParents {
     let condition = k8s::Condition {
         message: "".to_string(),
         type_: type_.to_string(),
         observed_generation: None,
         reason: reason.to_string(),
         status: status.to_string(),
-        last_transition_time: k8s::Time(DateTime::<Utc>::MIN_UTC),
+        last_transition_time: k8s::Time(Timestamp::MIN),
     };
-    gateway::TLSRouteStatusParents {
-        conditions: Some(vec![condition]),
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    gateway::TlsRouteStatusParents {
+        conditions: vec![condition],
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             port: None,
             section_name: None,
             name: name.to_string(),
@@ -48,7 +48,7 @@ fn route_with_valid_service_backends() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -73,7 +73,7 @@ fn route_with_valid_service_backends() {
     index.write().apply(backend2.clone());
 
     // Apply the route.
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -93,7 +93,7 @@ fn route_with_valid_service_backends() {
         &id,
         parent.clone(),
         vec![
-            gateway::TLSRouteRulesBackendRefs {
+            gateway::TlsRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend1.name_unchecked(),
@@ -101,7 +101,7 @@ fn route_with_valid_service_backends() {
                 port: Some(8080),
                 weight: None,
             },
-            gateway::TLSRouteRulesBackendRefs {
+            gateway::TlsRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend2.name_unchecked(),
@@ -117,8 +117,8 @@ fn route_with_valid_service_backends() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -127,9 +127,9 @@ fn route_with_valid_service_backends() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -145,7 +145,7 @@ fn route_with_valid_egress_network_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -162,7 +162,7 @@ fn route_with_valid_egress_network_backend() {
     index.write().apply(parent.clone());
 
     // Apply the route.
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -181,7 +181,7 @@ fn route_with_valid_egress_network_backend() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TLSRouteRulesBackendRefs {
+        vec![gateway::TlsRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: parent.name.clone(),
@@ -196,8 +196,8 @@ fn route_with_valid_egress_network_backend() {
     let accepted_condition = accepted();
     // All backends exist and can be resolved.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -206,9 +206,9 @@ fn route_with_valid_egress_network_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -224,7 +224,7 @@ fn route_with_invalid_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -245,7 +245,7 @@ fn route_with_invalid_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -265,7 +265,7 @@ fn route_with_invalid_service_backend() {
         &id,
         parent.clone(),
         vec![
-            gateway::TLSRouteRulesBackendRefs {
+            gateway::TlsRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: backend.name_unchecked(),
@@ -273,7 +273,7 @@ fn route_with_invalid_service_backend() {
                 port: Some(8080),
                 weight: None,
             },
-            gateway::TLSRouteRulesBackendRefs {
+            gateway::TlsRouteRulesBackendRefs {
                 group: Some("core".to_string()),
                 kind: Some("Service".to_string()),
                 name: "nonexistant-backend".to_string(),
@@ -289,8 +289,8 @@ fn route_with_invalid_service_backend() {
     let accepted_condition = accepted();
     // One of the backends does not exist so the status should be BackendNotFound.
     let backend_condition = backend_not_found();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -299,9 +299,9 @@ fn route_with_invalid_service_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -317,7 +317,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -338,7 +338,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -357,7 +357,7 @@ fn route_with_egress_network_backend_different_from_parent() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TLSRouteRulesBackendRefs {
+        vec![gateway::TlsRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -373,8 +373,8 @@ fn route_with_egress_network_backend_different_from_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -383,9 +383,9 @@ fn route_with_egress_network_backend_different_from_parent() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -401,7 +401,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -422,7 +422,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -441,7 +441,7 @@ fn route_with_egress_network_backend_and_service_parent() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TLSRouteRulesBackendRefs {
+        vec![gateway::TlsRouteRulesBackendRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("EgressNetwork".to_string()),
             name: backend.name_unchecked(),
@@ -457,8 +457,8 @@ fn route_with_egress_network_backend_and_service_parent() {
     let backend_condition = invalid_backend_kind(
         "EgressNetwork backend needs to be on a route that has an EgressNetwork parent",
     );
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -467,9 +467,9 @@ fn route_with_egress_network_backend_and_service_parent() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -485,7 +485,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -506,7 +506,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     index.write().apply(backend.clone());
 
     // Apply the route.
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -525,7 +525,7 @@ fn route_with_egress_network_parent_and_service_backend() {
     let route = make_route(
         &id,
         parent.clone(),
-        vec![gateway::TLSRouteRulesBackendRefs {
+        vec![gateway::TlsRouteRulesBackendRefs {
             group: Some("core".to_string()),
             kind: Some("Service".to_string()),
             name: backend.name_unchecked(),
@@ -539,8 +539,8 @@ fn route_with_egress_network_parent_and_service_backend() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -549,9 +549,9 @@ fn route_with_egress_network_parent_and_service_backend() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -567,7 +567,7 @@ fn route_accepted_after_server_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -588,7 +588,7 @@ fn route_accepted_after_server_create() {
             group: gateway::TLSRoute::group(&()),
         },
     };
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -609,7 +609,7 @@ fn route_accepted_after_server_create() {
         "False",
         "NoMatchingParent",
     );
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -634,7 +634,7 @@ fn route_accepted_after_server_create() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -652,7 +652,7 @@ fn route_accepted_after_egress_network_create() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -673,7 +673,7 @@ fn route_accepted_after_egress_network_create() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -689,8 +689,8 @@ fn route_accepted_after_egress_network_create() {
     // Create the expected update.
     let accepted_condition = no_matching_parent();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -699,10 +699,10 @@ fn route_accepted_after_egress_network_create() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -719,8 +719,8 @@ fn route_accepted_after_egress_network_create() {
 
     // Create the expected update.
     let accepted_condition = accepted();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group,
             kind: parent.kind,
             name: parent.name,
@@ -729,10 +729,10 @@ fn route_accepted_after_egress_network_create() {
             section_name: parent.section_name,
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition]),
+        conditions: vec![accepted_condition, backend_condition],
     };
 
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -750,7 +750,7 @@ fn route_rejected_after_server_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -784,7 +784,7 @@ fn route_rejected_after_server_delete() {
             group: gateway::TLSRoute::group(&()),
         },
     };
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("Server".to_string()),
         namespace: None,
@@ -800,7 +800,7 @@ fn route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status(&id.namespace, "srv-8080", "Accepted", "True", "Accepted");
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -823,7 +823,7 @@ fn route_rejected_after_server_delete() {
     // Create the expected update.
     let parent_status =
         make_parent_status("ns-0", "srv-8080", "Accepted", "False", "NoMatchingParent");
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -841,7 +841,7 @@ fn route_rejected_after_egress_network_delete() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -868,7 +868,7 @@ fn route_rejected_after_egress_network_delete() {
             name: "route-foo".into(),
         },
     };
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some(POLICY_API_GROUP.to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some("ns-0".to_string()),
@@ -884,8 +884,8 @@ fn route_rejected_after_egress_network_delete() {
     // Create the expected update.
     let accepted_condition = accepted();
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -894,10 +894,10 @@ fn route_rejected_after_egress_network_delete() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition, backend_condition.clone()]),
+        conditions: vec![accepted_condition, backend_condition.clone()],
     };
 
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -919,8 +919,8 @@ fn route_rejected_after_egress_network_delete() {
 
     // Create the expected update.
     let rejected_condition = no_matching_parent();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -929,10 +929,10 @@ fn route_rejected_after_egress_network_delete() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![rejected_condition, backend_condition.clone()]),
+        conditions: vec![rejected_condition, backend_condition.clone()],
     };
 
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&id, status).unwrap();
@@ -950,7 +950,7 @@ fn service_route_type_conflict() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -966,7 +966,7 @@ fn service_route_type_conflict() {
     let parent = super::make_service("ns-0", "svc");
     index.write().apply(parent.clone());
 
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("core".to_string()),
         kind: Some("Service".to_string()),
         namespace: parent.namespace(),
@@ -989,11 +989,11 @@ fn service_route_type_conflict() {
         metadata: k8s::ObjectMeta {
             name: Some(tcp_id.gkn.name.to_string()),
             namespace: Some(tcp_id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::TCPRouteSpec {
-            parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+        spec: gateway::TcpRouteSpec {
+            parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                 group: parent.group.clone(),
                 kind: parent.kind.clone(),
                 name: parent.name.clone(),
@@ -1002,6 +1002,7 @@ fn service_route_type_conflict() {
                 section_name: parent.section_name.clone(),
             }]),
             rules: vec![],
+            use_default_gateways: None,
         },
     };
     index.write().apply(tcp_route);
@@ -1010,8 +1011,8 @@ fn service_route_type_conflict() {
     let accepted_condition = accepted();
     // No backends were specified, so we have vacuously resolved them all.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -1020,9 +1021,9 @@ fn service_route_type_conflict() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+        conditions: vec![accepted_condition.clone(), backend_condition.clone()],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&tcp_id, status).unwrap();
@@ -1047,8 +1048,8 @@ fn service_route_type_conflict() {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::TCPRoute::kind(&()) {
             let conflict_condition = route_conflicted();
-            let parent_status = gateway::TLSRouteStatusParents {
-                parent_ref: gateway::TLSRouteStatusParentsParentRef {
+            let parent_status = gateway::TlsRouteStatusParents {
+                parent_ref: gateway::TlsRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1057,16 +1058,16 @@ fn service_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![conflict_condition, backend_condition.clone()]),
+                conditions: vec![conflict_condition, backend_condition.clone()],
             };
-            let status = gateway::TLSRouteStatus {
+            let status = gateway::TlsRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&tcp_id, status).unwrap();
             assert_eq!(patch, update.patch);
         } else {
-            let parent_status = gateway::TLSRouteStatusParents {
-                parent_ref: gateway::TLSRouteStatusParentsParentRef {
+            let parent_status = gateway::TlsRouteStatusParents {
+                parent_ref: gateway::TlsRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1075,9 +1076,9 @@ fn service_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+                conditions: vec![accepted_condition.clone(), backend_condition.clone()],
             };
-            let status = gateway::TLSRouteStatus {
+            let status = gateway::TlsRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&tls_id, status).unwrap();
@@ -1094,7 +1095,7 @@ fn egress_network_route_type_conflict() {
     let hostname = "test";
     let claim = kubert::lease::Claim {
         holder: "test".to_string(),
-        expiry: DateTime::<Utc>::MAX_UTC,
+        expiry: Timestamp::MAX,
     };
     let (_claims_tx, claims_rx) = watch::channel(Arc::new(claim));
     let (updates_tx, mut updates_rx) = mpsc::channel(10000);
@@ -1110,7 +1111,7 @@ fn egress_network_route_type_conflict() {
     let parent = super::make_egress_network("ns-0", "egress", accepted());
     index.write().apply(parent.clone());
 
-    let parent = gateway::TLSRouteParentRefs {
+    let parent = gateway::TlsRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: parent.namespace(),
@@ -1133,11 +1134,11 @@ fn egress_network_route_type_conflict() {
         metadata: k8s::ObjectMeta {
             name: Some(tcp_id.gkn.name.to_string()),
             namespace: Some(tcp_id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::TCPRouteSpec {
-            parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+        spec: gateway::TcpRouteSpec {
+            parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                 group: parent.group.clone(),
                 kind: parent.kind.clone(),
                 name: parent.name.clone(),
@@ -1146,6 +1147,7 @@ fn egress_network_route_type_conflict() {
                 section_name: parent.section_name.clone(),
             }]),
             rules: vec![],
+            use_default_gateways: None,
         },
     };
     index.write().apply(tcp_route);
@@ -1154,8 +1156,8 @@ fn egress_network_route_type_conflict() {
     let accepted_condition = accepted();
     // No backends were specified, so we have vacuously resolved them all.
     let backend_condition = resolved_refs();
-    let parent_status = gateway::TLSRouteStatusParents {
-        parent_ref: gateway::TLSRouteStatusParentsParentRef {
+    let parent_status = gateway::TlsRouteStatusParents {
+        parent_ref: gateway::TlsRouteStatusParentsParentRef {
             group: parent.group.clone(),
             kind: parent.kind.clone(),
             name: parent.name.clone(),
@@ -1164,9 +1166,9 @@ fn egress_network_route_type_conflict() {
             section_name: parent.section_name.clone(),
         },
         controller_name: POLICY_CONTROLLER_NAME.to_string(),
-        conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+        conditions: vec![accepted_condition.clone(), backend_condition.clone()],
     };
-    let status = gateway::TLSRouteStatus {
+    let status = gateway::TlsRouteStatus {
         parents: vec![parent_status],
     };
     let patch = crate::index::make_patch(&tcp_id, status).unwrap();
@@ -1191,8 +1193,8 @@ fn egress_network_route_type_conflict() {
         let update = updates_rx.try_recv().unwrap();
         if update.id.gkn.kind == gateway::TCPRoute::kind(&()) {
             let conflict_condition = route_conflicted();
-            let parent_status = gateway::TLSRouteStatusParents {
-                parent_ref: gateway::TLSRouteStatusParentsParentRef {
+            let parent_status = gateway::TlsRouteStatusParents {
+                parent_ref: gateway::TlsRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1201,16 +1203,16 @@ fn egress_network_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![conflict_condition, backend_condition.clone()]),
+                conditions: vec![conflict_condition, backend_condition.clone()],
             };
-            let status = gateway::TLSRouteStatus {
+            let status = gateway::TlsRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&tcp_id, status).unwrap();
             assert_eq!(patch, update.patch);
         } else {
-            let parent_status = gateway::TLSRouteStatusParents {
-                parent_ref: gateway::TLSRouteStatusParentsParentRef {
+            let parent_status = gateway::TlsRouteStatusParents {
+                parent_ref: gateway::TlsRouteStatusParentsParentRef {
                     group: parent.group.clone(),
                     kind: parent.kind.clone(),
                     name: parent.name.clone(),
@@ -1219,9 +1221,9 @@ fn egress_network_route_type_conflict() {
                     section_name: parent.section_name.clone(),
                 },
                 controller_name: POLICY_CONTROLLER_NAME.to_string(),
-                conditions: Some(vec![accepted_condition.clone(), backend_condition.clone()]),
+                conditions: vec![accepted_condition.clone(), backend_condition.clone()],
             };
-            let status = gateway::TLSRouteStatus {
+            let status = gateway::TlsRouteStatus {
                 parents: vec![parent_status],
             };
             let patch = crate::index::make_patch(&tls_id, status).unwrap();
@@ -1235,24 +1237,25 @@ fn egress_network_route_type_conflict() {
 
 fn make_route(
     id: &NamespaceGroupKindName,
-    parent: gateway::TLSRouteParentRefs,
-    backends: Vec<gateway::TLSRouteRulesBackendRefs>,
+    parent: gateway::TlsRouteParentRefs,
+    backends: Vec<gateway::TlsRouteRulesBackendRefs>,
 ) -> gateway::TLSRoute {
     gateway::TLSRoute {
         status: None,
         metadata: k8s::ObjectMeta {
             name: Some(id.gkn.name.to_string()),
             namespace: Some(id.namespace.clone()),
-            creation_timestamp: Some(k8s::Time(Utc::now())),
+            creation_timestamp: Some(k8s::Time(Timestamp::now())),
             ..Default::default()
         },
-        spec: gateway::TLSRouteSpec {
+        spec: gateway::TlsRouteSpec {
             parent_refs: Some(vec![parent]),
-            hostnames: None,
-            rules: vec![gateway::TLSRouteRules {
+            hostnames: Vec::default(),
+            rules: vec![gateway::TlsRouteRules {
                 name: None,
-                backend_refs: Some(backends),
+                backend_refs: backends,
             }],
+            use_default_gateways: None,
         },
     }
 }

--- a/policy-controller/runtime/src/admission.rs
+++ b/policy-controller/runtime/src/admission.rs
@@ -145,19 +145,19 @@ impl Admission {
         }
 
         if is_kind::<gateway::HTTPRoute>(&req) {
-            return self.admit_spec::<gateway::HTTPRouteSpec>(req).await;
+            return self.admit_spec::<gateway::HttpRouteSpec>(req).await;
         }
 
         if is_kind::<gateway::GRPCRoute>(&req) {
-            return self.admit_spec::<gateway::GRPCRouteSpec>(req).await;
+            return self.admit_spec::<gateway::GrpcRouteSpec>(req).await;
         }
 
         if is_kind::<gateway::TLSRoute>(&req) {
-            return self.admit_spec::<gateway::TLSRouteSpec>(req).await;
+            return self.admit_spec::<gateway::TlsRouteSpec>(req).await;
         }
 
         if is_kind::<gateway::TCPRoute>(&req) {
-            return self.admit_spec::<gateway::TCPRouteSpec>(req).await;
+            return self.admit_spec::<gateway::TcpRouteSpec>(req).await;
         }
 
         if is_kind::<HttpLocalRateLimitPolicy>(&req) {
@@ -474,7 +474,7 @@ impl Validate<ServerAuthorizationSpec> for Admission {
     }
 }
 
-fn validate_match(httproute_rules_match: gateway::HTTPRouteRulesMatches) -> Result<()> {
+fn validate_match(httproute_rules_match: gateway::HttpRouteRulesMatches) -> Result<()> {
     index::routes::http::try_match(httproute_rules_match).map(|_| ())
 }
 
@@ -572,7 +572,7 @@ impl Validate<HttpRouteSpec> for Admission {
     }
 }
 
-fn validate_http_backend_if_service(br: &gateway::HTTPRouteRulesBackendRefs) -> Result<()> {
+fn validate_http_backend_if_service(br: &gateway::HttpRouteRulesBackendRefs) -> Result<()> {
     let is_service = matches!(br.group.as_deref(), Some("core") | Some("") | None)
         && matches!(br.kind.as_deref(), Some("Service") | None);
 
@@ -586,7 +586,7 @@ fn validate_http_backend_if_service(br: &gateway::HTTPRouteRulesBackendRefs) -> 
     Ok(())
 }
 
-fn validate_grpc_backend_if_service(br: &gateway::GRPCRouteRulesBackendRefs) -> Result<()> {
+fn validate_grpc_backend_if_service(br: &gateway::GrpcRouteRulesBackendRefs) -> Result<()> {
     let is_service = matches!(br.group.as_deref(), Some("core") | Some("") | None)
         && matches!(br.kind.as_deref(), Some("Service") | None);
 
@@ -601,7 +601,7 @@ fn validate_grpc_backend_if_service(br: &gateway::GRPCRouteRulesBackendRefs) -> 
 }
 
 #[async_trait::async_trait]
-impl Validate<gateway::HTTPRouteSpec> for Admission {
+impl Validate<gateway::HttpRouteSpec> for Admission {
     fn lenient() -> bool {
         true
     }
@@ -611,7 +611,7 @@ impl Validate<gateway::HTTPRouteSpec> for Admission {
         _ns: &str,
         _name: &str,
         annotations: &BTreeMap<String, String>,
-        spec: gateway::HTTPRouteSpec,
+        spec: gateway::HttpRouteSpec,
     ) -> Result<()> {
         for parent in spec.parent_refs.iter().flatten() {
             if outbound_index::is_parent_egress_network(&parent.kind, &parent.group)
@@ -630,7 +630,7 @@ impl Validate<gateway::HTTPRouteSpec> for Admission {
             outbound_index::parse_timeouts(annotations)?;
         }
 
-        fn validate_filter(filter: gateway::HTTPRouteRulesFilters) -> Result<()> {
+        fn validate_filter(filter: gateway::HttpRouteRulesFilters) -> Result<()> {
             if let Some(request_header_modifier) = filter.request_header_modifier {
                 index::routes::http::request_header_modifier(request_header_modifier)?;
             }
@@ -647,7 +647,7 @@ impl Validate<gateway::HTTPRouteSpec> for Admission {
         // This is essentially equivalent to the indexer's conversion function
         // from `HttpRouteSpec` to `InboundRouteBinding`, except that we don't
         // actually allocate stuff in order to return an `InboundRouteBinding`.
-        for gateway::HTTPRouteRules {
+        for gateway::HttpRouteRules {
             filters,
             matches,
             backend_refs,
@@ -672,7 +672,7 @@ impl Validate<gateway::HTTPRouteSpec> for Admission {
 }
 
 #[async_trait::async_trait]
-impl Validate<gateway::GRPCRouteSpec> for Admission {
+impl Validate<gateway::GrpcRouteSpec> for Admission {
     fn lenient() -> bool {
         true
     }
@@ -682,7 +682,7 @@ impl Validate<gateway::GRPCRouteSpec> for Admission {
         _ns: &str,
         _name: &str,
         annotations: &BTreeMap<String, String>,
-        spec: gateway::GRPCRouteSpec,
+        spec: gateway::GrpcRouteSpec,
     ) -> Result<()> {
         for parent in spec.parent_refs.iter().flatten() {
             if outbound_index::is_parent_egress_network(&parent.kind, &parent.group)
@@ -701,7 +701,7 @@ impl Validate<gateway::GRPCRouteSpec> for Admission {
             outbound_index::parse_timeouts(annotations)?;
         }
 
-        fn validate_filter(filter: gateway::GRPCRouteRulesFilters) -> Result<()> {
+        fn validate_filter(filter: gateway::GrpcRouteRulesFilters) -> Result<()> {
             if let Some(request_header_modifier) = filter.request_header_modifier {
                 index::routes::grpc::request_header_modifier(request_header_modifier)?;
             }
@@ -711,7 +711,7 @@ impl Validate<gateway::GRPCRouteSpec> for Admission {
             Ok(())
         }
 
-        fn validate_match_rule(matches: gateway::GRPCRouteRulesMatches) -> Result<()> {
+        fn validate_match_rule(matches: gateway::GrpcRouteRulesMatches) -> Result<()> {
             index::routes::grpc::try_match(matches).map(|_| ())
         }
 
@@ -720,7 +720,7 @@ impl Validate<gateway::GRPCRouteSpec> for Admission {
         // of the rules are improperly constructed (e.g. include
         // a `GrpcMethodMatch` rule where neither `method.method`
         // nor `method.service` actually contain a value)
-        for gateway::GRPCRouteRules {
+        for gateway::GrpcRouteRules {
             filters,
             matches,
             backend_refs,
@@ -745,7 +745,7 @@ impl Validate<gateway::GRPCRouteSpec> for Admission {
 }
 
 #[async_trait::async_trait]
-impl Validate<gateway::TLSRouteSpec> for Admission {
+impl Validate<gateway::TlsRouteSpec> for Admission {
     fn lenient() -> bool {
         true
     }
@@ -755,7 +755,7 @@ impl Validate<gateway::TLSRouteSpec> for Admission {
         _ns: &str,
         _name: &str,
         _annotations: &BTreeMap<String, String>,
-        spec: gateway::TLSRouteSpec,
+        spec: gateway::TlsRouteSpec,
     ) -> Result<()> {
         for parent in spec.parent_refs.iter().flatten() {
             if outbound_index::is_parent_egress_network(&parent.kind, &parent.group)
@@ -774,7 +774,7 @@ impl Validate<gateway::TLSRouteSpec> for Admission {
 }
 
 #[async_trait::async_trait]
-impl Validate<gateway::TCPRouteSpec> for Admission {
+impl Validate<gateway::TcpRouteSpec> for Admission {
     fn lenient() -> bool {
         true
     }
@@ -784,7 +784,7 @@ impl Validate<gateway::TCPRouteSpec> for Admission {
         _ns: &str,
         _name: &str,
         _annotations: &BTreeMap<String, String>,
-        spec: gateway::TCPRouteSpec,
+        spec: gateway::TcpRouteSpec,
     ) -> Result<()> {
         for parent in spec.parent_refs.iter().flatten() {
             if outbound_index::is_parent_egress_network(&parent.kind, &parent.group)

--- a/policy-controller/runtime/src/lease.rs
+++ b/policy-controller/runtime/src/lease.rs
@@ -39,7 +39,7 @@ pub async fn init<T>(
                 tracing::debug!(?deploy, "Found Deployment");
                 break deploy;
             }
-            Err(k8s::Error::Api(error)) => error.into(),
+            Err(k8s::Error::Api(error)) => (*error).into(),
             Err(k8s::Error::Service(error)) => error,
             Err(k8s::Error::HyperError(error)) => error.into(),
             Err(error) => {
@@ -94,7 +94,7 @@ pub async fn init<T>(
                 tracing::info!(?lease, "Created Lease");
                 break;
             }
-            Err(k8s::Error::Api(error)) if error.code >= 500 => error.into(),
+            Err(k8s::Error::Api(error)) if error.code >= 500 => (*error).into(),
             Err(k8s::Error::Api(error)) => {
                 tracing::debug!(?error, "Lease already exists");
                 break;

--- a/policy-test/Cargo.toml
+++ b/policy-test/Cargo.toml
@@ -23,7 +23,7 @@ prost-types = "0.14"
 rand = "0.10"
 serde = "1"
 serde_json = "1"
-schemars = "0.8"
+schemars = "1"
 tonic = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { workspace = true }

--- a/policy-test/src/lib.rs
+++ b/policy-test/src/lib.rs
@@ -232,7 +232,7 @@ pub async fn await_gateway_route_status(
     client: &kube::Client,
     ns: &str,
     name: &str,
-) -> gateway::HTTPRouteStatus {
+) -> gateway::HttpRouteStatus {
     let route_status = await_condition(
         client,
         ns,
@@ -277,7 +277,7 @@ pub async fn await_grpc_route_status(
     client: &kube::Client,
     ns: &str,
     name: &str,
-) -> gateway::GRPCRouteStatus {
+) -> gateway::GrpcRouteStatus {
     let route_status = await_condition(
         client,
         ns,
@@ -301,7 +301,7 @@ pub async fn await_tls_route_status(
     client: &kube::Client,
     ns: &str,
     name: &str,
-) -> gateway::TLSRouteStatus {
+) -> gateway::TlsRouteStatus {
     let route_status = await_condition(
         client,
         ns,
@@ -325,7 +325,7 @@ pub async fn await_tcp_route_status(
     client: &kube::Client,
     ns: &str,
     name: &str,
-) -> gateway::TCPRouteStatus {
+) -> gateway::TcpRouteStatus {
     let route_status = await_condition(
         client,
         ns,
@@ -601,7 +601,7 @@ pub fn mk_egress_net(ns: &str, name: &str) -> policy::EgressNetwork {
 #[track_caller]
 pub fn assert_resource_meta(
     meta: &Option<grpc::meta::Metadata>,
-    parent_ref: gateway::HTTPRouteParentRefs,
+    parent_ref: gateway::HttpRouteParentRefs,
     port: u16,
 ) {
     println!("meta: {meta:?}");
@@ -628,7 +628,7 @@ pub fn assert_resource_meta(
 pub fn mk_route(
     ns: &str,
     name: &str,
-    parent_refs: Option<Vec<gateway::HTTPRouteParentRefs>>,
+    parent_refs: Option<Vec<gateway::HttpRouteParentRefs>>,
 ) -> policy::HttpRoute {
     use policy::httproute as api;
     api::HttpRoute {
@@ -647,7 +647,7 @@ pub fn mk_route(
 }
 
 pub fn find_route_condition<'a>(
-    statuses: impl IntoIterator<Item = &'a gateway::HTTPRouteStatusParents>,
+    statuses: impl IntoIterator<Item = &'a gateway::HttpRouteStatusParents>,
     parent_name: &'static str,
 ) -> Option<&'a k8s::Condition> {
     statuses
@@ -656,7 +656,6 @@ pub fn find_route_condition<'a>(
         .expect("route must have at least one status set")
         .conditions
         .iter()
-        .flatten()
         .find(|cond| cond.type_ == "Accepted")
 }
 
@@ -824,8 +823,8 @@ pub fn random_suffix(len: usize) -> String {
 pub fn egress_network_parent_ref(
     ns: impl ToString,
     port: Option<u16>,
-) -> gateway::HTTPRouteParentRefs {
-    gateway::HTTPRouteParentRefs {
+) -> gateway::HttpRouteParentRefs {
+    gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("EgressNetwork".to_string()),
         namespace: Some(ns.to_string()),

--- a/policy-test/src/outbound_api.rs
+++ b/policy-test/src/outbound_api.rs
@@ -586,7 +586,7 @@ fn grpc_route_backend(route: &grpc::outbound::GrpcRoute) -> Option<&grpc::outbou
 #[track_caller]
 pub fn assert_route_is_default<R: TestRoute>(
     route: &R::Route,
-    parent: &gateway::HTTPRouteParentRefs,
+    parent: &gateway::HttpRouteParentRefs,
     port: u16,
 ) {
     let rules = &R::rules_first_available(route);
@@ -606,7 +606,7 @@ pub fn assert_route_is_default<R: TestRoute>(
 #[track_caller]
 pub fn assert_backend_matches_reference(
     backend: &grpc::outbound::Backend,
-    obj_ref: &gateway::HTTPRouteParentRefs,
+    obj_ref: &gateway::HttpRouteParentRefs,
     port: u16,
 ) {
     let mut group = obj_ref.group.as_deref();

--- a/policy-test/src/test_route.rs
+++ b/policy-test/src/test_route.rs
@@ -24,8 +24,8 @@ pub trait TestRoute:
 
     fn make_route(
         ns: impl ToString,
-        parents: Vec<gateway::HTTPRouteParentRefs>,
-        rules: Vec<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+        parents: Vec<gateway::HttpRouteParentRefs>,
+        rules: Vec<Vec<gateway::HttpRouteRulesBackendRefs>>,
     ) -> Self;
     fn routes<F>(config: &outbound::OutboundPolicy, f: F)
     where
@@ -68,10 +68,10 @@ pub trait TestParent:
     fn make_parent_with_protocol(ns: impl ToString, app_protocol: Option<String>) -> Self;
     fn make_backend(ns: impl ToString) -> Option<Self>;
     fn conditions(&self) -> Vec<&Condition>;
-    fn obj_ref(&self) -> gateway::HTTPRouteParentRefs;
-    fn backend_ref(&self, port: u16) -> gateway::HTTPRouteRulesBackendRefs {
+    fn obj_ref(&self) -> gateway::HttpRouteParentRefs;
+    fn backend_ref(&self, port: u16) -> gateway::HttpRouteRulesBackendRefs {
         let dt = Default::default();
-        gateway::HTTPRouteRulesBackendRefs {
+        gateway::HttpRouteRulesBackendRefs {
             weight: None,
             group: Some(Self::group(&dt).to_string()),
             kind: Some(Self::kind(&dt).to_string()),
@@ -91,14 +91,14 @@ impl TestRoute for gateway::HTTPRoute {
 
     fn make_route(
         ns: impl ToString,
-        parents: Vec<gateway::HTTPRouteParentRefs>,
-        rules: Vec<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+        parents: Vec<gateway::HttpRouteParentRefs>,
+        rules: Vec<Vec<gateway::HttpRouteRulesBackendRefs>>,
     ) -> Self {
         let rules = rules
             .into_iter()
             .map(|backends| {
                 let backends = backends.into_iter().collect();
-                gateway::HTTPRouteRules {
+                gateway::HttpRouteRules {
                     name: None,
                     matches: Some(vec![]),
                     filters: None,
@@ -113,10 +113,11 @@ impl TestRoute for gateway::HTTPRoute {
                 name: Some("foo-route".to_string()),
                 ..Default::default()
             },
-            spec: gateway::HTTPRouteSpec {
+            spec: gateway::HttpRouteSpec {
                 parent_refs: Some(parents),
                 hostnames: None,
                 rules: Some(rules),
+                use_default_gateways: None,
             },
             status: None,
         }
@@ -187,7 +188,6 @@ impl TestRoute for gateway::HTTPRoute {
                 .parents
                 .iter()
                 .flat_map(|parent_status| &parent_status.conditions)
-                .flatten()
                 .collect()
         })
     }
@@ -217,8 +217,8 @@ impl TestRoute for policy::HttpRoute {
 
     fn make_route(
         ns: impl ToString,
-        parents: Vec<gateway::HTTPRouteParentRefs>,
-        rules: Vec<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+        parents: Vec<gateway::HttpRouteParentRefs>,
+        rules: Vec<Vec<gateway::HttpRouteRulesBackendRefs>>,
     ) -> Self {
         let rules = rules
             .into_iter()
@@ -312,7 +312,6 @@ impl TestRoute for policy::HttpRoute {
                 .parents
                 .iter()
                 .flat_map(|parent_status| &parent_status.conditions)
-                .flatten()
                 .collect()
         })
     }
@@ -342,15 +341,15 @@ impl TestRoute for gateway::GRPCRoute {
 
     fn make_route(
         ns: impl ToString,
-        parents: Vec<gateway::HTTPRouteParentRefs>,
-        rules: Vec<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+        parents: Vec<gateway::HttpRouteParentRefs>,
+        rules: Vec<Vec<gateway::HttpRouteRulesBackendRefs>>,
     ) -> Self {
         let rules = rules
             .into_iter()
             .map(|backends| {
                 let backends = backends
                     .into_iter()
-                    .map(|br| gateway::GRPCRouteRulesBackendRefs {
+                    .map(|br| gateway::GrpcRouteRulesBackendRefs {
                         filters: None,
                         weight: br.weight,
                         group: br.group,
@@ -360,7 +359,7 @@ impl TestRoute for gateway::GRPCRoute {
                         port: br.port,
                     })
                     .collect();
-                gateway::GRPCRouteRules {
+                gateway::GrpcRouteRules {
                     name: None,
                     matches: Some(vec![]),
                     filters: None,
@@ -375,11 +374,11 @@ impl TestRoute for gateway::GRPCRoute {
                 name: Some("foo-route".to_string()),
                 ..Default::default()
             },
-            spec: gateway::GRPCRouteSpec {
+            spec: gateway::GrpcRouteSpec {
                 parent_refs: Some(
                     parents
                         .into_iter()
-                        .map(|parents| gateway::GRPCRouteParentRefs {
+                        .map(|parents| gateway::GrpcRouteParentRefs {
                             group: parents.group,
                             kind: parents.kind,
                             namespace: parents.namespace,
@@ -391,6 +390,7 @@ impl TestRoute for gateway::GRPCRoute {
                 ),
                 hostnames: None,
                 rules: Some(rules),
+                use_default_gateways: None,
             },
             status: None,
         }
@@ -461,7 +461,6 @@ impl TestRoute for gateway::GRPCRoute {
                 .parents
                 .iter()
                 .flat_map(|parent_status| &parent_status.conditions)
-                .flatten()
                 .collect()
         })
     }
@@ -492,26 +491,24 @@ impl TestRoute for gateway::TLSRoute {
 
     fn make_route(
         ns: impl ToString,
-        parents: Vec<gateway::HTTPRouteParentRefs>,
-        rules: Vec<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+        parents: Vec<gateway::HttpRouteParentRefs>,
+        rules: Vec<Vec<gateway::HttpRouteRulesBackendRefs>>,
     ) -> Self {
         let rules = rules
             .into_iter()
-            .map(|backends| gateway::TLSRouteRules {
+            .map(|backends| gateway::TlsRouteRules {
                 name: None,
-                backend_refs: Some(
-                    backends
-                        .into_iter()
-                        .map(|br| gateway::TLSRouteRulesBackendRefs {
-                            weight: br.weight,
-                            group: br.group,
-                            kind: br.kind,
-                            name: br.name,
-                            namespace: br.namespace,
-                            port: br.port,
-                        })
-                        .collect(),
-                ),
+                backend_refs: backends
+                    .into_iter()
+                    .map(|br| gateway::TlsRouteRulesBackendRefs {
+                        weight: br.weight,
+                        group: br.group,
+                        kind: br.kind,
+                        name: br.name,
+                        namespace: br.namespace,
+                        port: br.port,
+                    })
+                    .collect(),
             })
             .collect();
         gateway::TLSRoute {
@@ -520,11 +517,11 @@ impl TestRoute for gateway::TLSRoute {
                 name: Some("foo-route".to_string()),
                 ..Default::default()
             },
-            spec: gateway::TLSRouteSpec {
+            spec: gateway::TlsRouteSpec {
                 parent_refs: Some(
                     parents
                         .into_iter()
-                        .map(|parent| gateway::TLSRouteParentRefs {
+                        .map(|parent| gateway::TlsRouteParentRefs {
                             group: parent.group,
                             kind: parent.kind,
                             namespace: parent.namespace,
@@ -534,8 +531,9 @@ impl TestRoute for gateway::TLSRoute {
                         })
                         .collect(),
                 ),
-                hostnames: None,
+                hostnames: Vec::default(),
                 rules,
+                use_default_gateways: None,
             },
             status: None,
         }
@@ -606,7 +604,6 @@ impl TestRoute for gateway::TLSRoute {
                 .parents
                 .iter()
                 .flat_map(|parent_status| &parent_status.conditions)
-                .flatten()
                 .collect()
         })
     }
@@ -637,26 +634,24 @@ impl TestRoute for gateway::TCPRoute {
 
     fn make_route(
         ns: impl ToString,
-        parents: Vec<gateway::HTTPRouteParentRefs>,
-        rules: Vec<Vec<gateway::HTTPRouteRulesBackendRefs>>,
+        parents: Vec<gateway::HttpRouteParentRefs>,
+        rules: Vec<Vec<gateway::HttpRouteRulesBackendRefs>>,
     ) -> Self {
         let rules = rules
             .into_iter()
-            .map(|backends| gateway::TCPRouteRules {
+            .map(|backends| gateway::TcpRouteRules {
                 name: None,
-                backend_refs: Some(
-                    backends
-                        .into_iter()
-                        .map(|br| gateway::TCPRouteRulesBackendRefs {
-                            weight: br.weight,
-                            group: br.group,
-                            kind: br.kind,
-                            name: br.name,
-                            namespace: br.namespace,
-                            port: br.port,
-                        })
-                        .collect(),
-                ),
+                backend_refs: backends
+                    .into_iter()
+                    .map(|br| gateway::TcpRouteRulesBackendRefs {
+                        weight: br.weight,
+                        group: br.group,
+                        kind: br.kind,
+                        name: br.name,
+                        namespace: br.namespace,
+                        port: br.port,
+                    })
+                    .collect(),
             })
             .collect();
         gateway::TCPRoute {
@@ -665,11 +660,11 @@ impl TestRoute for gateway::TCPRoute {
                 name: Some("foo-route".to_string()),
                 ..Default::default()
             },
-            spec: gateway::TCPRouteSpec {
+            spec: gateway::TcpRouteSpec {
                 parent_refs: Some(
                     parents
                         .into_iter()
-                        .map(|parent| gateway::TCPRouteParentRefs {
+                        .map(|parent| gateway::TcpRouteParentRefs {
                             group: parent.group,
                             kind: parent.kind,
                             namespace: parent.namespace,
@@ -680,6 +675,7 @@ impl TestRoute for gateway::TCPRoute {
                         .collect(),
                 ),
                 rules,
+                use_default_gateways: None,
             },
             status: None,
         }
@@ -750,7 +746,6 @@ impl TestRoute for gateway::TCPRoute {
                 .parents
                 .iter()
                 .flat_map(|parent_status| &parent_status.conditions)
-                .flatten()
                 .collect()
         })
     }
@@ -832,8 +827,8 @@ impl TestParent for k8s::Service {
             .collect()
     }
 
-    fn obj_ref(&self) -> gateway::HTTPRouteParentRefs {
-        gateway::HTTPRouteParentRefs {
+    fn obj_ref(&self) -> gateway::HttpRouteParentRefs {
+        gateway::HttpRouteParentRefs {
             kind: Some(k8s::Service::KIND.to_string()),
             name: self.name_unchecked(),
             namespace: self.namespace(),
@@ -877,8 +872,8 @@ impl TestParent for policy::EgressNetwork {
         self.status.as_ref().unwrap().conditions.iter().collect()
     }
 
-    fn obj_ref(&self) -> gateway::HTTPRouteParentRefs {
-        gateway::HTTPRouteParentRefs {
+    fn obj_ref(&self) -> gateway::HttpRouteParentRefs {
+        gateway::HttpRouteParentRefs {
             kind: Some(policy::EgressNetwork::kind(&()).to_string()),
             name: self.name_unchecked(),
             namespace: self.namespace(),

--- a/policy-test/tests/admit_grpc_route.rs
+++ b/policy-test/tests/admit_grpc_route.rs
@@ -9,8 +9,8 @@ async fn accepts_valid_egress_network() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::GRPCRouteSpec {
-            parent_refs: Some(vec![gateway::GRPCRouteParentRefs {
+        spec: gateway::GrpcRouteSpec {
+            parent_refs: Some(vec![gateway::GrpcRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -20,6 +20,7 @@ async fn accepts_valid_egress_network() {
             }]),
             hostnames: None,
             rules: Some(rules()),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -34,8 +35,8 @@ async fn rejects_egress_network_parent_with_no_port() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::GRPCRouteSpec {
-            parent_refs: Some(vec![gateway::GRPCRouteParentRefs {
+        spec: gateway::GrpcRouteSpec {
+            parent_refs: Some(vec![gateway::GrpcRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -45,20 +46,21 @@ async fn rejects_egress_network_parent_with_no_port() {
             }]),
             hostnames: None,
             rules: Some(rules()),
+            use_default_gateways: None,
         },
         status: None,
     })
     .await;
 }
 
-fn rules() -> Vec<gateway::GRPCRouteRules> {
-    vec![gateway::GRPCRouteRules {
+fn rules() -> Vec<gateway::GrpcRouteRules> {
+    vec![gateway::GrpcRouteRules {
         name: None,
-        matches: Some(vec![gateway::GRPCRouteRulesMatches {
-            method: Some(gateway::GRPCRouteRulesMatchesMethod {
+        matches: Some(vec![gateway::GrpcRouteRulesMatches {
+            method: Some(gateway::GrpcRouteRulesMatchesMethod {
                 method: Some("foo".to_string()),
                 service: Some("boo".to_string()),
-                r#type: Some(gateway::GRPCRouteRulesMatchesMethodType::Exact),
+                r#type: Some(gateway::GrpcRouteRulesMatchesMethodType::Exact),
             }),
             ..Default::default()
         }]),

--- a/policy-test/tests/admit_http_local_ratelimit_policy.rs
+++ b/policy-test/tests/admit_http_local_ratelimit_policy.rs
@@ -1,4 +1,4 @@
-use k8s_openapi::chrono;
+use k8s_openapi::jiff;
 use linkerd_policy_controller_k8s_api::{
     self as api,
     policy::{
@@ -93,7 +93,7 @@ fn mk_ratelimiter(
         },
         status: Some(HttpLocalRateLimitPolicyStatus {
             conditions: vec![api::Condition {
-                last_transition_time: api::Time(chrono::DateTime::<chrono::Utc>::MIN_UTC),
+                last_transition_time: api::Time(jiff::Timestamp::MIN),
                 message: "".to_string(),
                 observed_generation: None,
                 reason: "".to_string(),

--- a/policy-test/tests/admit_http_route.rs
+++ b/policy-test/tests/admit_http_route.rs
@@ -63,10 +63,10 @@ async fn rejects_relative_path_match() {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
             rules: Some(vec![policy::httproute::HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("foo/bar".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
                     ..Default::default()
                 }]),
@@ -88,20 +88,20 @@ async fn rejects_relative_redirect_path() {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
             rules: Some(vec![policy::httproute::HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
                     ..Default::default()
                 }]),
                 filters: Some(vec![policy::httproute::HttpRouteFilter::RequestRedirect {
-                    request_redirect: gateway::HTTPRouteRulesFiltersRequestRedirect {
+                    request_redirect: gateway::HttpRouteRulesFiltersRequestRedirect {
                         scheme: None,
                         hostname: None,
-                        path: Some(gateway::HTTPRouteRulesFiltersRequestRedirectPath {
+                        path: Some(gateway::HttpRouteRulesFiltersRequestRedirectPath {
                             replace_full_path: Some("foo/bar".to_string()),
-                            r#type: gateway::HTTPRouteRulesFiltersRequestRedirectPathType::ReplaceFullPath,
+                            r#type: gateway::HttpRouteRulesFiltersRequestRedirectPathType::ReplaceFullPath,
                             ..Default::default()
                         }),
                         port: None,
@@ -117,8 +117,8 @@ async fn rejects_relative_redirect_path() {
     .await;
 }
 
-fn server_parent_ref(ns: impl ToString) -> gateway::HTTPRouteParentRefs {
-    gateway::HTTPRouteParentRefs {
+fn server_parent_ref(ns: impl ToString) -> gateway::HttpRouteParentRefs {
+    gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("Server".to_string()),
         namespace: Some(ns.to_string()),
@@ -138,10 +138,10 @@ fn meta(ns: impl ToString) -> k8s::ObjectMeta {
 
 fn rules() -> Vec<policy::httproute::HttpRouteRule> {
     vec![policy::httproute::HttpRouteRule {
-        matches: Some(vec![gateway::HTTPRouteRulesMatches {
-            path: Some(gateway::HTTPRouteRulesMatchesPath {
+        matches: Some(vec![gateway::HttpRouteRulesMatches {
+            path: Some(gateway::HttpRouteRulesMatchesPath {
                 value: Some("/foo".to_string()),
-                r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
             }),
             ..Default::default()
         }]),

--- a/policy-test/tests/admit_http_route_gateway.rs
+++ b/policy-test/tests/admit_http_route_gateway.rs
@@ -5,10 +5,11 @@ use linkerd_policy_test::admission;
 async fn accepts_valid() {
     admission::accepts(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
             rules: Some(rules()),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -19,21 +20,21 @@ async fn accepts_valid() {
 async fn accepts_not_implemented_requestmirror() {
     admission::accepts(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
-                filters: Some(vec![gateway::HTTPRouteRulesFilters {
-                    request_mirror: Some(gateway::HTTPRouteRulesFiltersRequestMirror {
-                        backend_ref: gateway::HTTPRouteRulesFiltersRequestMirrorBackendRef {
+                filters: Some(vec![gateway::HttpRouteRulesFilters {
+                    request_mirror: Some(gateway::HttpRouteRulesFiltersRequestMirror {
+                        backend_ref: gateway::HttpRouteRulesFiltersRequestMirrorBackendRef {
                             group: None,
                             kind: None,
                             namespace: Some("foo".to_string()),
@@ -43,12 +44,13 @@ async fn accepts_not_implemented_requestmirror() {
                         percent: Some(100),
                         ..Default::default()
                     }),
-                    r#type: gateway::HTTPRouteRulesFiltersType::RequestMirror,
+                    r#type: gateway::HttpRouteRulesFiltersType::RequestMirror,
                     ..Default::default()
                 }]),
                 backend_refs: None,
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -63,34 +65,35 @@ async fn accepts_not_implemented_urlrewrite() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
-                filters: Some(vec![gateway::HTTPRouteRulesFilters {
-                    url_rewrite: Some(gateway::HTTPRouteRulesFiltersUrlRewrite {
+                filters: Some(vec![gateway::HttpRouteRulesFilters {
+                    url_rewrite: Some(gateway::HttpRouteRulesFiltersUrlRewrite {
                         hostname: Some("foo".to_string()),
-                        path: Some(gateway::HTTPRouteRulesFiltersUrlRewritePath {
+                        path: Some(gateway::HttpRouteRulesFiltersUrlRewritePath {
                             replace_full_path: Some("baz".to_string()),
                             r#type:
-                                gateway::HTTPRouteRulesFiltersUrlRewritePathType::ReplaceFullPath,
+                                gateway::HttpRouteRulesFiltersUrlRewritePathType::ReplaceFullPath,
                             ..Default::default()
                         }),
                     }),
-                    r#type: gateway::HTTPRouteRulesFiltersType::UrlRewrite,
+                    r#type: gateway::HttpRouteRulesFiltersType::UrlRewrite,
                     ..Default::default()
                 }]),
                 backend_refs: None,
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -105,30 +108,31 @@ async fn accepts_not_implemented_extensionref() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
-                filters: Some(vec![gateway::HTTPRouteRulesFilters {
-                    extension_ref: Some(gateway::HTTPRouteRulesFiltersExtensionRef {
+                filters: Some(vec![gateway::HttpRouteRulesFilters {
+                    extension_ref: Some(gateway::HttpRouteRulesFiltersExtensionRef {
                         group: "".to_string(),
                         kind: "Service".to_string(),
                         name: "foo".to_string(),
                     }),
-                    r#type: gateway::HTTPRouteRulesFiltersType::ExtensionRef,
+                    r#type: gateway::HttpRouteRulesFiltersType::ExtensionRef,
                     ..Default::default()
                 }]),
                 backend_refs: None,
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -139,20 +143,20 @@ async fn accepts_not_implemented_extensionref() {
 async fn accepts_backend_unknown_kind() {
     admission::accepts(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
                 filters: None,
-                backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                     weight: None,
                     group: Some("alien.example.com".to_string()),
                     kind: Some("ExoService".to_string()),
@@ -163,6 +167,7 @@ async fn accepts_backend_unknown_kind() {
                 }]),
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -173,20 +178,20 @@ async fn accepts_backend_unknown_kind() {
 async fn accepts_backend_service_with_port() {
     admission::accepts(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
                 filters: None,
-                backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                     weight: None,
                     group: Some("core".to_string()),
                     kind: Some("Service".to_string()),
@@ -197,6 +202,7 @@ async fn accepts_backend_service_with_port() {
                 }]),
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -207,20 +213,20 @@ async fn accepts_backend_service_with_port() {
 async fn accepts_backend_service_implicit_with_port() {
     admission::accepts(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
                 filters: None,
-                backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                     weight: None,
                     group: None,
                     kind: None,
@@ -231,6 +237,7 @@ async fn accepts_backend_service_implicit_with_port() {
                 }]),
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -241,22 +248,23 @@ async fn accepts_backend_service_implicit_with_port() {
 async fn rejects_relative_path_match() {
     admission::rejects(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
                 filters: None,
                 backend_refs: None,
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -267,38 +275,39 @@ async fn rejects_relative_path_match() {
 async fn rejects_relative_redirect_path() {
     admission::rejects(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
 
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
-                filters: Some(vec![gateway::HTTPRouteRulesFilters {
-                    request_redirect: Some(gateway::HTTPRouteRulesFiltersRequestRedirect {
+                filters: Some(vec![gateway::HttpRouteRulesFilters {
+                    request_redirect: Some(gateway::HttpRouteRulesFiltersRequestRedirect {
                         scheme: None,
                         hostname: None,
-                        path: Some(gateway::HTTPRouteRulesFiltersRequestRedirectPath {
+                        path: Some(gateway::HttpRouteRulesFiltersRequestRedirectPath {
                             replace_full_path: Some("foo/bar".to_string()),
                             r#type:
-                                gateway::HTTPRouteRulesFiltersRequestRedirectPathType::ReplaceFullPath,
+                                gateway::HttpRouteRulesFiltersRequestRedirectPathType::ReplaceFullPath,
                             ..Default::default()
                         }),
                         port: None,
                         status_code: None,
                     }),
-                    r#type: gateway::HTTPRouteRulesFiltersType::RequestRedirect,
+                    r#type: gateway::HttpRouteRulesFiltersType::RequestRedirect,
                     ..Default::default()
                 }]),
                 backend_refs: None,
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -309,20 +318,20 @@ async fn rejects_relative_redirect_path() {
 async fn rejects_backend_service_without_port() {
     admission::rejects(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
                 filters: None,
-                backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                     weight: None,
                     group: Some("core".to_string()),
                     kind: Some("Service".to_string()),
@@ -333,6 +342,7 @@ async fn rejects_backend_service_without_port() {
                 }]),
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -343,21 +353,21 @@ async fn rejects_backend_service_without_port() {
 async fn rejects_backend_service_implicit_without_port() {
     admission::rejects(|ns| gateway::HTTPRoute {
         metadata: meta(&ns),
-        spec: gateway::HTTPRouteSpec {
+        spec: gateway::HttpRouteSpec {
             parent_refs: Some(vec![server_parent_ref(ns)]),
 
             hostnames: None,
-            rules: Some(vec![gateway::HTTPRouteRules {
+            rules: Some(vec![gateway::HttpRouteRules {
                 name: None,
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
-                    ..gateway::HTTPRouteRulesMatches::default()
+                    ..gateway::HttpRouteRulesMatches::default()
                 }]),
                 filters: None,
-                backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                     weight: None,
                     group: None,
                     kind: None,
@@ -368,14 +378,15 @@ async fn rejects_backend_service_implicit_without_port() {
                 }]),
                 ..Default::default()
             }]),
+            use_default_gateways: None,
         },
         status: None,
     })
     .await;
 }
 
-fn server_parent_ref(ns: impl ToString) -> gateway::HTTPRouteParentRefs {
-    gateway::HTTPRouteParentRefs {
+fn server_parent_ref(ns: impl ToString) -> gateway::HttpRouteParentRefs {
+    gateway::HttpRouteParentRefs {
         group: Some("policy.linkerd.io".to_string()),
         kind: Some("Server".to_string()),
         namespace: Some(ns.to_string()),
@@ -393,15 +404,15 @@ fn meta(ns: impl ToString) -> api::ObjectMeta {
     }
 }
 
-fn rules() -> Vec<gateway::HTTPRouteRules> {
-    vec![gateway::HTTPRouteRules {
+fn rules() -> Vec<gateway::HttpRouteRules> {
+    vec![gateway::HttpRouteRules {
         name: None,
-        matches: Some(vec![gateway::HTTPRouteRulesMatches {
-            path: Some(gateway::HTTPRouteRulesMatchesPath {
+        matches: Some(vec![gateway::HttpRouteRulesMatches {
+            path: Some(gateway::HttpRouteRulesMatchesPath {
                 value: Some("/foo".to_string()),
-                r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
             }),
-            ..gateway::HTTPRouteRulesMatches::default()
+            ..gateway::HttpRouteRulesMatches::default()
         }]),
         filters: None,
         backend_refs: None,

--- a/policy-test/tests/admit_tcp_route.rs
+++ b/policy-test/tests/admit_tcp_route.rs
@@ -11,8 +11,8 @@ async fn accepts_valid_egress_network() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::TCPRouteSpec {
-            parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+        spec: gateway::TcpRouteSpec {
+            parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -21,6 +21,7 @@ async fn accepts_valid_egress_network() {
                 port: Some(555),
             }]),
             rules: rules(1),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -35,8 +36,8 @@ async fn rejects_egress_network_parent_with_no_port() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::TCPRouteSpec {
-            parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+        spec: gateway::TcpRouteSpec {
+            parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -45,6 +46,7 @@ async fn rejects_egress_network_parent_with_no_port() {
                 port: None,
             }]),
             rules: rules(1),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -59,8 +61,8 @@ async fn rejects_if_more_than_one_rule() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::TCPRouteSpec {
-            parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+        spec: gateway::TcpRouteSpec {
+            parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -69,25 +71,26 @@ async fn rejects_if_more_than_one_rule() {
                 port: Some(555),
             }]),
             rules: rules(2),
+            use_default_gateways: None,
         },
         status: None,
     })
     .await;
 }
 
-fn rules(n: u16) -> Vec<gateway::TCPRouteRules> {
+fn rules(n: u16) -> Vec<gateway::TcpRouteRules> {
     let mut rules = Vec::default();
     for n in 1..=n {
-        rules.push(gateway::TCPRouteRules {
+        rules.push(gateway::TcpRouteRules {
             name: None,
-            backend_refs: Some(vec![gateway::TCPRouteRulesBackendRefs {
+            backend_refs: vec![gateway::TcpRouteRulesBackendRefs {
                 weight: None,
                 name: format!("default-{n}"),
                 group: Some("policy.linkerd.ip".to_string()),
                 namespace: Some("root".to_string()),
                 port: None,
                 kind: Some("EgressNetwork".to_string()),
-            }]),
+            }],
         });
     }
     rules

--- a/policy-test/tests/admit_tls_route.rs
+++ b/policy-test/tests/admit_tls_route.rs
@@ -11,9 +11,9 @@ async fn accepts_valid_egress_network() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::TLSRouteSpec {
-            hostnames: None,
-            parent_refs: Some(vec![gateway::TLSRouteParentRefs {
+        spec: gateway::TlsRouteSpec {
+            hostnames: Vec::default(),
+            parent_refs: Some(vec![gateway::TlsRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -22,6 +22,7 @@ async fn accepts_valid_egress_network() {
                 port: Some(555),
             }]),
             rules: rules(1),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -36,9 +37,9 @@ async fn rejects_egress_network_parent_with_no_port() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::TLSRouteSpec {
-            hostnames: None,
-            parent_refs: Some(vec![gateway::TLSRouteParentRefs {
+        spec: gateway::TlsRouteSpec {
+            hostnames: Vec::default(),
+            parent_refs: Some(vec![gateway::TlsRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -47,6 +48,7 @@ async fn rejects_egress_network_parent_with_no_port() {
                 port: None,
             }]),
             rules: rules(1),
+            use_default_gateways: None,
         },
         status: None,
     })
@@ -61,9 +63,9 @@ async fn rejects_if_more_than_one_rule() {
             name: Some("test".to_string()),
             ..Default::default()
         },
-        spec: gateway::TLSRouteSpec {
-            hostnames: None,
-            parent_refs: Some(vec![gateway::TLSRouteParentRefs {
+        spec: gateway::TlsRouteSpec {
+            hostnames: Vec::default(),
+            parent_refs: Some(vec![gateway::TlsRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("EgressNetwork".to_string()),
                 namespace: Some(ns.to_string()),
@@ -72,25 +74,26 @@ async fn rejects_if_more_than_one_rule() {
                 port: Some(555),
             }]),
             rules: rules(2),
+            use_default_gateways: None,
         },
         status: None,
     })
     .await;
 }
 
-fn rules(n: u16) -> Vec<gateway::TLSRouteRules> {
+fn rules(n: u16) -> Vec<gateway::TlsRouteRules> {
     let mut rules = Vec::default();
     for n in 1..=n {
-        rules.push(gateway::TLSRouteRules {
+        rules.push(gateway::TlsRouteRules {
             name: None,
-            backend_refs: Some(vec![gateway::TLSRouteRulesBackendRefs {
+            backend_refs: vec![gateway::TlsRouteRulesBackendRefs {
                 weight: None,
                 name: format!("default-{n}"),
                 group: Some("policy.linkerd.ip".to_string()),
                 namespace: Some("root".to_string()),
                 port: None,
                 kind: Some("EgressNetwork".to_string()),
-            }]),
+            }],
         });
     }
     rules

--- a/policy-test/tests/e2e_authorization_policy.rs
+++ b/policy-test/tests/e2e_authorization_policy.rs
@@ -649,7 +649,7 @@ fn http_route(name: &str, ns: &str, server_name: &str, path: &str) -> k8s::polic
             ..Default::default()
         },
         spec: k8s::policy::HttpRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("Server".to_string()),
                 namespace: Some(ns.to_string()),
@@ -659,10 +659,10 @@ fn http_route(name: &str, ns: &str, server_name: &str, path: &str) -> k8s::polic
             }]),
             hostnames: None,
             rules: Some(vec![k8s::policy::httproute::HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some(path.to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
                     ..Default::default()
                 }]),

--- a/policy-test/tests/e2e_egress_network.rs
+++ b/policy-test/tests/e2e_egress_network.rs
@@ -203,8 +203,8 @@ async fn explicit_allow_http_route() {
                     name: Some("http-route".to_string()),
                     ..Default::default()
                 },
-                spec: gateway::HTTPRouteSpec {
-                    parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+                spec: gateway::HttpRouteSpec {
+                    parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                         namespace: None,
                         name: "egress".to_string(),
                         port: Some(80),
@@ -213,12 +213,12 @@ async fn explicit_allow_http_route() {
                         section_name: None,
                     }]),
                     hostnames: None,
-                    rules: Some(vec![gateway::HTTPRouteRules {
+                    rules: Some(vec![gateway::HttpRouteRules {
                         name: None,
-                        matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                            path: Some(gateway::HTTPRouteRulesMatchesPath {
+                        matches: Some(vec![gateway::HttpRouteRulesMatches {
+                            path: Some(gateway::HttpRouteRulesMatchesPath {
                                 value: Some("/get".to_string()),
-                                r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                                r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                             }),
                             ..Default::default()
                         }]),
@@ -226,6 +226,7 @@ async fn explicit_allow_http_route() {
                         filters: None,
                         ..Default::default()
                     }]),
+                    use_default_gateways: None,
                 },
                 status: None,
             },
@@ -310,8 +311,8 @@ async fn explicit_allow_tls_route() {
                     name: Some("tls-route".to_string()),
                     ..Default::default()
                 },
-                spec: gateway::TLSRouteSpec {
-                    parent_refs: Some(vec![gateway::TLSRouteParentRefs {
+                spec: gateway::TlsRouteSpec {
+                    parent_refs: Some(vec![gateway::TlsRouteParentRefs {
                         namespace: None,
                         name: "egress".to_string(),
                         port: Some(443),
@@ -319,18 +320,19 @@ async fn explicit_allow_tls_route() {
                         kind: Some("EgressNetwork".to_string()),
                         section_name: None,
                     }]),
-                    hostnames: Some(vec!["postman-echo.com".to_string()]),
-                    rules: vec![gateway::TLSRouteRules {
+                    hostnames: vec!["postman-echo.com".to_string()],
+                    rules: vec![gateway::TlsRouteRules {
                         name: None,
-                        backend_refs: Some(vec![gateway::TLSRouteRulesBackendRefs {
+                        backend_refs: vec![gateway::TlsRouteRulesBackendRefs {
                             weight: None,
                             namespace: None,
                             name: "egress".to_string(),
                             port: Some(443),
                             group: Some("policy.linkerd.io".to_string()),
                             kind: Some("EgressNetwork".to_string()),
-                        }]),
+                        }],
                     }],
+                    use_default_gateways: None,
                 },
                 status: None,
             },
@@ -418,8 +420,8 @@ async fn explicit_allow_tcp_route() {
                     name: Some("tcp-route".to_string()),
                     ..Default::default()
                 },
-                spec: gateway::TCPRouteSpec {
-                    parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+                spec: gateway::TcpRouteSpec {
+                    parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                         namespace: None,
                         name: "egress".to_string(),
                         port: Some(443),
@@ -427,17 +429,18 @@ async fn explicit_allow_tcp_route() {
                         kind: Some("EgressNetwork".to_string()),
                         section_name: None,
                     }]),
-                    rules: vec![gateway::TCPRouteRules {
+                    rules: vec![gateway::TcpRouteRules {
                         name: None,
-                        backend_refs: Some(vec![gateway::TCPRouteRulesBackendRefs {
+                        backend_refs: vec![gateway::TcpRouteRulesBackendRefs {
                             weight: None,
                             namespace: None,
                             name: "egress".to_string(),
                             port: Some(443),
                             group: Some("policy.linkerd.io".to_string()),
                             kind: Some("EgressNetwork".to_string()),
-                        }]),
+                        }],
                     }],
+                    use_default_gateways: None,
                 },
                 status: None,
             },
@@ -519,8 +522,8 @@ async fn routing_back_to_cluster_http_route() {
                     name: Some("http-route".to_string()),
                     ..Default::default()
                 },
-                spec: gateway::HTTPRouteSpec {
-                    parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+                spec: gateway::HttpRouteSpec {
+                    parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                         namespace: None,
                         name: "egress".to_string(),
                         port: Some(80),
@@ -529,16 +532,16 @@ async fn routing_back_to_cluster_http_route() {
                         section_name: None,
                     }]),
                     hostnames: Some(vec!["postman-echo.com".to_string()]),
-                    rules: Some(vec![gateway::HTTPRouteRules {
+                    rules: Some(vec![gateway::HttpRouteRules {
                         name: None,
-                        matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                            path: Some(gateway::HTTPRouteRulesMatchesPath {
+                        matches: Some(vec![gateway::HttpRouteRulesMatches {
+                            path: Some(gateway::HttpRouteRulesMatchesPath {
                                 value: Some("/get".to_string()),
-                                r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                                r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                             }),
                             ..Default::default()
                         }]),
-                        backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+                        backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
                             weight: None,
                             namespace: Some(ns.clone()),
                             name: "web".to_string(),
@@ -550,6 +553,7 @@ async fn routing_back_to_cluster_http_route() {
                         filters: None,
                         ..Default::default()
                     }]),
+                    use_default_gateways: None,
                 },
                 status: None,
             },
@@ -626,8 +630,8 @@ async fn routing_back_to_cluster_tls_route() {
                     name: Some("tls-route".to_string()),
                     ..Default::default()
                 },
-                spec: gateway::TLSRouteSpec {
-                    parent_refs: Some(vec![gateway::TLSRouteParentRefs {
+                spec: gateway::TlsRouteSpec {
+                    parent_refs: Some(vec![gateway::TlsRouteParentRefs {
                         namespace: None,
                         name: "egress".to_string(),
                         port: Some(443),
@@ -635,18 +639,19 @@ async fn routing_back_to_cluster_tls_route() {
                         kind: Some("EgressNetwork".to_string()),
                         section_name: None,
                     }]),
-                    hostnames: Some(vec!["postman-echo.com".to_string()]),
-                    rules: vec![gateway::TLSRouteRules {
+                    hostnames: vec!["postman-echo.com".to_string()],
+                    rules: vec![gateway::TlsRouteRules {
                         name: None,
-                        backend_refs: Some(vec![gateway::TLSRouteRulesBackendRefs {
+                        backend_refs: vec![gateway::TlsRouteRulesBackendRefs {
                             weight: None,
                             namespace: Some(ns.clone()),
                             name: "web".to_string(),
                             port: Some(80),
                             group: None,
                             kind: None,
-                        }]),
+                        }],
                     }],
+                    use_default_gateways: None,
                 },
                 status: None,
             },
@@ -718,8 +723,8 @@ async fn routing_back_to_cluster_tcp_route() {
                     name: Some("tcp-route".to_string()),
                     ..Default::default()
                 },
-                spec: gateway::TCPRouteSpec {
-                    parent_refs: Some(vec![gateway::TCPRouteParentRefs {
+                spec: gateway::TcpRouteSpec {
+                    parent_refs: Some(vec![gateway::TcpRouteParentRefs {
                         namespace: None,
                         name: "egress".to_string(),
                         port: Some(80),
@@ -727,17 +732,18 @@ async fn routing_back_to_cluster_tcp_route() {
                         kind: Some("EgressNetwork".to_string()),
                         section_name: None,
                     }]),
-                    rules: vec![gateway::TCPRouteRules {
+                    rules: vec![gateway::TcpRouteRules {
                         name: None,
-                        backend_refs: Some(vec![gateway::TCPRouteRulesBackendRefs {
+                        backend_refs: vec![gateway::TcpRouteRulesBackendRefs {
                             weight: None,
                             namespace: Some(ns.clone()),
                             name: "web".to_string(),
                             port: Some(80),
                             group: None,
                             kind: None,
-                        }]),
+                        }],
                     }],
+                    use_default_gateways: None,
                 },
                 status: None,
             },

--- a/policy-test/tests/e2e_http_routing.rs
+++ b/policy-test/tests/e2e_http_routing.rs
@@ -16,7 +16,7 @@ async fn path_based_routing() {
                     ..Default::default()
                 },
                 spec: k8s::policy::HttpRouteSpec {
-                    parent_refs: Some(vec![k8s::gateway::HTTPRouteParentRefs {
+                    parent_refs: Some(vec![k8s::gateway::HttpRouteParentRefs {
                         namespace: None,
                         name: "web".to_string(),
                         port: Some(80),
@@ -72,14 +72,14 @@ async fn path_based_routing() {
 
 fn rule(path: String, backend: String) -> k8s::policy::httproute::HttpRouteRule {
     k8s::policy::httproute::HttpRouteRule {
-        matches: Some(vec![gateway::HTTPRouteRulesMatches {
-            path: Some(gateway::HTTPRouteRulesMatchesPath {
+        matches: Some(vec![gateway::HttpRouteRulesMatches {
+            path: Some(gateway::HttpRouteRulesMatchesPath {
                 value: Some(path),
-                r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
             }),
             ..Default::default()
         }]),
-        backend_refs: Some(vec![gateway::HTTPRouteRulesBackendRefs {
+        backend_refs: Some(vec![gateway::HttpRouteRulesBackendRefs {
             weight: None,
             group: None,
             kind: None,

--- a/policy-test/tests/inbound_api.rs
+++ b/policy-test/tests/inbound_api.rs
@@ -742,7 +742,7 @@ fn mk_admin_route(ns: &str, name: &str) -> k8s::policy::HttpRoute {
             ..Default::default()
         },
         spec: api::HttpRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("Server".to_string()),
                 namespace: None,
@@ -752,14 +752,14 @@ fn mk_admin_route(ns: &str, name: &str) -> k8s::policy::HttpRoute {
             }]),
             hostnames: None,
             rules: Some(vec![api::HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/metrics".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
                     headers: None,
                     query_params: None,
-                    method: Some(gateway::HTTPRouteRulesMatchesMethod::Get),
+                    method: Some(gateway::HttpRouteRulesMatchesMethod::Get),
                 }]),
                 filters: None,
                 backend_refs: None,
@@ -782,7 +782,7 @@ fn mk_admin_route_with_path(ns: &str, name: &str, path: &str) -> k8s::policy::Ht
             ..Default::default()
         },
         spec: api::HttpRouteSpec {
-            parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+            parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("Server".to_string()),
                 namespace: None,
@@ -792,14 +792,14 @@ fn mk_admin_route_with_path(ns: &str, name: &str, path: &str) -> k8s::policy::Ht
             }]),
             hostnames: None,
             rules: Some(vec![api::HttpRouteRule {
-                matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                matches: Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some(path.to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                     }),
                     headers: None,
                     query_params: None,
-                    method: Some(gateway::HTTPRouteRulesMatchesMethod::Get),
+                    method: Some(gateway::HttpRouteRulesMatchesMethod::Get),
                 }]),
                 filters: None,
                 backend_refs: None,

--- a/policy-test/tests/inbound_api_external_workload.rs
+++ b/policy-test/tests/inbound_api_external_workload.rs
@@ -191,7 +191,7 @@ async fn external_workload_srv_with_http_route() {
                     ..Default::default()
                 },
                 spec: api::HttpRouteSpec {
-                    parent_refs: Some(vec![gateway::HTTPRouteParentRefs {
+                    parent_refs: Some(vec![gateway::HttpRouteParentRefs {
                         group: Some("policy.linkerd.io".to_string()),
                         kind: Some("Server".to_string()),
                         name: server.name_any(),
@@ -201,14 +201,14 @@ async fn external_workload_srv_with_http_route() {
                     }]),
                     hostnames: None,
                     rules: Some(vec![api::HttpRouteRule {
-                        matches: Some(vec![gateway::HTTPRouteRulesMatches {
-                            path: Some(gateway::HTTPRouteRulesMatchesPath {
+                        matches: Some(vec![gateway::HttpRouteRulesMatches {
+                            path: Some(gateway::HttpRouteRulesMatchesPath {
                                 value: Some("/endpoint".to_string()),
-                                r#type: Some(gateway::HTTPRouteRulesMatchesPathType::Exact),
+                                r#type: Some(gateway::HttpRouteRulesMatchesPathType::Exact),
                             }),
                             headers: None,
                             query_params: None,
-                            method: Some(gateway::HTTPRouteRulesMatchesMethod::Get),
+                            method: Some(gateway::HttpRouteRulesMatchesMethod::Get),
                         }]),
                         filters: None,
                         backend_refs: None,

--- a/policy-test/tests/inbound_http_route_status.rs
+++ b/policy-test/tests/inbound_http_route_status.rs
@@ -25,7 +25,7 @@ async fn inbound_accepted_parent() {
             },
         };
         let server = create(&client, server).await;
-        let srv_ref = vec![gateway::HTTPRouteParentRefs {
+        let srv_ref = vec![gateway::HttpRouteParentRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("Server".to_string()),
             namespace: server.namespace(),
@@ -68,7 +68,7 @@ async fn inbound_multiple_parents() {
     with_temp_ns(|client, ns| async move {
         // Exercise accepted test with a valid, and an invalid parent reference
         let srv_refs = vec![
-            gateway::HTTPRouteParentRefs {
+            gateway::HttpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("Server".to_string()),
                 namespace: Some(ns.clone()),
@@ -76,7 +76,7 @@ async fn inbound_multiple_parents() {
                 section_name: None,
                 port: None,
             },
-            gateway::HTTPRouteParentRefs {
+            gateway::HttpRouteParentRefs {
                 group: Some("policy.linkerd.io".to_string()),
                 kind: Some("Server".to_string()),
                 namespace: Some(ns.clone()),
@@ -152,7 +152,7 @@ async fn inbound_no_parent_ref_patch() {
             },
         };
         let server = create(&client, server).await;
-        let srv_ref = vec![gateway::HTTPRouteParentRefs {
+        let srv_ref = vec![gateway::HttpRouteParentRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("Server".to_string()),
             namespace: server.namespace(),
@@ -204,7 +204,7 @@ async fn inbound_accepted_reconcile_no_parent() {
         // Given a route with a nonexistent parentReference, we expect to have an
         // 'Accepted' condition with 'False' as a status.
         let server_name = "test-reconcile-inbound-server";
-        let srv_ref = vec![gateway::HTTPRouteParentRefs {
+        let srv_ref = vec![gateway::HttpRouteParentRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("Server".to_string()),
             namespace: Some(ns.clone()),
@@ -294,7 +294,7 @@ async fn inbound_accepted_reconcile_parent_delete() {
         create(&client, server).await;
 
         // Create parentReference and route
-        let srv_ref = vec![gateway::HTTPRouteParentRefs {
+        let srv_ref = vec![gateway::HttpRouteParentRefs {
             group: Some("policy.linkerd.io".to_string()),
             kind: Some("Server".to_string()),
             namespace: Some(ns.clone()),
@@ -355,7 +355,7 @@ async fn await_route_status(
     client: &kube::Client,
     ns: &str,
     name: &str,
-) -> gateway::HTTPRouteStatus {
+) -> gateway::HttpRouteStatus {
     use k8s::policy::httproute as api;
     let route_status = await_condition(client, ns, name, |obj: Option<&api::HttpRoute>| -> bool {
         obj.and_then(|route| route.status.as_ref()).is_some()

--- a/policy-test/tests/outbound_api.rs
+++ b/policy-test/tests/outbound_api.rs
@@ -132,11 +132,16 @@ async fn route_with_no_rules() {
         .await;
     }
 
-    test::<k8s::Service, gateway::HTTPRoute>().await;
+    // `gateway::HTTPRoute` is deliberately not exercised here: a rule-less
+    // Gateway API HTTPRoute cannot be expressed. `spec.rules` carries a CRD
+    // default of a single catch-all `PathPrefix: /` rule, so omitting the field
+    // yields one rule rather than none, and since Gateway API v1.5 an explicit
+    // empty list is rejected by `minItems: 1`. GRPCRoute has neither a default
+    // nor a minimum, and Linkerd's own HTTPRoute is only defaulted, so both can
+    // still send an explicit empty list.
     test::<k8s::Service, policy::HttpRoute>().await;
     test::<k8s::Service, gateway::GRPCRoute>().await;
     test::<policy::EgressNetwork, policy::HttpRoute>().await;
-    test::<policy::EgressNetwork, gateway::HTTPRoute>().await;
     test::<policy::EgressNetwork, gateway::GRPCRoute>().await;
 }
 

--- a/policy-test/tests/outbound_api_grpc.rs
+++ b/policy-test/tests/outbound_api_grpc.rs
@@ -53,17 +53,17 @@ async fn grpc_route_with_filters_service() {
                 vec![vec![backend.backend_ref(backend_port)]],
             );
             for rule in route.spec.rules.iter_mut().flatten() {
-                rule.filters = Some(vec![gateway::GRPCRouteRulesFilters {
+                rule.filters = Some(vec![gateway::GrpcRouteRulesFilters {
                     request_header_modifier: Some(
-                        gateway::GRPCRouteRulesFiltersRequestHeaderModifier {
+                        gateway::GrpcRouteRulesFiltersRequestHeaderModifier {
                             set: Some(vec![
-                                gateway::GRPCRouteRulesFiltersRequestHeaderModifierSet {
+                                gateway::GrpcRouteRulesFiltersRequestHeaderModifierSet {
                                     name: "set".to_string(),
                                     value: "set-value".to_string(),
                                 },
                             ]),
                             add: Some(vec![
-                                gateway::GRPCRouteRulesFiltersRequestHeaderModifierAdd {
+                                gateway::GrpcRouteRulesFiltersRequestHeaderModifierAdd {
                                     name: "add".to_string(),
                                     value: "add-value".to_string(),
                                 },
@@ -163,14 +163,14 @@ async fn policy_grpc_route_with_backend_filters() {
             );
             for rule in route.spec.rules.iter_mut().flatten() {
                 for backend in rule.backend_refs.iter_mut().flatten() {
-                    backend.filters = Some(vec![gateway::GRPCRouteRulesBackendRefsFilters {
+                    backend.filters = Some(vec![gateway::GrpcRouteRulesBackendRefsFilters {
                         request_header_modifier: Some(
-                            gateway::GRPCRouteRulesBackendRefsFiltersRequestHeaderModifier {
-                                set: Some(vec![gateway::GRPCRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
+                            gateway::GrpcRouteRulesBackendRefsFiltersRequestHeaderModifier {
+                                set: Some(vec![gateway::GrpcRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
                                     name: "set".to_string(),
                                     value: "set-value".to_string(),
                                 }]),
-                                add: Some(vec![gateway::GRPCRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
+                                add: Some(vec![gateway::GrpcRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
                                     name: "add".to_string(),
                                     value: "add-value".to_string(),
                                 }]),

--- a/policy-test/tests/outbound_api_http.rs
+++ b/policy-test/tests/outbound_api_http.rs
@@ -45,25 +45,25 @@ async fn gateway_http_route_with_filters_service() {
             let mut route =
                 gateway::HTTPRoute::make_route(ns, vec![parent.obj_ref()], vec![vec![]]);
             for rule in route.spec.rules.iter_mut().flatten() {
-                rule.matches = Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                rule.matches = Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix),
                     }),
                     ..Default::default()
                 }]);
                 rule.filters = Some(vec![
-                    gateway::HTTPRouteRulesFilters {
+                    gateway::HttpRouteRulesFilters {
                         request_header_modifier: Some(
-                            gateway::HTTPRouteRulesFiltersRequestHeaderModifier {
+                            gateway::HttpRouteRulesFiltersRequestHeaderModifier {
                                 set: Some(vec![
-                                    gateway::HTTPRouteRulesFiltersRequestHeaderModifierSet {
+                                    gateway::HttpRouteRulesFiltersRequestHeaderModifierSet {
                                         name: "set".to_string(),
                                         value: "set-value".to_string(),
                                     },
                                 ]),
                                 add: Some(vec![
-                                    gateway::HTTPRouteRulesFiltersRequestHeaderModifierAdd {
+                                    gateway::HttpRouteRulesFiltersRequestHeaderModifierAdd {
                                         name: "add".to_string(),
                                         value: "add-value".to_string(),
                                     },
@@ -71,22 +71,22 @@ async fn gateway_http_route_with_filters_service() {
                                 remove: Some(vec!["remove".to_string()]),
                             },
                         ),
-                        r#type: gateway::HTTPRouteRulesFiltersType::RequestHeaderModifier,
+                        r#type: gateway::HttpRouteRulesFiltersType::RequestHeaderModifier,
                         ..Default::default()
                     },
-                    gateway::HTTPRouteRulesFilters {
-                        request_redirect: Some(gateway::HTTPRouteRulesFiltersRequestRedirect {
-                            scheme: Some(gateway::HTTPRouteRulesFiltersRequestRedirectScheme::Http),
+                    gateway::HttpRouteRulesFilters {
+                        request_redirect: Some(gateway::HttpRouteRulesFiltersRequestRedirect {
+                            scheme: Some(gateway::HttpRouteRulesFiltersRequestRedirectScheme::Http),
                             hostname: Some("host".to_string()),
-                            path: Some(gateway::HTTPRouteRulesFiltersRequestRedirectPath {
+                            path: Some(gateway::HttpRouteRulesFiltersRequestRedirectPath {
                                 replace_prefix_match: Some("/path".to_string()),
-                                r#type: gateway::HTTPRouteRulesFiltersRequestRedirectPathType::ReplacePrefixMatch,
+                                r#type: gateway::HttpRouteRulesFiltersRequestRedirectPathType::ReplacePrefixMatch,
                                 ..Default::default()
                             }),
                             port: Some(5555),
                             status_code: Some(302),
                         }),
-                        r#type: gateway::HTTPRouteRulesFiltersType::RequestRedirect,
+                        r#type: gateway::HttpRouteRulesFiltersType::RequestRedirect,
                         ..Default::default()
                     },
                 ]);
@@ -204,25 +204,25 @@ async fn policy_http_route_with_filters_service() {
                 vec![vec![backend.backend_ref(backend_port)]],
             );
             for rule in route.spec.rules.iter_mut().flatten() {
-                rule.matches = Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                rule.matches = Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix),
                     }),
                     ..Default::default()
                 }]);
                 rule.filters = Some(vec![
                     policy::httproute::HttpRouteFilter::RequestHeaderModifier {
                         request_header_modifier:
-                            gateway::HTTPRouteRulesFiltersRequestHeaderModifier {
+                            gateway::HttpRouteRulesFiltersRequestHeaderModifier {
                                 set: Some(vec![
-                                    gateway::HTTPRouteRulesFiltersRequestHeaderModifierSet {
+                                    gateway::HttpRouteRulesFiltersRequestHeaderModifierSet {
                                         name: "set".to_string(),
                                         value: "set-value".to_string(),
                                     },
                                 ]),
                                 add: Some(vec![
-                                    gateway::HTTPRouteRulesFiltersRequestHeaderModifierAdd {
+                                    gateway::HttpRouteRulesFiltersRequestHeaderModifierAdd {
                                         name: "add".to_string(),
                                         value: "add-value".to_string(),
                                     },
@@ -231,12 +231,12 @@ async fn policy_http_route_with_filters_service() {
                             },
                     },
                     policy::httproute::HttpRouteFilter::RequestRedirect {
-                        request_redirect: gateway::HTTPRouteRulesFiltersRequestRedirect {
-                            scheme: Some(gateway::HTTPRouteRulesFiltersRequestRedirectScheme::Http),
+                        request_redirect: gateway::HttpRouteRulesFiltersRequestRedirect {
+                            scheme: Some(gateway::HttpRouteRulesFiltersRequestRedirectScheme::Http),
                             hostname: Some("host".to_string()),
-                            path: Some(gateway::HTTPRouteRulesFiltersRequestRedirectPath {
+                            path: Some(gateway::HttpRouteRulesFiltersRequestRedirectPath {
                                 replace_prefix_match: Some("/path".to_string()),
-                                r#type: gateway::HTTPRouteRulesFiltersRequestRedirectPathType::ReplacePrefixMatch,
+                                r#type: gateway::HttpRouteRulesFiltersRequestRedirectPathType::ReplacePrefixMatch,
                                 ..Default::default()
                             }),
                             port: Some(5555),
@@ -358,26 +358,26 @@ async fn gateway_http_route_with_backend_filters() {
                 vec![vec![backend.backend_ref(backend_port)]],
             );
             for rule in route.spec.rules.iter_mut().flatten() {
-                rule.matches = Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                rule.matches = Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix),
                     }),
                     ..Default::default()
                 }]);
                 for backend in rule.backend_refs.iter_mut().flatten() {
                     backend.filters = Some(vec![
-                        gateway::HTTPRouteRulesBackendRefsFilters {
+                        gateway::HttpRouteRulesBackendRefsFilters {
                             request_header_modifier: Some(
-                                gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifier {
+                                gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifier {
                                     set: Some(vec![
-                                        gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
+                                        gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
                                             name: "set".to_string(),
                                             value: "set-value".to_string(),
                                         },
                                     ]),
                                     add: Some(vec![
-                                        gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
+                                        gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
                                             name: "add".to_string(),
                                             value: "add-value".to_string(),
                                         },
@@ -385,22 +385,22 @@ async fn gateway_http_route_with_backend_filters() {
                                     remove: Some(vec!["remove".to_string()]),
                                 },
                             ),
-                            r#type: gateway::HTTPRouteRulesBackendRefsFiltersType::RequestHeaderModifier,
+                            r#type: gateway::HttpRouteRulesBackendRefsFiltersType::RequestHeaderModifier,
                             ..Default::default()
                         },
-                        gateway::HTTPRouteRulesBackendRefsFilters {
-                            request_redirect: Some(gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirect {
-                                scheme: Some(gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectScheme::Http),
+                        gateway::HttpRouteRulesBackendRefsFilters {
+                            request_redirect: Some(gateway::HttpRouteRulesBackendRefsFiltersRequestRedirect {
+                                scheme: Some(gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectScheme::Http),
                                 hostname: Some("host".to_string()),
-                                path: Some(gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectPath {
+                                path: Some(gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectPath {
                                     replace_prefix_match: Some("/path".to_string()),
-                                    r#type: gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectPathType::ReplacePrefixMatch,
+                                    r#type: gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectPathType::ReplacePrefixMatch,
                                     ..Default::default()
                                 }),
                                 port: Some(5555),
                                 status_code: Some(302),
                             }),
-                            r#type: gateway::HTTPRouteRulesBackendRefsFiltersType::RequestRedirect,
+                            r#type: gateway::HttpRouteRulesBackendRefsFiltersType::RequestRedirect,
                             ..Default::default()
                         },
                     ]);
@@ -520,22 +520,22 @@ async fn policy_http_route_with_backend_filters() {
                 vec![vec![backend.backend_ref(backend_port)]],
             );
             for rule in route.spec.rules.iter_mut().flatten() {
-                rule.matches = Some(vec![gateway::HTTPRouteRulesMatches {
-                    path: Some(gateway::HTTPRouteRulesMatchesPath {
+                rule.matches = Some(vec![gateway::HttpRouteRulesMatches {
+                    path: Some(gateway::HttpRouteRulesMatchesPath {
                         value: Some("/foo".to_string()),
-                        r#type: Some(gateway::HTTPRouteRulesMatchesPathType::PathPrefix),
+                        r#type: Some(gateway::HttpRouteRulesMatchesPathType::PathPrefix),
                     }),
                     ..Default::default()
                 }]);
                 for backend in rule.backend_refs.iter_mut().flatten() {
                     backend.filters = Some(vec![
-                        gateway::HTTPRouteRulesBackendRefsFilters {
-                            request_header_modifier: Some(gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifier {
-                                set: Some(vec![gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
+                        gateway::HttpRouteRulesBackendRefsFilters {
+                            request_header_modifier: Some(gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifier {
+                                set: Some(vec![gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifierSet {
                                     name: "set".to_string(),
                                     value: "set-value".to_string(),
                                 }]),
-                                add: Some(vec![gateway::HTTPRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
+                                add: Some(vec![gateway::HttpRouteRulesBackendRefsFiltersRequestHeaderModifierAdd {
                                     name: "add".to_string(),
                                     value: "add-value".to_string(),
                                 }]),
@@ -543,13 +543,13 @@ async fn policy_http_route_with_backend_filters() {
                             }),
                             ..Default::default()
                         },
-                        gateway::HTTPRouteRulesBackendRefsFilters {
-                            request_redirect: Some(gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirect {
-                                scheme: Some(gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectScheme::Http),
+                        gateway::HttpRouteRulesBackendRefsFilters {
+                            request_redirect: Some(gateway::HttpRouteRulesBackendRefsFiltersRequestRedirect {
+                                scheme: Some(gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectScheme::Http),
                                 hostname: Some("host".to_string()),
-                                path: Some(gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectPath {
+                                path: Some(gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectPath {
                                     replace_prefix_match: Some("/path".to_string()),
-                                    r#type: gateway::HTTPRouteRulesBackendRefsFiltersRequestRedirectPathType::ReplacePrefixMatch,
+                                    r#type: gateway::HttpRouteRulesBackendRefsFiltersRequestRedirectPathType::ReplacePrefixMatch,
                                     ..Default::default()
                                 }),
                                 port: Some(5555),
@@ -965,14 +965,14 @@ async fn http_route_gateway_timeouts() {
                     name: Some("foo-route".to_string()),
                     ..Default::default()
                 },
-                spec: gateway::HTTPRouteSpec {
+                spec: gateway::HttpRouteSpec {
                     parent_refs: Some(vec![parent.obj_ref()]),
                     hostnames: None,
-                    rules: Some(vec![gateway::HTTPRouteRules {
+                    rules: Some(vec![gateway::HttpRouteRules {
                         name: None,
                         matches: Some(vec![]),
                         filters: None,
-                        timeouts: Some(gateway::HTTPRouteRulesTimeouts {
+                        timeouts: Some(gateway::HttpRouteRulesTimeouts {
                             request: Some("5s".to_string()),
                             backend_request: None,
                         }),
@@ -980,6 +980,7 @@ async fn http_route_gateway_timeouts() {
                         backend_refs: Some(vec![backend.backend_ref(backend_port)]),
                         session_persistence: None,
                     }]),
+                    use_default_gateways: None,
                 },
                 status: None,
             };

--- a/policy-test/tests/outbound_http_route_status.rs
+++ b/policy-test/tests/outbound_http_route_status.rs
@@ -1,6 +1,6 @@
 // use k8s::Condition;
 // use k8s_gateway_api::{ParentReference, RouteParentStatus, RouteStatus};
-// use k8s_openapi::chrono::Utc;
+// use k8s_openapi::jiff::Timestamp;
 // use kube::ResourceExt;
 // use linkerd_policy_controller_core::POLICY_CONTROLLER_NAME;
 // use linkerd_policy_controller_k8s_api as k8s;
@@ -194,7 +194,7 @@
 //                     inner: RouteStatus {
 //                         parents: vec![RouteParentStatus {
 //                             conditions: vec![Condition {
-//                                 last_transition_time: k8s::Time(Utc::now()),
+//                                 last_transition_time: k8s::Time(Timestamp::now()),
 //                                 message: "".to_string(),
 //                                 observed_generation: None,
 //                                 reason: "Accepted".to_string(),

--- a/testutil/test_helper.go
+++ b/testutil/test_helper.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const GATEWAY_API_VERSION = "v1.2.1"
+const GATEWAY_API_VERSION = "v1.5.1"
 
 // TestHelper provides helpers for running the linkerd integration tests.
 type TestHelper struct {
@@ -745,7 +745,7 @@ func (h *TestHelper) DownloadCLIBinary(filepath, version string) error {
 
 func (h *TestHelper) InstallGatewayAPI() error {
 	url := fmt.Sprintf("https://github.com/kubernetes-sigs/gateway-api/releases/download/%s/experimental-install.yaml", GATEWAY_API_VERSION)
-	_, err := h.Kubectl("", "apply", "-f", url)
+	_, err := h.Kubectl("", "apply", "--server-side", "-f", url)
 	return err
 }
 


### PR DESCRIPTION
## kube-rs (a.k.a "kube") 1.1.0 -> 3.1.0

This forces the rest of the workspace along with it:

* k8s-openapi 0.25 -> 0.27
* schemars 0.8 -> 1
* ipnet switches from the `json` feature to `serde` + `schemars1`, since `json` still pulls in schemars 0.8
* chrono is replaced by jiff 0.2 and drops out of the tree entirely, because k8s-openapi 0.27 backs `metav1::Time` with `jiff::Timestamp` instead of `chrono::DateTime<Utc>`

Source changes:

* Timestamps: `creation_timestamp`, `last_transition_time` and the `Route::creation_timestamp` trait method move to `jiff::Timestamp`; `Utc::now()` becomes `Timestamp::now()` and `MIN_UTC`/`MAX_UTC` become `Timestamp::MIN`/`MAX`.
* schemars 1: the hand-written `JsonSchema` impl for `K8sDuration` uses `Cow<'static, str>` for `schema_name`, `inline_schema()` in place of the inverted `is_referenceable()`, and the `json_schema!` macro. The schema is unchanged; the format is still deliberately unset.
* kube 3.x deprecates `kube::error::ErrorResponse` in favor of `kube::core::Status`, and `Error::Api` now carries a `Box<Status>`.

## gateway-api-rs (a.k.a "gateway-api") 0.16.0 -> 0.21.0

This bumps the gateway api spec support from 1.2.1 to 1.5.1
Forced to be bumped in tandem with the kube-rs bump as gateway-api-rs 0.16.0 was pinned to kube-rs 1.1.0

* gateway-api renamed its generated sub-types, so `HTTPRoute*` becomes `HttpRoute*`, `GRPCRoute*` becomes `GrpcRoute*`, and likewise for TCP and TLS. The top-level CRD types keep their original names.
* Several gateway-api fields are no longer optional: `RouteStatusParents::conditions`, `Tls/TcpRouteRules::backend_refs`, and `TlsRouteSpec::hostnames`/`rules`. `Some(..)` wrappers and the matching `.flatten()` calls are dropped, and route spec literals gain the new `use_default_gateways` field.

Note one behavior change the type system forces: now that `RouteStatusParents::conditions` is a plain `Vec`, the `eq_time_insensitive_*_route_parent_statuses` helpers can no longer distinguish an empty condition list from an absent one, so those two cases now compare equal where they previously compared unequal.

### TLSRoute is pinned to `v1alpha2`

gateway-api-rs 0.21 moved its `TLSRoute` binding from `v1alpha2` to `v1`. The other three kinds are unaffected:

| kind      | 0.16.0   | 0.21.0   |
| --------- | -------- | -------- |
| HTTPRoute | v1       | v1       |
| GRPCRoute | v1       | v1       |
| TCPRoute  | v1alpha2 | v1alpha2 |
| TLSRoute  | v1alpha2 | **v1**   |

TLSRoute only graduated to `v1` in Gateway API v1.5:

| bundle | TLSRoute versions served |
| ------ | ------------------------ |
| v1.2.1 | v1alpha2                 |
| v1.3.0 | v1alpha2                 |
| v1.4.0 | v1alpha2, v1alpha3       |
| v1.5.1 | v1, v1alpha2, v1alpha3   |

In order to still support Gateway API v1.2.1, we now have in `policy-controller/k8s/api/src/lib.rs` a local type pinned to `v1alpha2` that shadows the one from the crate's glob import (`v1`). It reuses `TlsRouteSpec`/`TlsRouteStatus` unchanged, so it only overrides the group/version/kind the client addresses. It carries a hand-written `Serialize` because `kube::CustomResource` synthesizes `apiVersion`/`kind` rather than storing them as fields, plus a unit test asserting the pinned version.

### Backwards compatibility

CI now covers v1.2.1/standard as the minimum and v1.5.1/experimental as the maximum, alongside the CLI's vendored CRDs (still bundle v1.1.1; unchanged by this PR).

**No impact:**

* The webhook and RBAC are version-agnostic (`apiVersions: ["*"]`, and `is_kind` compares group and kind only), so TLSRoutes submitted as `v1` on a v1.5 cluster are still validated. Status patches address `v1alpha2`, which is served across the whole range.
* `useDefaultGateways`, new in v1.5 on all four route specs, is `Option` plus `skip_serializing_if`. Linkerd never sets it, and never writes route specs back (only the status subresource), so nothing is stripped from user objects.
* HTTPRoute and GRPCRoute keep their `v1` bindings, valid from v1.2 onward. Their v1.3.0 to v1.5.1 deltas are either additive (CORS and ExternalAuth filters, `requestRedirect.statusCode` widened from `[301, 302]` to `[301, 302, 303, 307, 308]`, GRPCRoute `matches` `maxItems` 8 to 64) or apiserver-side tightening that does not affect decoding.

**Worth watching: decoding is now stricter than the endpoints we address.**

The bindings are generated from the v1.5.1 schemas, so three fields lost their `Option`/`#[serde(default)]` and are mandatory on the wire:

| field                         | kinds              | required upstream since                                  |
| ----------------------------- | ------------------ | -------------------------------------------------------- |
| `status.parents[].conditions` | all four           | v1.5                                                     |
| `spec.rules[].backendRefs`    | TLSRoute, TCPRoute | v1.5                                                     |
| `spec.hostnames`              | TLSRoute           | only in the `v1`/`v1alpha3` schemas, never in `v1alpha2` |

On a pre-v1.5 cluster an object omitting the first two is perfectly legal but no longer decodes. The third is stricter still: `hostnames` is optional in `v1alpha2` in every release, so a TLSRoute without it fails to decode on any cluster in the supported range.

A failing object is logged and skipped rather than killing the watch; the route just never appears in the policy index. Admission is unaffected, since every Gateway API validator is `lenient()` and parse failures are admitted with a warning rather than denied, so there are no new rejections for users.

**Unchanged behaviour worth noting:** Linkerd still implements only the `RequestHeaderModifier`, `ResponseHeaderModifier` and `RequestRedirect` filters, so the new v1.5 `CORS` and `ExternalAuth` HTTPRoute filters are admitted and ignored, the same as the other filter types we do not support.