### PR TITLE
fix(cli): warn when authz skips unsupported target

### DIFF
--- a/pkg/k8s/policy.go
+++ b/pkg/k8s/policy.go
@@ -99,7 +99,7 @@ func AuthorizationsForResource(ctx context.Context, k8sAPI *KubernetesAPI, names
 
 	for _, p := range policies.Items {
 		target := p.Spec.TargetRef
-		if target.Kind == NamespaceKind && target.Group == K8sCoreAPIGroup {
+		if target.Kind == NamespaceKind && (target.Group == K8sCoreAPIGroup || target.Group == "") {
 			serverList, ok := allServersInNamespace[p.Namespace]
 			if !ok {
 				serverList, err = k8sAPI.L5dCrdClient.ServerV1beta3().Servers(p.Namespace).List(ctx, metav1.ListOptions{})
@@ -159,6 +159,12 @@ func AuthorizationsForResource(ctx context.Context, k8sAPI *KubernetesAPI, names
 					}
 				}
 			}
+		} else {
+			targetRef := fmt.Sprintf("%s/%s", target.Kind, target.Name)
+			if target.Group != "" {
+				targetRef = fmt.Sprintf("%s.%s/%s", target.Kind, target.Group, target.Name)
+			}
+			fmt.Fprintf(os.Stderr, "AuthorizationPolicy/%s targets %s which is not supported by this command; skipping\n", p.Name, targetRef)
 		}
 	}
 

--- a/pkg/k8s/policy_test.go
+++ b/pkg/k8s/policy_test.go
@@ -1,0 +1,150 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	policyv1alpha1 "github.com/linkerd/linkerd2/controller/gen/apis/policy/v1alpha1"
+	serverv1beta3 "github.com/linkerd/linkerd2/controller/gen/apis/server/v1beta3"
+	l5dcrdfake "github.com/linkerd/linkerd2/controller/gen/client/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestAuthorizationsForResourceTargets(t *testing.T) {
+	testCases := []struct {
+		name       string
+		policies   []*policyv1alpha1.AuthorizationPolicy
+		wantAuthzs []Authorization
+		wantStderr string
+	}{
+		{
+			name: "Namespace target with the core group is resolved",
+			policies: []*policyv1alpha1.AuthorizationPolicy{
+				authzPolicy("ns-authz", K8sCoreAPIGroup, NamespaceKind, "emojivoto"),
+			},
+			wantAuthzs: []Authorization{{Server: "web-http", AuthorizationPolicy: "ns-authz"}},
+		},
+		{
+			name: "Namespace target with an empty group is resolved",
+			policies: []*policyv1alpha1.AuthorizationPolicy{
+				authzPolicy("ns-authz", "", NamespaceKind, "emojivoto"),
+			},
+			wantAuthzs: []Authorization{{Server: "web-http", AuthorizationPolicy: "ns-authz"}},
+		},
+		{
+			name: "unsupported target is skipped with a warning",
+			policies: []*policyv1alpha1.AuthorizationPolicy{
+				authzPolicy("web-http-authz", PolicyAPIGroup, ServerKind, "web-http"),
+				authzPolicy("gw-route-authz", "gateway.networking.k8s.io", HTTPRouteKind, "gw-route"),
+			},
+			wantAuthzs: []Authorization{{Server: "web-http", AuthorizationPolicy: "web-http-authz"}},
+			wantStderr: "AuthorizationPolicy/gw-route-authz targets HTTPRoute.gateway.networking.k8s.io/gw-route which is not supported by this command; skipping\n",
+		},
+		{
+			name: "unsupported target with an empty group is rendered without a trailing dot",
+			policies: []*policyv1alpha1.AuthorizationPolicy{
+				authzPolicy("sa-authz", "", "ServiceAccount", "web"),
+			},
+			wantStderr: "AuthorizationPolicy/sa-authz targets ServiceAccount/web which is not supported by this command; skipping\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			k8sAPI, err := NewFakeAPI(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  namespace: emojivoto
+  labels:
+    app: web
+spec:
+  containers:
+  - name: web
+    ports:
+    - containerPort: 8080
+`)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			objs := []runtime.Object{
+				&serverv1beta3.Server{
+					ObjectMeta: metav1.ObjectMeta{Name: "web-http", Namespace: "emojivoto"},
+					Spec: serverv1beta3.ServerSpec{
+						PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+						Port:        intstr.FromInt(8080),
+					},
+				},
+			}
+			for _, p := range tc.policies {
+				objs = append(objs, p)
+			}
+			k8sAPI.L5dCrdClient = l5dcrdfake.NewSimpleClientset(objs...)
+
+			var authzs []Authorization
+			stderr := captureStderr(t, func() {
+				authzs, err = AuthorizationsForResource(context.Background(), k8sAPI, "emojivoto", "pod")
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if len(authzs) != len(tc.wantAuthzs) {
+				t.Fatalf("expected %d authorizations, got %+v", len(tc.wantAuthzs), authzs)
+			}
+			for i, want := range tc.wantAuthzs {
+				if authzs[i] != want {
+					t.Errorf("expected authorization %+v, got %+v", want, authzs[i])
+				}
+			}
+
+			if stderr != tc.wantStderr {
+				t.Errorf("expected stderr %q, got %q", tc.wantStderr, stderr)
+			}
+		})
+	}
+}
+
+func authzPolicy(name, group, kind, targetName string) *policyv1alpha1.AuthorizationPolicy {
+	return &policyv1alpha1.AuthorizationPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "emojivoto"},
+		Spec: policyv1alpha1.AuthorizationPolicySpec{
+			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+				Group: gatewayapiv1alpha2.Group(group),
+				Kind:  gatewayapiv1alpha2.Kind(kind),
+				Name:  gatewayapiv1alpha2.ObjectName(targetName),
+			},
+		},
+	}
+}
+
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("error creating os.Pipe(): %s", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	out := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		out <- buf.String()
+	}()
+
+	f()
+	w.Close()
+	return <-out
+}


### PR DESCRIPTION
## Problem

`linkerd authz` only resolves `AuthorizationPolicy` targets whose `targetRef` is `Namespace` (`core`), `Server.policy.linkerd.io`, or `HTTPRoute.policy.linkerd.io`. Any other target, most notably `HTTPRoute.gateway.networking.k8s.io`, is skipped without any indication, so the command prints an empty or partial authorization list for a workload that is in fact authorized, and the user has no hint that a policy was ignored.

`pkg/k8s/policy.go:100-163` (`AuthorizationsForResource`): the `if` / `else if` chain over `p.Spec.TargetRef` has no final `else`, so an unrecognized kind/group falls through silently. Every other failure path in that function (missing Server, bad selector, unresolvable HTTPRoute parent) already reports to stderr.

## Solution

Add the missing `else` branch: when the target kind/group is not one the command knows how to resolve, print `AuthorizationPolicy/<name> targets <Kind>.<group>/<name> which is not supported by this command; skipping` to stderr and continue, matching the surrounding warning style. When the group is empty the target is rendered as `<Kind>/<name>` rather than `<Kind>./<name>`. Output on stdout is unchanged.

The `Namespace` branch now also accepts an empty `targetRef.group`. The `AuthorizationPolicy` CRD allows `group` to be empty ("When empty, the Kubernetes core API group is inferred") and the policy controller treats an empty group as `core`, but this branch only matched the literal `core`, so a group-less `Namespace` policy was silently dropped and would otherwise have been misreported as unsupported by the new warning.

This is the "at minimum" item (3) from the issue. Actually resolving `gateway.networking.k8s.io` routes and disambiguating the group in the ROUTE column (items 1 and 2) depends on the gateway-api bump tracked in https://github.com/linkerd/linkerd2/issues/15619 and is intentionally left out of this change.

## Validation

New table test `TestAuthorizationsForResourceTargets` in `pkg/k8s/policy_test.go`. It builds a fake API with a pod and a `Server` selecting it, captures stderr, and covers: a `Namespace` target with group `core` (resolved, no warning), a `Namespace` target with an empty group (resolved, no warning), a `Server` policy alongside an `HTTPRoute.gateway.networking.k8s.io` policy (the `Server` policy is returned, the other produces the exact warning line), and an unsupported target with an empty group (rendered as `ServiceAccount/web`, not `ServiceAccount./web`).

Before the fix:

```
--- FAIL: TestAuthorizationsForResourceTargets (0.10s)
    --- FAIL: TestAuthorizationsForResourceTargets/Namespace_target_with_an_empty_group_is_resolved (0.02s)
        policy_test.go:102: expected 1 authorizations, got []
    --- FAIL: TestAuthorizationsForResourceTargets/unsupported_target_is_skipped_with_a_warning (0.02s)
        policy_test.go:111: expected stderr "AuthorizationPolicy/gw-route-authz targets HTTPRoute.gateway.networking.k8s.io/gw-route which is not supported by this command; skipping\n", got ""
    --- FAIL: TestAuthorizationsForResourceTargets/unsupported_target_with_an_empty_group_is_rendered_without_a_trailing_dot (0.02s)
        policy_test.go:111: expected stderr "AuthorizationPolicy/sa-authz targets ServiceAccount/web which is not supported by this command; skipping\n", got ""
FAIL
FAIL	github.com/linkerd/linkerd2/pkg/k8s	0.168s
```

After the fix:

```
--- PASS: TestAuthorizationsForResourceTargets (0.10s)
    --- PASS: TestAuthorizationsForResourceTargets/Namespace_target_with_the_core_group_is_resolved (0.03s)
    --- PASS: TestAuthorizationsForResourceTargets/Namespace_target_with_an_empty_group_is_resolved (0.02s)
    --- PASS: TestAuthorizationsForResourceTargets/unsupported_target_is_skipped_with_a_warning (0.02s)
    --- PASS: TestAuthorizationsForResourceTargets/unsupported_target_with_an_empty_group_is_rendered_without_a_trailing_dot (0.02s)
PASS
ok  	github.com/linkerd/linkerd2/pkg/k8s	1.169s
```

`go test -race ./pkg/k8s/`, `gofmt -l`, and `go vet ./pkg/k8s/ ./cli/cmd/` are clean.

## Links

- https://github.com/linkerd/linkerd2/issues/15618
- https://github.com/linkerd/linkerd2/issues/15619

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
