### PR TITLE
build(deps): bump golang to 1.26.7

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ${{ vars.LINKERD2_RUNNER || 'ubuntu-24.04' }}
     container:
-      image: golang:1.26.4
+      image: golang:1.26.7
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - run: go install gotest.tools/gotestsum@v0.4.2

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,5 +1,5 @@
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS go-deps
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -3,7 +3,7 @@ ARG RUNTIME_IMAGE="cr.l5d.io/linkerd/proxy-runtime:latest"
 ARG TARGETARCH
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS go-deps
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/
@@ -45,7 +45,7 @@ COPY proxy-identity proxy-identity
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -o /out/proxy-identity -mod=readonly -ldflags "-s -w" ./proxy-identity
 
 ## build proxy-init
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS proxy-init
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS proxy-init
 WORKDIR /build
 ARG PROXY_INIT_REPO="linkerd/linkerd2-proxy-init"
 ARG PROXY_INIT_REF="proxy-init/v2.4.9"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS go-deps
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linkerd/linkerd2
 
-go 1.26.4
+go 1.26.7
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.0

--- a/viz/metrics-api/Dockerfile
+++ b/viz/metrics-api/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS go-deps
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/viz/tap/Dockerfile
+++ b/viz/tap/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS go-deps
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM=linux/amd64
 
 # Precompile key slow-to-build dependencies
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS go-deps
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS go-deps
 WORKDIR /linkerd-build
 COPY go.mod go.sum ./
 COPY bin/install-deps bin/


### PR DESCRIPTION
This change addresses the following CVEs:
- [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218)
- [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091)
- [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090)
- [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089)
- [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088)
- [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972)
- [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026)