### PR TITLE
destination: skip Endpoints informer when EndpointSlices are enabled

### DIFF
--- a/controller/cmd/destination/main.go
+++ b/controller/cmd/destination/main.go
@@ -151,7 +151,7 @@ func Main(args []string) {
 			*kubeConfigPath,
 			true,
 			"local",
-			k8s.Endpoint, k8s.ES, k8s.Pod, k8s.Svc, k8s.SP, k8s.Srv, k8s.ExtWorkload,
+			k8s.ES, k8s.Pod, k8s.Svc, k8s.SP, k8s.Srv, k8s.ExtWorkload,
 		)
 	} else {
 		k8sAPI, err = k8s.InitializeAPI(


### PR DESCRIPTION
Fixes #15561

## Problem

On clusters with Kubernetes 1.33+ (e.g. EKS 1.34), `linkerd-destination` floods logs with:

```
level=info msg="Warning: v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
```

The destination controller initializes **both** the v1 `Endpoints` informer and the `discovery.k8s.io/v1` `EndpointSlice` informer when `--enable-endpoint-slices` is set (the default). The `Endpoints` informer is never consumed in that mode: every `Endpoint().Lister()` / `Endpoint().Informer()` call site is guarded by the slices-disabled branch (`endpoints_watcher.go`, `workload_watcher.go`, `service_publisher.go`, `port_publisher.go`, `cluster_store.go`). It still issues a watch on the deprecated API, which is what triggers the warning.

## Change

Remove `k8s.Endpoint` from the resource list passed to `k8s.InitializeAPI` when `enableEndpointSlices` is true. The fallback path (`enableEndpointSlices=false`) continues to watch `Endpoints` as before, so behavior is unchanged for clusters without EndpointSlice support.

## Verification

- `go build ./controller/cmd/destination/` passes
- `go vet ./controller/cmd/destination/` passes
- `go test ./controller/api/destination/watcher/...` and `./controller/api/destination/external-workload/...` pass

## Notes

- RBAC is untouched: the `endpoints` permission remains granted in `destination-rbac.yaml` since it is still needed in the slices-disabled path.