### PR TITLE
fix: guard nil ExternalWorkload in opaque protocol (#15551)

### DIFF
--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -770,8 +770,10 @@ func (wp *workloadPublisher) updateExternalWorkload(externalWorkload *ext.Extern
 	}
 
 	// Compute opaque protocol.
-	if err := SetToServerProtocolExternalWorkload(wp.k8sAPI, &wp.addr); err != nil {
-		wp.log.Errorf("Error computing opaque protocol for externalworkload %s: %q", wp.addr.ExternalWorkload.GetName(), err)
+	if wp.addr.ExternalWorkload != nil {
+		if err := SetToServerProtocolExternalWorkload(wp.k8sAPI, &wp.addr); err != nil {
+			wp.log.Errorf("Error computing opaque protocol for externalworkload %s: %q", wp.addr.ExternalWorkload.GetName(), err)
+		}
 	}
 
 	for _, l := range wp.listeners {


### PR DESCRIPTION
Deleting an `ExternalWorkload` panics `linkerd-destination` when a proxy holds a discovery subscription for that workload's IP:port. `submitExternalWorkloadUpdate` passes nil on removal; the ownership block above guards for it, the opaque protocol error branch does not — and that branch always runs on removal, since `SetToServerProtocolExternalWorkload` errors unconditionally on a nil workload.

Skips the computation when the workload is nil. Listeners are still notified.

Fixes #15551