### PR TITLE
destination: fix nil pointer panic when deleting an ExternalWorkload

### DIFF
--- a/controller/api/destination/watcher/workload_watcher.go
+++ b/controller/api/destination/watcher/workload_watcher.go
@@ -770,8 +770,10 @@ func (wp *workloadPublisher) updateExternalWorkload(externalWorkload *ext.Extern
 	}
 
 	// Compute opaque protocol.
-	if err := SetToServerProtocolExternalWorkload(wp.k8sAPI, &wp.addr); err != nil {
-		wp.log.Errorf("Error computing opaque protocol for externalworkload %s: %q", wp.addr.ExternalWorkload.GetName(), err)
+	if wp.addr.ExternalWorkload != nil {
+		if err := SetToServerProtocolExternalWorkload(wp.k8sAPI, &wp.addr); err != nil {
+			wp.log.Errorf("Error computing opaque protocol for externalworkload %s: %q", wp.addr.ExternalWorkload.GetName(), err)
+		}
 	}
 
 	for _, l := range wp.listeners {

--- a/controller/api/destination/watcher/workload_watcher_test.go
+++ b/controller/api/destination/watcher/workload_watcher_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/linkerd/linkerd2/controller/k8s"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIpWatcherGetPod(t *testing.T) {
@@ -129,3 +131,31 @@ status:
 		}
 	})
 }
+
+// TestUpdateExternalWorkloadNilDoesNotPanic is a regression test for
+// linkerdio/linkerd2#15551: when an ExternalWorkload is deleted,
+// submitExternalWorkloadUpdate passes nil to updateExternalWorkload, and the
+// opaque-protocol error branch dereferenced wp.addr.ExternalWorkload.GetName(),
+// panicking with a nil pointer dereference. The update must not panic when the
+// workload is nil (removal path).
+func TestUpdateExternalWorkloadNilDoesNotPanic(t *testing.T) {
+	metrics, err := workloadVecs.newMetrics(prometheus.Labels{})
+	if err != nil {
+		t.Fatalf("failed to initialize metrics: %s", err)
+	}
+	wp := &workloadPublisher{
+		log:     log.WithField("component", "workload-watcher"),
+		metrics: metrics,
+		listeners: []WorkloadUpdateListener{
+			stubWorkloadUpdateListener{},
+		},
+	}
+	require.NotPanics(t, func() {
+		wp.updateExternalWorkload(nil)
+	})
+}
+
+// stubWorkloadUpdateListener is a no-op WorkloadUpdateListener for tests.
+type stubWorkloadUpdateListener struct{}
+
+func (stubWorkloadUpdateListener) Update(*Address) error { return nil }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	github.com/stretchr/testify v1.11.1
 	go.opencensus.io v0.24.0
 	golang.org/x/tools v0.48.0
 	google.golang.org/grpc v1.83.0


### PR DESCRIPTION
## Problem

`linkerd-destination` panics with a nil pointer dereference when an `ExternalWorkload` is deleted, if any proxy holds an active discovery subscription for that workload's IP:port.

On deletion, `submitExternalWorkloadUpdate(ew, remove=true)` passes `nil` to `updateExternalWorkload`. The opaque-protocol error branch unconditionally dereferenced `wp.addr.ExternalWorkload.GetName()`, panicking.

```
panic: runtime error: invalid memory address or nil pointer dereference
watcher.(*workloadPublisher).updateExternalWorkload(0xc0022db0e0, 0x0)
\tcontroller/api/destination/watcher/workload_watcher.go:774
```

Fixes #15551

## Solution

Guard the opaque-protocol computation so it only runs when the workload is non-nil. On the removal path the workload is nil, so there is nothing to compute; subscribers are still notified via the existing listener update.

## Verification

Added `TestUpdateExternalWorkloadNilDoesNotPanic` which calls `updateExternalWorkload(nil)` and asserts no panic. Full `controller/api/destination/watcher` package tests pass.