### PR TITLE
build(deps): bump h2 from 0.4.15 to 0.4.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
for more information see
https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h.

this commit updates `h2` to a version to includes a patch to this
security vulnerability:

```
; cargo deny --all-features check advisories
error[vulnerability]: h2 unbounded empty DATA frames
   ┌─ /__w/linkerd2/linkerd2/Cargo.lock:73:1
   │
73 │ h2 0.4.15 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
   │
   ├ ID: RUSTSEC-2026-0258
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0258
   ├ The h2 crate, used internally by hyper, had a flaw that would accept and queue empty DATA frames without limit.
     If streams were not actively drained, this could lead to unbounded memory usage, or a panic if the length overflows.

     Low severity.

     Patched in v0.4.16.
   ├ Announcement: https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h
   ├ Solution: Upgrade to >=0.4.16 (try `cargo update -p h2`)
   ├ h2 v0.4.15
     ├── hyper v1.10.1
     │   ├── hyper-rustls v0.27.9
     │   │   └── kube-client v3.1.0
     │   │       ├── kube v3.1.0
     │   │       │   ├── gateway-api v0.21.0
     │   │       │   │   └── linkerd-policy-controller-k8s-api v0.1.0
     │   │       │   │       ├── linkerd-policy-controller-k8s-index v0.1.0
     │   │       │   │       │   └── linkerd-policy-controller-runtime v0.1.0
     │   │       │   │       │       └── linkerd-policy-controller v0.1.0
     │   │       │   │       ├── linkerd-policy-controller-k8s-status v0.1.0
     │   │       │   │       │   └── linkerd-policy-controller-runtime v0.1.0 (*)
     │   │       │   │       ├── linkerd-policy-controller-runtime v0.1.0 (*)
     │   │       │   │       └── linkerd-policy-test v0.1.0
     │   │       │   ├── linkerd-policy-controller-k8s-api v0.1.0 (*)
     │   │       │   ├── linkerd-policy-controller-k8s-index v0.1.0 (*)
     │   │       │   ├── linkerd-policy-controller-runtime v0.1.0 (*)
     │   │       │   └── linkerd-policy-test v0.1.0 (*)
     │   │       ├── kube-runtime v3.1.0
     │   │       │   ├── kube v3.1.0 (*)
     │   │       │   └── kubert v0.27.0
     │   │       │       ├── linkerd-policy-controller-k8s-index v0.1.0 (*)
     │   │       │       ├── linkerd-policy-controller-k8s-status v0.1.0 (*)
     │   │       │       └── linkerd-policy-controller-runtime v0.1.0 (*)
     │   │       └── kubert v0.27.0 (*)
     │   ├── hyper-timeout v0.5.2
     │   │   ├── kube-client v3.1.0 (*)
     │   │   └── tonic v0.14.6
     │   │       ├── linkerd-policy-controller-grpc v0.1.0
     │   │       │   ├── linkerd-policy-controller-runtime v0.1.0 (*)
     │   │       │   └── linkerd-policy-test v0.1.0 (*)
     │   │       ├── linkerd-policy-controller-runtime v0.1.0 (*)
     │   │       ├── linkerd-policy-test v0.1.0 (*)
     │   │       ├── linkerd2-proxy-api v0.20.0
     │   │       │   ├── linkerd-policy-controller-grpc v0.1.0 (*)
     │   │       │   └── linkerd-policy-test v0.1.0 (*)
     │   │       └── tonic-prost v0.14.6
     │   │           └── linkerd2-proxy-api v0.20.0 (*)
     │   ├── hyper-util v0.1.20
     │   │   ├── hyper-rustls v0.27.9 (*)
     │   │   ├── hyper-timeout v0.5.2 (*)
     │   │   ├── kube-client v3.1.0 (*)
     │   │   ├── kubert v0.27.0 (*)
     │   │   ├── linkerd-policy-controller-runtime v0.1.0 (*)
     │   │   ├── linkerd-policy-test v0.1.0 (*)
     │   │   └── tonic v0.14.6 (*)
     │   ├── kube-client v3.1.0 (*)
     │   ├── kubert v0.27.0 (*)
     │   ├── linkerd-policy-controller-runtime v0.1.0 (*)
     │   ├── linkerd-policy-test v0.1.0 (*)
     │   └── tonic v0.14.6 (*)
     └── tonic v0.14.6 (*)

advisories FAILED
```

Signed-off-by: katelyn martin <kate@buoyant.io>
