### PR TITLE
web: upgrade react-router-dom to v6

### DIFF
--- a/web/app/js/components/BreadcrumbHeader.jsx
+++ b/web/app/js/components/BreadcrumbHeader.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import { Trans } from '@lingui/macro';
 import _chunk from 'lodash/chunk';
 import _takeWhile from 'lodash/takeWhile';
@@ -98,7 +97,9 @@ BreadcrumbHeader.propTypes = {
   api: PropTypes.shape({
     PrefixedLink: PropTypes.func.isRequired,
   }).isRequired,
-  location: ReactRouterPropTypes.location.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
   pathPrefix: PropTypes.string.isRequired,
 };
 

--- a/web/app/js/components/Namespace.jsx
+++ b/web/app/js/components/Namespace.jsx
@@ -22,7 +22,7 @@ class Namespaces extends React.Component {
     this.api = props.api;
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
-    this.state = this.getInitialState(props.match.params);
+    this.state = this.getInitialState(props.params);
   }
 
   getInitialState(params) {
@@ -44,9 +44,8 @@ class Namespaces extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { match, isPageVisible } = this.props;
-    const { params } = match;
-    if (!_isEqual(prevProps.match.params.namespace, params.namespace)) {
+    const { params, isPageVisible } = this.props;
+    if (!_isEqual(prevProps.params.namespace, params.namespace)) {
       // React won't unmount this component when switching resource pages so we need to clear state
       this.api.cancelCurrentRequests();
       this.resetState(params);
@@ -188,20 +187,16 @@ Namespaces.propTypes = {
     urlsForResource: PropTypes.func.isRequired,
   }).isRequired,
   isPageVisible: PropTypes.bool.isRequired,
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      namespace: PropTypes.string,
-    }),
+  params: PropTypes.shape({
+    namespace: PropTypes.string,
   }),
   selectedNamespace: PropTypes.string.isRequired,
   updateNamespaceInContext: PropTypes.func.isRequired,
 };
 
 Namespaces.defaultProps = {
-  match: {
-    params: {
-      namespace: 'default',
-    },
+  params: {
+    namespace: 'default',
   },
 };
 

--- a/web/app/js/components/Navigation.jsx
+++ b/web/app/js/components/Navigation.jsx
@@ -8,14 +8,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Hidden from '@material-ui/core/Hidden';
 import IconButton from '@material-ui/core/IconButton';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactRouterPropTypes from 'react-router-prop-types';
 import TextField from '@material-ui/core/TextField';
 import Toolbar from '@material-ui/core/Toolbar';
 import { Trans } from '@lingui/macro';
@@ -234,9 +233,9 @@ class NavigationBase extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { history, checkNamespaceMatch, isPageVisible } = this.props;
-    if (history) {
-      checkNamespaceMatch(history.location.pathname);
+    const { location, checkNamespaceMatch, isPageVisible } = this.props;
+    if (location) {
+      checkNamespaceMatch(location.pathname);
     }
 
     handlePageVisibility({
@@ -383,10 +382,10 @@ class NavigationBase extends React.Component {
 
   handleConfirmNamespaceChange = () => {
     const { newNamespace } = this.state;
-    const { updateNamespaceInContext, history } = this.props;
+    const { updateNamespaceInContext, navigate } = this.props;
     this.setState({ showNamespaceChangeDialog: false });
     updateNamespaceInContext(newNamespace);
-    history.push(`/namespaces/${newNamespace}`);
+    navigate(`/namespaces/${newNamespace}`);
   };
 
   handleFilterInputChange = event => {
@@ -402,20 +401,20 @@ class NavigationBase extends React.Component {
   }
 
   handleNamespaceChange = (event, values) => {
-    const { history, updateNamespaceInContext, selectedNamespace } = this.props;
+    const { navigate, location, updateNamespaceInContext, selectedNamespace } = this.props;
 
     // event.stopPropagation();
     const namespace = values.name;
     if (namespace === selectedNamespace) {
       return;
     }
-    let path = history.location.pathname;
+    let path = location.pathname;
     const pathParts = path.split('/');
     if (pathParts.length === 3 || pathParts.length === 4) {
       // path is /namespaces/someNamespace/resourceType
       //      or /namespaces/someNamespace
       path = path.replace(selectedNamespace, namespace);
-      history.push(path);
+      navigate(path);
       updateNamespaceInContext(namespace);
     } else if (pathParts.length === 5) {
       // path is /namespace/someNamespace/resourceType/someResource
@@ -690,8 +689,10 @@ NavigationBase.propTypes = {
     PropTypes.object,
   ]).isRequired,
   isPageVisible: PropTypes.bool.isRequired,
-  history: ReactRouterPropTypes.history.isRequired,
-  location: ReactRouterPropTypes.location.isRequired,
+  navigate: PropTypes.func.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
+  }).isRequired,
   pathPrefix: PropTypes.string.isRequired,
   releaseVersion: PropTypes.string.isRequired,
   selectedNamespace: PropTypes.string.isRequired,
@@ -700,4 +701,23 @@ NavigationBase.propTypes = {
   uuid: PropTypes.string.isRequired,
 };
 
-export default withPageVisibility(withContext(withStyles(styles, { withTheme: true })(NavigationBase)));
+const NavigationWithContext = withPageVisibility(withContext(withStyles(styles, { withTheme: true })(NavigationBase)));
+
+// react-router v6 removed the `history`/`location`/`match` props that v5's <Route render={}>
+// used to inject. NavigationBase is a class component (can't use hooks directly), so this
+// function component reads the router state via hooks and forwards it down as plain props.
+function Navigation(props) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = useParams();
+
+  return (
+    <NavigationWithContext
+      {...props}
+      navigate={navigate}
+      location={location}
+      params={params} />
+  );
+}
+
+export default Navigation;

--- a/web/app/js/components/Navigation.test.jsx
+++ b/web/app/js/components/Navigation.test.jsx
@@ -1,13 +1,12 @@
 import _merge from 'lodash/merge';
 import ApiHelpers from './util/ApiHelpers.jsx';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import mediaQuery from 'css-mediaquery';
 import Navigation from './Navigation.jsx';
 import sinon from 'sinon';
 import sinonStubPromise from 'sinon-stub-promise';
 import { mount } from 'enzyme';
-import { createMemoryHistory } from 'history';
 import { i18nWrap } from '../../test/testHelpers.jsx';
 
 function createMatchMedia(width) {
@@ -20,13 +19,6 @@ function createMatchMedia(width) {
 
 sinonStubPromise(sinon);
 
-const loc = {
-  pathname: '',
-  hash: '',
-  pathPrefix: '',
-  search: '',
-};
-
 const curVer = "edge-1.2.3";
 const newVer = "edge-2.3.4";
 
@@ -35,8 +27,6 @@ const defaultProps = {
   checkNamespaceMatch: () => {},
   ChildComponent: () => null,
   classes: {},
-  history: createMemoryHistory('/namespaces'),
-  location: loc,
   pathPrefix: '',
   releaseVersion: curVer,
   selectedNamespace: 'emojivoto',
@@ -68,9 +58,9 @@ describe('Navigation', () => {
     });
 
     component = mount(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/namespaces']}>
         <Navigation {...defaultProps} />
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
     return withPromise(() => {
@@ -86,9 +76,9 @@ describe('Navigation', () => {
     });
 
     component = mount(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/namespaces']}>
         <Navigation {...defaultProps} />
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
     return withPromise(() => {
@@ -109,9 +99,9 @@ describe('Navigation', () => {
     });
 
     component = mount(
-      <BrowserRouter>
+      <MemoryRouter initialEntries={['/namespaces']}>
         <Navigation {...defaultProps} />
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
     return withPromise(() => {
@@ -134,9 +124,9 @@ describe('Namespace Select Button', () => {
 
     const component = mount(
       i18nWrap(
-        <BrowserRouter>
+        <MemoryRouter initialEntries={['/namespaces']}>
           <Navigation {...extraProps} />
-        </BrowserRouter>
+        </MemoryRouter>
       )
     );
 
@@ -147,9 +137,9 @@ describe('Namespace Select Button', () => {
   it('renders emojivoto text', () => {
     const component = mount(
       i18nWrap(
-        <BrowserRouter>
+        <MemoryRouter initialEntries={['/namespaces']}>
           <Navigation {...defaultProps} />
-        </BrowserRouter>
+        </MemoryRouter>
       )
     );
 

--- a/web/app/js/components/ResourceDetail.jsx
+++ b/web/app/js/components/ResourceDetail.jsx
@@ -32,17 +32,17 @@ const showNoTrafficMsgDelayMs = 6000;
 // resource types supported when querying API for edge data
 const edgeDataAvailable = ['cronjob', 'daemonset', 'deployment', 'job', 'pod', 'replicaset', 'replicationcontroller', 'statefulset'];
 
-const getResourceFromUrl = (match, pathPrefix) => {
+const getResourceFromUrl = (params, pathname, pathPrefix) => {
   const resource = {
-    namespace: match.params.namespace,
+    namespace: params.namespace,
   };
-  const regExp = RegExp(`${pathPrefix || ''}/namespaces/${match.params.namespace}/([^/]+)/([^/]+)`);
-  const urlParts = match.url.match(regExp);
+  const regExp = RegExp(`${pathPrefix || ''}/namespaces/${params.namespace}/([^/]+)/([^/]+)`);
+  const urlParts = pathname.match(regExp);
 
   resource.type = singularResource(urlParts[1]);
   resource.name = urlParts[2];
 
-  if (match.params[resource.type] !== resource.name) {
+  if (params[resource.type] !== resource.name) {
     console.error('Failed to extract resource from URL');
   }
   return resource;
@@ -55,11 +55,11 @@ export class ResourceDetailBase extends React.Component {
     this.unmeshedSources = {};
     this.handleApiError = this.handleApiError.bind(this);
     this.loadFromServer = this.loadFromServer.bind(this);
-    this.state = this.getInitialState(props.match, props.pathPrefix);
+    this.state = this.getInitialState(props.params, props.location.pathname, props.pathPrefix);
   }
 
-  getInitialState(match, pathPrefix) {
-    const resource = getResourceFromUrl(match, pathPrefix);
+  getInitialState(params, pathname, pathPrefix) {
+    const resource = getResourceFromUrl(params, pathname, pathPrefix);
     return {
       namespace: resource.namespace,
       resourceName: resource.name,
@@ -88,13 +88,13 @@ export class ResourceDetailBase extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { match, pathPrefix, isPageVisible } = this.props;
+    const { params, location, pathPrefix, isPageVisible } = this.props;
 
-    if (!_isEqual(prevProps.match.url, match.url)) {
+    if (!_isEqual(prevProps.location.pathname, location.pathname)) {
       // React won't unmount this component when switching resource pages so we need to clear state
       this.api.cancelCurrentRequests();
       this.unmeshedSources = {};
-      this.resetState(match, pathPrefix);
+      this.resetState(params, location.pathname, pathPrefix);
     }
 
     handlePageVisibility({
@@ -105,8 +105,8 @@ export class ResourceDetailBase extends React.Component {
     });
   }
 
-  resetState(match, pathPrefix) {
-    this.setState(this.getInitialState(match, pathPrefix));
+  resetState(params, pathname, pathPrefix) {
+    this.setState(this.getInitialState(params, pathname, pathPrefix));
   }
 
   componentWillUnmount() {
@@ -454,8 +454,11 @@ ResourceDetailBase.propTypes = {
     PrefixedLink: PropTypes.func.isRequired,
   }).isRequired,
   isPageVisible: PropTypes.bool.isRequired,
-  match: PropTypes.shape({
-    url: PropTypes.string.isRequired,
+  params: PropTypes.shape({
+    namespace: PropTypes.string.isRequired,
+  }).isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired,
   }).isRequired,
   pathPrefix: PropTypes.string.isRequired,
 };

--- a/web/app/js/index.js
+++ b/web/app/js/index.js
@@ -1,7 +1,7 @@
 import '../css/styles.css';
 import '../img/favicon.png'; // needs to be referenced somewhere so webpack bundles it
 
-import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { DETECTORS, LocaleResolver, TRANSFORMERS } from 'locales-detector';
 import { MuiThemeProvider, createTheme } from '@material-ui/core/styles';
 
@@ -14,7 +14,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import _find from 'lodash/find';
 import _isEmpty from 'lodash/isEmpty';
-import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import ApiHelpers from './components/util/ApiHelpers.jsx';
 import AppContext from './components/util/AppContext.jsx';
 import Community from './components/Community.jsx';
@@ -122,102 +122,101 @@ const AppHTML = function() {
       <CssBaseline />
       <MuiThemeProvider theme={theme}>
         <BrowserRouter>
-          <QueryParamProvider adapter={ReactRouter5Adapter}>
-            <Switch>
-              <Redirect exact from={`${pathPrefix}/`} to={`${pathPrefix}/namespaces`} />
-              <Redirect exact from={`${pathPrefix}/overview`} to={`${pathPrefix}/namespaces`} />
-              <Redirect exact from={`${pathPrefix}/deployments`} to={`${pathPrefix}/namespaces/_all/deployments`} />
-              <Redirect exact from={`${pathPrefix}/services`} to={`${pathPrefix}/namespaces/_all/services`} />
-              <Redirect exact from={`${pathPrefix}/daemonsets`} to={`${pathPrefix}/namespaces/_all/daemonsets`} />
-              <Redirect exact from={`${pathPrefix}/statefulsets`} to={`${pathPrefix}/namespaces/_all/statefulsets`} />
-              <Redirect exact from={`${pathPrefix}/jobs`} to={`${pathPrefix}/namespaces/_all/jobs`} />
-              <Redirect exact from={`${pathPrefix}/replicationcontrollers`} to={`${pathPrefix}/namespaces/_all/replicationcontrollers`} />
-              <Redirect exact from={`${pathPrefix}/pods`} to={`${pathPrefix}/namespaces/_all/pods`} />
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <Routes>
+              <Route path={`${pathPrefix}/`} element={<Navigate to={`${pathPrefix}/namespaces`} replace />} />
+              <Route path={`${pathPrefix}/overview`} element={<Navigate to={`${pathPrefix}/namespaces`} replace />} />
+              <Route path={`${pathPrefix}/deployments`} element={<Navigate to={`${pathPrefix}/namespaces/_all/deployments`} replace />} />
+              <Route path={`${pathPrefix}/services`} element={<Navigate to={`${pathPrefix}/namespaces/_all/services`} replace />} />
+              <Route path={`${pathPrefix}/daemonsets`} element={<Navigate to={`${pathPrefix}/namespaces/_all/daemonsets`} replace />} />
+              <Route path={`${pathPrefix}/statefulsets`} element={<Navigate to={`${pathPrefix}/namespaces/_all/statefulsets`} replace />} />
+              <Route path={`${pathPrefix}/jobs`} element={<Navigate to={`${pathPrefix}/namespaces/_all/jobs`} replace />} />
+              <Route path={`${pathPrefix}/replicationcontrollers`} element={<Navigate to={`${pathPrefix}/namespaces/_all/replicationcontrollers`} replace />} />
+              <Route path={`${pathPrefix}/pods`} element={<Navigate to={`${pathPrefix}/namespaces/_all/pods`} replace />} />
 
               <Route
                 path={`${pathPrefix}/controlplane`}
-                render={props => <Navigation {...props} ChildComponent={ServiceMesh} />} />
+                element={<Navigation ChildComponent={ServiceMesh} />} />
               <Route
                 path={`${pathPrefix}/gateways`}
-                render={props => <Navigation {...props} ChildComponent={Gateway} resource="gateway" />} />
+                element={<Navigation ChildComponent={Gateway} resource="gateway" />} />
               <Route
-                exact
                 path={`${pathPrefix}/namespaces/:namespace`}
-                render={props => <Navigation {...props} ChildComponent={Namespace} />} />
+                element={<Navigation ChildComponent={Namespace} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/pods/:pod`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/pods`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="pod" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="pod" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/daemonsets/:daemonset`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/daemonsets`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="daemonset" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="daemonset" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/statefulsets/:statefulset`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/statefulsets`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="statefulset" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="statefulset" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/jobs/:job`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/jobs`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="job" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="job" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/deployments/:deployment`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/services/:service`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/deployments`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="deployment" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="deployment" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/services`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="service" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="service" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/replicationcontrollers/:replicationcontroller`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/replicationcontrollers`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="replicationcontroller" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="replicationcontroller" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/cronjobs/:cronjob`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/cronjobs`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="cronjob" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="cronjob" />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/replicasets/:replicaset`}
-                render={props => <Navigation {...props} ChildComponent={ResourceDetail} />} />
+                element={<Navigation ChildComponent={ResourceDetail} />} />
               <Route
                 path={`${pathPrefix}/namespaces/:namespace/replicasets`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="replicaset" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="replicaset" />} />
               <Route
                 path={`${pathPrefix}/tap`}
-                render={props => <Navigation {...props} ChildComponent={Tap} />} />
+                element={<Navigation ChildComponent={Tap} />} />
               <Route
                 path={`${pathPrefix}/top`}
-                render={props => <Navigation {...props} ChildComponent={Top} />} />
+                element={<Navigation ChildComponent={Top} />} />
               <Route
                 path={`${pathPrefix}/routes`}
-                render={props => <Navigation {...props} ChildComponent={TopRoutes} />} />
+                element={<Navigation ChildComponent={TopRoutes} />} />
               <Route
                 path={`${pathPrefix}/namespaces`}
-                render={props => <Navigation {...props} ChildComponent={ResourceList} resource="namespace" />} />
+                element={<Navigation ChildComponent={ResourceList} resource="namespace" />} />
               <Route
                 path={`${pathPrefix}/community`}
-                render={props => <Navigation {...props} ChildComponent={Community} />} />
+                element={<Navigation ChildComponent={Community} />} />
               <Route
                 path={`${pathPrefix}/extensions`}
-                render={props => <Navigation {...props} ChildComponent={Extensions} />} />
-              <Route component={NoMatch} />
-            </Switch>
+                element={<Navigation ChildComponent={Extensions} />} />
+              <Route path="*" element={<NoMatch />} />
+            </Routes>
           </QueryParamProvider>
         </BrowserRouter>
       </MuiThemeProvider>

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -34,8 +34,7 @@
     "react-dom": "16.14.0",
     "react-linkify": "1.0.0-alpha",
     "react-page-visibility": "^7.0.0",
-    "react-router-dom": "5.3.4",
-    "react-router-prop-types": "1.0.5",
+    "react-router-dom": "6.30.4",
     "regenerator-runtime": "^0.14.1",
     "use-query-params": "2.2.2",
     "whatwg-fetch": "3.6.20"

--- a/web/app/test/testHelpers.jsx
+++ b/web/app/test/testHelpers.jsx
@@ -1,8 +1,7 @@
 import _merge from 'lodash/merge';
 import ApiHelpers from '../js/components/util/ApiHelpers.jsx';
-import { createMemoryHistory } from 'history';
 import React from 'react';
-import { Route, Router } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { I18nProvider } from '@lingui/react';
 import { i18n } from '@lingui/core';
 import { en } from 'make-plural/plurals'
@@ -21,13 +20,15 @@ i18n.load('en', catalogEn.messages);
 i18n.activate('en');
 
 export function routerWrap(Component, extraProps={}, route="/", currentLoc="/") {
-  const createElement = (ComponentToWrap, props) => (
-    <ComponentToWrap {...(_merge({}, componentDefaultProps, props, extraProps))} />
+  const createElement = ComponentToWrap => (
+    <ComponentToWrap {...(_merge({}, componentDefaultProps, extraProps))} />
   );
   return (
-    <Router history={createMemoryHistory(currentLoc)} createElement={createElement}>
-      <Route path={route} render={props => createElement(Component, props)} />
-    </Router>
+    <MemoryRouter initialEntries={[currentLoc]}>
+      <Routes>
+        <Route path={route} element={createElement(Component)} />
+      </Routes>
+    </MemoryRouter>
   );
 }
 

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -1054,7 +1054,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.29.7"
     "@babel/plugin-transform-react-pure-annotations" "^7.29.7"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.20.13", "@babel/runtime@^7.21.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.20.13", "@babel/runtime@^7.21.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
   integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
@@ -2002,6 +2002,11 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
+"@remix-run/router@1.23.3":
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
+  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -2237,7 +2242,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.3":
+"@types/prop-types@*":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
@@ -5665,19 +5670,7 @@ history@5.3.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6424,11 +6417,6 @@ is-wsl@^3.1.0:
   integrity sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==
   dependencies:
     is-inside-container "^1.0.0"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -7272,7 +7260,7 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7942,13 +7930,6 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-to-regexp@~0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
@@ -8319,7 +8300,7 @@ react-dom@16.14.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.6.tgz#aeee6159b159eb7f520d672cffcc69e7052d288f"
   integrity sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==
 
-react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.6:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8344,41 +8325,20 @@ react-page-visibility@^7.0.0:
   dependencies:
     prop-types "^15.7.2"
 
-react-router-dom@5.3.4:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.4.tgz#2ed62ffd88cae6db134445f4a0c0ae8b91d2e5e6"
-  integrity sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==
+react-router-dom@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.4.tgz#f7167bf3da6c7d9132130ea985dd06def25e84d5"
+  integrity sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==
   dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.3.4"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    "@remix-run/router" "1.23.3"
+    react-router "6.30.4"
 
-react-router-prop-types@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/react-router-prop-types/-/react-router-prop-types-1.0.5.tgz#2e671d8412a793106bf70dc15c9ecc83ea4bc15b"
-  integrity sha512-q1xlFU2ol2U5zeVbA5hyBuxD3scHenqgMgCTuJQUanA2SyG8A3Fb1S6DleOo1cnGJB5Q05hnLge64kRj+xsuPA==
+react-router@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
+  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
   dependencies:
-    "@types/prop-types" "^15.7.3"
-    prop-types "^15.7.2"
-
-react-router@5.3.4:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.3.4.tgz#8ca252d70fcc37841e31473c7a151cf777887bb5"
-  integrity sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==
-  dependencies:
-    "@babel/runtime" "^7.12.13"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
+    "@remix-run/router" "1.23.3"
 
 react-test-renderer@16.14.0, react-test-renderer@^16.0.0-0:
   version "16.14.0"
@@ -8626,11 +8586,6 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.4:
   version "1.22.8"
@@ -9486,12 +9441,7 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
-tiny-invariant@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tiny-warning@^1.0.0, tiny-warning@^1.0.2:
+tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -9934,11 +9884,6 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary

Upgrades `react-router-dom` in the web dashboard from `5.3.4` to `6.30.4`, as requested in #7252.

- `Switch` → `Routes`, `Redirect` → `Navigate`, and `<Route render={...}>` → `<Route element={...}>` throughout `index.js`.
- `Navigation` is a class component that previously received `history`/`location`/`match` as props injected by v5's `<Route render={}>`. Since v6 removed that prop-injection entirely and hooks can't be called from a class, `Navigation` is now a small function component that calls `useNavigate`/`useLocation`/`useParams` and forwards the results down as plain props to the (otherwise unchanged) `NavigationBase` class — the pattern React Router's own migration docs recommend for components that can't be converted to hooks outright.
- `Namespace` and `ResourceDetail` are updated to read `params`/`location` (forwarded by `Navigation`) instead of the old `match` object.
- Dropped `react-router-prop-types`, which only validated the now-removed `history`/`match` shapes.
- Swapped the `use-query-params` router adapter from `ReactRouter5Adapter` to `ReactRouter6Adapter` (already shipped in the installed `use-query-params` version, no bump needed there).
- Updated `Navigation.test.jsx` and the shared `testHelpers.jsx` router-mount helper to use `MemoryRouter`/`Routes` instead of manually constructing a v5 `history` object.

The `pathPrefix` manual-prefixing scheme (used when the dashboard is served behind the `kubectl proxy` API path) was left as-is rather than switched to v6's `basename` prop, to keep this PR focused on the version bump rather than also changing how proxied access is routed.

## Test plan

- [x] `yarn jest` — 15 suites / 95 tests passing
- [x] `yarn lingui compile && yarn webpack` (production build) compiles cleanly
- [x] Manually exercised the built bundle in a browser: `/` → `/namespaces` redirect, sidebar navigation (`Link`), and dynamic `:namespace` routes all render correctly with no console errors beyond pre-existing, unrelated warnings

Closes #7252