### PR TITLE
fix(multicluster): disallow exec auth provider in remote credentials

### DIFF
--- a/controller/api/destination/watcher/cluster_store.go
+++ b/controller/api/destination/watcher/cluster_store.go
@@ -265,6 +265,9 @@ func decodeK8sConfigFromSecret(data []byte, cluster string, enableEndpointSlices
 		return nil, nil, err
 	}
 
+	// Disallow the Exec auth provider.
+	cfg.ExecProvider = nil
+
 	ctx := context.Background()
 	var remoteAPI *k8s.API
 	if enableEndpointSlices {

--- a/multicluster/cmd/check.go
+++ b/multicluster/cmd/check.go
@@ -344,7 +344,11 @@ func (hc *healthChecker) linkAccess(ctx context.Context) error {
 }
 
 func (hc *healthChecker) checkLinks(ctx context.Context) error {
-	links, err := hc.KubeAPIClient().L5dCrdClient.LinkV1alpha3().Links("").List(ctx, metav1.ListOptions{})
+	namespace, err := hc.KubeAPIClient().GetNamespaceWithExtensionLabel(ctx, MulticlusterExtensionName)
+	if err != nil {
+		return err
+	}
+	links, err := hc.KubeAPIClient().L5dCrdClient.LinkV1alpha3().Links(namespace.Name).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -403,6 +407,8 @@ func (hc *healthChecker) checkRemoteClusterConnectivity(ctx context.Context) err
 			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %w", secret.Namespace, secret.Name, link.Spec.TargetClusterName, err))
 			continue
 		}
+		// Disallow the Exec auth provider.
+		clientConfig.ExecProvider = nil
 		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, healthcheck.RequestTimeout, 0, 0)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %w", secret.Namespace, secret.Name, link.Spec.TargetClusterName, err))
@@ -451,6 +457,8 @@ func (hc *healthChecker) checkRemoteClusterAnchors(ctx context.Context, localAnc
 			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: unable to parse api config: %s", secret.Namespace, secret.Name, link.Spec.TargetClusterName, err))
 			continue
 		}
+		// Disallow the Exec auth provider.
+		clientConfig.ExecProvider = nil
 		remoteAPI, err := k8s.NewAPIForConfig(clientConfig, "", []string{}, healthcheck.RequestTimeout, 0, 0)
 		if err != nil {
 			errors = append(errors, fmt.Sprintf("* secret: [%s/%s] cluster: [%s]: could not instantiate api for target cluster: %s", secret.Namespace, secret.Name, link.Spec.TargetClusterName, err))
@@ -817,7 +825,11 @@ func (hc *healthChecker) checkForOrphanedServices(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	links, err := hc.KubeAPIClient().L5dCrdClient.LinkV1alpha3().Links("").List(ctx, metav1.ListOptions{})
+	namespace, err := hc.KubeAPIClient().GetNamespaceWithExtensionLabel(ctx, MulticlusterExtensionName)
+	if err != nil {
+		return err
+	}
+	links, err := hc.KubeAPIClient().L5dCrdClient.LinkV1alpha3().Links(namespace.Name).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/multicluster/cmd/service-mirror/main.go
+++ b/multicluster/cmd/service-mirror/main.go
@@ -352,6 +352,8 @@ func restartClusterWatcher(
 	if err != nil {
 		return fmt.Errorf("unable to parse kube config: %w", err)
 	}
+	// Disallow the Exec auth provider.
+	cfg.ExecProvider = nil
 	remoteAPI, err := controllerK8s.InitializeAPIForConfig(ctx, cfg, false, link.Spec.TargetClusterName, controllerK8s.Svc, controllerK8s.Endpoint)
 	if err != nil {
 		return fmt.Errorf("cannot initialize api for target cluster %s: %w", link.Spec.TargetClusterName, err)


### PR DESCRIPTION
Cluster credentials secrets created by `linkerd multicluster link` use
the token auth provider. This change disallows the exec auth provider
since it is not used or necessary.

Additionally, we narrow Link resource lookups to restrict them to
the `linkerd-multicluster` namespace.

<!--  Thanks for sending a pull request!

If you already have a well-structured git commit message, chances are GitHub
set the title and description of this PR to the git commit message subject and
body, respectively. If so, you may delete these instructions and submit your PR.

If this is your first time, please read our contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md

The title and description of your Pull Request should match the git commit
subject and body, respectively. Git commit messages are structured as follows:

```
Subject

Problem

Solution

Validation

Fixes #[GitHub issue ID]

DCO Sign off
```

Example git commit message:

```
Introduce Pull Request Template

GitHub's community guidelines recommend a pull request template, the repo was
lacking one.

Introduce a `PULL_REQUEST_TEMPLATE.md` file.

Once merged, the
[Community profile checklist](https://github.com/linkerd/linkerd2/community)
should indicate the repo now provides a pull request template.

Fixes #3321

Signed-off-by: Jane Smith <jane.smith@example.com>
```

Note the git commit message subject becomes the pull request title.

For more details around git commits, see the section on Committing in our
contributor guide:
https://github.com/linkerd/linkerd2/blob/main/CONTRIBUTING.md#committing
-->
